### PR TITLE
#199: Kill RunContext.Log

### DIFF
--- a/cli/cmd_add.go
+++ b/cli/cmd_add.go
@@ -235,7 +235,7 @@ func execSrcAdd(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	src, err := newSource(rc.Log, rc.driverReg, typ, handle, loc, opts)
+	src, err := newSource(cmd.Context(), rc.driverReg, typ, handle, loc, opts)
 	if err != nil {
 		return err
 	}

--- a/cli/cmd_config_edit.go
+++ b/cli/cmd_config_edit.go
@@ -53,7 +53,7 @@ func execConfigEdit(cmd *cobra.Command, args []string) error {
 
 func execConfigEditOptions(cmd *cobra.Command, _ []string) error {
 	ctx := cmd.Context()
-	rc, log := RunContextFrom(ctx), lg.FromContext(ctx)
+	rc, log := RunContextFrom(ctx), logFrom(cmd)
 	cfg := rc.Config
 
 	before, err := ioz.MarshalYAML(cfg.Options)
@@ -94,7 +94,7 @@ func execConfigEditOptions(cmd *cobra.Command, _ []string) error {
 
 func execConfigEditSource(cmd *cobra.Command, args []string) error {
 	ctx := cmd.Context()
-	rc, log := RunContextFrom(ctx), lg.FromContext(ctx)
+	rc, log := RunContextFrom(ctx), logFrom(cmd)
 	cfg := rc.Config
 
 	src, err := cfg.Collection.Get(args[0])

--- a/cli/cmd_ping.go
+++ b/cli/cmd_ping.go
@@ -116,7 +116,7 @@ func execPing(cmd *cobra.Command, args []string) error {
 	}
 	timeout := OptPingTimeout.Get(cmdOpts)
 
-	rc.Log.Debug("Using ping timeout", lga.Val, timeout)
+	logFrom(cmd).Debug("Using ping timeout", lga.Val, timeout)
 
 	err = pingSources(cmd.Context(), rc.driverReg, srcs, rc.writers.pingw, timeout)
 	if errors.Is(err, context.Canceled) {
@@ -141,7 +141,7 @@ func pingSources(ctx context.Context, dp driver.Provider, srcs []*source.Source,
 		return err
 	}
 
-	log := lg.FromContext(ctx)
+	log := lg.From(ctx)
 	defer lg.WarnIfFuncError(log, "Close ping writer", w.Close)
 
 	resultCh := make(chan pingResult, len(srcs))

--- a/cli/cmd_ping.go
+++ b/cli/cmd_ping.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"context"
 	"errors"
+	"fmt"
 	"time"
 
 	"github.com/neilotoole/sq/libsq/core/options"
@@ -116,7 +117,7 @@ func execPing(cmd *cobra.Command, args []string) error {
 	}
 	timeout := OptPingTimeout.Get(cmdOpts)
 
-	logFrom(cmd).Debug("Using ping timeout", lga.Val, timeout)
+	logFrom(cmd).Debug("Using ping timeout", lga.Val, fmt.Sprintf("%v", timeout))
 
 	err = pingSources(cmd.Context(), rc.driverReg, srcs, rc.writers.pingw, timeout)
 	if errors.Is(err, context.Canceled) {

--- a/cli/cmd_slq.go
+++ b/cli/cmd_slq.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/neilotoole/sq/cli/flag"
 	"github.com/neilotoole/sq/drivers/csv"
-
 	"golang.org/x/exp/slices"
 
 	"github.com/neilotoole/sq/libsq/core/lg/lgm"
@@ -154,7 +153,6 @@ func execSLQInsert(ctx context.Context, rc *RunContext, mArgs map[string]string,
 	// stack.
 
 	inserter := libsq.NewDBWriter(
-		rc.Log,
 		destDB,
 		destTbl,
 		driver.Tuning.RecordChSize,
@@ -231,7 +229,7 @@ func execSLQPrint(ctx context.Context, rc *RunContext, mArgs map[string]string) 
 //
 //	$ sq '.person'  -->  $ sq '@active.person'
 func preprocessUserSLQ(ctx context.Context, rc *RunContext, args []string) (string, error) {
-	log, reg, dbases, coll := rc.Log, rc.driverReg, rc.databases, rc.Config.Collection
+	log, reg, dbases, coll := lg.From(ctx), rc.driverReg, rc.databases, rc.Config.Collection
 	activeSrc := coll.Active()
 
 	if len(args) == 0 {
@@ -408,7 +406,7 @@ func extractFlagArgsValues(cmd *cobra.Command) (map[string]string, error) {
 			// If the key already exists, don't overwrite. This mimics jq's
 			// behavior.
 
-			log := lg.FromContext(cmd.Context())
+			log := logFrom(cmd)
 			log.With("arg", k).Warn("Double use of --arg key; using first value.")
 
 			continue

--- a/cli/cmd_sql.go
+++ b/cli/cmd_sql.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/neilotoole/sq/cli/flag"
+	"github.com/neilotoole/sq/libsq/core/lg"
 
 	"github.com/neilotoole/sq/libsq/core/lg/lgm"
 
@@ -153,7 +154,6 @@ func execSQLInsert(ctx context.Context, rc *RunContext, fromSrc, destSrc *source
 	// stack.
 
 	inserter := libsq.NewDBWriter(
-		rc.Log,
 		destDB,
 		destTbl,
 		driver.Tuning.RecordChSize,
@@ -169,7 +169,7 @@ func execSQLInsert(ctx context.Context, rc *RunContext, fromSrc, destSrc *source
 		return errz.Wrapf(err, "insert %s.%s failed", destSrc.Handle, destTbl)
 	}
 
-	rc.Log.Debug(lgm.RowsAffected, lga.Count, affected)
+	lg.From(ctx).Debug(lgm.RowsAffected, lga.Count, affected)
 
 	// TODO: Should really use a Printer here
 	fmt.Fprintf(rc.Out, stringz.Plu("Inserted %d row(s) into %s\n",

--- a/cli/cmd_tbl_test.go
+++ b/cli/cmd_tbl_test.go
@@ -10,9 +10,7 @@ import (
 	"github.com/neilotoole/sq/testh/sakila"
 )
 
-func TestCmdTblCopy(t *testing.T) {
-	t.Parallel()
-
+func TestCmdTblCopy(t *testing.T) { //nolint:tparallel
 	for _, handle := range sakila.SQLAll() {
 		handle := handle
 
@@ -43,9 +41,7 @@ func TestCmdTblCopy(t *testing.T) {
 	}
 }
 
-func TestCmdTblDrop(t *testing.T) {
-	t.Parallel()
-
+func TestCmdTblDrop(t *testing.T) { //nolint:tparallel
 	for _, handle := range sakila.SQLAll() {
 		handle := handle
 

--- a/cli/cmd_version.go
+++ b/cli/cmd_version.go
@@ -67,7 +67,7 @@ func execVersion(cmd *cobra.Command, _ []string) error {
 		var err error
 		v, err := fetchBrewVersion(ctx)
 		if err != nil {
-			lg.Error(rc.Log, "Fetch brew version", err)
+			lg.Error(logFrom(cmd), "Fetch brew version", err)
 		}
 
 		// OK if v is empty

--- a/cli/config/config.go
+++ b/cli/config/config.go
@@ -14,8 +14,7 @@ import (
 )
 
 const (
-	EnvarLogPath     = "SQ_LOGFILE"
-	EnvarLogTruncate = "SQ_LOGFILE_TRUNCATE"
+	EnvarLogPath = "SQ_LOGFILE"
 
 	// EnvarConfigDir is the legacy envar for config location.
 	// Instead use EnvarConfig.

--- a/cli/config/yamlstore/upgrade.go
+++ b/cli/config/yamlstore/upgrade.go
@@ -40,7 +40,7 @@ type UpgradeRegistry map[string]UpgradeFunc
 func (fs *Store) doUpgrade(ctx context.Context, optsReg *options.Registry,
 	startVersion, targetVersion string,
 ) (*config.Config, error) {
-	log := lg.FromContext(ctx)
+	log := lg.From(ctx)
 	log.Debug("Starting config upgrade", lga.From, startVersion, lga.To, targetVersion)
 
 	if !semver.IsValid(targetVersion) {

--- a/cli/config/yamlstore/upgrades/v0.34.0/upgrade.go
+++ b/cli/config/yamlstore/upgrades/v0.34.0/upgrade.go
@@ -23,7 +23,7 @@ const Version = "v0.34.0"
 // - "sources" is renamed to "collection".
 // - "config.version" is set to "v0.34.0".
 func Upgrade(ctx context.Context, before []byte) (after []byte, err error) {
-	log := lg.FromContext(ctx)
+	log := lg.From(ctx)
 	log.Info("Starting config upgrade step", lga.To, Version)
 
 	// Load data

--- a/cli/config/yamlstore/yamlstore.go
+++ b/cli/config/yamlstore/yamlstore.go
@@ -59,7 +59,7 @@ func (fs *Store) Location() string {
 
 // Load reads config from disk. It implements Store.
 func (fs *Store) Load(ctx context.Context, optsReg *options.Registry) (*config.Config, error) {
-	log := lg.FromContext(ctx)
+	log := lg.From(ctx)
 	log.Debug("Loading config from file", lga.Path, fs.Path)
 
 	if fs.UpgradeRegistry != nil {

--- a/cli/config/yamlstore/yamlstore.go
+++ b/cli/config/yamlstore/yamlstore.go
@@ -63,7 +63,7 @@ func (fs *Store) Load(ctx context.Context, optsReg *options.Registry) (*config.C
 	log.Debug("Loading config from file", lga.Path, fs.Path)
 
 	if fs.UpgradeRegistry != nil {
-		mightNeedUpgrade, foundVers, err := checkNeedsUpgrade(fs.Path)
+		mightNeedUpgrade, foundVers, err := checkNeedsUpgrade(ctx, fs.Path)
 		if err != nil {
 			return nil, errz.Wrapf(err, "config: %s", fs.Path)
 		}

--- a/cli/error.go
+++ b/cli/error.go
@@ -21,11 +21,8 @@ import (
 // and logging errors. This func has a lot of (possibly needless)
 // redundancy; ultimately err will print if non-nil (even if
 // rc or any of its fields are nil).
-func printError(rc *RunContext, err error) {
-	log := lg.Discard()
-	if rc != nil && rc.Log != nil {
-		log = rc.Log
-	}
+func printError(ctx context.Context, rc *RunContext, err error) {
+	log := lg.From(ctx)
 
 	if err == nil {
 		log.Warn("printError called with nil error")

--- a/cli/logging.go
+++ b/cli/logging.go
@@ -22,7 +22,7 @@ import (
 // all returned values will be nil.
 func defaultLogging(ctx context.Context) (log *slog.Logger, h slog.Handler, closer func() error, err error) {
 	logFilePath, ok := os.LookupEnv(config.EnvarLogPath)
-	if !ok || logFilePath == "" || strings.TrimSpace(logFilePath) == "" {
+	if !ok || strings.TrimSpace(logFilePath) == "" {
 		lg.From(ctx).Debug("Logging: not enabled via envar", lga.Key, config.EnvarLogPath)
 		return lg.Discard(), nil, nil, nil
 	}

--- a/cli/logging.go
+++ b/cli/logging.go
@@ -1,61 +1,93 @@
 package cli
 
 import (
+	"context"
 	"os"
 	"path/filepath"
-	"strconv"
 	"strings"
 
 	"github.com/neilotoole/sq/cli/config"
-	"github.com/neilotoole/sq/libsq/core/cleanup"
 	"github.com/neilotoole/sq/libsq/core/errz"
 	"github.com/neilotoole/sq/libsq/core/lg"
+	"github.com/neilotoole/sq/libsq/core/lg/lga"
+	"github.com/spf13/cobra"
 	"golang.org/x/exp/slog"
 )
 
-// defaultLogging returns a log (and its associated closer) if
-// logging has been enabled via envars.
-func defaultLogging() (*slog.Logger, slog.Handler, *cleanup.Cleanup, error) {
-	truncate, _ := strconv.ParseBool(os.Getenv(config.EnvarLogTruncate))
-
+// defaultLogging returns a *slog.Logger, its slog.Handler, and
+// possibly a *cleanup.Cleanup, which the caller is responsible
+// for invoking at the appropriate time. If an error is returned, the
+// other returned values will be nil. If logging is not enabled,
+// all returned values will be nil.
+func defaultLogging(ctx context.Context) (log *slog.Logger, h slog.Handler, closer func() error, err error) {
 	logFilePath, ok := os.LookupEnv(config.EnvarLogPath)
 	if !ok || logFilePath == "" || strings.TrimSpace(logFilePath) == "" {
+		lg.From(ctx).Debug("Logging: not enabled via envar", lga.Key, config.EnvarLogPath)
 		return lg.Discard(), nil, nil, nil
 	}
+
+	lg.From(ctx).Debug("Logging: enabled via envar", lga.Key, config.EnvarLogPath)
 
 	// Let's try to create the dir holding the logfile... if it already exists,
 	// then os.MkdirAll will just no-op
 	parent := filepath.Dir(logFilePath)
-	err := os.MkdirAll(parent, 0o750)
+	err = os.MkdirAll(parent, 0o750)
 	if err != nil {
-		return lg.Discard(), nil, nil, errz.Wrapf(err, "failed to create parent dir of log file %s", logFilePath)
+		return nil, nil, nil, errz.Wrapf(err, "logging: failed to create parent dir of log file %s", logFilePath)
 	}
 
-	fileFlag := os.O_APPEND
-	if truncate {
-		fileFlag = os.O_TRUNC
-	}
-
-	logFile, err := os.OpenFile(logFilePath, os.O_RDWR|os.O_CREATE|fileFlag, 0o600)
+	logFile, err := os.OpenFile(logFilePath, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0o600)
 	if err != nil {
-		return lg.Discard(), nil, nil, errz.Wrapf(err, "unable to open log file: %s", logFilePath)
+		return nil, nil, nil, errz.Wrapf(err, "logging: unable to open log file: %s", logFilePath)
 	}
-	clnup := cleanup.New().AddE(logFile.Close)
+	closer = logFile.Close
 
-	replace := func(groups []string, a slog.Attr) slog.Attr {
-		// We want source to be "pkg/file.go".
-		if a.Key == slog.SourceKey {
-			fp := a.Value.String()
-			a.Value = slog.StringValue(filepath.Join(filepath.Base(filepath.Dir(fp)), filepath.Base(fp)))
-		}
-		return a
-	}
+	h = slog.HandlerOptions{
+		AddSource:   true,
+		Level:       slog.LevelDebug,
+		ReplaceAttr: logSourceReplace,
+	}.NewJSONHandler(logFile)
 
+	return slog.New(h), h, closer, nil
+}
+
+func stderrLogger() (*slog.Logger, slog.Handler) {
 	h := slog.HandlerOptions{
 		AddSource:   true,
 		Level:       slog.LevelDebug,
-		ReplaceAttr: replace,
-	}.NewJSONHandler(logFile)
+		ReplaceAttr: logSourceReplace,
+	}.NewJSONHandler(os.Stderr)
+	return slog.New(h), h
+}
 
-	return slog.New(h), h, clnup, nil
+// logSourceReplace overrides the default slog.SourceKey attr
+// to print "pkg/file.go" instead.
+func logSourceReplace(_ []string, a slog.Attr) slog.Attr {
+	// We want source to be "pkg/file.go".
+	if a.Key == slog.SourceKey {
+		fp := a.Value.String()
+		a.Value = slog.StringValue(filepath.Join(filepath.Base(filepath.Dir(fp)), filepath.Base(fp)))
+	}
+	return a
+}
+
+// logFrom is a convenience function for getting a *slog.Logger from a
+// *cobra.Command or context.Context.
+// If no logger present, lg.Discard() is returned.
+func logFrom(cmd *cobra.Command) *slog.Logger {
+	if cmd == nil {
+		return lg.Discard()
+	}
+
+	ctx := cmd.Context()
+	if ctx == nil {
+		return lg.Discard()
+	}
+
+	log := lg.From(ctx)
+	if log == nil {
+		return lg.Discard()
+	}
+
+	return log
 }

--- a/cli/run_test.go
+++ b/cli/run_test.go
@@ -12,7 +12,6 @@ import (
 	"testing"
 
 	"github.com/neilotoole/sq/cli/config/yamlstore"
-	"github.com/neilotoole/sq/libsq/core/lg"
 	"github.com/neilotoole/sq/libsq/core/options"
 
 	"github.com/stretchr/testify/require"
@@ -82,9 +81,6 @@ type Run struct {
 // commands to use the same config.
 func newRun(ctx context.Context, t *testing.T, from *Run) *Run {
 	ru := &Run{t: t, ctx: ctx}
-
-	log := lg.From(ctx)
-	_ = log
 
 	var cfgStore config.Store
 	if from != nil {

--- a/cli/run_test.go
+++ b/cli/run_test.go
@@ -11,8 +11,8 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/neilotoole/slogt"
 	"github.com/neilotoole/sq/cli/config/yamlstore"
+	"github.com/neilotoole/sq/libsq/core/lg"
 	"github.com/neilotoole/sq/libsq/core/options"
 
 	"github.com/stretchr/testify/require"
@@ -55,7 +55,6 @@ func newTestRunCtx(ctx context.Context, t testing.TB, cfgStore config.Store,
 		Stdin:           os.Stdin,
 		Out:             out,
 		ErrOut:          errOut,
-		Log:             slogt.New(t),
 		Config:          cfg,
 		ConfigStore:     cfgStore,
 		OptionsRegistry: optsReg,
@@ -67,6 +66,7 @@ func newTestRunCtx(ctx context.Context, t testing.TB, cfgStore config.Store,
 // run is a helper for testing sq commands.
 type Run struct {
 	t      *testing.T
+	ctx    context.Context
 	mu     sync.Mutex
 	rc     *cli.RunContext
 	out    *bytes.Buffer
@@ -81,7 +81,11 @@ type Run struct {
 // If from is non-nil, its config is used. This allows sequential
 // commands to use the same config.
 func newRun(ctx context.Context, t *testing.T, from *Run) *Run {
-	ru := &Run{t: t}
+	ru := &Run{t: t, ctx: ctx}
+
+	log := lg.From(ctx)
+	_ = log
+
 	var cfgStore config.Store
 	if from != nil {
 		cfgStore = from.rc.ConfigStore

--- a/cli/runcontext.go
+++ b/cli/runcontext.go
@@ -138,8 +138,10 @@ func newDefaultRunContext(ctx context.Context,
 		v0_34_0.Version: v0_34_0.Upgrade,
 	}
 
+	ctx = lg.NewContext(ctx, log)
+
 	var configErr error
-	rc.Config, rc.ConfigStore, configErr = yamlstore.Load(lg.NewContext(ctx, log),
+	rc.Config, rc.ConfigStore, configErr = yamlstore.Load(ctx,
 		args, rc.OptionsRegistry, upgrades)
 
 	log, logHandler, logCloser, logErr := defaultLogging(ctx)

--- a/cli/source.go
+++ b/cli/source.go
@@ -5,13 +5,13 @@ import (
 
 	"github.com/neilotoole/sq/cli/flag"
 	"github.com/neilotoole/sq/libsq/core/errz"
+	"github.com/neilotoole/sq/libsq/core/lg"
 	"github.com/neilotoole/sq/libsq/core/lg/lga"
 	"github.com/neilotoole/sq/libsq/core/options"
 	"github.com/neilotoole/sq/libsq/driver"
 	"github.com/neilotoole/sq/libsq/source"
 
 	"github.com/spf13/cobra"
-	"golang.org/x/exp/slog"
 )
 
 // determineSources figures out what the active source is
@@ -138,14 +138,16 @@ func checkStdinSource(ctx context.Context, rc *RunContext) (*source.Source, erro
 		}
 	}
 
-	return newSource(rc.Log, rc.driverReg, typ, source.StdinHandle, source.StdinHandle, options.Options{})
+	return newSource(ctx, rc.driverReg, typ, source.StdinHandle, source.StdinHandle, options.Options{})
 }
 
 // newSource creates a new Source instance where the
 // driver type is known. Opts may be nil.
-func newSource(log *slog.Logger, dp driver.Provider, typ source.DriverType, handle, loc string,
+func newSource(ctx context.Context, dp driver.Provider, typ source.DriverType, handle, loc string,
 	opts options.Options,
 ) (*source.Source, error) {
+	log := lg.From(ctx)
+
 	if opts == nil {
 		log.Debug("Create new data source",
 			lga.Handle, handle,

--- a/cli/writers.go
+++ b/cli/writers.go
@@ -246,7 +246,7 @@ func getFormat(cmd *cobra.Command, defaults options.Options) format.Format {
 
 var _ options.Opt = FormatOpt{}
 
-// NewFormatOpt returns an options.FormatOpt instance.
+// NewFormatOpt returns a new FormatOpt instance.
 func NewFormatOpt(key string, defaultVal format.Format, comment string, tags ...string) FormatOpt {
 	return FormatOpt{key: key, defaultVal: defaultVal, comment: comment, tags: tags}
 }
@@ -260,41 +260,41 @@ type FormatOpt struct {
 }
 
 // Tags implements options.Opt.
-func (o FormatOpt) Tags() []string {
-	return o.tags
+func (op FormatOpt) Tags() []string {
+	return op.tags
 }
 
 // Key implements options.Opt.
-func (o FormatOpt) Key() string {
-	return o.key
+func (op FormatOpt) Key() string {
+	return op.key
 }
 
 // String implements options.Opt.
-func (o FormatOpt) String() string {
-	return o.key
+func (op FormatOpt) String() string {
+	return op.key
 }
 
 // IsSet implements options.Opt.
-func (o FormatOpt) IsSet(opts options.Options) bool {
-	if opts == nil {
+func (op FormatOpt) IsSet(o options.Options) bool {
+	if o == nil {
 		return false
 	}
 
-	return opts.IsSet(o)
+	return o.IsSet(op)
 }
 
 // Process implements options.Processor. It converts matching
-// string values in opts into format.Format. If no match found,
+// string values in o into format.Format. If no match found,
 // the input arg is returned unchanged. Otherwise, a clone is
 // returned.
-func (o FormatOpt) Process(opts options.Options) (options.Options, error) {
-	if opts == nil {
+func (op FormatOpt) Process(o options.Options) (options.Options, error) {
+	if o == nil {
 		return nil, nil
 	}
 
-	v, ok := opts[o.key]
+	v, ok := o[op.key]
 	if !ok || v == nil {
-		return opts, nil
+		return o, nil
 	}
 
 	// v should be a string
@@ -302,35 +302,40 @@ func (o FormatOpt) Process(opts options.Options) (options.Options, error) {
 	s, ok = v.(string)
 	if !ok {
 		return nil, errz.Errorf("option {%s} should be {%T} but got {%T}: %v",
-			o.key, s, v, v)
+			op.key, s, v, v)
 	}
 
 	var f format.Format
 	if err := f.UnmarshalText([]byte(s)); err != nil {
-		return nil, errz.Wrapf(err, "option {%s} should is not a valid {%T}: %v", o.key, f, s)
+		return nil, errz.Wrapf(err, "option {%s} should is not a valid {%T}: %v", op.key, f, s)
 	}
 
-	opts = opts.Clone()
-	opts[o.key] = f
-	return opts, nil
+	o = o.Clone()
+	o[op.key] = f
+	return o, nil
 }
 
-// Get returns o's value in opts. If opts is nil, or no value
-// is set, o's default value is returned.
-func (o FormatOpt) Get(opts options.Options) format.Format {
-	if opts == nil {
-		return o.defaultVal
+// GetAny implements options.Opt.
+func (op FormatOpt) GetAny(o options.Options) any {
+	return op.Get(o)
+}
+
+// Get returns op's value in o. If o is nil, or no value
+// is set, op's default value is returned.
+func (op FormatOpt) Get(o options.Options) format.Format {
+	if o == nil {
+		return op.defaultVal
 	}
 
-	v, ok := opts[o.key]
+	v, ok := o[op.key]
 	if !ok {
-		return o.defaultVal
+		return op.defaultVal
 	}
 
 	var f format.Format
 	f, ok = v.(format.Format)
 	if !ok {
-		return o.defaultVal
+		return op.defaultVal
 	}
 
 	return f

--- a/cli/writers.go
+++ b/cli/writers.go
@@ -23,7 +23,6 @@ import (
 	"github.com/neilotoole/sq/cli/output/xlsxw"
 	"github.com/neilotoole/sq/cli/output/xmlw"
 	"github.com/neilotoole/sq/cli/output/yamlw"
-	"github.com/neilotoole/sq/libsq/core/lg"
 	"github.com/spf13/cobra"
 )
 
@@ -62,7 +61,7 @@ func newWriters(cmd *cobra.Command, opts options.Options, out, errOut io.Writer,
 ) (w *writers, out2, errOut2 io.Writer) {
 	var pr *output.Printing
 	pr, out2, errOut2 = getPrinting(cmd, opts, out, errOut)
-	log := lg.FromContext(cmd.Context())
+	log := logFrom(cmd)
 
 	// Package tablew has writer impls for each of the writer interfaces,
 	// so we use its writers as the baseline. Later we check the format

--- a/drivers/csv/csv.go
+++ b/drivers/csv/csv.go
@@ -68,6 +68,8 @@ func (d *driveri) DriverMetadata() driver.Metadata {
 
 // Open implements driver.DatabaseOpener.
 func (d *driveri) Open(ctx context.Context, src *source.Source) (driver.Database, error) {
+	lg.From(ctx).Debug(lgm.OpenSrc, lga.Src, src)
+
 	dbase := &database{
 		log:   d.log,
 		src:   src,

--- a/drivers/csv/detect_type.go
+++ b/drivers/csv/detect_type.go
@@ -35,7 +35,7 @@ func DetectTSV(ctx context.Context, openFn source.FileOpenFunc) (detected source
 func detectType(ctx context.Context, typ source.DriverType,
 	openFn source.FileOpenFunc,
 ) (detected source.DriverType, score float32, err error) {
-	log := lg.FromContext(ctx)
+	log := lg.From(ctx)
 	var r io.ReadCloser
 	r, err = openFn()
 	if err != nil {

--- a/drivers/csv/import.go
+++ b/drivers/csv/import.go
@@ -45,7 +45,7 @@ Default is comma.`,
 
 // importCSV loads the src CSV data into scratchDB.
 func importCSV(ctx context.Context, src *source.Source, openFn source.FileOpenFunc, scratchDB driver.Database) error {
-	log := lg.FromContext(ctx)
+	log := lg.From(ctx)
 
 	var err error
 	var r io.ReadCloser
@@ -109,7 +109,7 @@ func importCSV(ctx context.Context, src *source.Source, openFn source.FileOpenFu
 		configureEmptyNullMunge(mungers, recMeta)
 	}
 
-	insertWriter := libsq.NewDBWriter(log, scratchDB, tblDef.Name, driver.Tuning.RecordChSize)
+	insertWriter := libsq.NewDBWriter(scratchDB, tblDef.Name, driver.Tuning.RecordChSize)
 	err = execInsert(ctx, insertWriter, recMeta, mungers, recs, cr)
 	if err != nil {
 		return err

--- a/drivers/csv/insert.go
+++ b/drivers/csv/insert.go
@@ -89,7 +89,7 @@ func mungeCSV2InsertRecord(ctx context.Context, mungers []kind.MungeFunc, csvRec
 	a := make([]any, len(csvRec))
 	for i := range csvRec {
 		if i >= len(mungers) {
-			lg.FromContext(ctx).Error("no munger for field", lga.Index, i, lga.Val, csvRec[i])
+			lg.From(ctx).Error("no munger for field", lga.Index, i, lga.Val, csvRec[i])
 			// Maybe should panic here, or return an error?
 			// But, in future we may be able to handle ragged-edge records,
 			// so maybe logging the error is best.

--- a/drivers/json/import.go
+++ b/drivers/json/import.go
@@ -431,7 +431,7 @@ type importSchema struct {
 func execSchemaDelta(ctx context.Context, drvr driver.SQLDriver, db sqlz.DB,
 	curSchema, newSchema *importSchema,
 ) error {
-	log := lg.FromContext(ctx)
+	log := lg.From(ctx)
 	var err error
 	if curSchema == nil {
 		for _, tblDef := range newSchema.tblDefs {
@@ -584,7 +584,7 @@ func execInsertions(ctx context.Context, drvr driver.SQLDriver, db sqlz.DB, inse
 	//  We should be re-using the prepared statement, and probably
 	//  should batch the inserts as well. See driver.BatchInsert.
 
-	log := lg.FromContext(ctx)
+	log := lg.From(ctx)
 	var err error
 	var execer *driver.StmtExecer
 

--- a/drivers/json/import_json.go
+++ b/drivers/json/import_json.go
@@ -24,7 +24,7 @@ import (
 func DetectJSON(ctx context.Context, openFn source.FileOpenFunc) (detected source.DriverType, score float32,
 	err error,
 ) {
-	log := lg.FromContext(ctx)
+	log := lg.From(ctx)
 	var r1, r2 io.ReadCloser
 	r1, err = openFn()
 	if err != nil {
@@ -135,7 +135,7 @@ func DetectJSON(ctx context.Context, openFn source.FileOpenFunc) (detected sourc
 }
 
 func importJSON(ctx context.Context, job importJob) error {
-	log := lg.FromContext(ctx)
+	log := lg.From(ctx)
 
 	r, err := job.openFn()
 	if err != nil {

--- a/drivers/json/import_jsona.go
+++ b/drivers/json/import_jsona.go
@@ -28,7 +28,7 @@ import (
 func DetectJSONA(ctx context.Context, openFn source.FileOpenFunc) (detected source.DriverType,
 	score float32, err error,
 ) {
-	log := lg.FromContext(ctx)
+	log := lg.From(ctx)
 	var r io.ReadCloser
 	r, err = openFn()
 	if err != nil {
@@ -96,7 +96,7 @@ func DetectJSONA(ctx context.Context, openFn source.FileOpenFunc) (detected sour
 }
 
 func importJSONA(ctx context.Context, job importJob) error {
-	log := lg.FromContext(ctx)
+	log := lg.From(ctx)
 
 	predictR, err := job.openFn()
 	if err != nil {
@@ -137,7 +137,7 @@ func importJSONA(ctx context.Context, job importJob) error {
 	}
 	defer lg.WarnIfCloseError(log, lgm.CloseFileReader, r)
 
-	insertWriter := libsq.NewDBWriter(log, job.destDB, tblDef.Name, driver.Tuning.RecordChSize)
+	insertWriter := libsq.NewDBWriter(job.destDB, tblDef.Name, driver.Tuning.RecordChSize)
 
 	var cancelFn context.CancelFunc
 	ctx, cancelFn = context.WithCancel(ctx)

--- a/drivers/json/import_jsonl.go
+++ b/drivers/json/import_jsonl.go
@@ -22,7 +22,7 @@ import (
 func DetectJSONL(ctx context.Context, openFn source.FileOpenFunc) (detected source.DriverType,
 	score float32, err error,
 ) {
-	log := lg.FromContext(ctx)
+	log := lg.From(ctx)
 	var r io.ReadCloser
 	r, err = openFn()
 	if err != nil {
@@ -82,7 +82,7 @@ func DetectJSONL(ctx context.Context, openFn source.FileOpenFunc) (detected sour
 }
 
 func importJSONL(ctx context.Context, job importJob) error { //nolint:gocognit
-	log := lg.FromContext(ctx)
+	log := lg.From(ctx)
 
 	r, err := job.openFn()
 	if err != nil {

--- a/drivers/json/json.go
+++ b/drivers/json/json.go
@@ -95,6 +95,8 @@ func (d *driveri) DriverMetadata() driver.Metadata {
 
 // Open implements driver.DatabaseOpener.
 func (d *driveri) Open(ctx context.Context, src *source.Source) (driver.Database, error) {
+	lg.From(ctx).Debug(lgm.OpenSrc, lga.Src, src)
+
 	dbase := &database{log: d.log, src: src, clnup: cleanup.New(), files: d.files}
 
 	r, err := d.files.Open(src)

--- a/drivers/mysql/metadata.go
+++ b/drivers/mysql/metadata.go
@@ -324,6 +324,11 @@ func getDBVarsMeta(ctx context.Context, db sqlz.DB) ([]source.DBVar, error) {
 }
 
 // getAllTblMetas returns TableMetadata for each table/view in db.
+//
+// NOTE: getAllTblMetas has the potential to become deadlocked. It spawns
+// a number of goroutines, which can bump up against the max conn limit.
+// This function should be revisited to see if there's a better way
+// to implement it.
 func getAllTblMetas(ctx context.Context, db sqlz.DB) ([]*source.TableMetadata, error) {
 	log := lg.From(ctx)
 

--- a/drivers/mysql/metadata.go
+++ b/drivers/mysql/metadata.go
@@ -180,7 +180,7 @@ WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ?`
 
 // getColumnMetadata returns column metadata for tblName.
 func getColumnMetadata(ctx context.Context, db sqlz.DB, tblName string) ([]*source.ColMetadata, error) {
-	log := lg.FromContext(ctx)
+	log := lg.From(ctx)
 
 	const query = `SELECT column_name, data_type, column_type, ordinal_position, column_default,
        is_nullable, column_key, column_comment, extra
@@ -298,7 +298,7 @@ func setSourceSummaryMeta(ctx context.Context, db sqlz.DB, md *source.Metadata) 
 
 // getDBVarsMeta returns the database variables.
 func getDBVarsMeta(ctx context.Context, db sqlz.DB) ([]source.DBVar, error) {
-	log := lg.FromContext(ctx)
+	log := lg.From(ctx)
 	var dbVars []source.DBVar
 
 	rows, err := db.QueryContext(ctx, "SHOW VARIABLES")
@@ -325,7 +325,7 @@ func getDBVarsMeta(ctx context.Context, db sqlz.DB) ([]source.DBVar, error) {
 
 // getAllTblMetas returns TableMetadata for each table/view in db.
 func getAllTblMetas(ctx context.Context, db sqlz.DB) ([]*source.TableMetadata, error) {
-	log := lg.FromContext(ctx)
+	log := lg.From(ctx)
 
 	const query = `SELECT t.TABLE_SCHEMA, t.TABLE_NAME, t.TABLE_TYPE, t.TABLE_COMMENT,
        (DATA_LENGTH + INDEX_LENGTH) AS table_size,

--- a/drivers/mysql/mysql.go
+++ b/drivers/mysql/mysql.go
@@ -42,8 +42,7 @@ var _ driver.Provider = (*Provider)(nil)
 
 // Provider is the MySQL implementation of driver.Provider.
 type Provider struct {
-	Log       *slog.Logger
-	SQLConfig *driver.SQLConfig
+	Log *slog.Logger
 }
 
 // DriverFor implements driver.Provider.
@@ -52,15 +51,14 @@ func (p *Provider) DriverFor(typ source.DriverType) (driver.Driver, error) {
 		return nil, errz.Errorf("unsupported driver type {%s}", typ)
 	}
 
-	return &driveri{log: p.Log, sqlConfig: p.SQLConfig}, nil
+	return &driveri{log: p.Log}, nil
 }
 
 var _ driver.SQLDriver = (*driveri)(nil)
 
 // driveri is the MySQL implementation of driver.Driver.
 type driveri struct {
-	log       *slog.Logger
-	sqlConfig *driver.SQLConfig
+	log *slog.Logger
 }
 
 // DriverMetadata implements driver.Driver.
@@ -304,7 +302,18 @@ func (d *driveri) getTableRecordMeta(ctx context.Context, db sqlz.DB, tblName st
 }
 
 // Open implements driver.DatabaseOpener.
-func (d *driveri) Open(_ context.Context, src *source.Source) (driver.Database, error) {
+func (d *driveri) Open(ctx context.Context, src *source.Source) (driver.Database, error) {
+	lg.From(ctx).Debug(lgm.OpenSrc, lga.Src, src)
+
+	db, err := d.doOpen(ctx, src)
+	if err != nil {
+		return nil, errz.Err(err)
+	}
+
+	return &database{log: d.log, db: db, src: src, drvr: d}, nil
+}
+
+func (d *driveri) doOpen(ctx context.Context, src *source.Source) (*sql.DB, error) {
 	dsn, err := dsnFromLocation(src, true)
 	if err != nil {
 		return nil, err
@@ -315,8 +324,8 @@ func (d *driveri) Open(_ context.Context, src *source.Source) (driver.Database, 
 		return nil, errz.Err(err)
 	}
 
-	d.sqlConfig.Apply(db)
-	return &database{log: d.log, db: db, src: src, drvr: d}, nil
+	driver.ConfigureDB(ctx, db, src.Options)
+	return db, nil
 }
 
 // ValidateSource implements driver.Driver.
@@ -329,13 +338,13 @@ func (d *driveri) ValidateSource(src *source.Source) (*source.Source, error) {
 
 // Ping implements driver.Driver.
 func (d *driveri) Ping(ctx context.Context, src *source.Source) error {
-	dbase, err := d.Open(ctx, src)
+	db, err := d.doOpen(ctx, src)
 	if err != nil {
 		return err
 	}
-	defer lg.WarnIfCloseError(d.log, lgm.CloseDB, dbase.DB())
+	defer lg.WarnIfCloseError(d.log, lgm.CloseDB, db)
 
-	return dbase.DB().PingContext(ctx)
+	return db.PingContext(ctx)
 }
 
 // Truncate implements driver.SQLDriver. Arg reset is
@@ -345,12 +354,7 @@ func (d *driveri) Truncate(ctx context.Context, src *source.Source, tbl string, 
 	err error,
 ) {
 	// https://dev.mysql.com/doc/refman/8.0/en/truncate-table.html
-	dsn, err := dsnFromLocation(src, true)
-	if err != nil {
-		return 0, err
-	}
-
-	db, err := sql.Open(dbDrvr, dsn)
+	db, err := d.doOpen(ctx, src)
 	if err != nil {
 		return 0, errz.Err(err)
 	}

--- a/drivers/postgres/metadata.go
+++ b/drivers/postgres/metadata.go
@@ -176,7 +176,7 @@ func toNullableScanType(log *slog.Logger, colName, dbTypeName string, knd kind.K
 }
 
 func getSourceMetadata(ctx context.Context, src *source.Source, db sqlz.DB) (*source.Metadata, error) {
-	log := lg.FromContext(ctx)
+	log := lg.From(ctx)
 
 	md := &source.Metadata{
 		Handle:       src.Handle,
@@ -269,7 +269,7 @@ current_setting('server_version'), version(), "current_user"()`
 }
 
 func getPgSettings(ctx context.Context, db sqlz.DB) ([]source.DBVar, error) {
-	log := lg.FromContext(ctx)
+	log := lg.From(ctx)
 	rows, err := db.QueryContext(ctx, "SELECT name, setting FROM pg_settings ORDER BY name")
 	if err != nil {
 		return nil, errz.Err(err)
@@ -298,7 +298,7 @@ func getPgSettings(ctx context.Context, db sqlz.DB) ([]source.DBVar, error) {
 // getAllTable names returns all table (or view) names in the current
 // catalog & schema.
 func getAllTableNames(ctx context.Context, db sqlz.DB) ([]string, error) {
-	log := lg.FromContext(ctx)
+	log := lg.From(ctx)
 
 	const tblNamesQuery = `SELECT table_name FROM information_schema.tables
 WHERE table_catalog = current_catalog AND table_schema = current_schema()
@@ -329,7 +329,7 @@ ORDER BY table_name`
 }
 
 func getTableMetadata(ctx context.Context, db sqlz.DB, tblName string) (*source.TableMetadata, error) {
-	log := lg.FromContext(ctx)
+	log := lg.From(ctx)
 
 	const tblsQueryTpl = `SELECT table_catalog, table_schema, table_name, table_type, is_insertable_into,
   (SELECT COUNT(*) FROM "%s") AS table_row_count,
@@ -450,7 +450,7 @@ type pgColumn struct {
 
 // getPgColumns queries the column metadata for tblName.
 func getPgColumns(ctx context.Context, db sqlz.DB, tblName string) ([]*pgColumn, error) {
-	log := lg.FromContext(ctx)
+	log := lg.From(ctx)
 
 	// colsQuery gets column information from information_schema.columns.
 	//
@@ -460,8 +460,8 @@ func getPgColumns(ctx context.Context, db sqlz.DB, tblName string) ([]*pgColumn,
 	const colsQuery = `SELECT table_catalog,
   table_schema,
   table_name,
-  column_name, 
-  ordinal_position, 
+  column_name,
+  ordinal_position,
   column_default,
   is_nullable,
   data_type,
@@ -548,7 +548,7 @@ func colMetaFromPgColumn(log *slog.Logger, pgCol *pgColumn) *source.ColMetadata 
 // are returned. If tblName is specified, constraints just for that
 // table are returned.
 func getPgConstraints(ctx context.Context, db sqlz.DB, tblName string) ([]*pgConstraint, error) {
-	log := lg.FromContext(ctx)
+	log := lg.From(ctx)
 
 	var args []any
 	query := `SELECT kcu.table_catalog,kcu.table_schema,kcu.table_name,kcu.column_name,

--- a/drivers/sqlite3/metadata.go
+++ b/drivers/sqlite3/metadata.go
@@ -248,7 +248,7 @@ func DBTypeForKind(knd kind.Kind) string {
 
 // getTableMetadata returns metadata for tblName in db.
 func getTableMetadata(ctx context.Context, db sqlz.DB, tblName string) (*source.TableMetadata, error) {
-	log := lg.FromContext(ctx)
+	log := lg.From(ctx)
 	tblMeta := &source.TableMetadata{Name: tblName}
 	// Note that there's no easy way of getting the physical size of
 	// a table, so tblMeta.Size remains nil.
@@ -316,7 +316,7 @@ func getTableMetadata(ctx context.Context, db sqlz.DB, tblName string) (*source.
 // getAllTblMeta gets metadata for each of the
 // non-system tables in db.
 func getAllTblMeta(ctx context.Context, db sqlz.DB) ([]*source.TableMetadata, error) {
-	log := lg.FromContext(ctx)
+	log := lg.From(ctx)
 	// This query returns a row for each column of each table,
 	// order by table name then col id (ordinal).
 	// Results will look like:
@@ -423,7 +423,7 @@ ORDER BY m.name, p.cid
 
 // getTblRowCounts returns the number of rows in each table.
 func getTblRowCounts(ctx context.Context, db sqlz.DB, tblNames []string) ([]int64, error) {
-	log := lg.FromContext(ctx)
+	log := lg.From(ctx)
 
 	// See: https://stackoverflow.com/questions/7524612/how-to-count-rows-from-multiple-tables-in-sqlite
 	//

--- a/drivers/sqlserver/metadata.go
+++ b/drivers/sqlserver/metadata.go
@@ -113,7 +113,7 @@ func setScanType(ct *sqlz.ColumnTypeData, knd kind.Kind) {
 }
 
 func getSourceMetadata(ctx context.Context, src *source.Source, db sqlz.DB) (*source.Metadata, error) {
-	log := lg.FromContext(ctx)
+	log := lg.From(ctx)
 
 	const query = `SELECT DB_NAME(), SCHEMA_NAME(), SERVERPROPERTY('ProductVersion'), @@VERSION,
 (SELECT SUM(size) * 8192
@@ -256,7 +256,7 @@ func getTableMetadata(ctx context.Context, db sqlz.DB, tblCatalog,
 			Name:         dbCols[i].ColumnName,
 			Position:     dbCols[i].OrdinalPosition,
 			BaseType:     dbCols[i].DataType,
-			Kind:         kindFromDBTypeName(lg.FromContext(ctx), dbCols[i].ColumnName, dbCols[i].DataType),
+			Kind:         kindFromDBTypeName(lg.From(ctx), dbCols[i].ColumnName, dbCols[i].DataType),
 			Nullable:     dbCols[i].Nullable.Bool,
 			DefaultValue: dbCols[i].ColumnDefault.String,
 		}
@@ -297,7 +297,7 @@ func getTableMetadata(ctx context.Context, db sqlz.DB, tblCatalog,
 // getAllTables returns all of the table names, and the table types
 // (i.e. "BASE TABLE" or "VIEW").
 func getAllTables(ctx context.Context, db sqlz.DB) (tblNames, tblTypes []string, err error) {
-	log := lg.FromContext(ctx)
+	log := lg.From(ctx)
 
 	const query = `SELECT TABLE_NAME, TABLE_TYPE FROM INFORMATION_SCHEMA.TABLES
 WHERE TABLE_TYPE='BASE TABLE' OR TABLE_TYPE='VIEW'
@@ -328,7 +328,7 @@ ORDER BY TABLE_NAME ASC, TABLE_TYPE ASC`
 }
 
 func getColumnMeta(ctx context.Context, db sqlz.DB, tblCatalog, tblSchema, tblName string) ([]columnMeta, error) {
-	log := lg.FromContext(ctx)
+	log := lg.From(ctx)
 
 	// TODO: sq doesn't use all of these columns, no need to select them all.
 	const query = `SELECT
@@ -374,7 +374,7 @@ func getColumnMeta(ctx context.Context, db sqlz.DB, tblCatalog, tblSchema, tblNa
 }
 
 func getConstraints(ctx context.Context, db sqlz.DB, tblCatalog, tblSchema, tblName string) ([]constraintMeta, error) {
-	log := lg.FromContext(ctx)
+	log := lg.From(ctx)
 
 	const query = `SELECT kcu.TABLE_CATALOG, kcu.TABLE_SCHEMA, kcu.TABLE_NAME,  tc.CONSTRAINT_TYPE,
        kcu.COLUMN_NAME, kcu.CONSTRAINT_NAME

--- a/drivers/userdriver/userdriver.go
+++ b/drivers/userdriver/userdriver.go
@@ -84,6 +84,8 @@ func (d *drvr) DriverMetadata() driver.Metadata {
 
 // Open implements driver.DatabaseOpener.
 func (d *drvr) Open(ctx context.Context, src *source.Source) (driver.Database, error) {
+	lg.From(ctx).Debug(lgm.OpenSrc, lga.Src, src)
+
 	clnup := cleanup.New()
 
 	r, err := d.files.Open(src)

--- a/drivers/userdriver/xmlud/xmlimport.go
+++ b/drivers/userdriver/xmlud/xmlimport.go
@@ -36,7 +36,7 @@ func Import(ctx context.Context, def *userdriver.DriverDef, data io.Reader, dest
 	}
 
 	im := &importer{
-		log:           lg.FromContext(ctx),
+		log:           lg.From(ctx),
 		def:           def,
 		selStack:      newSelStack(),
 		rowStack:      newRowStack(),

--- a/drivers/xlsx/import.go
+++ b/drivers/xlsx/import.go
@@ -29,7 +29,7 @@ import (
 
 // xlsxToScratch loads the data in xlFile into scratchDB.
 func xlsxToScratch(ctx context.Context, src *source.Source, xlFile *xlsx.File, scratchDB driver.Database) error {
-	log := lg.FromContext(ctx)
+	log := lg.From(ctx)
 	start := time.Now()
 	log.Debug("Beginning import from XLSX",
 		lga.Src, src,
@@ -91,7 +91,7 @@ func xlsxToScratch(ctx context.Context, src *source.Source, xlFile *xlsx.File, s
 func importSheetToTable(ctx context.Context, sheet *xlsx.Sheet, hasHeader bool,
 	scratchDB driver.Database, tblDef *sqlmodel.TableDef,
 ) error {
-	log := lg.FromContext(ctx)
+	log := lg.From(ctx)
 	startTime := time.Now()
 
 	conn, err := scratchDB.DB().Conn(ctx)
@@ -189,7 +189,7 @@ func buildTblDefsForSheets(ctx context.Context, sheets []*xlsx.Sheet, hasHeader 
 			default:
 			}
 
-			tblDef, err := buildTblDefForSheet(lg.FromContext(gCtx), sheets[i], hasHeader)
+			tblDef, err := buildTblDefForSheet(lg.From(gCtx), sheets[i], hasHeader)
 			if err != nil {
 				return err
 			}

--- a/drivers/xlsx/xlsx.go
+++ b/drivers/xlsx/xlsx.go
@@ -51,7 +51,7 @@ var _ source.DriverDetectFunc = DetectXLSX
 func DetectXLSX(ctx context.Context, openFn source.FileOpenFunc) (detected source.DriverType, score float32,
 	err error,
 ) {
-	log := lg.FromContext(ctx)
+	log := lg.From(ctx)
 	var r io.ReadCloser
 	r, err = openFn()
 	if err != nil {
@@ -93,6 +93,8 @@ func (d *Driver) DriverMetadata() driver.Metadata {
 
 // Open implements driver.DatabaseOpener.
 func (d *Driver) Open(ctx context.Context, src *source.Source) (driver.Database, error) {
+	lg.From(ctx).Debug(lgm.OpenSrc, lga.Src, src)
+
 	r, err := d.files.Open(src)
 	if err != nil {
 		return nil, err

--- a/libsq/core/errz/errz.go
+++ b/libsq/core/errz/errz.go
@@ -9,6 +9,8 @@
 package errz
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"path/filepath"
 
@@ -75,4 +77,9 @@ func logValue(err error) slog.Value {
 	}
 
 	return slog.GroupValue(msgAttr, causeAttr, typeAttr)
+}
+
+// IsErrContextDeadlineExceeded returns true if err is context.DeadlineExceeded.
+func IsErrContextDeadlineExceeded(err error) bool {
+	return errors.Is(err, context.DeadlineExceeded)
 }

--- a/libsq/core/lg/lg.go
+++ b/libsq/core/lg/lg.go
@@ -19,15 +19,21 @@ import (
 type contextKey struct{}
 
 // NewContext returns a context that contains the given Logger.
-// Use FromContext to retrieve the Logger.
+// Use From to retrieve the Logger.
 func NewContext(ctx context.Context, l *slog.Logger) context.Context {
 	return context.WithValue(ctx, contextKey{}, l)
 }
 
-// FromContext returns the Logger stored in ctx by NewContext, or the Discard
-// Logger if there is none.
-func FromContext(ctx context.Context) *slog.Logger {
-	if l, ok := ctx.Value(contextKey{}).(*slog.Logger); ok {
+// From returns the Logger stored in ctx by NewContext, or the Discard
+// Logger if there is none. This function is typically named FromContext,
+// but we're experimenting with simply naming it From.
+func From(ctx context.Context) *slog.Logger {
+	v := ctx.Value(contextKey{})
+	if v == nil {
+		return Discard()
+	}
+
+	if l, ok := v.(*slog.Logger); ok {
 		return l
 	}
 	return Discard()

--- a/libsq/core/lg/lg_test.go
+++ b/libsq/core/lg/lg_test.go
@@ -14,7 +14,7 @@ func TestContext(t *testing.T) {
 	log := slogt.New(t)
 
 	ctx = lg.NewContext(ctx, log)
-	log = lg.FromContext(ctx)
+	log = lg.From(ctx)
 
 	log.Info("huzzah")
 }

--- a/libsq/core/options/options.go
+++ b/libsq/core/options/options.go
@@ -167,6 +167,19 @@ func (o Options) IsSet(opt Opt) bool {
 	return ok
 }
 
+// LogValue implements slog.LogValuer.
+func (o Options) LogValue() slog.Value {
+	if o == nil {
+		return slog.Value{}
+	}
+
+	attrs := make([]slog.Attr, 0, len(o))
+	for k, v := range o {
+		attrs = append(attrs, slog.Any(k, v))
+	}
+	return slog.GroupValue(attrs...)
+}
+
 // Merge overlays each of overlays onto base, returning a new Options.
 func Merge(base Options, overlays ...Options) Options {
 	o := base.Clone()

--- a/libsq/core/options/options.go
+++ b/libsq/core/options/options.go
@@ -15,6 +15,7 @@ package options
 import (
 	"fmt"
 	"sync"
+	"time"
 
 	"golang.org/x/exp/slog"
 
@@ -109,8 +110,8 @@ func (r *Registry) Opts() []Opt {
 // registered Opts, and invokes Process for each Opt that implements Processor.
 // This facilitates munging of underlying values, e.g. for options.Duration, a
 // string "1m30s" is converted to a time.Duration.
-func (r *Registry) Process(options Options) (Options, error) {
-	return process(options, r.Opts())
+func (r *Registry) Process(o Options) (Options, error) {
+	return process(o, r.Opts())
 }
 
 func process(options Options, opts []Opt) (Options, error) {
@@ -175,8 +176,20 @@ func (o Options) LogValue() slog.Value {
 
 	attrs := make([]slog.Attr, 0, len(o))
 	for k, v := range o {
-		attrs = append(attrs, slog.Any(k, v))
+		switch v := v.(type) {
+		case int:
+			attrs = append(attrs, slog.Int(k, v))
+		case string:
+			attrs = append(attrs, slog.String(k, v))
+		case bool:
+			attrs = append(attrs, slog.Bool(k, v))
+		case time.Duration:
+			attrs = append(attrs, slog.Duration(k, v))
+		default:
+			attrs = append(attrs, slog.Any(k, v))
+		}
 	}
+
 	return slog.GroupValue(attrs...)
 }
 
@@ -189,6 +202,19 @@ func Merge(base Options, overlays ...Options) Options {
 		}
 	}
 	return o
+}
+
+// Effective returns a new Options containing the effective values
+// of each Opt. That is to say, the returned Options contains either
+// the actual value of each Opt in o, or the default value for that Opt,
+// but it will not contain values for any Opt not in opts.
+func Effective(o Options, opts ...Opt) Options {
+	o2 := Options{}
+	for _, opt := range opts {
+		v := opt.GetAny(o)
+		o2[opt.Key()] = v
+	}
+	return o2
 }
 
 // Processor performs processing on o.

--- a/libsq/core/options/options_test.go
+++ b/libsq/core/options/options_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/neilotoole/slogt"
+	"github.com/neilotoole/sq/libsq/core/lg/lga"
 	"github.com/neilotoole/sq/testh/tutil"
 
 	"github.com/neilotoole/sq/cli"
@@ -147,4 +148,11 @@ func TestMerge(t *testing.T) {
 	got = options.Merge(o1, o2, o3)
 	require.NotEqual(t, o1, got)
 	require.Equal(t, got, options.Options{"a": 1, "b": 2, "c": 3})
+}
+
+func TestOptions_LogValue(t *testing.T) {
+	o1 := options.Options{"a": 1, "b": true, "c": "hello"}
+	log := slogt.New(t)
+
+	log.Debug("Logging options", lga.Opts, o1)
 }

--- a/libsq/core/options/options_test.go
+++ b/libsq/core/options/options_test.go
@@ -156,3 +156,13 @@ func TestOptions_LogValue(t *testing.T) {
 
 	log.Debug("Logging options", lga.Opts, o1)
 }
+
+func TestEffective(t *testing.T) {
+	optHello := options.NewString("hello", "world", "")
+	optCount := options.NewInt("count", 1, "")
+
+	in := options.Options{"count": 7}
+	want := options.Options{"count": 7, "hello": "world"}
+	got := options.Effective(in, optHello, optCount)
+	require.Equal(t, want, got)
+}

--- a/libsq/driver/driver.go
+++ b/libsq/driver/driver.go
@@ -9,8 +9,6 @@ import (
 
 	"github.com/neilotoole/sq/libsq/core/lg/lgm"
 	"github.com/neilotoole/sq/libsq/core/options"
-	"github.com/samber/lo"
-
 	"github.com/neilotoole/sq/libsq/driver/dialect"
 
 	"github.com/neilotoole/sq/libsq/core/lg/lga"
@@ -32,27 +30,21 @@ import (
 
 // ConfigureDB configures DB using o. It is no-op if o is nil.
 func ConfigureDB(ctx context.Context, db *sql.DB, o options.Options) {
-	if o == nil {
-		return
-	}
-
-	o2 := lo.PickBy(o, func(key string, value any) bool {
-		return strings.HasPrefix(key, "conn.")
-	})
+	o2 := options.Effective(o, OptConnMaxOpen, OptConnMaxIdle, OptConnMaxIdleTime, OptConnMaxLifetime)
 
 	lg.From(ctx).Debug("Setting config on DB conn", "config", o2)
 
-	db.SetMaxOpenConns(OptConnMaxOpen.Get(o))
-	db.SetMaxIdleConns(OptConnMaxIdle.Get(o))
-	db.SetConnMaxIdleTime(OptConnMaxIdleTime.Get(o))
-	db.SetConnMaxLifetime(OptConnMaxLifetime.Get(o))
+	db.SetMaxOpenConns(OptConnMaxOpen.Get(o2))
+	db.SetMaxIdleConns(OptConnMaxIdle.Get(o2))
+	db.SetConnMaxIdleTime(OptConnMaxIdleTime.Get(o2))
+	db.SetConnMaxLifetime(OptConnMaxLifetime.Get(o2))
 }
 
 var (
 	// OptConnMaxOpen controls sql.DB.SetMaxOpenConn.
 	OptConnMaxOpen = options.NewInt(
 		"conn.max-open",
-		3,
+		10,
 		"",
 		"source", "sql",
 	)

--- a/libsq/driver/driver.go
+++ b/libsq/driver/driver.go
@@ -44,8 +44,9 @@ var (
 	// OptConnMaxOpen controls sql.DB.SetMaxOpenConn.
 	OptConnMaxOpen = options.NewInt(
 		"conn.max-open",
-		10,
-		"",
+		0,
+		`Maximum number of open connections to the database.
+A value of zero indicates no limit.`,
 		"source", "sql",
 	)
 

--- a/libsq/driver/driver_test.go
+++ b/libsq/driver/driver_test.go
@@ -470,10 +470,10 @@ func TestDatabase_SourceMetadata(t *testing.T) { //nolint:tparallel
 // drivers when SourceMetadata is invoked concurrently. The results
 // are not good. In particular, the mysql impl can become deadlocked
 // if the concurrency is greater than the max conn count. That
-// impl (in particular mysql/getAllTblMetas) needs to be
+// functionality (in particular mysql/getAllTblMetas) needs to be
 // revisited.
 func TestDatabase_SourceMetadata_concurrent(t *testing.T) { //nolint:tparallel
-	const concurrency = 1
+	const concurrency = 5
 
 	handles := sakila.SQLLatest()
 	for _, handle := range handles {

--- a/libsq/driver/driver_test.go
+++ b/libsq/driver/driver_test.go
@@ -149,9 +149,7 @@ func TestDriver_CreateTable_Minimal(t *testing.T) {
 	}
 }
 
-func TestDriver_TableColumnTypes(t *testing.T) {
-	t.Parallel()
-
+func TestDriver_TableColumnTypes(t *testing.T) { //nolint:tparallel
 	testCases := sakila.SQLAll()
 	for _, handle := range testCases {
 		handle := handle
@@ -196,7 +194,8 @@ func TestDriver_TableColumnTypes(t *testing.T) {
 
 func TestSQLDriver_PrepareUpdateStmt(t *testing.T) {
 	t.Parallel()
-	testCases := sakila.SQLAll()
+	// testCases := sakila.SQLAll()
+	testCases := []string{sakila.Pg}
 
 	for _, handle := range testCases {
 		handle := handle
@@ -433,9 +432,7 @@ func TestRegistry_DriversMetadata_Doc(t *testing.T) {
 	}
 }
 
-func TestDatabase_TableMetadata(t *testing.T) {
-	t.Parallel()
-
+func TestDatabase_TableMetadata(t *testing.T) { //nolint:tparallel
 	for _, handle := range sakila.SQLAll() {
 		handle := handle
 
@@ -452,9 +449,7 @@ func TestDatabase_TableMetadata(t *testing.T) {
 	}
 }
 
-func TestDatabase_SourceMetadata(t *testing.T) {
-	t.Parallel()
-
+func TestDatabase_SourceMetadata(t *testing.T) { //nolint:tparallel
 	for _, handle := range sakila.SQLAll() {
 		handle := handle
 

--- a/libsq/driver/driver_test.go
+++ b/libsq/driver/driver_test.go
@@ -192,11 +192,8 @@ func TestDriver_TableColumnTypes(t *testing.T) { //nolint:tparallel
 	}
 }
 
-func TestSQLDriver_PrepareUpdateStmt(t *testing.T) {
-	t.Parallel()
-	// testCases := sakila.SQLAll()
-	testCases := []string{sakila.Pg}
-
+func TestSQLDriver_PrepareUpdateStmt(t *testing.T) { //nolint:tparallel
+	testCases := sakila.SQLAll()
 	for _, handle := range testCases {
 		handle := handle
 

--- a/libsq/driver/driver_test.go
+++ b/libsq/driver/driver_test.go
@@ -466,9 +466,14 @@ func TestDatabase_SourceMetadata(t *testing.T) { //nolint:tparallel
 	}
 }
 
-func TestDatabase_SourceMetadata_concurrent(t *testing.T) {
-	t.Parallel()
-	const concurrency = 10
+// TestDatabase_SourceMetadata_concurrent tests the behavior of the
+// drivers when SourceMetadata is invoked concurrently. The results
+// are not good. In particular, the mysql impl can become deadlocked
+// if the concurrency is greater than the max conn count. That
+// impl (in particular mysql/getAllTblMetas) needs to be
+// revisited.
+func TestDatabase_SourceMetadata_concurrent(t *testing.T) { //nolint:tparallel
+	const concurrency = 1
 
 	handles := sakila.SQLLatest()
 	for _, handle := range handles {

--- a/libsq/driver/record.go
+++ b/libsq/driver/record.go
@@ -410,7 +410,7 @@ func (bi BatchInsert) Munge(rec []any) error {
 func NewBatchInsert(ctx context.Context, drvr SQLDriver, db sqlz.DB,
 	destTbl string, destColNames []string, batchSize int,
 ) (*BatchInsert, error) {
-	log := lg.FromContext(ctx)
+	log := lg.From(ctx)
 
 	err := requireSingleConn(db)
 	if err != nil {

--- a/libsq/driver/scratch.go
+++ b/libsq/driver/scratch.go
@@ -1,11 +1,11 @@
 package driver
 
 import (
-	"golang.org/x/exp/slog"
+	"context"
 
 	"github.com/neilotoole/sq/libsq/source"
 )
 
 // ScratchSrcFunc is a function that returns a scratch source.
 // The caller is responsible for invoking cleanFn.
-type ScratchSrcFunc func(log *slog.Logger, name string) (src *source.Source, cleanFn func() error, err error)
+type ScratchSrcFunc func(ctx context.Context, name string) (src *source.Source, cleanFn func() error, err error)

--- a/libsq/engine.go
+++ b/libsq/engine.go
@@ -47,7 +47,7 @@ type engine struct {
 }
 
 func newEngine(ctx context.Context, qc *QueryContext, query string) (*engine, error) {
-	log := lg.FromContext(ctx)
+	log := lg.From(ctx)
 
 	a, err := ast.Parse(log, query)
 	if err != nil {
@@ -295,7 +295,7 @@ func (jt *joinCopyTask) executeTask(ctx context.Context) error {
 func execCopyTable(ctx context.Context, fromDB driver.Database, fromTblName string,
 	destDB driver.Database, destTblName string,
 ) error {
-	log := lg.FromContext(ctx)
+	log := lg.From(ctx)
 
 	createTblHook := func(ctx context.Context, originRecMeta sqlz.RecordMeta, destDB driver.Database,
 		tx sqlz.DB,
@@ -312,7 +312,7 @@ func execCopyTable(ctx context.Context, fromDB driver.Database, fromTblName stri
 		return nil
 	}
 
-	inserter := NewDBWriter(log, destDB, destTblName, driver.Tuning.RecordChSize, createTblHook)
+	inserter := NewDBWriter(destDB, destTblName, driver.Tuning.RecordChSize, createTblHook)
 
 	query := "SELECT * FROM " + fromDB.SQLDriver().Dialect().Enquote(fromTblName)
 	err := QuerySQL(ctx, fromDB, inserter, query)

--- a/libsq/libsq.go
+++ b/libsq/libsq.go
@@ -117,7 +117,7 @@ func SLQ2SQL(ctx context.Context, qc *QueryContext, query string) (targetSQL str
 // to wait for recw to complete.
 // The caller is responsible for closing dbase.
 func QuerySQL(ctx context.Context, dbase driver.Database, recw RecordWriter, query string, args ...any) error {
-	log := lg.FromContext(ctx)
+	log := lg.From(ctx)
 
 	rows, err := dbase.DB().QueryContext(ctx, query, args...)
 	if err != nil {

--- a/libsq/libsq_test.go
+++ b/libsq/libsq_test.go
@@ -88,9 +88,7 @@ func TestQuerySQL_Smoke(t *testing.T) {
 	}
 }
 
-func TestQuerySQL_Count(t *testing.T) {
-	t.Parallel()
-
+func TestQuerySQL_Count(t *testing.T) { //nolint:tparallel
 	testCases := sakila.SQLAll()
 	for _, handle := range testCases {
 		handle := handle

--- a/libsq/source/files_test.go
+++ b/libsq/source/files_test.go
@@ -56,7 +56,9 @@ func TestFiles_Type(t *testing.T) {
 	for _, tc := range testCases {
 		tc := tc
 		t.Run(tc.loc, func(t *testing.T) {
-			fs, err := source.NewFiles(slogt.New(t))
+			ctx := lg.NewContext(context.Background(), slogt.New(t))
+
+			fs, err := source.NewFiles(ctx)
 			require.NoError(t, err)
 			fs.AddDriverDetectors(testh.DriverDetectors()...)
 
@@ -97,8 +99,8 @@ func TestFiles_DetectType(t *testing.T) {
 		tc := tc
 
 		t.Run(filepath.Base(tc.loc), func(t *testing.T) {
-			ctx := context.Background()
-			fs, err := source.NewFiles(slogt.New(t))
+			ctx := lg.NewContext(context.Background(), slogt.New(t))
+			fs, err := source.NewFiles(ctx)
 			require.NoError(t, err)
 			fs.AddDriverDetectors(testh.DriverDetectors()...)
 
@@ -148,6 +150,7 @@ func TestDetectMagicNumber(t *testing.T) {
 }
 
 func TestFiles_NewReader(t *testing.T) {
+	ctx := lg.NewContext(context.Background(), slogt.New(t))
 	fpath := sakila.PathCSVActor
 	wantBytes := proj.ReadFile(fpath)
 
@@ -157,7 +160,7 @@ func TestFiles_NewReader(t *testing.T) {
 		Location: proj.Abs(fpath),
 	}
 
-	fs, err := source.NewFiles(slogt.New(t))
+	fs, err := source.NewFiles(ctx)
 	require.NoError(t, err)
 
 	g := &errgroup.Group{}

--- a/libsq/source/internal_test.go
+++ b/libsq/source/internal_test.go
@@ -6,6 +6,7 @@ import (
 	"runtime"
 	"testing"
 
+	"github.com/neilotoole/sq/libsq/core/lg"
 	"github.com/neilotoole/sq/testh/tutil"
 
 	"github.com/neilotoole/slogt"
@@ -27,7 +28,9 @@ var (
 )
 
 func TestFiles_Open(t *testing.T) {
-	fs, err := NewFiles(slogt.New(t))
+	ctx := lg.NewContext(context.Background(), slogt.New(t))
+
+	fs, err := NewFiles(ctx)
 	require.NoError(t, err)
 	t.Cleanup(func() { assert.NoError(t, fs.Close()) })
 

--- a/libsq/source/source.go
+++ b/libsq/source/source.go
@@ -91,6 +91,7 @@ func (s *Source) LogValue() slog.Value {
 		slog.String(lga.Handle, s.Handle),
 		slog.String(lga.Driver, string(s.Type)),
 		slog.String(lga.Loc, s.RedactedLocation()),
+		slog.Any(lga.Opts, s.Options),
 	)
 }
 

--- a/libsq/source/source_test.go
+++ b/libsq/source/source_test.go
@@ -3,7 +3,10 @@ package source_test
 import (
 	"testing"
 
+	"github.com/neilotoole/slogt"
 	"github.com/neilotoole/sq/drivers/sqlite3"
+	"github.com/neilotoole/sq/libsq/core/lg/lga"
+	"github.com/neilotoole/sq/libsq/core/options"
 	"github.com/neilotoole/sq/testh/proj"
 
 	"github.com/neilotoole/sq/testh/tutil"
@@ -540,4 +543,21 @@ func TestCollection_Tree(t *testing.T) {
 	require.Equal(t, directGroupCount, len(gotTree.Groups))
 	require.Equal(t, 1, allGroupCount)
 	require.False(t, gotTree.Active)
+}
+
+func TestSource_LogValue(t *testing.T) {
+	log := slogt.New(t)
+
+	src := &source.Source{
+		Handle:   "@sakila",
+		Type:     sqlite3.Type,
+		Location: "/tmp/sakila.db",
+		Options:  nil,
+	}
+
+	log.Debug("src with nil Options", lga.Src, src)
+
+	src.Options = options.Options{"a": 1, "b": true, "c": "hello"}
+
+	log.Debug("src with non-nil Options", lga.Src, src)
 }

--- a/testh/sakila/sakila_test.go
+++ b/testh/sakila/sakila_test.go
@@ -10,9 +10,7 @@ import (
 )
 
 // TestSakila_SQL is a sanity check for Sakila SQL test sources.
-func TestSakila_SQL(t *testing.T) {
-	t.Parallel()
-
+func TestSakila_SQL(t *testing.T) { //nolint:tparallel
 	// Verify that the latest-version aliases are as expected
 	require.Equal(t, sakila.Pg, sakila.Pg12)
 	require.Equal(t, sakila.My, sakila.My8)


### PR DESCRIPTION
We're now using the idiom of getting the log from the context, e.g. `lg.From(ctx)`. That makes `RunContext.Log` redundant. 