### PR TITLE
Support for postgres non-default schema

### DIFF
--- a/libsq/driver/driver.go
+++ b/libsq/driver/driver.go
@@ -263,8 +263,7 @@ func NewDatabases(log lg.Log, drvrs Provider, scratchSrcFn ScratchSrcFunc) *Data
 // the Database: it will be closed via d.Close.
 //
 // NOTE: This entire logic re caching/not-closing is a bit sketchy,
-//
-//	and needs to be revisited.
+// and needs to be revisited.
 //
 // Open implements DatabaseOpener.
 func (d *Databases) Open(ctx context.Context, src *source.Source) (Database, error) {

--- a/libsq/source/metadata.go
+++ b/libsq/source/metadata.go
@@ -24,6 +24,10 @@ type Metadata struct {
 	// including catalog/schema etc. For example, "sakila.public"
 	FQName string `json:"name_fq"`
 
+	// Schema is the schema name, for example "public".
+	// This may be empty for some sources.
+	Schema string `json:"schema,omitempty"`
+
 	// SourceType is the source driver type.
 	SourceType Type `json:"driver"`
 

--- a/libsq/source/source.go
+++ b/libsq/source/source.go
@@ -51,10 +51,18 @@ func ReservedHandles() []string {
 
 // Source describes a data source.
 type Source struct {
-	Handle   string          `yaml:"handle" json:"handle"`
-	Type     Type            `yaml:"type" json:"type"`
-	Location string          `yaml:"location" json:"location"`
-	Options  options.Options `yaml:"options,omitempty" json:"options,omitempty"`
+	// Handle is used to refer to a source, e.g. "@sakila".
+	Handle string `yaml:"handle" json:"handle"`
+
+	// Type is the driver type, e.g. postgres.Type.
+	Type Type `yaml:"type" json:"type"`
+
+	// Location is the source location, such as a DB connection URI,
+	// or a file path.
+	Location string `yaml:"location" json:"location"`
+
+	// Options are additional params, typically empty.
+	Options options.Options `yaml:"options,omitempty" json:"options,omitempty"`
 }
 
 func (s *Source) String() string {

--- a/testh/testdata/sources.sq.yml
+++ b/testh/testdata/sources.sq.yml
@@ -5,16 +5,16 @@ sources:
       location: sqlite3://${SQ_ROOT}/drivers/sqlite3/testdata/sakila.db
     - handle: '@sakila_pg9'
       type: postgres
-      location: postgres://sakila:p_ssW0rd@${SQ_TEST_SRC__SAKILA_PG9}/sakila?sslmode=disable
+      location: postgres://sakila:p_ssW0rd@${SQ_TEST_SRC__SAKILA_PG9}/sakila
     - handle: '@sakila_pg10'
       type: postgres
-      location: postgres://sakila:p_ssW0rd@${SQ_TEST_SRC__SAKILA_PG10}/sakila?sslmode=disable
+      location: postgres://sakila:p_ssW0rd@${SQ_TEST_SRC__SAKILA_PG10}/sakila
     - handle: '@sakila_pg11'
       type: postgres
-      location: postgres://sakila:p_ssW0rd@${SQ_TEST_SRC__SAKILA_PG11}/sakila?sslmode=disable
+      location: postgres://sakila:p_ssW0rd@${SQ_TEST_SRC__SAKILA_PG11}/sakila
     - handle: '@sakila_pg12'
       type: postgres
-      location: postgres://sakila:p_ssW0rd@${SQ_TEST_SRC__SAKILA_PG12}/sakila?sslmode=disable
+      location: postgres://sakila:p_ssW0rd@${SQ_TEST_SRC__SAKILA_PG12}/sakila
     - handle: '@sakila_my56'
       type: mysql
       location: mysql://sakila:p_ssW0rd@${SQ_TEST_SRC__SAKILA_MY56}/sakila


### PR DESCRIPTION
See #142 .

The user needs to add `search_path=custom_schema` in the postgres connection string.
A test has been added to verify this. Docs should also be updated.