### PR TITLE
Minor refactor of cli.writers

### DIFF
--- a/cli/cmd_add.go
+++ b/cli/cmd_add.go
@@ -95,7 +95,7 @@ func execSrcAdd(rc *RunContext, cmd *cobra.Command, args []string) error {
 	if cmd.Flags().Changed(flagDriver) {
 		val, _ := cmd.Flags().GetString(flagDriver)
 		typ = source.Type(strings.TrimSpace(val))
-		if !rc.reg.HasProviderFor(typ) {
+		if !rc.registry.HasProviderFor(typ) {
 			return errz.Errorf("unsupported source driver type %q", val)
 		}
 	} else {
@@ -154,7 +154,7 @@ func execSrcAdd(rc *RunContext, cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	src, err := newSource(rc.Log, rc.registry(), typ, handle, loc, opts)
+	src, err := newSource(rc.Log, rc.registry, typ, handle, loc, opts)
 	if err != nil {
 		return err
 	}
@@ -172,7 +172,7 @@ func execSrcAdd(rc *RunContext, cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	drvr, err := rc.registry().DriverFor(src.Type)
+	drvr, err := rc.registry.DriverFor(src.Type)
 	if err != nil {
 		return err
 	}
@@ -188,5 +188,5 @@ func execSrcAdd(rc *RunContext, cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	return rc.writers().srcw.Source(src)
+	return rc.writers.srcw.Source(src)
 }

--- a/cli/cmd_drivers.go
+++ b/cli/cmd_drivers.go
@@ -26,6 +26,6 @@ func execDrivers(rc *RunContext, cmd *cobra.Command, args []string) error {
 		return errz.Errorf("invalid arguments: zero arguments expected")
 	}
 
-	drvrs := rc.registry().DriversMetadata()
-	return rc.writers().metaw.DriverMetadata(drvrs)
+	drvrs := rc.registry.DriversMetadata()
+	return rc.writers.metaw.DriverMetadata(drvrs)
 }

--- a/cli/cmd_inspect.go
+++ b/cli/cmd_inspect.go
@@ -106,7 +106,7 @@ func execInspect(rc *RunContext, cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	dbase, err := rc.databases().Open(rc.Context, src)
+	dbase, err := rc.databases.Open(rc.Context, src)
 	if err != nil {
 		return errz.Wrapf(err, "failed to inspect %s", src.Handle)
 	}
@@ -119,7 +119,7 @@ func execInspect(rc *RunContext, cmd *cobra.Command, args []string) error {
 			return err
 		}
 
-		return rc.writers().metaw.TableMetadata(tblMeta)
+		return rc.writers.metaw.TableMetadata(tblMeta)
 	}
 
 	meta, err := dbase.SourceMetadata(rc.Context)
@@ -133,5 +133,5 @@ func execInspect(rc *RunContext, cmd *cobra.Command, args []string) error {
 		meta.DBVars = nil
 	}
 
-	return rc.writers().metaw.SourceMetadata(meta)
+	return rc.writers.metaw.SourceMetadata(meta)
 }

--- a/cli/cmd_list.go
+++ b/cli/cmd_list.go
@@ -23,5 +23,5 @@ func execSrcList(rc *RunContext, cmd *cobra.Command, args []string) error {
 		return errz.Errorf(msgInvalidArgs)
 	}
 
-	return rc.writers().srcw.SourceSet(rc.Config.Sources)
+	return rc.writers.srcw.SourceSet(rc.Config.Sources)
 }

--- a/cli/cmd_notify.go
+++ b/cli/cmd_notify.go
@@ -38,7 +38,7 @@ func newNotifyListCmd() (*cobra.Command, runFunc) {
 }
 
 func execNotifyList(rc *RunContext, cmd *cobra.Command, args []string) error {
-	return rc.writers().notifyw.NotifyDestinations(rc.Config.Notification.Destinations)
+	return rc.writers.notifyw.NotifyDestinations(rc.Config.Notification.Destinations)
 }
 
 func newNotifyRemoveCmd() (*cobra.Command, runFunc) {
@@ -165,7 +165,7 @@ func execNotifyAddSlack(rc *RunContext, cmd *cobra.Command, args []string) error
 		return err
 	}
 
-	return rc.writers().notifyw.NotifyDestinations([]notify.Destination{*dest})
+	return rc.writers.notifyw.NotifyDestinations([]notify.Destination{*dest})
 }
 
 func newNotifyAddHipChatCmd() (*cobra.Command, runFunc) {

--- a/cli/cmd_ping.go
+++ b/cli/cmd_ping.go
@@ -100,7 +100,7 @@ func execPing(rc *RunContext, cmd *cobra.Command, args []string) error {
 
 	rc.Log.Debugf("Using timeout value: %s", timeout)
 
-	return pingSources(rc.Context, rc.Log, rc.registry(), srcs, rc.writers().pingw, timeout)
+	return pingSources(rc.Context, rc.Log, rc.registry, srcs, rc.writers.pingw, timeout)
 }
 
 // pingSources pings each of the sources in srcs, and prints results

--- a/cli/cmd_remove.go
+++ b/cli/cmd_remove.go
@@ -41,7 +41,7 @@ func execSrcRemove(rc *RunContext, cmd *cobra.Command, args []string) error {
 	}
 
 	fmt.Fprintf(rc.Out, "Removed data source ")
-	_, _ = rc.wrtr.fmt.Hilite.Fprintf(rc.Out, "%s", src.Handle)
+	_, _ = rc.writers.fmt.Hilite.Fprintf(rc.Out, "%s", src.Handle)
 	fmt.Fprintln(rc.Out)
 
 	return nil

--- a/cli/cmd_scratch.go
+++ b/cli/cmd_scratch.go
@@ -57,7 +57,7 @@ func execScratch(rc *RunContext, cmd *cobra.Command, args []string) error {
 			src = defaultScratch
 		}
 
-		return rc.writers().srcw.Source(src)
+		return rc.writers.srcw.Source(src)
 	}
 
 	// Set the scratch src
@@ -79,5 +79,5 @@ func execScratch(rc *RunContext, cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	return rc.writers().srcw.Source(src)
+	return rc.writers.srcw.Source(src)
 }

--- a/cli/cmd_slq.go
+++ b/cli/cmd_slq.go
@@ -93,7 +93,7 @@ func execSLQ(rc *RunContext, cmd *cobra.Command, args []string) error {
 // execSQLInsert executes the SQL and inserts resulting records
 // into destTbl in destSrc.
 func execSLQInsert(rc *RunContext, destSrc *source.Source, destTbl string) error {
-	args, srcs, dbases := rc.Args, rc.Config.Sources, rc.databases()
+	args, srcs, dbases := rc.Args, rc.Config.Sources, rc.databases
 	slq, err := preprocessUserSLQ(rc, args)
 	if err != nil {
 		return err
@@ -113,7 +113,7 @@ func execSLQInsert(rc *RunContext, destSrc *source.Source, destTbl string) error
 	// stack.
 
 	inserter := libsq.NewDBWriter(rc.Log, destDB, destTbl, libsq.DefaultRecordChSize)
-	err = libsq.ExecuteSLQ(ctx, rc.Log, rc.dbases, rc.dbases, srcs, slq, inserter)
+	err = libsq.ExecuteSLQ(ctx, rc.Log, rc.databases, rc.databases, srcs, slq, inserter)
 	if err != nil {
 		return errz.Wrapf(err, "insert %s.%s failed", destSrc.Handle, destTbl)
 	}
@@ -133,8 +133,8 @@ func execSLQPrint(rc *RunContext) error {
 		return err
 	}
 
-	recw := output.NewRecordWriterAdapter(rc.writers().recordw)
-	err = libsq.ExecuteSLQ(rc.Context, rc.Log, rc.dbases, rc.dbases, rc.Config.Sources, slq, recw)
+	recw := output.NewRecordWriterAdapter(rc.writers.recordw)
+	err = libsq.ExecuteSLQ(rc.Context, rc.Log, rc.databases, rc.databases, rc.Config.Sources, slq, recw)
 	if err != nil {
 		return err
 	}
@@ -172,7 +172,7 @@ func execSLQPrint(rc *RunContext) error {
 //
 //  $ sq '.person'  -->  sq '@active.person'
 func preprocessUserSLQ(rc *RunContext, args []string) (string, error) {
-	log, reg, dbases, srcs := rc.Log, rc.registry(), rc.databases(), rc.Config.Sources
+	log, reg, dbases, srcs := rc.Log, rc.registry, rc.databases, rc.Config.Sources
 	activeSrc := srcs.Active()
 
 	if len(args) == 0 {

--- a/cli/cmd_sql.go
+++ b/cli/cmd_sql.go
@@ -103,12 +103,12 @@ func execSQL(rc *RunContext, cmd *cobra.Command, args []string) error {
 // to the configured writer.
 func execSQLPrint(rc *RunContext, fromSrc *source.Source) error {
 	args := rc.Args
-	dbase, err := rc.databases().Open(rc.Context, fromSrc)
+	dbase, err := rc.databases.Open(rc.Context, fromSrc)
 	if err != nil {
 		return err
 	}
 
-	recw := output.NewRecordWriterAdapter(rc.writers().recordw)
+	recw := output.NewRecordWriterAdapter(rc.writers.recordw)
 	err = libsq.QuerySQL(rc.Context, rc.Log, dbase, recw, args[0])
 	if err != nil {
 		return err
@@ -121,7 +121,7 @@ func execSQLPrint(rc *RunContext, fromSrc *source.Source) error {
 // into destTbl in destSrc.
 func execSQLInsert(rc *RunContext, fromSrc, destSrc *source.Source, destTbl string) error {
 	args := rc.Args
-	dbases := rc.databases()
+	dbases := rc.databases
 	ctx, cancelFn := context.WithCancel(rc.Context)
 	defer cancelFn()
 

--- a/cli/cmd_sql_test.go
+++ b/cli/cmd_sql_test.go
@@ -132,7 +132,6 @@ func TestCmdSQL_StdinQuery(t *testing.T) {
 			require.NoError(t, err)
 
 			ru := newRun(t).hush()
-			//ru := newRun(t)
 			ru.rc.Stdin = f
 
 			err = ru.exec("sql", "--no-header", "SELECT * FROM "+tc.tbl)

--- a/cli/cmd_src.go
+++ b/cli/cmd_src.go
@@ -42,7 +42,7 @@ func execSrc(rc *RunContext, cmd *cobra.Command, args []string) error {
 			return nil
 		}
 
-		return rc.writers().srcw.Source(src)
+		return rc.writers.srcw.Source(src)
 	}
 
 	src, err := cfg.Sources.SetActive(args[0])
@@ -55,5 +55,5 @@ func execSrc(rc *RunContext, cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	return rc.writers().srcw.Source(src)
+	return rc.writers.srcw.Source(src)
 }

--- a/cli/cmd_tbl.go
+++ b/cli/cmd_tbl.go
@@ -61,7 +61,7 @@ func execTblCopy(rc *RunContext, cmd *cobra.Command, args []string) error {
 		return errz.New("one or two table args required")
 	}
 
-	tblHandles, err := parseTableHandleArgs(rc.reg, rc.Config.Sources, args)
+	tblHandles, err := parseTableHandleArgs(rc.registry, rc.Config.Sources, args)
 	if err != nil {
 		return err
 	}
@@ -108,7 +108,7 @@ func execTblCopy(rc *RunContext, cmd *cobra.Command, args []string) error {
 	}
 
 	var dbase driver.Database
-	dbase, err = rc.databases().Open(rc.Context, tblHandles[0].src)
+	dbase, err = rc.databases.Open(rc.Context, tblHandles[0].src)
 	if err != nil {
 		return err
 	}
@@ -160,7 +160,7 @@ func newTblTruncateCmd() (*cobra.Command, runFunc) {
 
 func execTblTruncate(rc *RunContext, cmd *cobra.Command, args []string) (err error) {
 	var tblHandles []tblHandle
-	tblHandles, err = parseTableHandleArgs(rc.reg, rc.Config.Sources, args)
+	tblHandles, err = parseTableHandleArgs(rc.registry, rc.Config.Sources, args)
 	if err != nil {
 		return err
 	}
@@ -200,7 +200,7 @@ func newTblDropCmd() (*cobra.Command, runFunc) {
 
 func execTblDrop(rc *RunContext, cmd *cobra.Command, args []string) (err error) {
 	var tblHandles []tblHandle
-	tblHandles, err = parseTableHandleArgs(rc.reg, rc.Config.Sources, args)
+	tblHandles, err = parseTableHandleArgs(rc.registry, rc.Config.Sources, args)
 	if err != nil {
 		return err
 	}
@@ -212,7 +212,7 @@ func execTblDrop(rc *RunContext, cmd *cobra.Command, args []string) (err error) 
 		}
 
 		var dbase driver.Database
-		dbase, err = rc.databases().Open(rc.Context, tblH.src)
+		dbase, err = rc.databases.Open(rc.Context, tblH.src)
 		if err != nil {
 			return err
 		}

--- a/cli/cmd_version.go
+++ b/cli/cmd_version.go
@@ -26,16 +26,16 @@ func execVersion(rc *RunContext, cmd *cobra.Command, args []string) error {
 		version = "0.0.0-dev"
 	}
 
-	rc.wrtr.fmt.Hilite.Fprintf(rc.Out, "sq %s", version)
+	rc.writers.fmt.Hilite.Fprintf(rc.Out, "sq %s", version)
 
 	if len(buildinfo.Commit) > 0 {
 		fmt.Fprint(rc.Out, "    ")
-		rc.wrtr.fmt.Faint.Fprint(rc.Out, "#"+buildinfo.Commit)
+		rc.writers.fmt.Faint.Fprint(rc.Out, "#"+buildinfo.Commit)
 	}
 
 	if len(buildinfo.Timestamp) > 0 {
 		fmt.Fprint(rc.Out, "    ")
-		rc.wrtr.fmt.Faint.Fprint(rc.Out, buildinfo.Timestamp)
+		rc.writers.fmt.Faint.Fprint(rc.Out, buildinfo.Timestamp)
 	}
 
 	fmt.Fprintln(rc.Out)

--- a/cli/config/config.go
+++ b/cli/config/config.go
@@ -84,7 +84,7 @@ func (f *Format) UnmarshalText(text []byte) error {
 	switch Format(text) {
 	default:
 		return errz.Errorf("unknown output format %q", string(text))
-	case FormatJSON, FormatJSONA, FormatJSONL, FormatTable, FormatGrid, FormatRaw,
+	case FormatJSON, FormatJSONA, FormatJSONL, FormatTable, FormatRaw,
 		FormatHTML, FormatMarkdown, FormatXLSX, FormatXML, FormatCSV, FormatTSV:
 	}
 
@@ -92,13 +92,12 @@ func (f *Format) UnmarshalText(text []byte) error {
 	return nil
 }
 
-// Constants
+// Output format values.
 const (
 	FormatJSON     Format = "json"
 	FormatJSONL    Format = "jsonl"
 	FormatJSONA    Format = "jsona"
-	FormatTable    Format = "table" // FIXME: rename to FormatText
-	FormatGrid     Format = "grid"
+	FormatTable    Format = "table"
 	FormatRaw      Format = "raw"
 	FormatHTML     Format = "html"
 	FormatMarkdown Format = "markdown"

--- a/cli/consts.go
+++ b/cli/consts.go
@@ -37,7 +37,7 @@ const (
 	flagJSONShort  = "j"
 	flagJSONA      = "jsona"
 	flagJSONAShort = "A"
-	flagJSONAUsage = "JSON: output each record's values as JSON array on its own line"
+	flagJSONAUsage = "JSON: output each record's values as a JSON array on its own line"
 	flagJSONL      = "jsonl"
 	flagJSONLShort = "l"
 	flagJSONLUsage = "JSON: output each record as a JSON object on its own line"

--- a/cli/source.go
+++ b/cli/source.go
@@ -97,7 +97,6 @@ func activeSrcFromFlagsOrConfig(cmd *cobra.Command, srcs *source.Set) (*source.S
 // and returned.
 func checkStdinSource(rc *RunContext) (*source.Source, error) {
 	cmd := rc.Cmd
-	reg := rc.registry()
 
 	f := rc.Stdin
 	info, err := f.Stat()
@@ -130,7 +129,7 @@ func checkStdinSource(rc *RunContext) (*source.Source, error) {
 	if cmd.Flags().Changed(flagDriver) {
 		val, _ := cmd.Flags().GetString(flagDriver)
 		typ = source.Type(val)
-		if !reg.HasProviderFor(typ) {
+		if !rc.registry.HasProviderFor(typ) {
 			return nil, errz.Errorf("unknown driver type: %s", typ)
 		}
 	}
@@ -150,7 +149,7 @@ func checkStdinSource(rc *RunContext) (*source.Source, error) {
 		}
 	}
 
-	return newSource(rc.Log, reg, typ, source.StdinHandle, source.StdinHandle, opts)
+	return newSource(rc.Log, rc.registry, typ, source.StdinHandle, source.StdinHandle, opts)
 }
 
 // newSource creates a new Source instance where the

--- a/main.go
+++ b/main.go
@@ -23,6 +23,7 @@ func main() {
 
 	err := cli.Execute(ctx, os.Stdin, os.Stdout, os.Stderr, os.Args)
 	if err != nil {
+		cancelFn()
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
- Ditched unnecessary accessor methods on `cli.writers`.
- Other related minor tidying.