### PR TITLE
Bug #87: generated SQL should always quote table and column names in join statement

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -101,13 +101,6 @@ func ExecuteWith(ctx context.Context, rc *RunContext, args []string) error {
 	rc.Log.Debugf("Build: %s %s %s", buildinfo.Version, buildinfo.Commit, buildinfo.Timestamp)
 	rc.Log.Debugf("Config (cfg version %q) from: %s", rc.Config.Version, rc.ConfigStore.Location())
 
-	// NOTE: (Feb 2021): The project has been finally been upgraded
-	//  to spf13/cobra v1.1.3, which does provide support
-	//  for context.Context. However, the sq codebase is still using
-	//  the workaround to smuggle Context to the commands. Presumably
-	//  we'll refactor the code at some point to make use of cobra's
-	//  support for Context.
-
 	ctx = WithRunContext(ctx, rc)
 
 	rootCmd := newCommandTree(rc)

--- a/libsq/ast/node.go
+++ b/libsq/ast/node.go
@@ -39,8 +39,8 @@ type Node interface {
 }
 
 // Selectable is a marker interface to indicate that the node can be
-// selected from. That is, the node represents a SQL table or join and
-// can be used like "SELECT * FROM [selectable]".
+// selected from. That is, the node represents a SQL table, view, or
+// join table, and can be used like "SELECT * FROM [selectable]".
 type Selectable interface {
 	Selectable()
 }

--- a/libsq/ast/sqlbuilder/basebuilder.go
+++ b/libsq/ast/sqlbuilder/basebuilder.go
@@ -192,15 +192,33 @@ func (fb *BaseFragmentBuilder) Join(fnJoin *ast.Join) (string, error) {
 			operator = "="
 		}
 
-		onClause = fmt.Sprintf(" ON %s %s %s", leftOperand, operator, rightOperand)
+		onClause = fmt.Sprintf("ON %s %s %s", leftOperand, operator, rightOperand)
 	}
 
 	sql := fmt.Sprintf("FROM %s%s%s %s %s%s%s", fb.Quote, fnJoin.LeftTbl().SelValue(), fb.Quote, joinType, fb.Quote, fnJoin.RightTbl().SelValue(), fb.Quote)
-	if onClause != "" {
-		sql = sql + " " + onClause
-	}
+	sql = sqlAppend(sql, onClause)
+	//
+	//if onClause != "" {
+	//	sql = sql + " " + onClause
+	//}
 
 	return sql, nil
+}
+
+// sqlAppend is a convenience function for building the SQL string.
+// The main purpose is to ensure that there's always a consistent amount
+// of whitespace. Thus, if existing has a space suffix and add has a
+// space prefix, the returned string will only have one space. If add
+// is the empty string or just whitespace, this function simply
+// returns existing.
+func sqlAppend(existing, add string) string {
+	add = strings.TrimSpace(add)
+	if add == "" {
+		return existing
+	}
+
+	existing = strings.TrimSpace(existing)
+	return existing + " " + add
 }
 
 // quoteTableOrColSelector returns a quote table, col, or table/col

--- a/libsq/ast/sqlbuilder/basebuilder.go
+++ b/libsq/ast/sqlbuilder/basebuilder.go
@@ -197,10 +197,6 @@ func (fb *BaseFragmentBuilder) Join(fnJoin *ast.Join) (string, error) {
 
 	sql := fmt.Sprintf("FROM %s%s%s %s %s%s%s", fb.Quote, fnJoin.LeftTbl().SelValue(), fb.Quote, joinType, fb.Quote, fnJoin.RightTbl().SelValue(), fb.Quote)
 	sql = sqlAppend(sql, onClause)
-	//
-	//if onClause != "" {
-	//	sql = sql + " " + onClause
-	//}
 
 	return sql, nil
 }

