### PR TITLE
enable short driver names

### DIFF
--- a/cli/cmd_add.go
+++ b/cli/cmd_add.go
@@ -158,8 +158,9 @@ func execSrcAdd(cmd *cobra.Command, args []string) error {
 	//
 	// The second form is particularly nice for bash completion etc.
 	if typ == sqlite3.Type {
-		if !strings.HasPrefix(loc, sqlite3.Prefix) {
-			loc = sqlite3.Prefix + loc
+		r, prefix := source.IsSQLitePrefix(loc)
+		if !r {
+			loc = prefix + loc
 		}
 	}
 

--- a/libsq/source/location_test.go
+++ b/libsq/source/location_test.go
@@ -20,9 +20,13 @@ func TestIsSQL(t *testing.T) {
 		{loc: "https://path/to/data.xlsx", want: false},
 		{loc: "http://path/to/data.xlsx", want: false},
 		{loc: "sqlite3:///path/to/sqlite.db", want: true},
+		{loc: "sl:///path/to/sqlite.db", want: true},
 		{loc: "sqlserver://sq:p_ssW0rd@localhost?database=sqtest", want: true},
+		{loc: "ms://sq:p_ssW0rd@localhost?database=sqtest", want: true},
 		{loc: "postgres://sq:p_ssW0rd@localhost/sqtest?sslmode=disable", want: true},
+		{loc: "pg://sq:p_ssW0rd@localhost/sqtest?sslmode=disable", want: true},
 		{loc: "mysql://sq:p_ssW0rd@tcp(localhost:3306)/sqtest", want: true},
+		{loc: "my://sq:p_ssW0rd@tcp(localhost:3306)/sqtest", want: true},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
This is for #54 
This makes `add` use shot drive name like `sq add -h @sakila_sl3  "sqlite3://sakila.db"`
