### PR TITLE
CSV: check for mismatch field count vs explicitly specified column names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [v0.24.3] - 2023-03-14
 
 ### Added
 
@@ -153,6 +153,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#89]: Bug with SQL generated for joins.
 
 
+[v0.24.3]: https://github.com/neilotoole/sq/compare/v0.24.2...v0.24.3
 [v0.24.2]: https://github.com/neilotoole/sq/compare/v0.24.1...v0.24.2
 [v0.24.1]: https://github.com/neilotoole/sq/compare/v0.24.0...v0.24.1
 [v0.24.0]: https://github.com/neilotoole/sq/compare/v0.23.0...v0.24.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- When a CSV source has explicit column names (via `--opts cols=A,B,C`), `sq` verifies
+- When a CSV source has explicit column names (via `--opts cols=A,B,C`), `sq` now verifies
   that the CSV data record field count matches the number of explicit columns.
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+- When a CSV source has explicit column names (via `--opts cols=A,B,C`), `sq` verifies
+  that the CSV data record field count matches the number of explicit columns.
+
+
 ## [v0.24.2] - 2023-03-13
 
 ### Fixed


### PR DESCRIPTION
When a CSV source has explicit column names (via `--opts cols=A,B,C`), `sq` now verifies
  that the CSV data record field count matches the number of explicit columns.