### PR TITLE
JSON ingest performance

### DIFF
--- a/cli/output/raww/raww_test.go
+++ b/cli/output/raww/raww_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/neilotoole/sq/cli/output"
 	"github.com/neilotoole/sq/cli/output/raww"
-	"github.com/neilotoole/sq/libsq/core/lg"
 	"github.com/neilotoole/sq/testh"
 	"github.com/neilotoole/sq/testh/fixt"
 	"github.com/neilotoole/sq/testh/proj"
@@ -51,8 +50,7 @@ func TestRecordWriter_TblActor(t *testing.T) {
 }
 
 func TestRecordWriter_TblBytes(t *testing.T) {
-	th := testh.New(t)
-	th.Log = lg.Discard()
+	th := testh.New(t, testh.OptNoLog())
 	src := th.Source(testsrc.MiscDB)
 	sink, err := th.QuerySQL(src, nil, "SELECT col_bytes FROM tbl_bytes WHERE col_name='gopher.gif'")
 	require.NoError(t, err)

--- a/drivers/json/ingest.go
+++ b/drivers/json/ingest.go
@@ -11,6 +11,8 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/neilotoole/sq/libsq/core/ioz/checksum"
+
 	"github.com/neilotoole/sq/libsq/core/errz"
 	"github.com/neilotoole/sq/libsq/core/kind"
 	"github.com/neilotoole/sq/libsq/core/lg"
@@ -655,15 +657,9 @@ type insertion struct {
 // it initializes insertion.stmtHash.
 func newInsertion(tbl string, cols []string, vals []any) *insertion {
 	return &insertion{
-		stmtHash: buildInsertStmtHash(tbl, cols),
+		stmtHash: checksum.SumAll(tbl, cols...),
 		tbl:      tbl,
 		cols:     cols,
 		vals:     vals,
 	}
-}
-
-// buildInsertStmtHash returns a concatenation of tbl and cols that can
-// uniquely identify a db insert statement.
-func buildInsertStmtHash(tbl string, cols []string) string {
-	return tbl + "__" + strings.Join(cols, "_")
 }

--- a/drivers/json/ingest.go
+++ b/drivers/json/ingest.go
@@ -44,6 +44,17 @@ type ingestJob struct {
 	//
 	// TODO: flatten should come from src.Options
 	flatten bool
+
+	stmtCache map[string]*driver.StmtExecer
+}
+
+// Close closes the ingestJob.
+func (jb *ingestJob) Close() error {
+	var err error
+	for _, stmt := range jb.stmtCache {
+		err = errz.Append(err, stmt.Close())
+	}
+	return err
 }
 
 // execInsertions performs db INSERT for each of the insertions.

--- a/drivers/json/ingest.go
+++ b/drivers/json/ingest.go
@@ -81,7 +81,7 @@ func (jb *ingestJob) execInsertions(ctx context.Context, drvr driver.SQLDriver,
 			}
 
 			// Note that we don't close the execer here, because we cache it.
-			// It will be closed when via ingestJob.Close.
+			// It will be closed via ingestJob.Close.
 			jb.stmtCache[insert.stmtHash] = execer
 		}
 

--- a/drivers/json/ingest_json.go
+++ b/drivers/json/ingest_json.go
@@ -140,6 +140,7 @@ func DetectJSON(sampleSize int) files.TypeDetectFunc { // FIXME: is DetectJSON a
 
 func ingestJSON(ctx context.Context, job *ingestJob) error {
 	log := lg.FromContext(ctx)
+	defer lg.WarnIfCloseError(log, "Close JSON ingest job", job)
 
 	r, err := job.newRdrFn(ctx)
 	if err != nil {

--- a/drivers/json/ingest_jsona.go
+++ b/drivers/json/ingest_jsona.go
@@ -102,7 +102,7 @@ func DetectJSONA(sampleSize int) files.TypeDetectFunc {
 	}
 }
 
-func ingestJSONA(ctx context.Context, job ingestJob) error {
+func ingestJSONA(ctx context.Context, job *ingestJob) error {
 	log := lg.FromContext(ctx)
 
 	predictR, err := job.newRdrFn(ctx)

--- a/drivers/json/ingest_jsonl.go
+++ b/drivers/json/ingest_jsonl.go
@@ -86,10 +86,9 @@ func DetectJSONL(sampleSize int) files.TypeDetectFunc {
 	}
 }
 
-// DetectJSONL implements files.TypeDetectFunc.
-
 func ingestJSONL(ctx context.Context, job *ingestJob) error { //nolint:gocognit
 	log := lg.FromContext(ctx)
+	defer lg.WarnIfCloseError(log, "Close JSONL ingest job", job)
 
 	r, err := job.newRdrFn(ctx)
 	if err != nil {

--- a/drivers/json/ingest_jsonl.go
+++ b/drivers/json/ingest_jsonl.go
@@ -88,7 +88,7 @@ func DetectJSONL(sampleSize int) files.TypeDetectFunc {
 
 // DetectJSONL implements files.TypeDetectFunc.
 
-func ingestJSONL(ctx context.Context, job ingestJob) error { //nolint:gocognit
+func ingestJSONL(ctx context.Context, job *ingestJob) error { //nolint:gocognit
 	log := lg.FromContext(ctx)
 
 	r, err := job.newRdrFn(ctx)
@@ -133,13 +133,11 @@ func ingestJSONL(ctx context.Context, job ingestJob) error { //nolint:gocognit
 				}
 
 				var newSchema *ingestSchema
-				newSchema, err = proc.buildSchemaFlat()
-				if err != nil {
+				if newSchema, err = proc.buildSchemaFlat(); err != nil {
 					return err
 				}
 
-				err = execSchemaDelta(ctx, drvr, conn, curSchema, newSchema)
-				if err != nil {
+				if err = execSchemaDelta(ctx, drvr, conn, curSchema, newSchema); err != nil {
 					return err
 				}
 
@@ -150,13 +148,11 @@ func ingestJSONL(ctx context.Context, job ingestJob) error { //nolint:gocognit
 				curSchema = newSchema
 				newSchema = nil
 
-				insertions, err = proc.buildInsertionsFlat(curSchema)
-				if err != nil {
+				if insertions, err = proc.buildInsertionsFlat(curSchema); err != nil {
 					return err
 				}
 
-				err = execInsertions(ctx, drvr, conn, insertions)
-				if err != nil {
+				if err = job.execInsertions(ctx, drvr, conn, insertions); err != nil {
 					return err
 				}
 			}
@@ -198,13 +194,11 @@ func ingestJSONL(ctx context.Context, job ingestJob) error { //nolint:gocognit
 
 		// The schema exists in the DB, and the current JSON chunk hasn't
 		// dirtied the schema, so it's safe to insert the recent rows.
-		insertions, err = proc.buildInsertionsFlat(curSchema)
-		if err != nil {
+		if insertions, err = proc.buildInsertionsFlat(curSchema); err != nil {
 			return err
 		}
 
-		err = execInsertions(ctx, drvr, conn, insertions)
-		if err != nil {
+		if err = job.execInsertions(ctx, drvr, conn, insertions); err != nil {
 			return err
 		}
 	}

--- a/drivers/json/ingest_test.go
+++ b/drivers/json/ingest_test.go
@@ -20,6 +20,105 @@ import (
 	"github.com/neilotoole/sq/testh/tu"
 )
 
+func BenchmarkIngestJSONL_Flat(b *testing.B) {
+	// $ go test -count=10 -benchtime=5s -bench BenchmarkIngestJSONL_Flat > old.bench.txt
+	// # Make changes
+	// $ go test -count=10 -benchtime=5s -bench BenchmarkIngestJSONL_Flat > new.bench.txt
+	// $ benchstat old.bench.text new.bench.txt
+
+	// Either fpath (testdata file path) or input should be provided.
+	testCases := []struct {
+		name      string
+		fpath     string
+		input     string
+		wantRows  int
+		wantCols  []string
+		wantKinds []kind.Kind
+		wantErr   bool
+	}{
+		{
+			name:      "actor",
+			fpath:     "actor.jsonl",
+			wantRows:  sakila.TblActorCount,
+			wantCols:  sakila.TblActorCols(),
+			wantKinds: sakila.TblActorColKinds(),
+		},
+		{
+			name:      "film_actor",
+			fpath:     "film_actor.jsonl",
+			wantRows:  sakila.TblFilmActorCount,
+			wantCols:  sakila.TblFilmActorCols(),
+			wantKinds: sakila.TblFilmActorColKinds(),
+		},
+		{
+			name:      "actor_nested",
+			fpath:     "jsonl_actor_nested.jsonl",
+			wantRows:  4,
+			wantCols:  []string{"actor_id", "name_first_name", "name_last_name", "last_update"},
+			wantKinds: []kind.Kind{kind.Int, kind.Text, kind.Text, kind.Datetime},
+		},
+		{
+			name: "recs_medium",
+			input: `{"a": 1, "b": 1, "c": true, "d": "2020-06-11", "e": 2.0}
+{"a": 1.0, "b": 1, "c": false, "d": "2020-06-12", "e":2.01}`,
+			wantRows:  2,
+			wantCols:  []string{"a", "b", "c", "d", "e"},
+			wantKinds: []kind.Kind{kind.Int, kind.Int, kind.Bool, kind.Date, kind.Float},
+		},
+		{
+			name: "recs_small",
+			input: `{"b": 1}
+{"a": 1.1, "b": 2}`,
+			wantRows:  2,
+			wantCols:  []string{"b", "a"},
+			wantKinds: []kind.Kind{kind.Int, kind.Float},
+		},
+		{
+			name: "recs_null",
+			input: `{"a": null, "b": null}
+{"a": 1.1, "b": 2.0000}`,
+			wantRows:  2,
+			wantCols:  []string{"a", "b"},
+			wantKinds: []kind.Kind{kind.Float, kind.Int},
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+
+		newRdrFn := func(_ context.Context) (io.ReadCloser, error) { //nolint:unparam
+			return io.NopCloser(strings.NewReader(tc.input)), nil
+		}
+
+		if tc.fpath != "" {
+			newRdrFn = func(_ context.Context) (io.ReadCloser, error) {
+				return os.Open(filepath.Join("testdata", tc.fpath))
+			}
+		}
+
+		b.Run(tc.name, func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for i := 0; i < b.N; i++ {
+				b.StopTimer()
+				th := testh.New(b, testh.OptNoLog())
+				src := th.Source(testsrc.EmptyDB)
+				grip := th.Open(src)
+
+				job := json.NewIngestJob(src, newRdrFn, grip, 0, true)
+
+				b.StartTimer()
+				err := json.IngestJSONL(th.Context, job)
+				if tc.wantErr {
+					require.Error(b, err)
+					return
+				}
+			}
+		})
+	}
+}
+
 func TestIngestJSONL_Flat(t *testing.T) {
 	t.Parallel()
 

--- a/drivers/json/ingest_test.go
+++ b/drivers/json/ingest_test.go
@@ -124,6 +124,7 @@ func TestIngestJSONL_Flat(t *testing.T) {
 
 	// Either fpath (testdata file path) or input should be provided.
 	testCases := []struct {
+		name      string
 		fpath     string
 		input     string
 		wantRows  int
@@ -132,24 +133,28 @@ func TestIngestJSONL_Flat(t *testing.T) {
 		wantErr   bool
 	}{
 		{
+			name:      "actor",
 			fpath:     "actor.jsonl",
 			wantRows:  sakila.TblActorCount,
 			wantCols:  sakila.TblActorCols(),
 			wantKinds: sakila.TblActorColKinds(),
 		},
 		{
+			name:      "film_actor",
 			fpath:     "film_actor.jsonl",
 			wantRows:  sakila.TblFilmActorCount,
 			wantCols:  sakila.TblFilmActorCols(),
 			wantKinds: sakila.TblFilmActorColKinds(),
 		},
 		{
+			name:      "actor_nested",
 			fpath:     "jsonl_actor_nested.jsonl",
 			wantRows:  4,
 			wantCols:  []string{"actor_id", "name_first_name", "name_last_name", "last_update"},
 			wantKinds: []kind.Kind{kind.Int, kind.Text, kind.Text, kind.Datetime},
 		},
 		{
+			name: "recs_medium",
 			input: `{"a": 1, "b": 1, "c": true, "d": "2020-06-11", "e": 2.0}
 {"a": 1.0, "b": 1, "c": false, "d": "2020-06-12", "e":2.01}`,
 			wantRows:  2,
@@ -157,6 +162,7 @@ func TestIngestJSONL_Flat(t *testing.T) {
 			wantKinds: []kind.Kind{kind.Int, kind.Int, kind.Bool, kind.Date, kind.Float},
 		},
 		{
+			name: "recs_small",
 			input: `{"b": 1}
 {"a": 1.1, "b": 2}`,
 			wantRows:  2,
@@ -164,6 +170,7 @@ func TestIngestJSONL_Flat(t *testing.T) {
 			wantKinds: []kind.Kind{kind.Int, kind.Float},
 		},
 		{
+			name: "recs_null",
 			input: `{"a": null, "b": null}
 {"a": 1.1, "b": 2.0000}`,
 			wantRows:  2,
@@ -172,10 +179,10 @@ func TestIngestJSONL_Flat(t *testing.T) {
 		},
 	}
 
-	for i, tc := range testCases {
+	for _, tc := range testCases {
 		tc := tc
 
-		t.Run(tu.Name(i, tc.fpath, tc.input), func(t *testing.T) {
+		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
 			newRdrFn := func(ctx context.Context) (io.ReadCloser, error) {

--- a/drivers/json/internal_test.go
+++ b/drivers/json/internal_test.go
@@ -29,12 +29,12 @@ var (
 // If sampleSize <= 0, a default value is used.
 func newIngestJob(fromSrc *source.Source, newRdrFn files.NewReaderFunc, destGrip driver.Grip, sampleSize int,
 	flatten bool,
-) ingestJob {
+) *ingestJob {
 	if sampleSize <= 0 {
 		sampleSize = driver.OptIngestSampleSize.Get(fromSrc.Options)
 	}
 
-	return ingestJob{
+	return &ingestJob{
 		fromSrc:    fromSrc,
 		newRdrFn:   newRdrFn,
 		destGrip:   destGrip,

--- a/drivers/json/internal_test.go
+++ b/drivers/json/internal_test.go
@@ -40,6 +40,7 @@ func newIngestJob(fromSrc *source.Source, newRdrFn files.NewReaderFunc, destGrip
 		destGrip:   destGrip,
 		sampleSize: sampleSize,
 		flatten:    flatten,
+		stmtCache:  map[string]*driver.StmtExecer{},
 	}
 }
 

--- a/drivers/json/json.go
+++ b/drivers/json/json.go
@@ -97,7 +97,7 @@ func (d *driveri) Open(ctx context.Context, src *source.Source) (driver.Grip, er
 	allowCache := driver.OptIngestCache.Get(options.FromContext(ctx))
 
 	ingestFn := func(ctx context.Context, destGrip driver.Grip) error {
-		job := ingestJob{
+		job := &ingestJob{
 			fromSrc: src,
 			newRdrFn: func(ctx context.Context) (io.ReadCloser, error) {
 				log.Debug("JSON ingest job newRdrFn", lga.Src, src)

--- a/drivers/json/json.go
+++ b/drivers/json/json.go
@@ -106,6 +106,7 @@ func (d *driveri) Open(ctx context.Context, src *source.Source) (driver.Grip, er
 			destGrip:   destGrip,
 			sampleSize: driver.OptIngestSampleSize.Get(src.Options),
 			flatten:    true,
+			stmtCache:  map[string]*driver.StmtExecer{},
 		}
 
 		return d.ingestFn(ctx, job)

--- a/drivers/postgres/postgres_test.go
+++ b/drivers/postgres/postgres_test.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/neilotoole/sq/drivers/postgres"
 	"github.com/neilotoole/sq/libsq/core/errz"
-	"github.com/neilotoole/sq/libsq/core/lg"
 	"github.com/neilotoole/sq/libsq/core/schema"
 	"github.com/neilotoole/sq/libsq/core/stringz"
 	"github.com/neilotoole/sq/libsq/core/tablefq"
@@ -274,8 +273,7 @@ func BenchmarkDatabase_SourceMetadata(b *testing.B) {
 	for _, handle := range sakila.PgAll() {
 		handle := handle
 		b.Run(handle, func(b *testing.B) {
-			th := testh.New(b)
-			th.Log = lg.Discard()
+			th := testh.New(b, testh.OptNoLog())
 			grip := th.Open(th.Source(handle))
 			b.ResetTimer()
 

--- a/libsq/core/ioz/checksum/checksum.go
+++ b/libsq/core/ioz/checksum/checksum.go
@@ -29,6 +29,17 @@ func Sum(b []byte) string {
 	return fmt.Sprintf("%x", sum)
 }
 
+// SumAll returns the hash of a, and all the elements
+// of b, as a hex string.
+func SumAll[T ~string](a T, b ...T) string {
+	h := crc32.NewIEEE()
+	_, _ = h.Write([]byte(a))
+	for _, col := range b {
+		_, _ = h.Write([]byte(col))
+	}
+	return fmt.Sprintf("%x", h.Sum32())
+}
+
 // Rand returns a random checksum.
 func Rand() string {
 	b := make([]byte, 128)
@@ -36,7 +47,7 @@ func Rand() string {
 	return Sum(b)
 }
 
-// Checksum is a checksum of a file.
+// Checksum is a checksum value.
 type Checksum string
 
 // Write appends a checksum line to w, including

--- a/testh/record.go
+++ b/testh/record.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/neilotoole/sq/drivers/sqlite3"
 	"github.com/neilotoole/sq/libsq/core/kind"
-	"github.com/neilotoole/sq/libsq/core/lg"
 	"github.com/neilotoole/sq/libsq/core/record"
 	"github.com/neilotoole/sq/libsq/core/sqlz"
 )
@@ -36,8 +35,7 @@ func RecordsFromTbl(tb testing.TB, handle, tbl string) (recMeta record.Meta, rec
 	key := fmt.Sprintf("#rec_sink__%s__%s", handle, tbl)
 	sink, ok := recSinkCache[key]
 	if !ok {
-		th := New(tb)
-		th.Log = lg.Discard()
+		th := New(tb, OptNoLog())
 		src := th.Source(handle)
 		var err error
 		sink, err = th.QuerySQL(src, nil, "SELECT * FROM "+tbl)


### PR DESCRIPTION
Previously, JSON ingest jobs created, used, and closed a SQL prepared statement for _every single row_ of ingest data. Obviously this was wildly inefficient.

Now, the prepared statements are cached. There's still significant improvements that could be made, e.g. by using `driver.BatchInsert` (as seen with the CSV ingester), but this is a good start.

Benchmarks are better by `-23.76%` to `-77.62%` on the various metrics.

[wip.benchstat.txt](https://github.com/neilotoole/sq/files/14054113/wip.benchstat.txt)

```
goos: darwin
goarch: arm64
pkg: github.com/neilotoole/sq/drivers/json
                                 │ old.bench.txt │             new.bench.txt             │
                                 │    sec/op     │    sec/op     vs base                 │
IngestJSONL_Flat/actor-10           70.22m ± ∞ ¹   43.67m ± ∞ ¹        ~ (p=1.000 n=1) ²
IngestJSONL_Flat/film_actor-10       2.080 ± ∞ ¹    1.209 ± ∞ ¹        ~ (p=1.000 n=1) ²
IngestJSONL_Flat/actor_nested-10    1.907m ± ∞ ¹   1.463m ± ∞ ¹        ~ (p=1.000 n=1) ²
IngestJSONL_Flat/recs_medium-10     1.143m ± ∞ ¹   1.001m ± ∞ ¹        ~ (p=1.000 n=1) ²
IngestJSONL_Flat/recs_small-10      1.086m ± ∞ ¹   1.073m ± ∞ ¹        ~ (p=1.000 n=1) ²
IngestJSONL_Flat/recs_null-10      1165.9µ ± ∞ ¹   954.3µ ± ∞ ¹        ~ (p=1.000 n=1) ²
geomean                             8.595m         6.553m        -23.76%
¹ need >= 6 samples for confidence interval at level 0.95
² need >= 4 samples to detect a difference at alpha level 0.05

                                 │ old.bench.txt  │             new.bench.txt              │
                                 │      B/op      │     B/op       vs base                 │
IngestJSONL_Flat/actor-10          23.510Mi ± ∞ ¹   1.184Mi ± ∞ ¹        ~ (p=1.000 n=1) ²
IngestJSONL_Flat/film_actor-10     624.45Mi ± ∞ ¹   16.97Mi ± ∞ ¹        ~ (p=1.000 n=1) ²
IngestJSONL_Flat/actor_nested-10    505.9Ki ± ∞ ¹   161.6Ki ± ∞ ¹        ~ (p=1.000 n=1) ²
IngestJSONL_Flat/recs_medium-10     251.8Ki ± ∞ ¹   136.2Ki ± ∞ ¹        ~ (p=1.000 n=1) ²
IngestJSONL_Flat/recs_small-10      238.0Ki ± ∞ ¹   238.2Ki ± ∞ ¹        ~ (p=1.000 n=1) ²
IngestJSONL_Flat/recs_null-10       239.1Ki ± ∞ ¹   126.9Ki ± ∞ ¹        ~ (p=1.000 n=1) ²
geomean                             2.143Mi         491.1Ki        -77.62%
¹ need >= 6 samples for confidence interval at level 0.95
² need >= 4 samples to detect a difference at alpha level 0.05

                                 │ old.bench.txt │             new.bench.txt             │
                                 │   allocs/op   │  allocs/op    vs base                 │
IngestJSONL_Flat/actor-10           82.96k ± ∞ ¹   28.48k ± ∞ ¹        ~ (p=1.000 n=1) ²
IngestJSONL_Flat/film_actor-10     1617.1k ± ∞ ¹   323.9k ± ∞ ¹        ~ (p=1.000 n=1) ²
IngestJSONL_Flat/actor_nested-10    2.141k ± ∞ ¹   1.316k ± ∞ ¹        ~ (p=1.000 n=1) ²
IngestJSONL_Flat/recs_medium-10      953.0 ± ∞ ¹    661.0 ± ∞ ¹        ~ (p=1.000 n=1) ²
IngestJSONL_Flat/recs_small-10       535.0 ± ∞ ¹    536.0 ± ∞ ¹        ~ (p=1.000 n=1) ²
IngestJSONL_Flat/recs_null-10        574.0 ± ∞ ¹    389.0 ± ∞ ¹        ~ (p=1.000 n=1) ²
geomean                             6.619k         3.445k        -47.94%
¹ need >= 6 samples for confidence interval at level 0.95
² need >= 4 samples to detect a difference at alpha level 0.05
```
