### PR TITLE
Removed dependencies on neilotoole/errgroup in favor of sync/errgroup

### DIFF
--- a/drivers/mysql/metadata.go
+++ b/drivers/mysql/metadata.go
@@ -357,7 +357,6 @@ ORDER BY c.TABLE_NAME ASC, c.ORDINAL_POSITION ASC`
 
 	// g is an errgroup for fetching the
 	// row count for each table.
-	// g, gCtx := errgroup.WithContextN(ctx, 32, 1024)
 	g, gCtx := errgroup.WithContext(ctx)
 	g.SetLimit(driver.Tuning.ErrgroupNumG)
 

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,6 @@ require (
 	github.com/mattn/go-sqlite3 v1.14.16
 	github.com/microsoft/go-mssqldb v0.19.0
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/neilotoole/errgroup v0.1.5
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/ryboe/q v1.0.18
 	// Be very careful changing pkg segmentio/encoding. A specific version is by our json encoder.

--- a/go.sum
+++ b/go.sum
@@ -200,8 +200,6 @@ github.com/muesli/mango-pflag v0.1.0 h1:UADqbYgpUyRoBja3g6LUL+3LErjpsOwaC9ywvBWe
 github.com/muesli/mango-pflag v0.1.0/go.mod h1:YEQomTxaCUp8PrbhFh10UfbhbQrM/xJ4i2PB8VTLLW0=
 github.com/muesli/roff v0.1.0 h1:YD0lalCotmYuF5HhZliKWlIx7IEhiXeSfq7hNjFqGF8=
 github.com/muesli/roff v0.1.0/go.mod h1:pjAHQM9hdUUwm/krAfrLGgJkXJ+YuhtsfZ42kieB2Ig=
-github.com/neilotoole/errgroup v0.1.5 h1:DxEGoIfFm5ooGicidR+okiHjoOaGRKFaSxDPVZuuu2I=
-github.com/neilotoole/errgroup v0.1.5/go.mod h1:Q2nLGf+594h0CLBs/Mbg6qOr7GtqDK7C2S41udRnToE=
 github.com/neilotoole/slogt v0.0.0-20230402033048-91bc251cef6e h1:DB9JEjH43YJBSOxdpOmym/DWZyw5+rz/ROcdEcnDC+0=
 github.com/neilotoole/slogt v0.0.0-20230402033048-91bc251cef6e/go.mod h1:N2nPVMllazwsFNK3YVzKR07Ydpiu1lBTWZQ5Mxcwthg=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
@@ -322,7 +320,6 @@ golang.org/x/net v0.4.0 h1:Q5QPcMlvfxFTAPV0+07Xz/MpK9NTXu2VDUuy0FeMfaU=
 golang.org/x/net v0.4.0/go.mod h1:MBQ8lrhLObU/6UmLb4fmbmk5OcyYmqtbGd/9yIeKjEE=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.1.0 h1:wsuoTGHzEhffawBOhz5CYhcrV4IdKZbEyZjBMuTp12o=
 golang.org/x/sync v0.1.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=

--- a/libsq/engine.go
+++ b/libsq/engine.go
@@ -10,12 +10,12 @@ import (
 
 	"golang.org/x/exp/slog"
 
-	"github.com/neilotoole/errgroup"
 	"github.com/neilotoole/sq/libsq/ast"
 	"github.com/neilotoole/sq/libsq/core/errz"
 	"github.com/neilotoole/sq/libsq/core/sqlmodel"
 	"github.com/neilotoole/sq/libsq/core/sqlz"
 	"github.com/neilotoole/sq/libsq/driver"
+	"golang.org/x/sync/errgroup"
 )
 
 // engine executes a queryModel and writes to a RecordWriter.
@@ -172,7 +172,9 @@ func (ng *engine) executeTasks(ctx context.Context) error {
 	default:
 	}
 
-	g, gCtx := errgroup.WithContextN(ctx, driver.Tuning.ErrgroupNumG, driver.Tuning.ErrgroupQSize)
+	g, gCtx := errgroup.WithContext(ctx)
+	g.SetLimit(driver.Tuning.ErrgroupNumG)
+
 	for _, task := range ng.tasks {
 		task := task
 

--- a/libsq/source/files_test.go
+++ b/libsq/source/files_test.go
@@ -13,9 +13,9 @@ import (
 
 	"github.com/neilotoole/sq/testh/tutil"
 
-	"github.com/neilotoole/errgroup"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/neilotoole/sq/drivers/csv"
 	"github.com/neilotoole/sq/drivers/mysql"


### PR DESCRIPTION
Once upon a time, I created [neilotoole/errgroup](https://github.com/neilotoole/errgroup). The diff with `sync/errgroup` was that `neilotoole/errgroup` could limit the number of goroutines. Well, that functionality is now in `sync/errgroup` (`Group.SetLimit`), and `neilotoole/errgroup` is retired.
