### PR TITLE
More file closing

### DIFF
--- a/libsq/files/download.go
+++ b/libsq/files/download.go
@@ -7,15 +7,14 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/neilotoole/sq/libsq/core/lg"
-	"github.com/neilotoole/sq/libsq/core/lg/lgm"
-
 	"github.com/neilotoole/streamcache"
 
 	"github.com/neilotoole/sq/libsq/core/errz"
 	"github.com/neilotoole/sq/libsq/core/ioz"
 	"github.com/neilotoole/sq/libsq/core/ioz/checksum"
 	"github.com/neilotoole/sq/libsq/core/ioz/httpz"
+	"github.com/neilotoole/sq/libsq/core/lg"
+	"github.com/neilotoole/sq/libsq/core/lg/lgm"
 	"github.com/neilotoole/sq/libsq/core/options"
 	"github.com/neilotoole/sq/libsq/files/downloader"
 	"github.com/neilotoole/sq/libsq/source"

--- a/testh/record.go
+++ b/testh/record.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/neilotoole/sq/testh/tu"
+
 	"github.com/stretchr/testify/require"
 
 	"github.com/neilotoole/sq/drivers/sqlite3"
@@ -32,16 +34,23 @@ func RecordsFromTbl(tb testing.TB, handle, tbl string) (recMeta record.Meta, rec
 	recSinkMu.Lock()
 	defer recSinkMu.Unlock()
 
+	tu.OpenFileCount(tb, true, "start")
+
 	key := fmt.Sprintf("#rec_sink__%s__%s", handle, tbl)
 	sink, ok := recSinkCache[key]
 	if !ok {
 		th := New(tb, OptNoLog())
 		src := th.Source(handle)
 		var err error
+		tu.OpenFileCount(tb, true, "before query")
+
 		sink, err = th.QuerySQL(src, nil, "SELECT * FROM "+tbl)
 		require.NoError(tb, err)
 		recSinkCache[key] = sink
+		tu.OpenFileCount(tb, true, "after query")
+
 		th.Close()
+		tu.OpenFileCount(tb, true, "after close")
 	}
 
 	// Make copies so that the caller can mutate their records

--- a/testh/record.go
+++ b/testh/record.go
@@ -14,7 +14,6 @@ import (
 	"github.com/neilotoole/sq/libsq/core/kind"
 	"github.com/neilotoole/sq/libsq/core/record"
 	"github.com/neilotoole/sq/libsq/core/sqlz"
-	"github.com/neilotoole/sq/testh/tu"
 )
 
 var (
@@ -33,23 +32,17 @@ func RecordsFromTbl(tb testing.TB, handle, tbl string) (recMeta record.Meta, rec
 	recSinkMu.Lock()
 	defer recSinkMu.Unlock()
 
-	tu.OpenFileCount(tb, true, "start")
-
 	key := fmt.Sprintf("#rec_sink__%s__%s", handle, tbl)
 	sink, ok := recSinkCache[key]
 	if !ok {
 		th := New(tb, OptNoLog())
 		src := th.Source(handle)
 		var err error
-		tu.OpenFileCount(tb, true, "before query")
-
 		sink, err = th.QuerySQL(src, nil, "SELECT * FROM "+tbl)
 		require.NoError(tb, err)
 		recSinkCache[key] = sink
-		tu.OpenFileCount(tb, true, "after query")
 
 		th.Close()
-		tu.OpenFileCount(tb, true, "after close")
 	}
 
 	// Make copies so that the caller can mutate their records

--- a/testh/record.go
+++ b/testh/record.go
@@ -8,14 +8,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/neilotoole/sq/testh/tu"
-
 	"github.com/stretchr/testify/require"
 
 	"github.com/neilotoole/sq/drivers/sqlite3"
 	"github.com/neilotoole/sq/libsq/core/kind"
 	"github.com/neilotoole/sq/libsq/core/record"
 	"github.com/neilotoole/sq/libsq/core/sqlz"
+	"github.com/neilotoole/sq/testh/tu"
 )
 
 var (

--- a/testh/testh.go
+++ b/testh/testh.go
@@ -5,7 +5,6 @@ package testh
 import (
 	"context"
 	"database/sql"
-	"io"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -312,27 +311,12 @@ func (h *Helper) Source(handle string) *source.Source {
 
 	if src.Type == drivertype.SQLite {
 		// This could be easily generalized for CSV/XLSX etc.
-		fpath, err := sqlite3.PathFromLocation(src)
+		srcPath, err := sqlite3.PathFromLocation(src)
 		require.NoError(t, err)
 
-		srcFile, err := os.Open(fpath)
-		require.NoError(t, err)
-		defer func() {
-			assert.NoError(t, srcFile.Close())
-		}()
-
-		destFile, err := h.files.CreateTemp("*_"+filepath.Base(src.Location), true)
-		require.NoError(t, err)
-		defer func() {
-			assert.NoError(t, destFile.Close())
-		}()
-
-		destFileName := destFile.Name()
-
-		_, err = io.Copy(destFile, srcFile)
-		require.NoError(t, err)
-
-		src.Location = sqlite3.Prefix + destFileName
+		dstPath := filepath.Join(tu.TempDir(t, false), filepath.Base(srcPath))
+		require.NoError(t, ioz.CopyFile(dstPath, srcPath, true))
+		src.Location = sqlite3.Prefix + dstPath
 	}
 
 	h.srcCache[handle] = src


### PR DESCRIPTION
On Windows, sometimes the run would fail due to file handles still being open when trying to clean up tests.