--- a/libsq/ast/sqlbuilder/internal_test.go
+++ b/libsq/ast/sqlbuilder/internal_test.go
@@ -1,0 +1,38 @@
+package sqlbuilder
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestQuoteTableOrColSelector(t *testing.T) {
+	testCases := []struct {
+		in      string
+		want    string
+		wantErr bool
+	}{
+		{in: "", wantErr: true},
+		{in: "  ", wantErr: true},
+		{in: "not_start_with_period", wantErr: true},
+		{in: ".table", want: `"table"`},
+		{in: ".table.col", want: `"table"."col"`},
+		{in: ".table.col.other", wantErr: true},
+	}
+
+	const quote = `"`
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.in, func(t *testing.T) {
+			got, gotErr := quoteTableOrColSelector(quote, tc.in)
+			if tc.wantErr {
+				require.Error(t, gotErr)
+				return
+			}
+
+			require.NoError(t, gotErr)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/libsq/driver/driver.go
+++ b/libsq/driver/driver.go
@@ -260,6 +260,9 @@ func NewDatabases(log lg.Log, drvrs Provider, scratchSrcFn ScratchSrcFunc) *Data
 // same handle. Thus, the caller should typically not close
 // the Database: it will be closed via d.Close.
 //
+// NOTE: This entire logic re caching/not-closing is a bit sketchy,
+//  and needs to be revisited.
+//
 // Open implements DatabaseOpener.
 func (d *Databases) Open(ctx context.Context, src *source.Source) (Database, error) {
 	d.mu.Lock()

--- a/libsq/engine.go
+++ b/libsq/engine.go
@@ -240,11 +240,6 @@ func (ng *engine) crossSourceJoin(ctx context.Context, fnJoin *ast.Join) (fromCl
 	ng.tasks = append(ng.tasks, leftCopyTask)
 	ng.tasks = append(ng.tasks, rightCopyTask)
 
-	//err = execJoinCopyTasks(ctx, ng.log, joinDB, joinCopyTasks)
-	//if err != nil {
-	//	return "", nil, err
-	//}
-
 	joinDBFragBuilder, _ := joinDB.SQLDriver().SQLBuilder()
 	fromClause, err = joinDBFragBuilder.Join(fnJoin)
 	if err != nil {

--- a/libsq/engine_test.go
+++ b/libsq/engine_test.go
@@ -17,6 +17,7 @@ func TestSLQ2SQL(t *testing.T) {
 		wantSQL string
 		wantErr bool
 	}{
+		// Obviously we could use about 1,000 additional test cases.
 		{
 			handles: []string{sakila.SL3},
 			slq:     `@sakila_sl3 | .actor, .film_actor | join(.film_actor.actor_id == .actor.actor_id)`,
@@ -42,5 +43,4 @@ func TestSLQ2SQL(t *testing.T) {
 			require.Equal(t, tc.wantSQL, gotSQL)
 		})
 	}
-
 }

--- a/libsq/engine_test.go
+++ b/libsq/engine_test.go
@@ -1,0 +1,46 @@
+package libsq_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/neilotoole/sq/libsq"
+	"github.com/neilotoole/sq/testh"
+	"github.com/neilotoole/sq/testh/sakila"
+)
+
+func TestSLQ2SQL(t *testing.T) {
+	testCases := []struct {
+		handles []string
+		slq     string
+		wantSQL string
+		wantErr bool
+	}{
+		{
+			handles: []string{sakila.SL3},
+			slq:     `@sakila_sl3 | .actor, .film_actor | join(.film_actor.actor_id == .actor.actor_id)`,
+			wantSQL: `SELECT * FROM "actor" INNER JOIN "film_actor" ON "film_actor"."actor_id" = "actor"."actor_id"`,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+
+		t.Run(testh.Name(tc.slq), func(t *testing.T) {
+			th := testh.New(t)
+			srcs := th.NewSourceSet(tc.handles...)
+
+			gotSQL, gotErr := libsq.EngineSLQ2SQL(th.Context, th.Log, th.Databases(), th.Databases(), srcs, tc.slq)
+			if tc.wantErr {
+				require.Error(t, gotErr)
+				return
+			}
+
+			require.NoError(t, gotErr)
+
+			require.Equal(t, tc.wantSQL, gotSQL)
+		})
+	}
+
+}

--- a/libsq/internal_test.go
+++ b/libsq/internal_test.go
@@ -1,0 +1,24 @@
+package libsq
+
+import (
+	"context"
+
+	"github.com/neilotoole/lg"
+
+	"github.com/neilotoole/sq/libsq/driver"
+	"github.com/neilotoole/sq/libsq/source"
+)
+
+// EngineSLQ2SQL is a dedicated testing function that simulates
+// execution of a SLQ query, but instead of executing the resulting
+// SQL query, that ultimate SQL is returned. Effectively it is
+// equivalent to libsq.ExecuteSLQ, but without the execution.
+// Admittedly, this is an ugly workaround.
+func EngineSLQ2SQL(ctx context.Context, log lg.Log, dbOpener driver.DatabaseOpener, joinDBOpener driver.JoinDatabaseOpener, srcs *source.Set, query string) (targetSQL string, err error) {
+	var ng *engine
+	ng, err = newEngine(ctx, log, dbOpener, joinDBOpener, srcs, query)
+	if err != nil {
+		return "", err
+	}
+	return ng.targetSQL, nil
+}

--- a/testh/testh.go
+++ b/testh/testh.go
@@ -171,7 +171,7 @@ func (h *Helper) Source(handle string) *source.Source {
 	defer h.mu.Unlock()
 	t := h.T
 
-	// invoke h.Registry to ensure that its cleanup side-effects
+	// invoke h.init to ensure that its cleanup side-effects
 	// happen in the correct order (files get cleaned after
 	// databases, etc.).
 	h.init()
@@ -247,6 +247,17 @@ func (h *Helper) Source(handle string) *source.Source {
 	}
 
 	return src
+}
+
+// NewSourceSet is a convenience function for building a
+// new *source.Set incorporating the supplied handles. See
+// Helper.Source for more on the behavior.
+func (h *Helper) NewSourceSet(handles ...string) *source.Set {
+	srcs := &source.Set{}
+	for _, handle := range handles {
+		require.NoError(h.T, srcs.Add(h.Source(handle)))
+	}
+	return srcs
 }
 
 // Open opens a Database for src via h's internal Databases


### PR DESCRIPTION
See #87.

- `BaseFragmentBuilder` now always quotes table and col names in the JOIN statement.
- Refactoring of `libsq.engine` so that the SQL generated from SQL input can be tested.