### PR TITLE
#263: cmd version: structure yaml output correctly

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -24,7 +24,7 @@ Include below the output of `sq version --yaml`:
 
 ```yaml
 # REPLACE THIS WITH YOUR OUTPUT
-buildinfo:
+build:
   version: v0.39.0
   commit: eedc11ec46d1f0e78628158cc6fd58850601d701
   timestamp: 2023-06-21T11:41:34Z

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -24,10 +24,9 @@ Include below the output of `sq version --yaml`:
 
 ```yaml
 # REPLACE THIS WITH YOUR OUTPUT
-build:
-  version: v0.39.0
-  commit: eedc11ec46d1f0e78628158cc6fd58850601d701
-  timestamp: 2023-06-21T11:41:34Z
+version: v0.39.0
+commit: eedc11ec46d1f0e78628158cc6fd58850601d701
+timestamp: 2023-06-21T11:41:34Z
 latest_version: v0.39.0
 host:
   platform: darwin

--- a/cli/buildinfo/buildinfo.go
+++ b/cli/buildinfo/buildinfo.go
@@ -36,9 +36,9 @@ var (
 
 // BuildInfo encapsulates Version, Commit and Timestamp.
 type BuildInfo struct {
-	Version   string `json:"version"`
-	Commit    string `json:"commit,omitempty"`
-	Timestamp string `json:"timestamp,omitempty"`
+	Version   string `json:"version" yaml:"version"`
+	Commit    string `json:"commit,omitempty" yaml:"commit,omitempty"`
+	Timestamp string `json:"timestamp,omitempty" yaml:"timestamp,omitempty"`
 }
 
 // String returns a string representation of BuildInfo.

--- a/cli/output/yamlw/versionwriter.go
+++ b/cli/output/yamlw/versionwriter.go
@@ -29,13 +29,17 @@ func NewVersionWriter(out io.Writer, pr *output.Printing) output.VersionWriter {
 // Version implements output.VersionWriter.
 func (w *versionWriter) Version(bi buildinfo.BuildInfo, latestVersion string, hi hostinfo.Info) error {
 	type cliBuildInfo struct {
-		buildinfo.BuildInfo
-		LatestVersion string        `json:"latest_version"`
-		Host          hostinfo.Info `json:"host"`
+		Version       string        `json:"version" yaml:"version"`
+		Commit        string        `json:"commit,omitempty" yaml:"commit,omitempty"`
+		Timestamp     string        `json:"timestamp,omitempty" yaml:"timestamp,omitempty"`
+		LatestVersion string        `json:"latest_version" yaml:"latest_version"`
+		Host          hostinfo.Info `json:"host" yaml:"host"`
 	}
 
 	cbi := cliBuildInfo{
-		BuildInfo:     bi,
+		Version:       bi.Version,
+		Commit:        bi.Commit,
+		Timestamp:     bi.Timestamp,
 		LatestVersion: latestVersion,
 		Host:          hi,
 	}


### PR DESCRIPTION
See #263.

`sq version`: Fix yaml output structure.