### PR TITLE
#229: refactor mysql source metadata impl

### DIFF
--- a/drivers/mysql/internal_test.go
+++ b/drivers/mysql/internal_test.go
@@ -12,7 +12,11 @@ import (
 	"github.com/neilotoole/sq/libsq/source"
 )
 
-var KindFromDBTypeName = kindFromDBTypeName
+// Export for testing.
+var (
+	KindFromDBTypeName     = kindFromDBTypeName
+	GetTableRowCountsBatch = getTableRowCountsBatch
+)
 
 func TestPlaceholders(t *testing.T) {
 	testCases := []struct {

--- a/drivers/mysql/metadata.go
+++ b/drivers/mysql/metadata.go
@@ -561,7 +561,7 @@ func getTableRowCounts(ctx context.Context, db sqlz.DB, tblNames []string) (map[
 			// We could also do this entire thing in a transaction, but where's
 			// the fun in that...
 			schema, tblName, ok := extractTblNameFromNotExistErr(err)
-			if ok {
+			if ok && tblName != "" {
 				log.Warn("Table doesn't exist, will try again without that table",
 					lga.Schema, schema, lga.Table, tblName)
 				tblNames = lo.Without(tblNames, tblName)

--- a/drivers/mysql/metadata.go
+++ b/drivers/mysql/metadata.go
@@ -3,11 +3,16 @@ package mysql
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"reflect"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/go-sql-driver/mysql"
+
+	"github.com/samber/lo"
 
 	"github.com/neilotoole/sq/libsq/core/record"
 
@@ -357,11 +362,6 @@ func getDBProperties(ctx context.Context, db sqlz.DB) (map[string]any, error) {
 }
 
 // getAllTblMetas returns TableMetadata for each table/view in db.
-//
-// NOTE: getAllTblMetas has the potential to become deadlocked. It spawns
-// a number of goroutines, which can bump up against the max conn limit.
-// This function should be revisited to see if there's a better way
-// to implement it.
 func getAllTblMetas(ctx context.Context, db sqlz.DB) ([]*source.TableMetadata, error) {
 	log := lg.FromContext(ctx)
 
@@ -388,16 +388,13 @@ ORDER BY c.TABLE_NAME ASC, c.ORDINAL_POSITION ASC`
 	// |sakila      |actor     |BASE TABLE|             |32768     |last_update|4               |          |timestamp|timestamp           |NO         |CURRENT_TIMESTAMP|              |on update CURRENT_TIMESTAMP|
 	// |sakila      |actor_info|VIEW      |VIEW         |NULL      |actor_id   |1               |          |smallint |smallint(5) unsigned|NO         |0                |              |                           |
 
-	var tblMetas []*source.TableMetadata
-	var schema string
-	var curTblName, curTblType, curTblComment sql.NullString
-	var curTblSize sql.NullInt64
-	var curTblMeta *source.TableMetadata
-
-	// g is an errgroup for fetching the
-	// row count for each table.
-	g, gCtx := errgroup.WithContext(ctx)
-	g.SetLimit(driver.OptTuningErrgroupLimit.Get(options.FromContext(ctx)))
+	var (
+		tblMetas                              []*source.TableMetadata
+		schema                                string
+		curTblName, curTblType, curTblComment sql.NullString
+		curTblSize                            sql.NullInt64
+		curTblMeta                            *source.TableMetadata
+	)
 
 	rows, err := db.QueryContext(ctx, query)
 	if err != nil {
@@ -443,26 +440,6 @@ ORDER BY c.TABLE_NAME ASC, c.ORDINAL_POSITION ASC`
 			}
 
 			tblMetas = append(tblMetas, curTblMeta)
-
-			rowCountTbl, rowCount, i := curTblName.String, &curTblMeta.RowCount, len(tblMetas)-1
-			g.Go(func() error {
-				gErr := db.QueryRowContext(gCtx, "SELECT COUNT(*) FROM `"+rowCountTbl+"`").Scan(rowCount)
-				if gErr != nil {
-					if hasErrCode(gErr, errNumTableNotExist) {
-						// The table was probably dropped while we were collecting
-						// metadata, but that's ok. We set the element to nil
-						// and we'll filter it out later.
-						log.Debug("Failed to get row count for table: ignoring error",
-							lga.Table, curTblName.String,
-							lga.Err, gErr)
-						tblMetas[i] = nil
-						return nil
-					}
-
-					return errw(gErr)
-				}
-				return nil
-			})
 		}
 
 		col := &source.ColMetadata{
@@ -487,11 +464,6 @@ ORDER BY c.TABLE_NAME ASC, c.ORDINAL_POSITION ASC`
 		curTblMeta.Columns = append(curTblMeta.Columns, col)
 	}
 
-	err = g.Wait()
-	if err != nil {
-		return nil, err
-	}
-
 	err = rows.Err()
 	if err != nil {
 		return nil, errw(err)
@@ -501,14 +473,153 @@ ORDER BY c.TABLE_NAME ASC, c.ORDINAL_POSITION ASC`
 	// count for the table (which can happen if the table is dropped
 	// during the metadata collection process). So we filter out any
 	// nil elements.
-	retTblMetas := make([]*source.TableMetadata, 0, len(tblMetas))
+	tblMetas = lo.Reject(tblMetas, func(item *source.TableMetadata, index int) bool {
+		return item == nil
+	})
+
+	tblNames := make([]string, 0, len(tblMetas))
 	for i := range tblMetas {
 		if tblMetas[i] != nil {
-			retTblMetas = append(retTblMetas, tblMetas[i])
+			tblNames = append(tblNames, tblMetas[i].Name)
 		}
 	}
 
-	return retTblMetas, nil
+	// We still need to populate table row counts.
+	var mTblRowCounts map[string]int64
+	if mTblRowCounts, err = getTableRowCountsBatch(ctx, db, tblNames); err != nil {
+		return nil, err
+	}
+
+	for i := range tblMetas {
+		tblMetas[i].RowCount = mTblRowCounts[tblMetas[i].Name]
+	}
+
+	return tblMetas, nil
+}
+
+// getTableRowCountsBatch invokes getTableRowCounts, but batches tblNames
+// into chunks, because MySQL will error if the query becomes too large.
+func getTableRowCountsBatch(ctx context.Context, db sqlz.DB, tblNames []string) (map[string]int64, error) {
+	// TODO: What value should batchSize be?
+	const batchSize = 100
+	var (
+		all     = map[string]int64{}
+		batches = lo.Chunk(tblNames, batchSize)
+	)
+
+	for i := range batches {
+		got, err := getTableRowCounts(ctx, db, batches[i])
+		if err != nil {
+			return nil, err
+		}
+
+		for k, v := range got {
+			all[k] = v
+		}
+	}
+
+	return all, nil
+}
+
+// getTableRowCounts returns a map of table name to count of rows
+// in that table, as returned by "SELECT COUNT(*) FROM tblName".
+// If a table does not exist, the error is logged, but then
+// disregarded, as it's possible that a table can be deleted during
+// the operation. Thus the length of the returned map may be less
+// than len(tblNames).
+func getTableRowCounts(ctx context.Context, db sqlz.DB, tblNames []string) (map[string]int64, error) {
+	log := lg.FromContext(ctx)
+
+	var rows *sql.Rows
+	var err error
+
+	for {
+		if len(tblNames) == 0 {
+			return map[string]int64{}, nil
+		}
+
+		var qb strings.Builder
+		for i := 0; i < len(tblNames); i++ {
+			if i > 0 {
+				qb.WriteString("\nUNION\n")
+			}
+			qb.WriteString(fmt.Sprintf("SELECT %s AS tn, COUNT(*) AS rc FROM %s",
+				stringz.SingleQuote(tblNames[i]), stringz.BacktickQuote(tblNames[i])))
+		}
+
+		query := qb.String()
+		rows, err = db.QueryContext(ctx, query)
+		if err == nil {
+			// The query is good, continue below.
+			break
+		}
+
+		err = errw(err)
+		if errz.IsErrNotExist(err) {
+			// Sometimes a table can get deleted during the operation. If so,
+			// we just remove that table from the list, and try again.
+			// We could also do this entire thing in a transaction, but where's
+			// the fun in that...
+			schema, tblName, ok := extractTblNameFromNotExistErr(err)
+			if ok {
+				log.Warn("Table doesn't exist, will try again without that table",
+					lga.Schema, schema, lga.Table, tblName)
+				tblNames = lo.Without(tblNames, tblName)
+				continue
+			}
+		}
+		return nil, err
+	}
+
+	defer lg.WarnIfCloseError(log, lgm.CloseDBRows, rows)
+
+	var (
+		m       = make(map[string]int64, len(tblNames))
+		count   int64
+		tblName string
+	)
+	for rows.Next() {
+		if err = rows.Scan(&tblName, &count); err != nil {
+			return nil, errw(err)
+		}
+
+		m[tblName] = count
+	}
+
+	if err = rows.Err(); err != nil {
+		return nil, errw(err)
+	}
+
+	return m, nil
+}
+
+// extractTblNameFromNotExistErr is a filthy hack to extract schema
+// and table from err 1146 (table doesn't exist).
+func extractTblNameFromNotExistErr(err error) (schema, table string, ok bool) {
+	if err == nil {
+		return "", "", false
+	}
+
+	var e *mysql.MySQLError
+	if !errors.As(err, &e) {
+		return "", "", false
+	}
+
+	if e.Number != errNumTableNotExist {
+		return "", "", false
+	}
+
+	s := strings.TrimSuffix(strings.TrimPrefix(e.Message, "Table '"), "' doesn't exist")
+
+	if s == "" {
+		return "", "", false
+	}
+
+	if schema, table, ok = strings.Cut(s, "."); ok {
+		return schema, table, ok
+	}
+
+	return "", "", false
 }
 
 // newInsertMungeFunc is lifted from driver.DefaultInsertMungeFunc.

--- a/drivers/mysql/metadata_test.go
+++ b/drivers/mysql/metadata_test.go
@@ -65,10 +65,11 @@ func TestKindFromDBTypeName(t *testing.T) {
 	}
 }
 
-func TestDatabase_SourceMetadata(t *testing.T) {
+func TestDatabase_SourceMetadata_MySQL(t *testing.T) {
 	t.Parallel()
 
-	for _, handle := range sakila.MyAll() {
+	handles := sakila.MyAll()
+	for _, handle := range handles {
 		handle := handle
 
 		t.Run(handle, func(t *testing.T) {
@@ -103,4 +104,14 @@ func TestDatabase_TableMetadata(t *testing.T) {
 			require.Equal(t, sakila.TblActor, md.Name)
 		})
 	}
+}
+
+func TestGetTableRowCounts(t *testing.T) {
+	th, _, dbase, _ := testh.NewWith(t, sakila.My)
+
+	counts, err := mysql.GetTableRowCountsBatch(th.Context, dbase.DB(), []string{sakila.TblActor, sakila.TblFilm})
+	require.NoError(t, err)
+	require.Len(t, counts, 2)
+	require.Equal(t, int64(sakila.TblActorCount), counts[sakila.TblActor])
+	require.Equal(t, int64(sakila.TblFilmCount), counts[sakila.TblFilm])
 }

--- a/drivers/sqlserver/metadata.go
+++ b/drivers/sqlserver/metadata.go
@@ -161,21 +161,20 @@ GROUP BY database_id) AS total_size_bytes`
 			default:
 			}
 
-			var tblMeta *source.TableMetadata
-			tblMeta, err = getTableMetadata(gCtx, db, catalog, schema, tblNames[i], tblTypes[i])
-			if err != nil {
-				if hasErrCode(err, errCodeObjectNotExist) {
+			tblMeta, gErr := getTableMetadata(gCtx, db, catalog, schema, tblNames[i], tblTypes[i])
+			if gErr != nil {
+				if hasErrCode(gErr, errCodeObjectNotExist) {
 					// This can happen if the table is dropped while
 					// we're collecting metadata. We log a warning and continue.
 					log.Warn("Table metadata: table not found (continuing regardless)",
 						lga.Table, tblNames[i],
-						lga.Err, err,
+						lga.Err, gErr,
 					)
 
 					return nil
 				}
 
-				return err
+				return gErr
 			}
 			tblMetas[i] = tblMeta
 			return nil

--- a/libsq/core/lg/lga/lga.go
+++ b/libsq/core/lg/lga/lga.go
@@ -31,6 +31,7 @@ const (
 	SQL       = "sql"
 	Src       = "src"
 	ScanType  = "scan_type"
+	Schema    = "schema"
 	Table     = "table"
 	Target    = "target"
 	To        = "to"

--- a/libsq/driver/driver.go
+++ b/libsq/driver/driver.go
@@ -517,8 +517,11 @@ func OpeningPing(ctx context.Context, src *source.Source, db *sql.DB) error {
 	defer cancelFn()
 
 	if err := db.PingContext(ctx); err != nil {
-		lg.WarnIfCloseError(lg.FromContext(ctx), lgm.CloseDB, db)
-		return errz.Wrapf(err, "open %s", src.Handle)
+		err = errz.Wrapf(err, "open ping %s", src.Handle)
+		log := lg.FromContext(ctx)
+		log.Error("Failed opening ping", lga.Src, src, lga.Err, err)
+		lg.WarnIfCloseError(log, lgm.CloseDB, db)
+		return err
 	}
 
 	return nil

--- a/libsq/driver/driver_test.go
+++ b/libsq/driver/driver_test.go
@@ -448,7 +448,9 @@ func TestDatabase_TableMetadata(t *testing.T) { //nolint:tparallel
 	}
 }
 
-func TestDatabase_SourceMetadata(t *testing.T) { //nolint:tparallel
+func TestDatabase_SourceMetadata(t *testing.T) {
+	t.Parallel()
+
 	for _, handle := range sakila.SQLAll() {
 		handle := handle
 
@@ -466,13 +468,9 @@ func TestDatabase_SourceMetadata(t *testing.T) { //nolint:tparallel
 }
 
 // TestDatabase_SourceMetadata_concurrent tests the behavior of the
-// drivers when SourceMetadata is invoked concurrently. The results
-// are not good. In particular, the mysql impl can become deadlocked
-// if the concurrency is greater than the max conn count. That
-// functionality (in particular mysql/getAllTblMetas) needs to be
-// revisited.
+// drivers when SourceMetadata is invoked concurrently.
 func TestDatabase_SourceMetadata_concurrent(t *testing.T) { //nolint:tparallel
-	const concurrency = 5
+	const concurrency = 10
 
 	handles := sakila.SQLLatest()
 	for _, handle := range handles {
@@ -482,7 +480,6 @@ func TestDatabase_SourceMetadata_concurrent(t *testing.T) { //nolint:tparallel
 			t.Parallel()
 
 			th, _, dbase, _ := testh.NewWith(t, handle)
-
 			g, gCtx := errgroup.WithContext(th.Context)
 			for i := 0; i < concurrency; i++ {
 				g.Go(func() error {


### PR DESCRIPTION
For #229, refactor the `mysql` driver source metadata implementation. This includes removing a race condition.