### PR TITLE
Refactor/rename database to pool

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ env:
   GO_VERSION: 1.21.0
   GORELEASER_VERSION: 1.20.0
   GOLANGCI_LINT_VERSION: v1.54.1
-  TPARSE_VERSION: v0.11.1
+  TPARSE_VERSION: v0.13.2
   BUILD_TAGS: 'sqlite_vtable sqlite_stat4 sqlite_fts5 sqlite_introspect sqlite_json sqlite_math_functions'
 
 jobs:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ on:
 env:
   GO_VERSION: 1.21.0
   GORELEASER_VERSION: 1.20.0
-  GOLANGCI_LINT_VERSION: v1.54.1
+  GOLANGCI_LINT_VERSION: v1.55.2
   TPARSE_VERSION: v0.13.2
   BUILD_TAGS: 'sqlite_vtable sqlite_stat4 sqlite_fts5 sqlite_introspect sqlite_json sqlite_math_functions'
 
@@ -129,6 +129,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
+          skip-cache: true
           version: ${{ env.GOLANGCI_LINT_VERSION }}
 
 

--- a/cli/cmd_inspect.go
+++ b/cli/cmd_inspect.go
@@ -166,14 +166,14 @@ func execInspect(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	dbase, err := ru.Databases.Open(ctx, src)
+	pool, err := ru.Pools.Open(ctx, src)
 	if err != nil {
 		return errz.Wrapf(err, "failed to inspect %s", src.Handle)
 	}
 
 	if table != "" {
 		var tblMeta *source.TableMetadata
-		tblMeta, err = dbase.TableMetadata(ctx, table)
+		tblMeta, err = pool.TableMetadata(ctx, table)
 		if err != nil {
 			return err
 		}
@@ -183,11 +183,11 @@ func execInspect(cmd *cobra.Command, args []string) error {
 
 	if cmdFlagIsSetTrue(cmd, flag.InspectDBProps) {
 		var db *sql.DB
-		if db, err = dbase.DB(ctx); err != nil {
+		if db, err = pool.DB(ctx); err != nil {
 			return err
 		}
 		var props map[string]any
-		sqlDrvr := dbase.SQLDriver()
+		sqlDrvr := pool.SQLDriver()
 		if props, err = sqlDrvr.DBProperties(ctx, db); err != nil {
 			return err
 		}
@@ -197,7 +197,7 @@ func execInspect(cmd *cobra.Command, args []string) error {
 
 	overviewOnly := cmdFlagIsSetTrue(cmd, flag.InspectOverview)
 
-	srcMeta, err := dbase.SourceMetadata(ctx, overviewOnly)
+	srcMeta, err := pool.SourceMetadata(ctx, overviewOnly)
 	if err != nil {
 		return errz.Wrapf(err, "failed to read %s source metadata", src.Handle)
 	}

--- a/cli/cmd_sql.go
+++ b/cli/cmd_sql.go
@@ -118,7 +118,7 @@ func execSQL(cmd *cobra.Command, args []string) error {
 // to the configured writer.
 func execSQLPrint(ctx context.Context, ru *run.Run, fromSrc *source.Source) error {
 	args := ru.Args
-	dbase, err := ru.Databases.Open(ctx, fromSrc)
+	dbase, err := ru.Pools.Open(ctx, fromSrc)
 	if err != nil {
 		return err
 	}
@@ -138,7 +138,7 @@ func execSQLInsert(ctx context.Context, ru *run.Run,
 	fromSrc, destSrc *source.Source, destTbl string,
 ) error {
 	args := ru.Args
-	dbases := ru.Databases
+	dbases := ru.Pools
 	ctx, cancelFn := context.WithCancel(ctx)
 	defer cancelFn()
 
@@ -147,18 +147,18 @@ func execSQLInsert(ctx context.Context, ru *run.Run,
 		return err
 	}
 
-	destDB, err := dbases.Open(ctx, destSrc)
+	destPool, err := dbases.Open(ctx, destSrc)
 	if err != nil {
 		return err
 	}
 
 	// Note: We don't need to worry about closing fromDB and
-	// destDB because they are closed by dbases.Close, which
+	// destPool because they are closed by dbases.Close, which
 	// is invoked by ru.Close, and ru is closed further up the
 	// stack.
 
 	inserter := libsq.NewDBWriter(
-		destDB,
+		destPool,
 		destTbl,
 		driver.OptTuningRecChanSize.Get(destSrc.Options),
 		libsq.DBWriterCreateTableIfNotExistsHook(destTbl),

--- a/cli/cmd_sql.go
+++ b/cli/cmd_sql.go
@@ -138,22 +138,22 @@ func execSQLInsert(ctx context.Context, ru *run.Run,
 	fromSrc, destSrc *source.Source, destTbl string,
 ) error {
 	args := ru.Args
-	dbases := ru.Pools
+	pools := ru.Pools
 	ctx, cancelFn := context.WithCancel(ctx)
 	defer cancelFn()
 
-	fromDB, err := dbases.Open(ctx, fromSrc)
+	fromDB, err := pools.Open(ctx, fromSrc)
 	if err != nil {
 		return err
 	}
 
-	destPool, err := dbases.Open(ctx, destSrc)
+	destPool, err := pools.Open(ctx, destSrc)
 	if err != nil {
 		return err
 	}
 
 	// Note: We don't need to worry about closing fromDB and
-	// destPool because they are closed by dbases.Close, which
+	// destPool because they are closed by pools.Close, which
 	// is invoked by ru.Close, and ru is closed further up the
 	// stack.
 

--- a/cli/cmd_sql.go
+++ b/cli/cmd_sql.go
@@ -118,13 +118,13 @@ func execSQL(cmd *cobra.Command, args []string) error {
 // to the configured writer.
 func execSQLPrint(ctx context.Context, ru *run.Run, fromSrc *source.Source) error {
 	args := ru.Args
-	dbase, err := ru.Pools.Open(ctx, fromSrc)
+	pool, err := ru.Pools.Open(ctx, fromSrc)
 	if err != nil {
 		return err
 	}
 
 	recw := output.NewRecordWriterAdapter(ctx, ru.Writers.Record)
-	err = libsq.QuerySQL(ctx, dbase, nil, recw, args[0])
+	err = libsq.QuerySQL(ctx, pool, nil, recw, args[0])
 	if err != nil {
 		return err
 	}

--- a/cli/cmd_tbl.go
+++ b/cli/cmd_tbl.go
@@ -124,13 +124,13 @@ func execTblCopy(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	var dbase driver.Pool
-	dbase, err = ru.Pools.Open(ctx, tblHandles[0].src)
+	var pool driver.Pool
+	pool, err = ru.Pools.Open(ctx, tblHandles[0].src)
 	if err != nil {
 		return err
 	}
 
-	db, err := dbase.DB(ctx)
+	db, err := pool.DB(ctx)
 	if err != nil {
 		return err
 	}
@@ -257,13 +257,13 @@ func execTblDrop(cmd *cobra.Command, args []string) (err error) {
 			return errz.Errorf("driver type {%s} (%s) doesn't support dropping tables", tblH.src.Type, tblH.src.Handle)
 		}
 
-		var dbase driver.Pool
-		if dbase, err = ru.Pools.Open(ctx, tblH.src); err != nil {
+		var pool driver.Pool
+		if pool, err = ru.Pools.Open(ctx, tblH.src); err != nil {
 			return err
 		}
 
 		var db *sql.DB
-		if db, err = dbase.DB(ctx); err != nil {
+		if db, err = pool.DB(ctx); err != nil {
 			return err
 		}
 

--- a/cli/cmd_tbl.go
+++ b/cli/cmd_tbl.go
@@ -124,8 +124,8 @@ func execTblCopy(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	var dbase driver.Database
-	dbase, err = ru.Databases.Open(ctx, tblHandles[0].src)
+	var dbase driver.Pool
+	dbase, err = ru.Pools.Open(ctx, tblHandles[0].src)
 	if err != nil {
 		return err
 	}
@@ -257,8 +257,8 @@ func execTblDrop(cmd *cobra.Command, args []string) (err error) {
 			return errz.Errorf("driver type {%s} (%s) doesn't support dropping tables", tblH.src.Type, tblH.src.Handle)
 		}
 
-		var dbase driver.Database
-		if dbase, err = ru.Databases.Open(ctx, tblH.src); err != nil {
+		var dbase driver.Pool
+		if dbase, err = ru.Pools.Open(ctx, tblH.src); err != nil {
 			return err
 		}
 

--- a/cli/complete.go
+++ b/cli/complete.go
@@ -392,13 +392,13 @@ func (c activeSchemaCompleter) complete(cmd *cobra.Command, args []string, toCom
 	ctx, cancelFn := context.WithTimeout(cmd.Context(), OptShellCompletionTimeout.Get(ru.Config.Options))
 	defer cancelFn()
 
-	dbase, err := ru.Pools.Open(ctx, src)
+	pool, err := ru.Pools.Open(ctx, src)
 	if err != nil {
 		lg.Unexpected(log, err)
 		return nil, cobra.ShellCompDirectiveError
 	}
 
-	db, err := dbase.DB(ctx)
+	db, err := pool.DB(ctx)
 	if err != nil {
 		lg.Unexpected(log, err)
 		return nil, cobra.ShellCompDirectiveError
@@ -768,14 +768,14 @@ func getTableNamesForHandle(ctx context.Context, ru *run.Run, handle string) ([]
 		return nil, err
 	}
 
-	dbase, err := ru.Pools.Open(ctx, src)
+	pool, err := ru.Pools.Open(ctx, src)
 	if err != nil {
 		return nil, err
 	}
 
 	// TODO: We shouldn't have to load the full metadata just to get
 	// the table names. driver.SQLDriver should have a method ListTables.
-	md, err := dbase.SourceMetadata(ctx, false)
+	md, err := pool.SourceMetadata(ctx, false)
 	if err != nil {
 		return nil, err
 	}

--- a/cli/complete.go
+++ b/cli/complete.go
@@ -149,7 +149,7 @@ func completeSLQ(cmd *cobra.Command, args []string, toComplete string) ([]string
 // completeDriverType is a completionFunc that suggests drivers.
 func completeDriverType(cmd *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
 	ru := getRun(cmd)
-	if ru.Databases == nil {
+	if ru.Pools == nil {
 		if err := preRun(cmd, ru); err != nil {
 			lg.Unexpected(logFrom(cmd), err)
 			return nil, cobra.ShellCompDirectiveError
@@ -392,7 +392,7 @@ func (c activeSchemaCompleter) complete(cmd *cobra.Command, args []string, toCom
 	ctx, cancelFn := context.WithTimeout(cmd.Context(), OptShellCompletionTimeout.Get(ru.Config.Options))
 	defer cancelFn()
 
-	dbase, err := ru.Databases.Open(ctx, src)
+	dbase, err := ru.Pools.Open(ctx, src)
 	if err != nil {
 		lg.Unexpected(log, err)
 		return nil, cobra.ShellCompDirectiveError
@@ -768,7 +768,7 @@ func getTableNamesForHandle(ctx context.Context, ru *run.Run, handle string) ([]
 		return nil, err
 	}
 
-	dbase, err := ru.Databases.Open(ctx, src)
+	dbase, err := ru.Pools.Open(ctx, src)
 	if err != nil {
 		return nil, err
 	}

--- a/cli/diff/source.go
+++ b/cli/diff/source.go
@@ -195,7 +195,7 @@ func fetchSourceMeta(ctx context.Context, ru *run.Run, handle string) (*source.S
 	if err != nil {
 		return nil, nil, err
 	}
-	dbase, err := ru.Databases.Open(ctx, src)
+	dbase, err := ru.Pools.Open(ctx, src)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/cli/diff/source.go
+++ b/cli/diff/source.go
@@ -195,11 +195,11 @@ func fetchSourceMeta(ctx context.Context, ru *run.Run, handle string) (*source.S
 	if err != nil {
 		return nil, nil, err
 	}
-	dbase, err := ru.Pools.Open(ctx, src)
+	pool, err := ru.Pools.Open(ctx, src)
 	if err != nil {
 		return nil, nil, err
 	}
-	md, err := dbase.SourceMetadata(ctx, false)
+	md, err := pool.SourceMetadata(ctx, false)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/cli/diff/table.go
+++ b/cli/diff/table.go
@@ -113,11 +113,11 @@ func buildTableStructureDiff(cfg *Config, showRowCounts bool, td1, td2 *tableDat
 func fetchTableMeta(ctx context.Context, ru *run.Run, src *source.Source, table string) (
 	*source.TableMetadata, error,
 ) {
-	dbase, err := ru.Pools.Open(ctx, src)
+	pool, err := ru.Pools.Open(ctx, src)
 	if err != nil {
 		return nil, err
 	}
-	md, err := dbase.TableMetadata(ctx, table)
+	md, err := pool.TableMetadata(ctx, table)
 	if err != nil {
 		if errz.IsErrNotExist(err) {
 			return nil, nil //nolint:nilnil

--- a/cli/diff/table.go
+++ b/cli/diff/table.go
@@ -113,7 +113,7 @@ func buildTableStructureDiff(cfg *Config, showRowCounts bool, td1, td2 *tableDat
 func fetchTableMeta(ctx context.Context, ru *run.Run, src *source.Source, table string) (
 	*source.TableMetadata, error,
 ) {
-	dbase, err := ru.Databases.Open(ctx, src)
+	dbase, err := ru.Pools.Open(ctx, src)
 	if err != nil {
 		return nil, err
 	}

--- a/cli/output/adapter_test.go
+++ b/cli/output/adapter_test.go
@@ -51,11 +51,11 @@ func TestRecordWriterAdapter(t *testing.T) {
 
 			th := testh.New(t)
 			src := th.Source(tc.handle)
-			dbase := th.Open(src)
+			pool := th.Open(src)
 
 			sink := &testh.RecordSink{}
 			recw := output.NewRecordWriterAdapter(th.Context, sink)
-			err := libsq.QuerySQL(th.Context, dbase, nil, recw, tc.sqlQuery)
+			err := libsq.QuerySQL(th.Context, pool, nil, recw, tc.sqlQuery)
 			require.NoError(t, err)
 			written, err := recw.Wait()
 			require.NoError(t, err)

--- a/cli/run.go
+++ b/cli/run.go
@@ -157,19 +157,19 @@ func FinishRunInit(ctx context.Context, ru *run.Run) error {
 	ru.DriverRegistry = driver.NewRegistry(log)
 	dr := ru.DriverRegistry
 
-	ru.Databases = driver.NewDatabases(log, dr, scratchSrcFunc)
-	ru.Cleanup.AddC(ru.Databases)
+	ru.Pools = driver.NewPools(log, dr, scratchSrcFunc)
+	ru.Cleanup.AddC(ru.Pools)
 
 	dr.AddProvider(sqlite3.Type, &sqlite3.Provider{Log: log})
 	dr.AddProvider(postgres.Type, &postgres.Provider{Log: log})
 	dr.AddProvider(sqlserver.Type, &sqlserver.Provider{Log: log})
 	dr.AddProvider(mysql.Type, &mysql.Provider{Log: log})
-	csvp := &csv.Provider{Log: log, Scratcher: ru.Databases, Files: ru.Files}
+	csvp := &csv.Provider{Log: log, Scratcher: ru.Pools, Files: ru.Files}
 	dr.AddProvider(csv.TypeCSV, csvp)
 	dr.AddProvider(csv.TypeTSV, csvp)
 	ru.Files.AddDriverDetectors(csv.DetectCSV, csv.DetectTSV)
 
-	jsonp := &json.Provider{Log: log, Scratcher: ru.Databases, Files: ru.Files}
+	jsonp := &json.Provider{Log: log, Scratcher: ru.Pools, Files: ru.Files}
 	dr.AddProvider(json.TypeJSON, jsonp)
 	dr.AddProvider(json.TypeJSONA, jsonp)
 	dr.AddProvider(json.TypeJSONL, jsonp)
@@ -180,7 +180,7 @@ func FinishRunInit(ctx context.Context, ru *run.Run) error {
 		json.DetectJSONL(sampleSize),
 	)
 
-	dr.AddProvider(xlsx.Type, &xlsx.Provider{Log: log, Scratcher: ru.Databases, Files: ru.Files})
+	dr.AddProvider(xlsx.Type, &xlsx.Provider{Log: log, Scratcher: ru.Pools, Files: ru.Files})
 	ru.Files.AddDriverDetectors(xlsx.DetectXLSX)
 	// One day we may have more supported user driver genres.
 	userDriverImporters := map[string]userdriver.ImportFunc{
@@ -210,7 +210,7 @@ func FinishRunInit(ctx context.Context, ru *run.Run) error {
 			Log:       log,
 			DriverDef: userDriverDef,
 			ImportFn:  importFn,
-			Scratcher: ru.Databases,
+			Scratcher: ru.Pools,
 			Files:     ru.Files,
 		}
 

--- a/cli/run/run.go
+++ b/cli/run/run.go
@@ -75,8 +75,8 @@ type Run struct {
 	// Files manages file access.
 	Files *source.Files
 
-	// Databases mediates access to databases.
-	Databases *driver.Databases
+	// Pools mediates access to db pools.
+	Pools *driver.Pools
 
 	// Writers holds the various writer types that
 	// the CLI uses to print output.
@@ -101,10 +101,10 @@ func (ru *Run) Close() error {
 // NewQueryContext returns a *libsq.QueryContext constructed from ru.
 func NewQueryContext(ru *Run, args map[string]string) *libsq.QueryContext {
 	return &libsq.QueryContext{
-		Collection:      ru.Config.Collection,
-		DBOpener:        ru.Databases,
-		JoinDBOpener:    ru.Databases,
-		ScratchDBOpener: ru.Databases,
-		Args:            args,
+		Collection:        ru.Config.Collection,
+		PoolOpener:        ru.Pools,
+		JoinPoolOpener:    ru.Pools,
+		ScratchPoolOpener: ru.Pools,
+		Args:              args,
 	}
 }

--- a/drivers/csv/csv.go
+++ b/drivers/csv/csv.go
@@ -69,7 +69,7 @@ func (d *driveri) DriverMetadata() driver.Metadata {
 func (d *driveri) Open(ctx context.Context, src *source.Source) (driver.Pool, error) {
 	lg.FromContext(ctx).Debug(lgm.OpenSrc, lga.Src, src)
 
-	pool := &database{
+	pool := &pool{
 		log:   d.log,
 		src:   src,
 		files: d.files,
@@ -113,8 +113,8 @@ func (d *driveri) Ping(_ context.Context, src *source.Source) error {
 	return nil
 }
 
-// database implements driver.Pool.
-type database struct {
+// pool implements driver.Pool.
+type pool struct {
 	log   *slog.Logger
 	src   *source.Source
 	impl  driver.Pool
@@ -122,28 +122,28 @@ type database struct {
 }
 
 // DB implements driver.Pool.
-func (d *database) DB(ctx context.Context) (*sql.DB, error) {
-	return d.impl.DB(ctx)
+func (p *pool) DB(ctx context.Context) (*sql.DB, error) {
+	return p.impl.DB(ctx)
 }
 
 // SQLDriver implements driver.Pool.
-func (d *database) SQLDriver() driver.SQLDriver {
-	return d.impl.SQLDriver()
+func (p *pool) SQLDriver() driver.SQLDriver {
+	return p.impl.SQLDriver()
 }
 
 // Source implements driver.Pool.
-func (d *database) Source() *source.Source {
-	return d.src
+func (p *pool) Source() *source.Source {
+	return p.src
 }
 
 // TableMetadata implements driver.Pool.
-func (d *database) TableMetadata(ctx context.Context, tblName string) (*source.TableMetadata, error) {
+func (p *pool) TableMetadata(ctx context.Context, tblName string) (*source.TableMetadata, error) {
 	if tblName != source.MonotableName {
 		return nil, errz.Errorf("table name should be %s for CSV/TSV etc., but got: %s",
 			source.MonotableName, tblName)
 	}
 
-	srcMeta, err := d.SourceMetadata(ctx, false)
+	srcMeta, err := p.SourceMetadata(ctx, false)
 	if err != nil {
 		return nil, err
 	}
@@ -153,22 +153,22 @@ func (d *database) TableMetadata(ctx context.Context, tblName string) (*source.T
 }
 
 // SourceMetadata implements driver.Pool.
-func (d *database) SourceMetadata(ctx context.Context, noSchema bool) (*source.Metadata, error) {
-	md, err := d.impl.SourceMetadata(ctx, noSchema)
+func (p *pool) SourceMetadata(ctx context.Context, noSchema bool) (*source.Metadata, error) {
+	md, err := p.impl.SourceMetadata(ctx, noSchema)
 	if err != nil {
 		return nil, err
 	}
 
-	md.Handle = d.src.Handle
-	md.Location = d.src.Location
-	md.Driver = d.src.Type
+	md.Handle = p.src.Handle
+	md.Location = p.src.Location
+	md.Driver = p.src.Type
 
-	md.Name, err = source.LocationFileName(d.src)
+	md.Name, err = source.LocationFileName(p.src)
 	if err != nil {
 		return nil, err
 	}
 
-	md.Size, err = d.files.Size(d.src)
+	md.Size, err = p.files.Size(p.src)
 	if err != nil {
 		return nil, err
 	}
@@ -178,8 +178,8 @@ func (d *database) SourceMetadata(ctx context.Context, noSchema bool) (*source.M
 }
 
 // Close implements driver.Pool.
-func (d *database) Close() error {
-	d.log.Debug(lgm.CloseDB, lga.Handle, d.src.Handle)
+func (p *pool) Close() error {
+	p.log.Debug(lgm.CloseDB, lga.Handle, p.src.Handle)
 
-	return errz.Err(d.impl.Close())
+	return errz.Err(p.impl.Close())
 }

--- a/drivers/csv/csv.go
+++ b/drivers/csv/csv.go
@@ -69,23 +69,23 @@ func (d *driveri) DriverMetadata() driver.Metadata {
 func (d *driveri) Open(ctx context.Context, src *source.Source) (driver.Pool, error) {
 	lg.FromContext(ctx).Debug(lgm.OpenSrc, lga.Src, src)
 
-	dbase := &database{
+	pool := &database{
 		log:   d.log,
 		src:   src,
 		files: d.files,
 	}
 
 	var err error
-	dbase.impl, err = d.scratcher.OpenScratch(ctx, src.Handle)
+	pool.impl, err = d.scratcher.OpenScratch(ctx, src.Handle)
 	if err != nil {
 		return nil, err
 	}
 
-	if err = ingestCSV(ctx, src, d.files.OpenFunc(src), dbase.impl); err != nil {
+	if err = ingestCSV(ctx, src, d.files.OpenFunc(src), pool.impl); err != nil {
 		return nil, err
 	}
 
-	return dbase, nil
+	return pool, nil
 }
 
 // Truncate implements driver.Driver.

--- a/drivers/csv/insert.go
+++ b/drivers/csv/insert.go
@@ -122,13 +122,13 @@ func createTblDef(tblName string, colNames []string, kinds []kind.Kind) *sqlmode
 }
 
 // getIngestRecMeta returns record.Meta to use with RecordWriter.Open.
-func getIngestRecMeta(ctx context.Context, scratchDB driver.Database, tblDef *sqlmodel.TableDef) (record.Meta, error) {
-	db, err := scratchDB.DB(ctx)
+func getIngestRecMeta(ctx context.Context, scratchPool driver.Pool, tblDef *sqlmodel.TableDef) (record.Meta, error) {
+	db, err := scratchPool.DB(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	drvr := scratchDB.SQLDriver()
+	drvr := scratchPool.SQLDriver()
 
 	colTypes, err := drvr.TableColumnTypes(ctx, db, tblDef.Name, tblDef.ColNames())
 	if err != nil {

--- a/drivers/json/import.go
+++ b/drivers/json/import.go
@@ -30,11 +30,11 @@ import (
 
 // importJob describes a single import job, where the JSON
 // at fromSrc is read via openFn and the resulting records
-// are written to destDB.
+// are written to destPool.
 type importJob struct {
-	fromSrc *source.Source
-	openFn  source.FileOpenFunc
-	destDB  driver.Database
+	fromSrc  *source.Source
+	openFn   source.FileOpenFunc
+	destPool driver.Pool
 
 	// sampleSize is the maximum number of values to
 	// sample to determine the kind of an element.
@@ -57,18 +57,18 @@ var (
 )
 
 // getRecMeta returns record.Meta to use with RecordWriter.Open.
-func getRecMeta(ctx context.Context, scratchDB driver.Database, tblDef *sqlmodel.TableDef) (record.Meta, error) {
-	db, err := scratchDB.DB(ctx)
+func getRecMeta(ctx context.Context, scratchPool driver.Pool, tblDef *sqlmodel.TableDef) (record.Meta, error) {
+	db, err := scratchPool.DB(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	colTypes, err := scratchDB.SQLDriver().TableColumnTypes(ctx, db, tblDef.Name, tblDef.ColNames())
+	colTypes, err := scratchPool.SQLDriver().TableColumnTypes(ctx, db, tblDef.Name, tblDef.ColNames())
 	if err != nil {
 		return nil, err
 	}
 
-	destMeta, _, err := scratchDB.SQLDriver().RecordMeta(ctx, colTypes)
+	destMeta, _, err := scratchPool.SQLDriver().RecordMeta(ctx, colTypes)
 	if err != nil {
 		return nil, err
 	}

--- a/drivers/json/import_json.go
+++ b/drivers/json/import_json.go
@@ -143,9 +143,9 @@ func importJSON(ctx context.Context, job importJob) error {
 	}
 	defer lg.WarnIfCloseError(log, lgm.CloseFileReader, r)
 
-	drvr := job.destDB.SQLDriver()
+	drvr := job.destPool.SQLDriver()
 
-	db, err := job.destDB.DB(ctx)
+	db, err := job.destPool.DB(ctx)
 	if err != nil {
 		return err
 	}

--- a/drivers/json/import_jsonl.go
+++ b/drivers/json/import_jsonl.go
@@ -94,8 +94,8 @@ func importJSONL(ctx context.Context, job importJob) error { //nolint:gocognit
 	}
 	defer lg.WarnIfCloseError(log, lgm.CloseFileReader, r)
 
-	drvr := job.destDB.SQLDriver()
-	db, err := job.destDB.DB(ctx)
+	drvr := job.destPool.SQLDriver()
+	db, err := job.destPool.DB(ctx)
 	if err != nil {
 		return err
 	}

--- a/drivers/json/import_test.go
+++ b/drivers/json/import_test.go
@@ -85,8 +85,8 @@ func TestImportJSONL_Flat(t *testing.T) {
 				}
 			}
 
-			th, src, _, dbase, _ := testh.NewWith(t, testsrc.EmptyDB)
-			job := json.NewImportJob(src, openFn, dbase, 0, true)
+			th, src, _, pool, _ := testh.NewWith(t, testsrc.EmptyDB)
+			job := json.NewImportJob(src, openFn, pool, 0, true)
 
 			err := json.ImportJSONL(th.Context, job)
 			if tc.wantErr {
@@ -110,8 +110,8 @@ func TestImportJSON_Flat(t *testing.T) {
 		return os.Open("testdata/actor.json")
 	}
 
-	th, src, _, dbase, _ := testh.NewWith(t, testsrc.EmptyDB)
-	job := json.NewImportJob(src, openFn, dbase, 0, true)
+	th, src, _, pool, _ := testh.NewWith(t, testsrc.EmptyDB)
+	job := json.NewImportJob(src, openFn, pool, 0, true)
 
 	err := json.ImportJSON(th.Context, job)
 	require.NoError(t, err)

--- a/drivers/json/internal_test.go
+++ b/drivers/json/internal_test.go
@@ -26,7 +26,7 @@ var (
 
 // newImportJob is a constructor for the unexported importJob type.
 // If sampleSize <= 0, a default value is used.
-func newImportJob(fromSrc *source.Source, openFn source.FileOpenFunc, destDB driver.Database, sampleSize int,
+func newImportJob(fromSrc *source.Source, openFn source.FileOpenFunc, destPool driver.Pool, sampleSize int,
 	flatten bool,
 ) importJob {
 	if sampleSize <= 0 {
@@ -36,7 +36,7 @@ func newImportJob(fromSrc *source.Source, openFn source.FileOpenFunc, destDB dri
 	return importJob{
 		fromSrc:    fromSrc,
 		openFn:     openFn,
-		destDB:     destDB,
+		destPool:   destPool,
 		sampleSize: sampleSize,
 		flatten:    flatten,
 	}

--- a/drivers/json/json.go
+++ b/drivers/json/json.go
@@ -96,24 +96,24 @@ func (d *driveri) DriverMetadata() driver.Metadata {
 func (d *driveri) Open(ctx context.Context, src *source.Source) (driver.Pool, error) {
 	lg.FromContext(ctx).Debug(lgm.OpenSrc, lga.Src, src)
 
-	pool := &database{log: d.log, src: src, clnup: cleanup.New(), files: d.files}
+	p := &pool{log: d.log, src: src, clnup: cleanup.New(), files: d.files}
 
 	r, err := d.files.Open(src)
 	if err != nil {
 		return nil, err
 	}
 
-	pool.impl, err = d.scratcher.OpenScratch(ctx, src.Handle)
+	p.impl, err = d.scratcher.OpenScratch(ctx, src.Handle)
 	if err != nil {
 		lg.WarnIfCloseError(d.log, lgm.CloseFileReader, r)
-		lg.WarnIfFuncError(d.log, lgm.CloseDB, pool.clnup.Run)
+		lg.WarnIfFuncError(d.log, lgm.CloseDB, p.clnup.Run)
 		return nil, err
 	}
 
 	job := importJob{
 		fromSrc:    src,
 		openFn:     d.files.OpenFunc(src),
-		destPool:   pool.impl,
+		destPool:   p.impl,
 		sampleSize: driver.OptIngestSampleSize.Get(src.Options),
 		flatten:    true,
 	}
@@ -121,7 +121,7 @@ func (d *driveri) Open(ctx context.Context, src *source.Source) (driver.Pool, er
 	err = d.importFn(ctx, job)
 	if err != nil {
 		lg.WarnIfCloseError(d.log, lgm.CloseFileReader, r)
-		lg.WarnIfFuncError(d.log, lgm.CloseDB, pool.clnup.Run)
+		lg.WarnIfFuncError(d.log, lgm.CloseDB, p.clnup.Run)
 		return nil, err
 	}
 
@@ -130,7 +130,7 @@ func (d *driveri) Open(ctx context.Context, src *source.Source) (driver.Pool, er
 		return nil, err
 	}
 
-	return pool, nil
+	return p, nil
 }
 
 // Truncate implements driver.Driver.
@@ -160,8 +160,8 @@ func (d *driveri) Ping(_ context.Context, src *source.Source) error {
 	return nil
 }
 
-// database implements driver.Pool.
-type database struct {
+// pool implements driver.Pool.
+type pool struct {
 	log   *slog.Logger
 	src   *source.Source
 	impl  driver.Pool
@@ -170,28 +170,28 @@ type database struct {
 }
 
 // DB implements driver.Pool.
-func (d *database) DB(ctx context.Context) (*sql.DB, error) {
-	return d.impl.DB(ctx)
+func (p *pool) DB(ctx context.Context) (*sql.DB, error) {
+	return p.impl.DB(ctx)
 }
 
 // SQLDriver implements driver.Pool.
-func (d *database) SQLDriver() driver.SQLDriver {
-	return d.impl.SQLDriver()
+func (p *pool) SQLDriver() driver.SQLDriver {
+	return p.impl.SQLDriver()
 }
 
 // Source implements driver.Pool.
-func (d *database) Source() *source.Source {
-	return d.src
+func (p *pool) Source() *source.Source {
+	return p.src
 }
 
 // TableMetadata implements driver.Pool.
-func (d *database) TableMetadata(ctx context.Context, tblName string) (*source.TableMetadata, error) {
+func (p *pool) TableMetadata(ctx context.Context, tblName string) (*source.TableMetadata, error) {
 	if tblName != source.MonotableName {
 		return nil, errz.Errorf("table name should be %s for CSV/TSV etc., but got: %s",
 			source.MonotableName, tblName)
 	}
 
-	srcMeta, err := d.SourceMetadata(ctx, false)
+	srcMeta, err := p.SourceMetadata(ctx, false)
 	if err != nil {
 		return nil, err
 	}
@@ -201,22 +201,22 @@ func (d *database) TableMetadata(ctx context.Context, tblName string) (*source.T
 }
 
 // SourceMetadata implements driver.Pool.
-func (d *database) SourceMetadata(ctx context.Context, noSchema bool) (*source.Metadata, error) {
-	md, err := d.impl.SourceMetadata(ctx, noSchema)
+func (p *pool) SourceMetadata(ctx context.Context, noSchema bool) (*source.Metadata, error) {
+	md, err := p.impl.SourceMetadata(ctx, noSchema)
 	if err != nil {
 		return nil, err
 	}
 
-	md.Handle = d.src.Handle
-	md.Location = d.src.Location
-	md.Driver = d.src.Type
+	md.Handle = p.src.Handle
+	md.Location = p.src.Location
+	md.Driver = p.src.Type
 
-	md.Name, err = source.LocationFileName(d.src)
+	md.Name, err = source.LocationFileName(p.src)
 	if err != nil {
 		return nil, err
 	}
 
-	md.Size, err = d.files.Size(d.src)
+	md.Size, err = p.files.Size(p.src)
 	if err != nil {
 		return nil, err
 	}
@@ -226,8 +226,8 @@ func (d *database) SourceMetadata(ctx context.Context, noSchema bool) (*source.M
 }
 
 // Close implements driver.Pool.
-func (d *database) Close() error {
-	d.log.Debug(lgm.CloseDB, lga.Handle, d.src.Handle)
+func (p *pool) Close() error {
+	p.log.Debug(lgm.CloseDB, lga.Handle, p.src.Handle)
 
-	return errz.Combine(d.impl.Close(), d.clnup.Run())
+	return errz.Combine(p.impl.Close(), p.clnup.Run())
 }

--- a/drivers/mysql/metadata.go
+++ b/drivers/mysql/metadata.go
@@ -165,7 +165,7 @@ func getNewRecordFunc(rowMeta record.Meta) driver.NewRecordFunc {
 }
 
 // getTableMetadata gets the metadata for a single table. It is the
-// implementation of driver.Database.TableMetadata.
+// implementation of driver.Pool.TableMetadata.
 func getTableMetadata(ctx context.Context, db sqlz.DB, tblName string) (*source.TableMetadata, error) {
 	query := `SELECT TABLE_SCHEMA, TABLE_NAME, TABLE_TYPE, TABLE_COMMENT, (DATA_LENGTH + INDEX_LENGTH) AS table_size,
 (SELECT COUNT(*) FROM ` + "`" + tblName + "`" + `) AS row_count
@@ -243,7 +243,7 @@ ORDER BY cols.ordinal_position ASC`
 	return cols, errw(rows.Err())
 }
 
-// getSourceMetadata is the implementation of driver.Database.SourceMetadata.
+// getSourceMetadata is the implementation of driver.Pool.SourceMetadata.
 //
 // Multiple queries are required to build the SourceMetadata, and this
 // impl makes use of errgroup to make concurrent queries. In the initial

--- a/drivers/mysql/metadata_test.go
+++ b/drivers/mysql/metadata_test.go
@@ -79,8 +79,8 @@ func TestDatabase_SourceMetadata_MySQL(t *testing.T) {
 		t.Run(handle, func(t *testing.T) {
 			t.Parallel()
 
-			th, _, _, dbase, _ := testh.NewWith(t, handle)
-			md, err := dbase.SourceMetadata(th.Context, false)
+			th, _, _, pool, _ := testh.NewWith(t, handle)
+			md, err := pool.SourceMetadata(th.Context, false)
 			require.NoError(t, err)
 			require.Equal(t, "sakila", md.Name)
 			require.Equal(t, handle, md.Handle)
@@ -102,8 +102,8 @@ func TestDatabase_TableMetadata(t *testing.T) {
 		t.Run(handle, func(t *testing.T) {
 			t.Parallel()
 
-			th, _, _, dbase, _ := testh.NewWith(t, handle)
-			md, err := dbase.TableMetadata(th.Context, sakila.TblActor)
+			th, _, _, pool, _ := testh.NewWith(t, handle)
+			md, err := pool.TableMetadata(th.Context, sakila.TblActor)
 			require.NoError(t, err)
 			require.Equal(t, sakila.TblActor, md.Name)
 		})

--- a/drivers/mysql/mysql.go
+++ b/drivers/mysql/mysql.go
@@ -423,7 +423,7 @@ func (d *driveri) Open(ctx context.Context, src *source.Source) (driver.Pool, er
 		return nil, err
 	}
 
-	return &database{log: d.log, db: db, src: src, drvr: d}, nil
+	return &pool{log: d.log, db: db, src: src, drvr: d}, nil
 }
 
 func (d *driveri) doOpen(ctx context.Context, src *source.Source) (*sql.DB, error) {
@@ -519,8 +519,8 @@ func (d *driveri) Truncate(ctx context.Context, src *source.Source, tbl string, 
 	return beforeCount, errw(tx.Commit())
 }
 
-// database implements driver.Pool.
-type database struct {
+// pool implements driver.Pool.
+type pool struct {
 	log  *slog.Logger
 	db   *sql.DB
 	src  *source.Source
@@ -528,34 +528,34 @@ type database struct {
 }
 
 // DB implements driver.Pool.
-func (d *database) DB(context.Context) (*sql.DB, error) {
-	return d.db, nil
+func (p *pool) DB(context.Context) (*sql.DB, error) {
+	return p.db, nil
 }
 
 // SQLDriver implements driver.Pool.
-func (d *database) SQLDriver() driver.SQLDriver {
-	return d.drvr
+func (p *pool) SQLDriver() driver.SQLDriver {
+	return p.drvr
 }
 
 // Source implements driver.Pool.
-func (d *database) Source() *source.Source {
-	return d.src
+func (p *pool) Source() *source.Source {
+	return p.src
 }
 
 // TableMetadata implements driver.Pool.
-func (d *database) TableMetadata(ctx context.Context, tblName string) (*source.TableMetadata, error) {
-	return getTableMetadata(ctx, d.db, tblName)
+func (p *pool) TableMetadata(ctx context.Context, tblName string) (*source.TableMetadata, error) {
+	return getTableMetadata(ctx, p.db, tblName)
 }
 
 // SourceMetadata implements driver.Pool.
-func (d *database) SourceMetadata(ctx context.Context, noSchema bool) (*source.Metadata, error) {
-	return getSourceMetadata(ctx, d.src, d.db, noSchema)
+func (p *pool) SourceMetadata(ctx context.Context, noSchema bool) (*source.Metadata, error) {
+	return getSourceMetadata(ctx, p.src, p.db, noSchema)
 }
 
 // Close implements driver.Pool.
-func (d *database) Close() error {
-	d.log.Debug(lgm.CloseDB, lga.Handle, d.src.Handle)
-	return errw(d.db.Close())
+func (p *pool) Close() error {
+	p.log.Debug(lgm.CloseDB, lga.Handle, p.src.Handle)
+	return errw(p.db.Close())
 }
 
 // dsnFromLocation builds the mysql driver DSN from src.Location.

--- a/drivers/mysql/mysql.go
+++ b/drivers/mysql/mysql.go
@@ -410,8 +410,8 @@ func (d *driveri) getTableRecordMeta(ctx context.Context, db sqlz.DB, tblName st
 	return destCols, nil
 }
 
-// Open implements driver.DatabaseOpener.
-func (d *driveri) Open(ctx context.Context, src *source.Source) (driver.Database, error) {
+// Open implements driver.PoolOpener.
+func (d *driveri) Open(ctx context.Context, src *source.Source) (driver.Pool, error) {
 	lg.FromContext(ctx).Debug(lgm.OpenSrc, lga.Src, src)
 
 	db, err := d.doOpen(ctx, src)
@@ -519,7 +519,7 @@ func (d *driveri) Truncate(ctx context.Context, src *source.Source, tbl string, 
 	return beforeCount, errw(tx.Commit())
 }
 
-// database implements driver.Database.
+// database implements driver.Pool.
 type database struct {
 	log  *slog.Logger
 	db   *sql.DB
@@ -527,32 +527,32 @@ type database struct {
 	drvr *driveri
 }
 
-// DB implements driver.Database.
+// DB implements driver.Pool.
 func (d *database) DB(context.Context) (*sql.DB, error) {
 	return d.db, nil
 }
 
-// SQLDriver implements driver.Database.
+// SQLDriver implements driver.Pool.
 func (d *database) SQLDriver() driver.SQLDriver {
 	return d.drvr
 }
 
-// Source implements driver.Database.
+// Source implements driver.Pool.
 func (d *database) Source() *source.Source {
 	return d.src
 }
 
-// TableMetadata implements driver.Database.
+// TableMetadata implements driver.Pool.
 func (d *database) TableMetadata(ctx context.Context, tblName string) (*source.TableMetadata, error) {
 	return getTableMetadata(ctx, d.db, tblName)
 }
 
-// SourceMetadata implements driver.Database.
+// SourceMetadata implements driver.Pool.
 func (d *database) SourceMetadata(ctx context.Context, noSchema bool) (*source.Metadata, error) {
 	return getSourceMetadata(ctx, d.src, d.db, noSchema)
 }
 
-// Close implements driver.Database.
+// Close implements driver.Pool.
 func (d *database) Close() error {
 	d.log.Debug(lgm.CloseDB, lga.Handle, d.src.Handle)
 	return errw(d.db.Close())

--- a/drivers/postgres/postgres.go
+++ b/drivers/postgres/postgres.go
@@ -144,8 +144,8 @@ func (d *driveri) Renderer() *render.Renderer {
 	return r
 }
 
-// Open implements driver.DatabaseOpener.
-func (d *driveri) Open(ctx context.Context, src *source.Source) (driver.Database, error) {
+// Open implements driver.PoolOpener.
+func (d *driveri) Open(ctx context.Context, src *source.Source) (driver.Pool, error) {
 	lg.FromContext(ctx).Debug(lgm.OpenSrc, lga.Src, src)
 
 	db, err := d.doOpen(ctx, src)
@@ -709,7 +709,7 @@ func (d *driveri) RecordMeta(ctx context.Context, colTypes []*sql.ColumnType) (
 	return recMeta, mungeFn, nil
 }
 
-// database is the postgres implementation of driver.Database.
+// database is the postgres implementation of driver.Pool.
 type database struct {
 	log  *slog.Logger
 	drvr *driveri
@@ -717,22 +717,22 @@ type database struct {
 	src  *source.Source
 }
 
-// DB implements driver.Database.
+// DB implements driver.Pool.
 func (d *database) DB(context.Context) (*sql.DB, error) {
 	return d.db, nil
 }
 
-// SQLDriver implements driver.Database.
+// SQLDriver implements driver.Pool.
 func (d *database) SQLDriver() driver.SQLDriver {
 	return d.drvr
 }
 
-// Source implements driver.Database.
+// Source implements driver.Pool.
 func (d *database) Source() *source.Source {
 	return d.src
 }
 
-// TableMetadata implements driver.Database.
+// TableMetadata implements driver.Pool.
 func (d *database) TableMetadata(ctx context.Context, tblName string) (*source.TableMetadata, error) {
 	db, err := d.DB(ctx)
 	if err != nil {
@@ -742,7 +742,7 @@ func (d *database) TableMetadata(ctx context.Context, tblName string) (*source.T
 	return getTableMetadata(ctx, db, tblName)
 }
 
-// SourceMetadata implements driver.Database.
+// SourceMetadata implements driver.Pool.
 func (d *database) SourceMetadata(ctx context.Context, noSchema bool) (*source.Metadata, error) {
 	db, err := d.DB(ctx)
 	if err != nil {
@@ -751,7 +751,7 @@ func (d *database) SourceMetadata(ctx context.Context, noSchema bool) (*source.M
 	return getSourceMetadata(ctx, d.src, db, noSchema)
 }
 
-// Close implements driver.Database.
+// Close implements driver.Pool.
 func (d *database) Close() error {
 	d.log.Debug(lgm.CloseDB, lga.Handle, d.src.Handle)
 

--- a/drivers/postgres/postgres.go
+++ b/drivers/postgres/postgres.go
@@ -169,10 +169,10 @@ func (d *driveri) doOpen(ctx context.Context, src *source.Source) (*sql.DB, erro
 	}
 
 	if src.Catalog != "" && src.Catalog != dbCfg.ConnConfig.Database {
-		// The catalog differs from the pool in the connection string.
-		// OOTB, Postgres doesn't support cross-pool references. So,
+		// The catalog differs from the database in the connection string.
+		// OOTB, Postgres doesn't support cross-database references. So,
 		// we'll need to change the connection string to use the catalog
-		// as the pool. Note that we don't modify src.Location, but it's
+		// as the database. Note that we don't modify src.Location, but it's
 		// not entirely clear if that's the correct approach. Are there any
 		// downsides to modifying it (as long as the modified Location is not
 		// persisted back to config)?
@@ -187,7 +187,7 @@ func (d *driveri) doOpen(ctx context.Context, src *source.Source) (*sql.DB, erro
 		if err != nil {
 			return nil, errw(err)
 		}
-		log.Debug("Using catalog as pool in connection string",
+		log.Debug("Using catalog as database in connection string",
 			lga.Src, src,
 			lga.Catalog, src.Catalog,
 			lga.Conn, source.RedactLocation(connStr),

--- a/drivers/postgres/postgres_test.go
+++ b/drivers/postgres/postgres_test.go
@@ -222,12 +222,12 @@ func TestAlternateSchema(t *testing.T) {
 	src2 := src.Clone()
 	src2.Handle += "2"
 	src2.Location += "?search_path=" + schemaName
-	dbase2 := th.Open(src2)
-	md2, err := dbase2.SourceMetadata(ctx, false)
+	pool2 := th.Open(src2)
+	md2, err := pool2.SourceMetadata(ctx, false)
 	require.NoError(t, err)
 	require.Equal(t, schemaName, md2.Schema)
 
-	tblMeta2, err := dbase2.TableMetadata(ctx, tblName)
+	tblMeta2, err := pool2.TableMetadata(ctx, tblName)
 	require.NoError(t, err)
 	require.Equal(t, int64(wantRowCount), tblMeta2.RowCount)
 }
@@ -279,10 +279,10 @@ func BenchmarkDatabase_SourceMetadata(b *testing.B) {
 		b.Run(handle, func(b *testing.B) {
 			th := testh.New(b)
 			th.Log = lg.Discard()
-			dbase := th.Open(th.Source(handle))
+			pool := th.Open(th.Source(handle))
 			b.ResetTimer()
 
-			md, err := dbase.SourceMetadata(th.Context, false)
+			md, err := pool.SourceMetadata(th.Context, false)
 			require.NoError(b, err)
 			require.Equal(b, "sakila", md.Name)
 		})

--- a/drivers/sqlite3/metadata_test.go
+++ b/drivers/sqlite3/metadata_test.go
@@ -204,7 +204,7 @@ func TestRecordMetadata(t *testing.T) {
 		t.Run(tc.tbl, func(t *testing.T) {
 			t.Parallel()
 
-			th, _, drvr, dbase, db := testh.NewWith(t, sakila.SL3)
+			th, _, drvr, pool, db := testh.NewWith(t, sakila.SL3)
 
 			query := fmt.Sprintf("SELECT %s FROM %s", strings.Join(tc.colNames, ", "), tc.tbl)
 			rows, err := db.QueryContext(th.Context, query) //nolint:rowserrcheck
@@ -235,7 +235,7 @@ func TestRecordMetadata(t *testing.T) {
 			}
 
 			// Now check our table metadata
-			gotTblMeta, err := dbase.TableMetadata(th.Context, tc.tbl)
+			gotTblMeta, err := pool.TableMetadata(th.Context, tc.tbl)
 			require.NoError(t, err)
 			require.Equal(t, tc.tbl, gotTblMeta.Name)
 			require.Equal(t, tc.rowCount, gotTblMeta.RowCount)
@@ -285,12 +285,12 @@ func TestAggregateFuncsQuery(t *testing.T) {
 func BenchmarkDatabase_SourceMetadata(b *testing.B) {
 	const numTables = 1000
 
-	th, src, drvr, dbase, db := testh.NewWith(b, testsrc.MiscDB)
+	th, src, drvr, pool, db := testh.NewWith(b, testsrc.MiscDB)
 	tblNames := createTypeTestTbls(th, src, numTables, true)
 
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
-		srcMeta, err := dbase.SourceMetadata(th.Context, false)
+		srcMeta, err := pool.SourceMetadata(th.Context, false)
 		require.NoError(b, err)
 		require.True(b, len(srcMeta.Tables) > len(tblNames))
 	}

--- a/drivers/sqlite3/sqlite3.go
+++ b/drivers/sqlite3/sqlite3.go
@@ -130,8 +130,8 @@ func (d *driveri) DriverMetadata() driver.Metadata {
 	}
 }
 
-// Open implements driver.DatabaseOpener.
-func (d *driveri) Open(ctx context.Context, src *source.Source) (driver.Database, error) {
+// Open implements driver.PoolOpener.
+func (d *driveri) Open(ctx context.Context, src *source.Source) (driver.Pool, error) {
 	lg.FromContext(ctx).Debug(lgm.OpenSrc, lga.Src, src)
 
 	db, err := d.doOpen(ctx, src)
@@ -896,7 +896,7 @@ func (d *driveri) getTableRecordMeta(ctx context.Context, db sqlz.DB, tblName st
 	return destCols, nil
 }
 
-// database implements driver.Database.
+// database implements driver.Pool.
 type database struct {
 	log  *slog.Logger
 	db   *sql.DB
@@ -908,22 +908,22 @@ type database struct {
 	closed  bool
 }
 
-// DB implements driver.Database.
+// DB implements driver.Pool.
 func (d *database) DB(context.Context) (*sql.DB, error) {
 	return d.db, nil
 }
 
-// SQLDriver implements driver.Database.
+// SQLDriver implements driver.Pool.
 func (d *database) SQLDriver() driver.SQLDriver {
 	return d.drvr
 }
 
-// Source implements driver.Database.
+// Source implements driver.Pool.
 func (d *database) Source() *source.Source {
 	return d.src
 }
 
-// TableMetadata implements driver.Database.
+// TableMetadata implements driver.Pool.
 func (d *database) TableMetadata(ctx context.Context, tblName string) (*source.TableMetadata, error) {
 	db, err := d.DB(ctx)
 	if err != nil {
@@ -933,7 +933,7 @@ func (d *database) TableMetadata(ctx context.Context, tblName string) (*source.T
 	return getTableMetadata(ctx, db, tblName)
 }
 
-// SourceMetadata implements driver.Database.
+// SourceMetadata implements driver.Pool.
 func (d *database) SourceMetadata(ctx context.Context, noSchema bool) (*source.Metadata, error) {
 	// https://stackoverflow.com/questions/9646353/how-to-find-sqlite-database-file-version
 
@@ -988,7 +988,7 @@ func (d *database) SourceMetadata(ctx context.Context, noSchema bool) (*source.M
 	return md, nil
 }
 
-// Close implements driver.Database.
+// Close implements driver.Pool.
 func (d *database) Close() error {
 	d.closeMu.Lock()
 	defer d.closeMu.Unlock()

--- a/drivers/sqlite3/sqlite3.go
+++ b/drivers/sqlite3/sqlite3.go
@@ -143,7 +143,7 @@ func (d *driveri) Open(ctx context.Context, src *source.Source) (driver.Pool, er
 		return nil, err
 	}
 
-	return &database{log: d.log, db: db, src: src, drvr: d}, nil
+	return &pool{log: d.log, db: db, src: src, drvr: d}, nil
 }
 
 func (d *driveri) doOpen(ctx context.Context, src *source.Source) (*sql.DB, error) {
@@ -896,8 +896,8 @@ func (d *driveri) getTableRecordMeta(ctx context.Context, db sqlz.DB, tblName st
 	return destCols, nil
 }
 
-// database implements driver.Pool.
-type database struct {
+// pool implements driver.Pool.
+type pool struct {
 	log  *slog.Logger
 	db   *sql.DB
 	src  *source.Source
@@ -909,23 +909,23 @@ type database struct {
 }
 
 // DB implements driver.Pool.
-func (d *database) DB(context.Context) (*sql.DB, error) {
-	return d.db, nil
+func (p *pool) DB(context.Context) (*sql.DB, error) {
+	return p.db, nil
 }
 
 // SQLDriver implements driver.Pool.
-func (d *database) SQLDriver() driver.SQLDriver {
-	return d.drvr
+func (p *pool) SQLDriver() driver.SQLDriver {
+	return p.drvr
 }
 
 // Source implements driver.Pool.
-func (d *database) Source() *source.Source {
-	return d.src
+func (p *pool) Source() *source.Source {
+	return p.src
 }
 
 // TableMetadata implements driver.Pool.
-func (d *database) TableMetadata(ctx context.Context, tblName string) (*source.TableMetadata, error) {
-	db, err := d.DB(ctx)
+func (p *pool) TableMetadata(ctx context.Context, tblName string) (*source.TableMetadata, error) {
+	db, err := p.DB(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -934,19 +934,19 @@ func (d *database) TableMetadata(ctx context.Context, tblName string) (*source.T
 }
 
 // SourceMetadata implements driver.Pool.
-func (d *database) SourceMetadata(ctx context.Context, noSchema bool) (*source.Metadata, error) {
+func (p *pool) SourceMetadata(ctx context.Context, noSchema bool) (*source.Metadata, error) {
 	// https://stackoverflow.com/questions/9646353/how-to-find-sqlite-database-file-version
 
-	md := &source.Metadata{Handle: d.src.Handle, Driver: Type, DBDriver: dbDrvr}
+	md := &source.Metadata{Handle: p.src.Handle, Driver: Type, DBDriver: dbDrvr}
 
-	dsn, err := PathFromLocation(d.src)
+	dsn, err := PathFromLocation(p.src)
 	if err != nil {
 		return nil, err
 	}
 
 	const q = "SELECT sqlite_version(), (SELECT name FROM pragma_database_list ORDER BY seq limit 1);"
 
-	err = d.db.QueryRowContext(ctx, q).Scan(&md.DBVersion, &md.Schema)
+	err = p.db.QueryRowContext(ctx, q).Scan(&md.DBVersion, &md.Schema)
 	if err != nil {
 		return nil, errw(err)
 	}
@@ -961,9 +961,9 @@ func (d *database) SourceMetadata(ctx context.Context, noSchema bool) (*source.M
 	md.Size = fi.Size()
 	md.Name = fi.Name()
 	md.FQName = fi.Name() + "/" + md.Schema
-	md.Location = d.src.Location
+	md.Location = p.src.Location
 
-	md.DBProperties, err = getDBProperties(ctx, d.db)
+	md.DBProperties, err = getDBProperties(ctx, p.db)
 	if err != nil {
 		return nil, err
 	}
@@ -972,7 +972,7 @@ func (d *database) SourceMetadata(ctx context.Context, noSchema bool) (*source.M
 		return md, nil
 	}
 
-	md.Tables, err = getAllTableMetadata(ctx, d.db, md.Schema)
+	md.Tables, err = getAllTableMetadata(ctx, p.db, md.Schema)
 	if err != nil {
 		return nil, err
 	}
@@ -989,18 +989,18 @@ func (d *database) SourceMetadata(ctx context.Context, noSchema bool) (*source.M
 }
 
 // Close implements driver.Pool.
-func (d *database) Close() error {
-	d.closeMu.Lock()
-	defer d.closeMu.Unlock()
+func (p *pool) Close() error {
+	p.closeMu.Lock()
+	defer p.closeMu.Unlock()
 
-	if d.closed {
-		d.log.Warn("SQLite DB already closed", lga.Src, d.src)
+	if p.closed {
+		p.log.Warn("SQLite DB already closed", lga.Src, p.src)
 		return nil
 	}
 
-	d.log.Debug(lgm.CloseDB, lga.Handle, d.src.Handle)
-	err := errw(d.db.Close())
-	d.closed = true
+	p.log.Debug(lgm.CloseDB, lga.Handle, p.src.Handle)
+	err := errw(p.db.Close())
+	p.closed = true
 	return err
 }
 

--- a/drivers/sqlserver/sqlserver.go
+++ b/drivers/sqlserver/sqlserver.go
@@ -162,8 +162,8 @@ func (d *driveri) Renderer() *render.Renderer {
 	return r
 }
 
-// Open implements driver.DatabaseOpener.
-func (d *driveri) Open(ctx context.Context, src *source.Source) (driver.Database, error) {
+// Open implements driver.PoolOpener.
+func (d *driveri) Open(ctx context.Context, src *source.Source) (driver.Pool, error) {
 	lg.FromContext(ctx).Debug(lgm.OpenSrc, lga.Src, src)
 
 	db, err := d.doOpen(ctx, src)
@@ -638,7 +638,7 @@ func (d *driveri) getTableColsMeta(ctx context.Context, db sqlz.DB, tblName stri
 	return destCols, nil
 }
 
-// database implements driver.Database.
+// database implements driver.Pool.
 type database struct {
 	log  *slog.Logger
 	drvr *driveri
@@ -646,24 +646,24 @@ type database struct {
 	src  *source.Source
 }
 
-var _ driver.Database = (*database)(nil)
+var _ driver.Pool = (*database)(nil)
 
-// DB implements driver.Database.
+// DB implements driver.Pool.
 func (d *database) DB(context.Context) (*sql.DB, error) {
 	return d.db, nil
 }
 
-// SQLDriver implements driver.Database.
+// SQLDriver implements driver.Pool.
 func (d *database) SQLDriver() driver.SQLDriver {
 	return d.drvr
 }
 
-// Source implements driver.Database.
+// Source implements driver.Pool.
 func (d *database) Source() *source.Source {
 	return d.src
 }
 
-// TableMetadata implements driver.Database.
+// TableMetadata implements driver.Pool.
 func (d *database) TableMetadata(ctx context.Context, tblName string) (*source.TableMetadata, error) {
 	const query = `SELECT TABLE_CATALOG, TABLE_SCHEMA, TABLE_TYPE
 FROM INFORMATION_SCHEMA.TABLES
@@ -680,12 +680,12 @@ WHERE TABLE_NAME = @p1`
 	return getTableMetadata(ctx, d.db, catalog, schema, tblName, tblType)
 }
 
-// SourceMetadata implements driver.Database.
+// SourceMetadata implements driver.Pool.
 func (d *database) SourceMetadata(ctx context.Context, noSchema bool) (*source.Metadata, error) {
 	return getSourceMetadata(ctx, d.src, d.db, noSchema)
 }
 
-// Close implements driver.Database.
+// Close implements driver.Pool.
 func (d *database) Close() error {
 	d.log.Debug(lgm.CloseDB, lga.Handle, d.src.Handle)
 

--- a/drivers/sqlserver/sqlserver.go
+++ b/drivers/sqlserver/sqlserver.go
@@ -175,7 +175,7 @@ func (d *driveri) Open(ctx context.Context, src *source.Source) (driver.Pool, er
 		return nil, err
 	}
 
-	return &database{log: d.log, db: db, src: src, drvr: d}, nil
+	return &pool{log: d.log, db: db, src: src, drvr: d}, nil
 }
 
 func (d *driveri) doOpen(ctx context.Context, src *source.Source) (*sql.DB, error) {
@@ -638,33 +638,33 @@ func (d *driveri) getTableColsMeta(ctx context.Context, db sqlz.DB, tblName stri
 	return destCols, nil
 }
 
-// database implements driver.Pool.
-type database struct {
+// pool implements driver.Pool.
+type pool struct {
 	log  *slog.Logger
 	drvr *driveri
 	db   *sql.DB
 	src  *source.Source
 }
 
-var _ driver.Pool = (*database)(nil)
+var _ driver.Pool = (*pool)(nil)
 
 // DB implements driver.Pool.
-func (d *database) DB(context.Context) (*sql.DB, error) {
+func (d *pool) DB(context.Context) (*sql.DB, error) {
 	return d.db, nil
 }
 
 // SQLDriver implements driver.Pool.
-func (d *database) SQLDriver() driver.SQLDriver {
+func (d *pool) SQLDriver() driver.SQLDriver {
 	return d.drvr
 }
 
 // Source implements driver.Pool.
-func (d *database) Source() *source.Source {
+func (d *pool) Source() *source.Source {
 	return d.src
 }
 
 // TableMetadata implements driver.Pool.
-func (d *database) TableMetadata(ctx context.Context, tblName string) (*source.TableMetadata, error) {
+func (d *pool) TableMetadata(ctx context.Context, tblName string) (*source.TableMetadata, error) {
 	const query = `SELECT TABLE_CATALOG, TABLE_SCHEMA, TABLE_TYPE
 FROM INFORMATION_SCHEMA.TABLES
 WHERE TABLE_NAME = @p1`
@@ -681,12 +681,12 @@ WHERE TABLE_NAME = @p1`
 }
 
 // SourceMetadata implements driver.Pool.
-func (d *database) SourceMetadata(ctx context.Context, noSchema bool) (*source.Metadata, error) {
+func (d *pool) SourceMetadata(ctx context.Context, noSchema bool) (*source.Metadata, error) {
 	return getSourceMetadata(ctx, d.src, d.db, noSchema)
 }
 
 // Close implements driver.Pool.
-func (d *database) Close() error {
+func (d *pool) Close() error {
 	d.log.Debug(lgm.CloseDB, lga.Handle, d.src.Handle)
 
 	return errw(d.db.Close())

--- a/drivers/userdriver/userdriver_test.go
+++ b/drivers/userdriver/userdriver_test.go
@@ -40,15 +40,15 @@ func TestDriver(t *testing.T) {
 			err := drvr.Ping(th.Context, src)
 			require.NoError(t, err)
 
-			dbase, err := drvr.Open(th.Context, src)
+			pool, err := drvr.Open(th.Context, src)
 			require.NoError(t, err)
-			t.Cleanup(func() { assert.NoError(t, dbase.Close()) })
+			t.Cleanup(func() { assert.NoError(t, pool.Close()) })
 
-			srcMeta, err := dbase.SourceMetadata(th.Context, false)
+			srcMeta, err := pool.SourceMetadata(th.Context, false)
 			require.NoError(t, err)
 			require.True(t, stringz.InSlice(srcMeta.TableNames(), tc.tbl))
 
-			tblMeta, err := dbase.TableMetadata(th.Context, tc.tbl)
+			tblMeta, err := pool.TableMetadata(th.Context, tc.tbl)
 			require.NoError(t, err)
 			require.Equal(t, tc.tbl, tblMeta.Name)
 

--- a/drivers/userdriver/xmlud/xmlimport_test.go
+++ b/drivers/userdriver/xmlud/xmlimport_test.go
@@ -33,7 +33,7 @@ func TestImport_Ppl(t *testing.T) {
 	require.Equal(t, driverPpl, udDef.Name)
 	require.Equal(t, xmlud.Genre, udDef.Genre)
 
-	scratchDB, err := th.Databases().OpenScratch(th.Context, "ppl")
+	scratchDB, err := th.Pools().OpenScratch(th.Context, "ppl")
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		assert.NoError(t, scratchDB.Close())
@@ -78,7 +78,7 @@ func TestImport_RSS(t *testing.T) {
 	require.Equal(t, driverRSS, udDef.Name)
 	require.Equal(t, xmlud.Genre, udDef.Genre)
 
-	scratchDB, err := th.Databases().OpenScratch(th.Context, "rss")
+	scratchDB, err := th.Pools().OpenScratch(th.Context, "rss")
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		assert.NoError(t, scratchDB.Close())

--- a/drivers/xlsx/database.go
+++ b/drivers/xlsx/database.go
@@ -146,7 +146,7 @@ func (p *pool) TableMetadata(ctx context.Context, tblName string) (*source.Table
 func (p *pool) Close() error {
 	p.log.Debug(lgm.CloseDB, lga.Handle, p.src.Handle)
 
-	// No need to explicitly invoke c.scratchDB.Close because
+	// No need to explicitly invoke c.scratchPool.Close because
 	// that's already added to c.clnup
 	return p.clnup.Run()
 }

--- a/drivers/xlsx/ingest.go
+++ b/drivers/xlsx/ingest.go
@@ -39,7 +39,7 @@ func hasSheet(xfile *excelize.File, sheetName string) bool {
 	return slices.Contains(xfile.GetSheetList(), sheetName)
 }
 
-// sheetTable maps a sheet to a pool table.
+// sheetTable maps a sheet to a database table.
 type sheetTable struct {
 	sheet             *xSheet
 	def               *sqlmodel.TableDef

--- a/drivers/xlsx/ingest.go
+++ b/drivers/xlsx/ingest.go
@@ -39,7 +39,7 @@ func hasSheet(xfile *excelize.File, sheetName string) bool {
 	return slices.Contains(xfile.GetSheetList(), sheetName)
 }
 
-// sheetTable maps a sheet to a database table.
+// sheetTable maps a sheet to a pool table.
 type sheetTable struct {
 	sheet             *xSheet
 	def               *sqlmodel.TableDef
@@ -94,7 +94,7 @@ func (xs *xSheet) loadSampleRows(ctx context.Context, sampleSize int) error {
 
 // ingestXLSX loads the data in xfile into scratchDB.
 // If includeSheetNames is non-empty, only the named sheets are ingested.
-func ingestXLSX(ctx context.Context, src *source.Source, scratchDB driver.Database,
+func ingestXLSX(ctx context.Context, src *source.Source, scratchDB driver.Pool,
 	xfile *excelize.File, includeSheetNames []string,
 ) error {
 	log := lg.FromContext(ctx)
@@ -173,7 +173,7 @@ func ingestXLSX(ctx context.Context, src *source.Source, scratchDB driver.Databa
 
 // ingestSheetToTable imports the sheet data into the appropriate table
 // in scratchDB. The scratch table must already exist.
-func ingestSheetToTable(ctx context.Context, scratchDB driver.Database, sheetTbl *sheetTable) error {
+func ingestSheetToTable(ctx context.Context, scratchDB driver.Pool, sheetTbl *sheetTable) error {
 	var (
 		log          = lg.FromContext(ctx)
 		startTime    = time.Now()

--- a/drivers/xlsx/xlsx.go
+++ b/drivers/xlsx/xlsx.go
@@ -71,7 +71,7 @@ func (d *Driver) Open(ctx context.Context, src *source.Source) (driver.Pool, err
 	clnup := cleanup.New()
 	clnup.AddE(scratchDB.Close)
 
-	dbase := &pool{
+	pool := &pool{
 		log:         d.log,
 		src:         src,
 		scratchPool: scratchDB,
@@ -79,7 +79,7 @@ func (d *Driver) Open(ctx context.Context, src *source.Source) (driver.Pool, err
 		clnup:       clnup,
 	}
 
-	return dbase, nil
+	return pool, nil
 }
 
 // Truncate implements driver.Driver.

--- a/drivers/xlsx/xlsx.go
+++ b/drivers/xlsx/xlsx.go
@@ -63,18 +63,18 @@ func (d *Driver) DriverMetadata() driver.Metadata {
 func (d *Driver) Open(ctx context.Context, src *source.Source) (driver.Pool, error) {
 	lg.FromContext(ctx).Debug(lgm.OpenSrc, lga.Src, src)
 
-	scratchDB, err := d.scratcher.OpenScratch(ctx, src.Handle)
+	scratchPool, err := d.scratcher.OpenScratch(ctx, src.Handle)
 	if err != nil {
 		return nil, err
 	}
 
 	clnup := cleanup.New()
-	clnup.AddE(scratchDB.Close)
+	clnup.AddE(scratchPool.Close)
 
 	p := &pool{
 		log:         d.log,
 		src:         src,
-		scratchPool: scratchDB,
+		scratchPool: scratchPool,
 		files:       d.files,
 		clnup:       clnup,
 	}

--- a/drivers/xlsx/xlsx.go
+++ b/drivers/xlsx/xlsx.go
@@ -71,7 +71,7 @@ func (d *Driver) Open(ctx context.Context, src *source.Source) (driver.Pool, err
 	clnup := cleanup.New()
 	clnup.AddE(scratchDB.Close)
 
-	pool := &pool{
+	p := &pool{
 		log:         d.log,
 		src:         src,
 		scratchPool: scratchDB,
@@ -79,7 +79,7 @@ func (d *Driver) Open(ctx context.Context, src *source.Source) (driver.Pool, err
 		clnup:       clnup,
 	}
 
-	return pool, nil
+	return p, nil
 }
 
 // Truncate implements driver.Driver.

--- a/drivers/xlsx/xlsx_test.go
+++ b/drivers/xlsx/xlsx_test.go
@@ -161,7 +161,7 @@ func TestOpenFileFormats(t *testing.T) {
 				Location: filepath.Join("testdata", "file_formats", tc.filename),
 			})
 
-			dbase, err := th.Databases().Open(th.Context, src)
+			dbase, err := th.Pools().Open(th.Context, src)
 			require.NoError(t, err)
 			db, err := dbase.DB(th.Context)
 			if tc.wantErr {

--- a/drivers/xlsx/xlsx_test.go
+++ b/drivers/xlsx/xlsx_test.go
@@ -161,9 +161,9 @@ func TestOpenFileFormats(t *testing.T) {
 				Location: filepath.Join("testdata", "file_formats", tc.filename),
 			})
 
-			dbase, err := th.Pools().Open(th.Context, src)
+			pool, err := th.Pools().Open(th.Context, src)
 			require.NoError(t, err)
-			db, err := dbase.DB(th.Context)
+			db, err := pool.DB(th.Context)
 			if tc.wantErr {
 				require.Error(t, err)
 				return

--- a/libsq/driver/driver.go
+++ b/libsq/driver/driver.go
@@ -456,9 +456,9 @@ func (d *Pools) Open(ctx context.Context, src *source.Source) (Pool, error) {
 
 	key := src.Handle + "_" + hashSource(src)
 
-	dbase, ok := d.pools[key]
+	pool, ok := d.pools[key]
 	if ok {
-		return dbase, nil
+		return pool, nil
 	}
 
 	drvr, err := d.drvrs.DriverFor(src.Type)
@@ -470,15 +470,15 @@ func (d *Pools) Open(ctx context.Context, src *source.Source) (Pool, error) {
 	o := options.Merge(baseOptions, src.Options)
 
 	ctx = options.NewContext(ctx, o)
-	dbase, err = drvr.Open(ctx, src)
+	pool, err = drvr.Open(ctx, src)
 	if err != nil {
 		return nil, err
 	}
 
-	d.clnup.AddC(dbase)
+	d.clnup.AddC(pool)
 
-	d.pools[key] = dbase
-	return dbase, nil
+	d.pools[key] = pool
+	return pool, nil
 }
 
 // OpenScratch returns a scratch database instance. It is not

--- a/libsq/driver/driver.go
+++ b/libsq/driver/driver.go
@@ -166,31 +166,31 @@ type Provider interface {
 	DriverFor(typ source.DriverType) (Driver, error)
 }
 
-// DatabaseOpener opens a Database.
-type DatabaseOpener interface {
-	// Open returns a Database instance for src.
-	Open(ctx context.Context, src *source.Source) (Database, error)
+// PoolOpener opens a Pool.
+type PoolOpener interface {
+	// Open returns a Pool instance for src.
+	Open(ctx context.Context, src *source.Source) (Pool, error)
 }
 
-// JoinDatabaseOpener can open a join database.
-type JoinDatabaseOpener interface {
-	// OpenJoin opens an appropriate Database for use as
+// JoinPoolOpener can open a join database.
+type JoinPoolOpener interface {
+	// OpenJoin opens an appropriate Pool for use as
 	// a work DB for joining across sources.
-	OpenJoin(ctx context.Context, srcs ...*source.Source) (Database, error)
+	OpenJoin(ctx context.Context, srcs ...*source.Source) (Pool, error)
 }
 
-// ScratchDatabaseOpener opens a scratch database. A scratch database is
+// ScratchPoolOpener opens a scratch database pool. A scratch database is
 // typically a short-lived database used as a target for loading
 // non-SQL data (such as CSV).
-type ScratchDatabaseOpener interface {
-	// OpenScratch returns a database for scratch use.
-	OpenScratch(ctx context.Context, name string) (Database, error)
+type ScratchPoolOpener interface {
+	// OpenScratch returns a pool for scratch use.
+	OpenScratch(ctx context.Context, name string) (Pool, error)
 }
 
 // Driver is the core interface that must be implemented for each type
 // of data source.
 type Driver interface {
-	DatabaseOpener
+	PoolOpener
 
 	// DriverMetadata returns driver metadata.
 	DriverMetadata() Metadata
@@ -341,13 +341,12 @@ type SQLDriver interface {
 	DBProperties(ctx context.Context, db sqlz.DB) (map[string]any, error)
 }
 
-// Database models a database handle. It is conceptually equivalent to
+// Pool models a database handle representing a pool of underlying
+// connections. It is conceptually equivalent to
 // stdlib sql.DB, and in fact encapsulates a sql.DB instance. The
 // realized sql.DB instance can be accessed via the DB method.
-//
-// REVISIT: maybe rename driver.Database to driver.Pool or such?
-type Database interface {
-	// DB returns the sql.DB object for this Database.
+type Pool interface {
+	// DB returns the sql.DB object for this Pool.
 	// This operation can take a long time if opening the DB requires
 	// an ingest of data.
 	// For example, with file-based sources such as XLSX, invoking Open
@@ -366,13 +365,13 @@ type Database interface {
 	// If noSchema is true, schema details are not populated
 	// on the returned source.Metadata.
 	//
-	// TODO: SourceMetadata doesn't really belong on driver.Database? It
+	// TODO: SourceMetadata doesn't really belong on driver.Pool? It
 	// should be moved to driver.Driver?
 	SourceMetadata(ctx context.Context, noSchema bool) (*source.Metadata, error)
 
 	// TableMetadata returns metadata for the specified table in the data source.
 	//
-	// TODO: TableMetadata doesn't really belong on driver.Database? It
+	// TODO: TableMetadata doesn't really belong on driver.Pool? It
 	// should be moved to driver.Driver?
 	TableMetadata(ctx context.Context, tblName string) (*source.TableMetadata, error)
 
@@ -411,45 +410,45 @@ type Metadata struct {
 }
 
 var (
-	_ DatabaseOpener     = (*Databases)(nil)
-	_ JoinDatabaseOpener = (*Databases)(nil)
+	_ PoolOpener     = (*Pools)(nil)
+	_ JoinPoolOpener = (*Pools)(nil)
 )
 
-// Databases provides a mechanism for getting Database instances.
+// Pools provides a mechanism for getting Pool instances.
 // Note that at this time instances returned by Open are cached
 // and then closed by Close. This may be a bad approach.
-type Databases struct {
+type Pools struct {
 	log          *slog.Logger
 	drvrs        Provider
 	mu           sync.Mutex
 	scratchSrcFn ScratchSrcFunc
-	dbases       map[string]Database
+	pools        map[string]Pool
 	clnup        *cleanup.Cleanup
 }
 
-// NewDatabases returns a Databases instances.
-func NewDatabases(log *slog.Logger, drvrs Provider, scratchSrcFn ScratchSrcFunc) *Databases {
-	return &Databases{
+// NewPools returns a Pools instances.
+func NewPools(log *slog.Logger, drvrs Provider, scratchSrcFn ScratchSrcFunc) *Pools {
+	return &Pools{
 		log:          log,
 		drvrs:        drvrs,
 		mu:           sync.Mutex{},
 		scratchSrcFn: scratchSrcFn,
-		dbases:       map[string]Database{},
+		pools:        map[string]Pool{},
 		clnup:        cleanup.New(),
 	}
 }
 
-// Open returns an opened Database for src. The returned Database
+// Open returns an opened Pool for src. The returned Pool
 // may be cached and returned on future invocations for the
 // same source (where each source fields is identical).
 // Thus, the caller should typically not close
-// the Database: it will be closed via d.Close.
+// the Pool: it will be closed via d.Close.
 //
 // NOTE: This entire logic re caching/not-closing is a bit sketchy,
 // and needs to be revisited.
 //
-// Open implements DatabaseOpener.
-func (d *Databases) Open(ctx context.Context, src *source.Source) (Database, error) {
+// Open implements PoolOpener.
+func (d *Pools) Open(ctx context.Context, src *source.Source) (Pool, error) {
 	lg.FromContext(ctx).Debug(lgm.OpenSrc, lga.Src, src)
 
 	d.mu.Lock()
@@ -457,7 +456,7 @@ func (d *Databases) Open(ctx context.Context, src *source.Source) (Database, err
 
 	key := src.Handle + "_" + hashSource(src)
 
-	dbase, ok := d.dbases[key]
+	dbase, ok := d.pools[key]
 	if ok {
 		return dbase, nil
 	}
@@ -478,16 +477,16 @@ func (d *Databases) Open(ctx context.Context, src *source.Source) (Database, err
 
 	d.clnup.AddC(dbase)
 
-	d.dbases[key] = dbase
+	d.pools[key] = dbase
 	return dbase, nil
 }
 
 // OpenScratch returns a scratch database instance. It is not
-// necessary for the caller to close the returned Database as
+// necessary for the caller to close the returned Pool as
 // its Close method will be invoked by d.Close.
 //
-// OpenScratch implements ScratchDatabaseOpener.
-func (d *Databases) OpenScratch(ctx context.Context, name string) (Database, error) {
+// OpenScratch implements ScratchPoolOpener.
+func (d *Pools) OpenScratch(ctx context.Context, name string) (Pool, error) {
 	const msgCloseScratch = "close scratch db"
 
 	scratchSrc, cleanFn, err := d.scratchSrcFn(ctx, name)
@@ -509,7 +508,7 @@ func (d *Databases) OpenScratch(ctx context.Context, name string) (Database, err
 		return nil, errz.Errorf("driver for scratch source %s is not a SQLDriver but is %T", scratchSrc.Handle, drvr)
 	}
 
-	var backingDB Database
+	var backingDB Pool
 	backingDB, err = sqlDrvr.Open(ctx, scratchSrc)
 	if err != nil {
 		lg.WarnIfFuncError(d.log, msgCloseScratch, cleanFn)
@@ -530,8 +529,8 @@ func (d *Databases) OpenScratch(ctx context.Context, name string) (Database, err
 // the join etc.). Currently the implementation simply delegates
 // to OpenScratch.
 //
-// OpenJoin implements JoinDatabaseOpener.
-func (d *Databases) OpenJoin(ctx context.Context, srcs ...*source.Source) (Database, error) {
+// OpenJoin implements JoinPoolOpener.
+func (d *Pools) OpenJoin(ctx context.Context, srcs ...*source.Source) (Pool, error) {
 	var names []string
 	for _, src := range srcs {
 		names = append(names, src.Handle[1:])
@@ -542,7 +541,7 @@ func (d *Databases) OpenJoin(ctx context.Context, srcs ...*source.Source) (Datab
 }
 
 // Close closes d, invoking Close on any instances opened via d.Open.
-func (d *Databases) Close() error {
+func (d *Pools) Close() error {
 	d.log.Debug("Closing databases(s)...", lga.Count, d.clnup.Len())
 	return d.clnup.Run()
 }

--- a/libsq/driver/driver.go
+++ b/libsq/driver/driver.go
@@ -508,15 +508,15 @@ func (d *Pools) OpenScratch(ctx context.Context, name string) (Pool, error) {
 		return nil, errz.Errorf("driver for scratch source %s is not a SQLDriver but is %T", scratchSrc.Handle, drvr)
 	}
 
-	var backingDB Pool
-	backingDB, err = sqlDrvr.Open(ctx, scratchSrc)
+	var backingPool Pool
+	backingPool, err = sqlDrvr.Open(ctx, scratchSrc)
 	if err != nil {
 		lg.WarnIfFuncError(d.log, msgCloseScratch, cleanFn)
 		return nil, err
 	}
 
 	d.clnup.AddE(cleanFn)
-	return backingDB, nil
+	return backingPool, nil
 }
 
 // OpenJoin opens an appropriate database for use as

--- a/libsq/driver/driver_test.go
+++ b/libsq/driver/driver_test.go
@@ -272,12 +272,12 @@ func TestDriver_Open(t *testing.T) {
 			th := testh.New(t)
 			src := th.Source(handle)
 			drvr := th.DriverFor(src)
-			dbase, err := drvr.Open(th.Context, src)
+			pool, err := drvr.Open(th.Context, src)
 			require.NoError(t, err)
-			db, err := dbase.DB(th.Context)
+			db, err := pool.DB(th.Context)
 			require.NoError(t, err)
 			require.NoError(t, db.PingContext(th.Context))
-			require.NoError(t, dbase.Close())
+			require.NoError(t, pool.Close())
 		})
 	}
 }
@@ -441,9 +441,9 @@ func TestDatabase_TableMetadata(t *testing.T) { //nolint:tparallel
 		t.Run(handle, func(t *testing.T) {
 			t.Parallel()
 
-			th, _, _, dbase, _ := testh.NewWith(t, handle)
+			th, _, _, pool, _ := testh.NewWith(t, handle)
 
-			tblMeta, err := dbase.TableMetadata(th.Context, sakila.TblActor)
+			tblMeta, err := pool.TableMetadata(th.Context, sakila.TblActor)
 			require.NoError(t, err)
 			require.Equal(t, sakila.TblActor, tblMeta.Name)
 			require.Equal(t, int64(sakila.TblActorCount), tblMeta.RowCount)
@@ -460,9 +460,9 @@ func TestDatabase_SourceMetadata(t *testing.T) {
 		t.Run(handle, func(t *testing.T) {
 			t.Parallel()
 
-			th, _, _, dbase, _ := testh.NewWith(t, handle)
+			th, _, _, pool, _ := testh.NewWith(t, handle)
 
-			md, err := dbase.SourceMetadata(th.Context, false)
+			md, err := pool.SourceMetadata(th.Context, false)
 			require.NoError(t, err)
 			require.Equal(t, sakila.TblActor, md.Tables[0].Name)
 			require.Equal(t, int64(sakila.TblActorCount), md.Tables[0].RowCount)
@@ -482,11 +482,11 @@ func TestDatabase_SourceMetadata_concurrent(t *testing.T) { //nolint:tparallel
 		t.Run(handle, func(t *testing.T) {
 			t.Parallel()
 
-			th, _, _, dbase, _ := testh.NewWith(t, handle)
+			th, _, _, pool, _ := testh.NewWith(t, handle)
 			g, gCtx := errgroup.WithContext(th.Context)
 			for i := 0; i < concurrency; i++ {
 				g.Go(func() error {
-					md, err := dbase.SourceMetadata(gCtx, false)
+					md, err := pool.SourceMetadata(gCtx, false)
 					require.NoError(t, err)
 					require.NotNil(t, md)
 					gotTbl := md.Table(sakila.TblActor)
@@ -539,7 +539,7 @@ func TestSQLDriver_AlterTableRename(t *testing.T) {
 		handle := handle
 
 		t.Run(handle, func(t *testing.T) {
-			th, src, drvr, dbase, db := testh.NewWith(t, handle)
+			th, src, drvr, pool, db := testh.NewWith(t, handle)
 
 			// Make a copy of the table to play with
 			tbl := th.CopyTable(true, src, tablefq.From(sakila.TblActor), tablefq.T{}, true)
@@ -550,7 +550,7 @@ func TestSQLDriver_AlterTableRename(t *testing.T) {
 			require.NoError(t, err)
 			defer th.DropTable(src, tablefq.From(newName))
 
-			md, err := dbase.TableMetadata(th.Context, newName)
+			md, err := pool.TableMetadata(th.Context, newName)
 			require.NoError(t, err)
 			require.Equal(t, newName, md.Name)
 			sink, err := th.QuerySQL(src, nil, "SELECT * FROM "+newName)
@@ -567,7 +567,7 @@ func TestSQLDriver_AlterTableRenameColumn(t *testing.T) {
 		handle := handle
 
 		t.Run(handle, func(t *testing.T) {
-			th, src, drvr, dbase, db := testh.NewWith(t, handle)
+			th, src, drvr, pool, db := testh.NewWith(t, handle)
 
 			// Make a copy of the table to play with
 			tbl := th.CopyTable(true, src, tablefq.From(sakila.TblActor), tablefq.T{}, true)
@@ -576,7 +576,7 @@ func TestSQLDriver_AlterTableRenameColumn(t *testing.T) {
 			err := drvr.AlterTableRenameColumn(th.Context, db, tbl, "first_name", newName)
 			require.NoError(t, err)
 
-			md, err := dbase.TableMetadata(th.Context, tbl)
+			md, err := pool.TableMetadata(th.Context, tbl)
 			require.NoError(t, err)
 			require.NotNil(t, md.Column(newName))
 			sink, err := th.QuerySQL(src, nil, fmt.Sprintf("SELECT %s FROM %s", newName, tbl))
@@ -623,13 +623,13 @@ func TestSQLDriver_CurrentSchema(t *testing.T) {
 		tc := tc
 
 		t.Run(tc.handle, func(t *testing.T) {
-			th, _, drvr, dbase, db := testh.NewWith(t, tc.handle)
+			th, _, drvr, pool, db := testh.NewWith(t, tc.handle)
 
 			gotSchema, err := drvr.CurrentSchema(th.Context, db)
 			require.NoError(t, err)
 			require.Equal(t, tc.want, gotSchema)
 
-			md, err := dbase.SourceMetadata(th.Context, false)
+			md, err := pool.SourceMetadata(th.Context, false)
 			require.NoError(t, err)
 			require.NotNil(t, md)
 			require.Equal(t, md.Schema, gotSchema)

--- a/libsq/libsq.go
+++ b/libsq/libsq.go
@@ -118,26 +118,26 @@ func SLQ2SQL(ctx context.Context, qc *QueryContext, query string) (targetSQL str
 
 // QuerySQL executes the SQL query, writing the results to recw. If db is
 // non-nil, the query is executed against it. Otherwise, the connection is
-// obtained from dbase.
+// obtained from pool.
 // Note that QuerySQL may return before recw has finished writing, thus the
 // caller may wish to wait for recw to complete.
-// The caller is responsible for closing dbase (and db, if non-nil).
-func QuerySQL(ctx context.Context, dbase driver.Pool, db sqlz.DB,
+// The caller is responsible for closing pool (and db, if non-nil).
+func QuerySQL(ctx context.Context, pool driver.Pool, db sqlz.DB,
 	recw RecordWriter, query string, args ...any,
 ) error {
 	log := lg.FromContext(ctx)
-	errw := dbase.SQLDriver().ErrWrapFunc()
+	errw := pool.SQLDriver().ErrWrapFunc()
 
 	if db == nil {
 		var err error
-		if db, err = dbase.DB(ctx); err != nil {
+		if db, err = pool.DB(ctx); err != nil {
 			return err
 		}
 	}
 
 	rows, err := db.QueryContext(ctx, query, args...)
 	if err != nil {
-		return errz.Wrapf(errw(err), `SQL query against %s failed: %s`, dbase.Source().Handle, query)
+		return errz.Wrapf(errw(err), `SQL query against %s failed: %s`, pool.Source().Handle, query)
 	}
 	defer lg.WarnIfCloseError(log, lgm.CloseDBRows, rows)
 
@@ -183,7 +183,7 @@ func QuerySQL(ctx context.Context, dbase driver.Pool, db sqlz.DB,
 		}
 	}
 
-	drvr := dbase.SQLDriver()
+	drvr := pool.SQLDriver()
 	recMeta, recFromScanRowFn, err := drvr.RecordMeta(ctx, colTypes)
 	if err != nil {
 		return errw(err)
@@ -213,7 +213,7 @@ func QuerySQL(ctx context.Context, dbase driver.Pool, db sqlz.DB,
 		err = rows.Scan(scanRow...)
 		if err != nil {
 			cancelFn()
-			return errz.Wrapf(errw(err), "query against %s", dbase.Source().Handle)
+			return errz.Wrapf(errw(err), "query against %s", pool.Source().Handle)
 		}
 
 		// recFromScanRowFn returns a new Record with appropriate

--- a/libsq/libsq.go
+++ b/libsq/libsq.go
@@ -30,14 +30,14 @@ type QueryContext struct {
 	// Collection is the set of sources.
 	Collection *source.Collection
 
-	// DBOpener is used to open databases.
-	DBOpener driver.DatabaseOpener
+	// PoolOpener is used to open databases.
+	PoolOpener driver.PoolOpener
 
-	// JoinDBOpener is used to open the joindb.
-	JoinDBOpener driver.JoinDatabaseOpener
+	// JoinPoolOpener is used to open the joindb.
+	JoinPoolOpener driver.JoinPoolOpener
 
-	// ScratchDBOpener is used to open the scratchdb.
-	ScratchDBOpener driver.ScratchDatabaseOpener
+	// ScratchPoolOpener is used to open the scratchdb.
+	ScratchPoolOpener driver.ScratchPoolOpener
 
 	// Args defines variables that are substituted into the query.
 	// May be nil or empty.
@@ -122,7 +122,7 @@ func SLQ2SQL(ctx context.Context, qc *QueryContext, query string) (targetSQL str
 // Note that QuerySQL may return before recw has finished writing, thus the
 // caller may wish to wait for recw to complete.
 // The caller is responsible for closing dbase (and db, if non-nil).
-func QuerySQL(ctx context.Context, dbase driver.Database, db sqlz.DB,
+func QuerySQL(ctx context.Context, dbase driver.Pool, db sqlz.DB,
 	recw RecordWriter, query string, args ...any,
 ) error {
 	log := lg.FromContext(ctx)

--- a/libsq/pipeline.go
+++ b/libsq/pipeline.go
@@ -44,16 +44,16 @@ type pipeline struct {
 	rc *render.Context
 
 	// tasks contains tasks that must be completed before targetSQL
-	// is executed against targetDB. Typically tasks is used to
+	// is executed against targetPool. Typically tasks is used to
 	// set up the joindb before it is queried.
 	tasks []tasker
 
-	// targetSQL is the ultimate SQL query to be executed against targetDB.
+	// targetSQL is the ultimate SQL query to be executed against targetPool.
 	targetSQL string
 
-	// targetDB is the destination for the ultimate SQL query to
+	// targetPool is the destination for the ultimate SQL query to
 	// be executed against.
-	targetDB driver.Database
+	targetPool driver.Pool
 }
 
 // newPipeline parses query, returning a pipeline prepared for
@@ -87,7 +87,7 @@ func newPipeline(ctx context.Context, qc *QueryContext, query string) (*pipeline
 func (p *pipeline) execute(ctx context.Context, recw RecordWriter) error {
 	lg.FromContext(ctx).Debug(
 		"Execute SQL query",
-		lga.Src, p.targetDB.Source(),
+		lga.Src, p.targetPool.Source(),
 		lga.SQL, p.targetSQL,
 	)
 
@@ -95,7 +95,7 @@ func (p *pipeline) execute(ctx context.Context, recw RecordWriter) error {
 		return err
 	}
 
-	return QuerySQL(ctx, p.targetDB, nil, recw, p.targetSQL)
+	return QuerySQL(ctx, p.targetPool, nil, recw, p.targetSQL)
 }
 
 // executeTasks executes any tasks in pipeline.tasks.
@@ -146,15 +146,15 @@ func (p *pipeline) prepareNoTable(ctx context.Context, qm *queryModel) error {
 	if handle == "" {
 		if src = p.qc.Collection.Active(); src == nil {
 			log.Debug("No active source, will use scratchdb.")
-			p.targetDB, err = p.qc.ScratchDBOpener.OpenScratch(ctx, "scratch")
+			p.targetPool, err = p.qc.ScratchPoolOpener.OpenScratch(ctx, "scratch")
 			if err != nil {
 				return err
 			}
 
 			p.rc = &render.Context{
-				Renderer: p.targetDB.SQLDriver().Renderer(),
+				Renderer: p.targetPool.SQLDriver().Renderer(),
 				Args:     p.qc.Args,
-				Dialect:  p.targetDB.SQLDriver().Dialect(),
+				Dialect:  p.targetPool.SQLDriver().Dialect(),
 			}
 			return nil
 		}
@@ -165,14 +165,14 @@ func (p *pipeline) prepareNoTable(ctx context.Context, qm *queryModel) error {
 	}
 
 	// At this point, src is non-nil.
-	if p.targetDB, err = p.qc.DBOpener.Open(ctx, src); err != nil {
+	if p.targetPool, err = p.qc.PoolOpener.Open(ctx, src); err != nil {
 		return err
 	}
 
 	p.rc = &render.Context{
-		Renderer: p.targetDB.SQLDriver().Renderer(),
+		Renderer: p.targetPool.SQLDriver().Renderer(),
 		Args:     p.qc.Args,
-		Dialect:  p.targetDB.SQLDriver().Dialect(),
+		Dialect:  p.targetPool.SQLDriver().Dialect(),
 	}
 
 	return nil
@@ -182,7 +182,7 @@ func (p *pipeline) prepareNoTable(ctx context.Context, qm *queryModel) error {
 //
 // When this function returns, pipeline.rc will be set.
 func (p *pipeline) prepareFromTable(ctx context.Context, tblSel *ast.TblSelectorNode) (fromClause string,
-	fromConn driver.Database, err error,
+	fromConn driver.Pool, err error,
 ) {
 	handle := tblSel.Handle()
 	if handle == "" {
@@ -197,7 +197,7 @@ func (p *pipeline) prepareFromTable(ctx context.Context, tblSel *ast.TblSelector
 		return "", nil, err
 	}
 
-	fromConn, err = p.qc.DBOpener.Open(ctx, src)
+	fromConn, err = p.qc.PoolOpener.Open(ctx, src)
 	if err != nil {
 		return "", nil, err
 	}
@@ -270,7 +270,7 @@ func (jc *joinClause) isSingleSource() bool {
 //
 // When this function returns, pipeline.rc will be set.
 func (p *pipeline) prepareFromJoin(ctx context.Context, jc *joinClause) (fromClause string,
-	fromConn driver.Database, err error,
+	fromConn driver.Pool, err error,
 ) {
 	if jc.isSingleSource() {
 		return p.joinSingleSource(ctx, jc)
@@ -283,14 +283,14 @@ func (p *pipeline) prepareFromJoin(ctx context.Context, jc *joinClause) (fromCla
 //
 // On return, pipeline.rc will be set.
 func (p *pipeline) joinSingleSource(ctx context.Context, jc *joinClause) (fromClause string,
-	fromDB driver.Database, err error,
+	fromDB driver.Pool, err error,
 ) {
 	src, err := p.qc.Collection.Get(jc.leftTbl.Handle())
 	if err != nil {
 		return "", nil, err
 	}
 
-	fromDB, err = p.qc.DBOpener.Open(ctx, src)
+	fromDB, err = p.qc.PoolOpener.Open(ctx, src)
 	if err != nil {
 		return "", nil, err
 	}
@@ -315,7 +315,7 @@ func (p *pipeline) joinSingleSource(ctx context.Context, jc *joinClause) (fromCl
 //
 // On return, pipeline.rc will be set.
 func (p *pipeline) joinCrossSource(ctx context.Context, jc *joinClause) (fromClause string,
-	fromDB driver.Database, err error,
+	fromDB driver.Pool, err error,
 ) {
 	// FIXME: finish tidying up
 
@@ -330,7 +330,7 @@ func (p *pipeline) joinCrossSource(ctx context.Context, jc *joinClause) (fromCla
 	}
 
 	// Open the join db
-	joinDB, err := p.qc.JoinDBOpener.OpenJoin(ctx, srcs...)
+	joinDB, err := p.qc.JoinPoolOpener.OpenJoin(ctx, srcs...)
 	if err != nil {
 		return "", nil, err
 	}
@@ -356,16 +356,16 @@ func (p *pipeline) joinCrossSource(ctx context.Context, jc *joinClause) (fromCla
 		if src, err = p.qc.Collection.Get(handle); err != nil {
 			return "", nil, err
 		}
-		var db driver.Database
-		if db, err = p.qc.DBOpener.Open(ctx, src); err != nil {
+		var db driver.Pool
+		if db, err = p.qc.PoolOpener.Open(ctx, src); err != nil {
 			return "", nil, err
 		}
 
 		task := &joinCopyTask{
-			fromDB:  db,
-			fromTbl: tbl.Table(),
-			toDB:    joinDB,
-			toTbl:   tbl.TblAliasOrName(),
+			fromPool: db,
+			fromTbl:  tbl.Table(),
+			toPool:   joinDB,
+			toTbl:    tbl.TblAliasOrName(),
 		}
 
 		tbl.SyncTblNameAlias()
@@ -389,59 +389,59 @@ type tasker interface {
 
 // joinCopyTask is a specification of a table data copy task to be performed
 // for a cross-source join. That is, the data in fromDB.fromTblName will
-// be copied to a table in toDB. If colNames is
+// be copied to a table in toPool. If colNames is
 // empty, all cols in fromTbl are to be copied.
 type joinCopyTask struct {
-	fromDB  driver.Database
-	fromTbl tablefq.T
-	toDB    driver.Database
-	toTbl   tablefq.T
+	fromPool driver.Pool
+	fromTbl  tablefq.T
+	toPool   driver.Pool
+	toTbl    tablefq.T
 }
 
 func (jt *joinCopyTask) executeTask(ctx context.Context) error {
-	return execCopyTable(ctx, jt.fromDB, jt.fromTbl, jt.toDB, jt.toTbl)
+	return execCopyTable(ctx, jt.fromPool, jt.fromTbl, jt.toPool, jt.toTbl)
 }
 
-// execCopyTable performs the work of copying fromDB.fromTbl to destDB.destTbl.
-func execCopyTable(ctx context.Context, fromDB driver.Database, fromTbl tablefq.T,
-	destDB driver.Database, destTbl tablefq.T,
+// execCopyTable performs the work of copying fromDB.fromTbl to destPool.destTbl.
+func execCopyTable(ctx context.Context, fromDB driver.Pool, fromTbl tablefq.T,
+	destPool driver.Pool, destTbl tablefq.T,
 ) error {
 	log := lg.FromContext(ctx)
 
-	createTblHook := func(ctx context.Context, originRecMeta record.Meta, destDB driver.Database,
+	createTblHook := func(ctx context.Context, originRecMeta record.Meta, destPool driver.Pool,
 		tx sqlz.DB,
 	) error {
 		destColNames := originRecMeta.Names()
 		destColKinds := originRecMeta.Kinds()
 		destTblDef := sqlmodel.NewTableDef(destTbl.Table, destColNames, destColKinds)
 
-		err := destDB.SQLDriver().CreateTable(ctx, tx, destTblDef)
+		err := destPool.SQLDriver().CreateTable(ctx, tx, destTblDef)
 		if err != nil {
-			return errz.Wrapf(err, "failed to create dest table %s.%s", destDB.Source().Handle, destTbl)
+			return errz.Wrapf(err, "failed to create dest table %s.%s", destPool.Source().Handle, destTbl)
 		}
 
 		return nil
 	}
 
 	inserter := NewDBWriter(
-		destDB,
+		destPool,
 		destTbl.Table,
-		driver.OptTuningRecChanSize.Get(destDB.Source().Options),
+		driver.OptTuningRecChanSize.Get(destPool.Source().Options),
 		createTblHook,
 	)
 
 	query := "SELECT * FROM " + fromTbl.Render(fromDB.SQLDriver().Dialect().Enquote)
 	err := QuerySQL(ctx, fromDB, nil, inserter, query)
 	if err != nil {
-		return errz.Wrapf(err, "insert %s.%s failed", destDB.Source().Handle, destTbl)
+		return errz.Wrapf(err, "insert %s.%s failed", destPool.Source().Handle, destTbl)
 	}
 
 	affected, err := inserter.Wait() // Wait for the writer to finish processing
 	if err != nil {
-		return errz.Wrapf(err, "insert %s.%s failed", destDB.Source().Handle, destTbl)
+		return errz.Wrapf(err, "insert %s.%s failed", destPool.Source().Handle, destTbl)
 	}
 	log.Debug("Copied rows to dest", lga.Count, affected,
 		lga.From, fmt.Sprintf("%s.%s", fromDB.Source().Handle, fromTbl),
-		lga.To, fmt.Sprintf("%s.%s", destDB.Source().Handle, destTbl))
+		lga.To, fmt.Sprintf("%s.%s", destPool.Source().Handle, destTbl))
 	return nil
 }

--- a/libsq/prepare.go
+++ b/libsq/prepare.go
@@ -7,9 +7,9 @@ import (
 )
 
 // prepare prepares the pipeline to execute queryModel.
-// When this method returns, targetDB and targetSQL will be set,
+// When this method returns, targetPool and targetSQL will be set,
 // as will any tasks (which may be empty). The tasks must be executed
-// against targetDB before targetSQL is executed (the pipeline.execute
+// against targetPool before targetSQL is executed (the pipeline.execute
 // method does this work).
 func (p *pipeline) prepare(ctx context.Context, qm *queryModel) error {
 	var (
@@ -25,11 +25,11 @@ func (p *pipeline) prepare(ctx context.Context, qm *queryModel) error {
 		}
 	case len(qm.Joins) > 0:
 		jc := &joinClause{leftTbl: qm.Table, joins: qm.Joins}
-		if frags.From, p.targetDB, err = p.prepareFromJoin(ctx, jc); err != nil {
+		if frags.From, p.targetPool, err = p.prepareFromJoin(ctx, jc); err != nil {
 			return err
 		}
 	default:
-		if frags.From, p.targetDB, err = p.prepareFromTable(ctx, qm.Table); err != nil {
+		if frags.From, p.targetPool, err = p.prepareFromTable(ctx, qm.Table); err != nil {
 			return err
 		}
 	}

--- a/libsq/query_no_src_test.go
+++ b/libsq/query_no_src_test.go
@@ -31,13 +31,13 @@ func TestQuery_no_source(t *testing.T) {
 			t.Logf("\nquery: %s\n want: %s", tc.in, tc.want)
 			th := testh.New(t)
 			coll := th.NewCollection()
-			dbases := th.Databases()
+			dbases := th.Pools()
 
 			qc := &libsq.QueryContext{
-				Collection:      coll,
-				DBOpener:        dbases,
-				JoinDBOpener:    dbases,
-				ScratchDBOpener: dbases,
+				Collection:        coll,
+				PoolOpener:        dbases,
+				JoinPoolOpener:    dbases,
+				ScratchPoolOpener: dbases,
 			}
 
 			gotSQL, gotErr := libsq.SLQ2SQL(th.Context, qc, tc.in)

--- a/libsq/query_no_src_test.go
+++ b/libsq/query_no_src_test.go
@@ -31,13 +31,13 @@ func TestQuery_no_source(t *testing.T) {
 			t.Logf("\nquery: %s\n want: %s", tc.in, tc.want)
 			th := testh.New(t)
 			coll := th.NewCollection()
-			dbases := th.Pools()
+			pools := th.Pools()
 
 			qc := &libsq.QueryContext{
 				Collection:        coll,
-				PoolOpener:        dbases,
-				JoinPoolOpener:    dbases,
-				ScratchPoolOpener: dbases,
+				PoolOpener:        pools,
+				JoinPoolOpener:    pools,
+				ScratchPoolOpener: pools,
 			}
 
 			gotSQL, gotErr := libsq.SLQ2SQL(th.Context, qc, tc.in)

--- a/libsq/query_test.go
+++ b/libsq/query_test.go
@@ -168,14 +168,14 @@ func doExecQueryTestCase(t *testing.T, tc queryTestCase) {
 			require.NoError(t, err)
 
 			th := testh.New(t)
-			dbases := th.Databases()
+			dbases := th.Pools()
 
 			qc := &libsq.QueryContext{
-				Collection:      coll,
-				DBOpener:        dbases,
-				JoinDBOpener:    dbases,
-				ScratchDBOpener: dbases,
-				Args:            tc.args,
+				Collection:        coll,
+				PoolOpener:        dbases,
+				JoinPoolOpener:    dbases,
+				ScratchPoolOpener: dbases,
+				Args:              tc.args,
 			}
 
 			if tc.beforeRun != nil {

--- a/libsq/query_test.go
+++ b/libsq/query_test.go
@@ -168,13 +168,13 @@ func doExecQueryTestCase(t *testing.T, tc queryTestCase) {
 			require.NoError(t, err)
 
 			th := testh.New(t)
-			dbases := th.Pools()
+			pools := th.Pools()
 
 			qc := &libsq.QueryContext{
 				Collection:        coll,
-				PoolOpener:        dbases,
-				JoinPoolOpener:    dbases,
-				ScratchPoolOpener: dbases,
+				PoolOpener:        pools,
+				JoinPoolOpener:    pools,
+				ScratchPoolOpener: pools,
 				Args:              tc.args,
 			}
 

--- a/testh/testh.go
+++ b/testh/testh.go
@@ -368,9 +368,9 @@ func (h *Helper) NewCollection(handles ...string) *source.Collection {
 	return coll
 }
 
-// Open opens a Pool for src via h's internal Pools
+// Open opens a driver.Pool for src via h's internal Pools
 // instance: thus subsequent calls to Open may return the
-// same Pool instance. The opened Pool will be closed
+// same Pool instance. The opened driver.Pool will be closed
 // during h.Close.
 func (h *Helper) Open(src *source.Source) driver.Pool {
 	ctx, cancelFn := context.WithTimeout(h.Context, h.dbOpenTimeout)
@@ -396,7 +396,7 @@ func (h *Helper) OpenDB(src *source.Source) *sql.DB {
 	return db
 }
 
-// openNew opens a new Pool. It is the caller's responsibility
+// openNew opens a new driver.Pool. It is the caller's responsibility
 // to close the returned Pool. Unlike method Open, this method
 // will always invoke the driver's Open method.
 //

--- a/testh/testh.go
+++ b/testh/testh.go
@@ -762,22 +762,22 @@ func (h *Helper) Files() *source.Files {
 
 // SourceMetadata returns metadata for src.
 func (h *Helper) SourceMetadata(src *source.Source) (*source.Metadata, error) {
-	dbases, err := h.Pools().Open(h.Context, src)
+	pools, err := h.Pools().Open(h.Context, src)
 	if err != nil {
 		return nil, err
 	}
 
-	return dbases.SourceMetadata(h.Context, false)
+	return pools.SourceMetadata(h.Context, false)
 }
 
 // TableMetadata returns metadata for src's table.
 func (h *Helper) TableMetadata(src *source.Source, tbl string) (*source.TableMetadata, error) {
-	dbases, err := h.Pools().Open(h.Context, src)
+	pools, err := h.Pools().Open(h.Context, src)
 	if err != nil {
 		return nil, err
 	}
 
-	return dbases.TableMetadata(h.Context, tbl)
+	return pools.TableMetadata(h.Context, tbl)
 }
 
 // DiffDB fails the test if src's metadata is substantially different


### PR DESCRIPTION
The type name `driver.Database` was confusing. It's been renamed to `driver.Pool`, which, admittedly, may not be much better. It may change again.