### PR TITLE
Refactor/introduce query context

### DIFF
--- a/cli/completion.go
+++ b/cli/completion.go
@@ -16,7 +16,7 @@ type completionFunc func(cmd *cobra.Command, args []string, toComplete string) (
 var (
 	_ completionFunc = completeDriverType
 	_ completionFunc = completeSLQ
-	_ completionFunc = new(handleTableCompleter).complete
+	_ completionFunc = (*handleTableCompleter)(nil).complete
 )
 
 // completeHandle is a completionFunc that suggests handles.
@@ -109,8 +109,6 @@ type handleTableCompleter struct {
 	// is set to 1 to if the command accepts only one argument.
 	max int
 }
-
-var _ completionFunc = (*handleTableCompleter)(nil).complete
 
 // complete is the completionFunc for handleTableCompleter.
 func (c *handleTableCompleter) complete(cmd *cobra.Command, args []string,

--- a/libsq/query_args_test.go
+++ b/libsq/query_args_test.go
@@ -1,4 +1,4 @@
-package drivers_test
+package libsq_test
 
 import (
 	"testing"

--- a/libsq/query_cols_test.go
+++ b/libsq/query_cols_test.go
@@ -1,4 +1,4 @@
-package drivers_test
+package libsq_test
 
 import (
 	"testing"

--- a/libsq/query_count_test.go
+++ b/libsq/query_count_test.go
@@ -1,4 +1,4 @@
-package drivers_test
+package libsq_test
 
 import (
 	"testing"

--- a/libsq/query_datetime_test.go
+++ b/libsq/query_datetime_test.go
@@ -1,4 +1,4 @@
-package drivers_test
+package libsq_test
 
 import (
 	"testing"

--- a/libsq/query_filter_test.go
+++ b/libsq/query_filter_test.go
@@ -1,4 +1,4 @@
-package drivers_test
+package libsq_test
 
 import (
 	"testing"

--- a/libsq/query_groupby_test.go
+++ b/libsq/query_groupby_test.go
@@ -1,4 +1,4 @@
-package drivers_test
+package libsq_test
 
 import (
 	"testing"

--- a/libsq/query_join_test.go
+++ b/libsq/query_join_test.go
@@ -1,4 +1,4 @@
-package drivers_test
+package libsq_test
 
 import (
 	"testing"

--- a/libsq/query_orderby_test.go
+++ b/libsq/query_orderby_test.go
@@ -1,4 +1,4 @@
-package drivers_test
+package libsq_test
 
 import (
 	"testing"

--- a/libsq/query_test.go
+++ b/libsq/query_test.go
@@ -1,8 +1,10 @@
-package drivers_test
+package libsq_test
 
 import (
 	"strings"
 	"testing"
+
+	"github.com/neilotoole/sq/libsq"
 
 	"golang.org/x/exp/slices"
 
@@ -10,7 +12,6 @@ import (
 
 	"github.com/neilotoole/sq/libsq/source"
 
-	"github.com/neilotoole/sq/libsq"
 	"github.com/stretchr/testify/require"
 
 	_ "github.com/mattn/go-sqlite3"

--- a/libsq/query_unique_test.go
+++ b/libsq/query_unique_test.go
@@ -1,4 +1,4 @@
-package drivers_test
+package libsq_test
 
 import (
 	"testing"

--- a/testh/testh.go
+++ b/testh/testh.go
@@ -458,12 +458,16 @@ func (h *Helper) QuerySLQ(query string) (*RecordSink, error) {
 		_ = h.Source(handle)
 	}
 
-	srcs := h.srcs
-	dbases := h.Databases()
+	qc := &libsq.QueryContext{
+		Sources:      h.srcs,
+		DBOpener:     h.databases,
+		JoinDBOpener: h.databases,
+	}
+
 	sink := &RecordSink{}
 	recw := output.NewRecordWriterAdapter(sink)
 
-	err = libsq.ExecuteSLQ(h.Context, h.Log, dbases, dbases, srcs, query, recw)
+	err = libsq.ExecuteSLQ(h.Context, h.Log, qc, query, recw)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
- Introduce `libsq.QueryContext`, which encapsulates `source.Set`, db opener, etc.
- Moved `drivers/query_X_test.go` to pkg `libsq`.