### PR TITLE
#242 - Handle *uint64 returned from db

### DIFF
--- a/drivers/mysql/mysql_test.go
+++ b/drivers/mysql/mysql_test.go
@@ -74,3 +74,19 @@ func TestDriver_CreateTable_NotNullDefault(t *testing.T) {
 		})
 	}
 }
+
+// TestBug252_ShowCollation_uint64 tests the
+// bug https://github.com/neilotoole/sq/issues/252.
+func TestBug252_ShowCollation_uint64(t *testing.T) {
+	testCases := sakila.MyAll()
+	for _, handle := range testCases {
+		handle := handle
+		t.Run(handle, func(t *testing.T) {
+			th, src, _, _ := testh.NewWith(t, handle)
+
+			sink, err := th.QuerySQL(src, "SHOW COLLATION")
+			require.NoError(t, err)
+			require.NotNil(t, sink)
+		})
+	}
+}

--- a/libsq/driver/record.go
+++ b/libsq/driver/record.go
@@ -286,6 +286,8 @@ func NewRecordFromScanRow(meta record.Meta, row []any, skip []int) (rec record.R
 			rec[i] = int64(*col)
 		case *uint32:
 			rec[i] = int64(*col)
+		case *uint64:
+			rec[i] = int64(*col)
 		case *float32:
 			rec[i] = float64(*col)
 		}


### PR DESCRIPTION
Somehow `NewRecordFromScanRow` had missed the `*int64` case.