### PR TITLE
#261: jsonw: deadlock occurred when record was large, due to mutex on Flush() call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Breaking changes are annotated with ☢️.
 
+## [v0.38.1] - 2023-06-19
+
+### Fixed
+
+- [#261]: The JSON writer (`--json`) could get deadlocked when a record contained
+  a large amount of data, triggering an internal `Flush()` (which is mutex-guarded)
+  from within the mutex-guarded `WriteRecords()` method.
+
 ## [v0.38.0] - 2023-06-18
 
 This release has significant improvements (and breaking changes)
@@ -41,7 +49,6 @@ to SLQ (`sq`'s query language).
   $ sq -H '(1+2)*3'
   9
   ```
-
 
 ### Fixed
 
@@ -599,6 +606,7 @@ make working with lots of sources much easier.
 [#254]: https://github.com/neilotoole/sq/issues/254
 [#256]: https://github.com/neilotoole/sq/issues/256
 [#258]: https://github.com/neilotoole/sq/issues/258
+[#261]: https://github.com/neilotoole/sq/issues/261
 
 [v0.15.2]: https://github.com/neilotoole/sq/releases/tag/v0.15.2
 [v0.15.3]: https://github.com/neilotoole/sq/compare/v0.15.2...v0.15.3
@@ -638,3 +646,4 @@ make working with lots of sources much easier.
 [v0.37.0]: https://github.com/neilotoole/sq/compare/v0.36.2...v0.37.0
 [v0.37.1]: https://github.com/neilotoole/sq/compare/v0.37.0...v0.37.1
 [v0.38.0]: https://github.com/neilotoole/sq/compare/v0.37.1...v0.38.0
+[v0.38.1]: https://github.com/neilotoole/sq/compare/v0.38.0...v0.38.1

--- a/cli/output/jsonw/recordwriter.go
+++ b/cli/output/jsonw/recordwriter.go
@@ -135,7 +135,7 @@ func (w *stdWriter) writeRecord(rec record.Record) error {
 	w.b = w.b[:0]
 
 	if w.outBuf.Len() > w.pr.FlushThreshold {
-		return w.Flush()
+		return w.doFlush()
 	}
 
 	return nil
@@ -145,11 +145,14 @@ func (w *stdWriter) writeRecord(rec record.Record) error {
 func (w *stdWriter) Flush() error {
 	w.mu.Lock()
 	defer w.mu.Unlock()
+	return w.doFlush()
+}
+
+func (w *stdWriter) doFlush() error {
 	if w.err != nil {
 		return w.err
 	}
-	_, err := w.outBuf.WriteTo(w.out)
-	if err != nil {
+	if _, err := w.outBuf.WriteTo(w.out); err != nil {
 		return errz.Err(err)
 	}
 	return nil


### PR DESCRIPTION
See #261.