### PR TITLE
Ingest checksum issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Breaking changes are annotated with ☢️, and alpha/beta features with 🐥.
 
-## [v0.47.0] - 2024-01-28
+## [v0.47.0] - UPCOMING
 
 This is a significant release, focused on improving i/o, responsiveness,
 and performance. The headline features are [caching](https://sq.io/docs/source#cache)

--- a/libsq/core/ioz/ioz.go
+++ b/libsq/core/ioz/ioz.go
@@ -383,16 +383,16 @@ func (w *notifyOnceWriter) Write(p []byte) (n int, err error) {
 	return w.w.Write(p)
 }
 
-// NotifyOnEOFReader returns an io.Reader that invokes fn
+// NotifyOnEOFReader returns an [io.Reader] that invokes fn
 // when r.Read returns [io.EOF]. The error that fn returns is
 // what's returned to the r caller: fn can transform the error
 // or return it unchanged. If r or fn is nil, r is returned.
 //
-// If r is an io.ReadCloser, the returned reader will also
-// implement io.ReadCloser.
+// If r is an [io.ReadCloser], the returned reader will also
+// implement [io.ReadCloser].
 //
-// See also: NotifyOnErrorReader, which is a generalization of
-// NotifyOnEOFReader.
+// See also: [NotifyOnErrorReader], which is a generalization of
+// [NotifyOnEOFReader].
 func NotifyOnEOFReader(r io.Reader, fn func(error) error) io.Reader {
 	if r == nil || fn == nil {
 		return r
@@ -434,13 +434,13 @@ func (r *notifyOnEOFReadCloser) Close() error {
 	return nil
 }
 
-// NotifyOnErrorReader returns an io.Reader that invokes fn
+// NotifyOnErrorReader returns an [io.Reader] that invokes fn
 // when r.Read returns an error. The error that fn returns is
 // what's returned to the r caller: fn can transform the error
 // or return it unchanged. If r or fn is nil, r is returned.
 //
-// See also: NotifyOnEOFReader, which is a specialization of
-// NotifyOnErrorReader.
+// See also: [NotifyOnEOFReader], which is a specialization of
+// [NotifyOnErrorReader].
 func NotifyOnErrorReader(r io.Reader, fn func(error) error) io.Reader {
 	if r == nil || fn == nil {
 		return r
@@ -454,6 +454,7 @@ type notifyOnErrorReader struct {
 	fn func(error) error
 }
 
+// Read implements io.Reader.
 func (r *notifyOnErrorReader) Read(p []byte) (n int, err error) {
 	n, err = r.r.Read(p)
 	if err != nil {

--- a/libsq/driver/driver_test.go
+++ b/libsq/driver/driver_test.go
@@ -246,16 +246,18 @@ func TestDriver_Ping(t *testing.T) {
 }
 
 func TestDriver_Open(t *testing.T) {
-	t.Parallel()
+	//t.Parallel()
 	testCases := sakila.AllHandles()
 	testCases = append(testCases, sakila.CSVActor, sakila.CSVActorHTTP)
+
+	testCases = []string{sakila.CSVActorHTTP}
 
 	for _, handle := range testCases {
 		handle := handle
 
 		t.Run(handle, func(t *testing.T) {
 			tu.SkipShort(t, handle == sakila.XLSX)
-			t.Parallel()
+			//t.Parallel()
 
 			th := testh.New(t)
 			src := th.Source(handle)

--- a/libsq/driver/driver_test.go
+++ b/libsq/driver/driver_test.go
@@ -246,18 +246,16 @@ func TestDriver_Ping(t *testing.T) {
 }
 
 func TestDriver_Open(t *testing.T) {
-	//t.Parallel()
+	t.Parallel()
 	testCases := sakila.AllHandles()
 	testCases = append(testCases, sakila.CSVActor, sakila.CSVActorHTTP)
-
-	testCases = []string{sakila.CSVActorHTTP}
 
 	for _, handle := range testCases {
 		handle := handle
 
 		t.Run(handle, func(t *testing.T) {
 			tu.SkipShort(t, handle == sakila.XLSX)
-			//t.Parallel()
+			t.Parallel()
 
 			th := testh.New(t)
 			src := th.Source(handle)

--- a/libsq/files/cache.go
+++ b/libsq/files/cache.go
@@ -88,7 +88,7 @@ func (fs *Files) WriteIngestChecksum(ctx context.Context, src, backingSrc *sourc
 		return err
 	}
 
-	if location.TypeOf(src.Location) == location.TypeRemoteFile {
+	if location.TypeOf(src.Location) == location.TypeHTTP {
 		// If the source is remote, check if there was a download,
 		// and if so, make sure it's completed.
 		stream, ok := fs.streams[src.Handle]
@@ -141,9 +141,9 @@ func (fs *Files) CachedBackingSourceFor(ctx context.Context, src *source.Source)
 	defer fs.mu.Unlock()
 
 	switch location.TypeOf(src.Location) {
-	case location.TypeLocalFile:
+	case location.TypeFile:
 		return fs.cachedBackingSourceForFile(ctx, src)
-	case location.TypeRemoteFile:
+	case location.TypeHTTP:
 		return fs.cachedBackingSourceForRemoteFile(ctx, src)
 	default:
 		return nil, false, errz.Errorf("caching not applicable for source: %s", src.Handle)

--- a/libsq/files/cache.go
+++ b/libsq/files/cache.go
@@ -103,8 +103,8 @@ func (fs *Files) WriteIngestChecksum(ctx context.Context, src, backingSrc *sourc
 			}
 		}
 
-		// So, the stream is completely read from, but
-
+		// So, the stream is completely read from, but...
+		// FIXME: deal with the rest of the stuff here.
 	}
 
 	// Write the checksums file.

--- a/libsq/files/detect.go
+++ b/libsq/files/detect.go
@@ -117,7 +117,7 @@ func (fs *Files) detectType(ctx context.Context, handle, loc string) (typ driver
 	start := time.Now()
 
 	var newRdrFn NewReaderFunc
-	if location.TypeOf(loc) == location.TypeLocalFile {
+	if location.TypeOf(loc) == location.TypeFile {
 		newRdrFn = func(ctx context.Context) (io.ReadCloser, error) {
 			return errz.Return(os.Open(loc))
 		}

--- a/libsq/files/download.go
+++ b/libsq/files/download.go
@@ -127,7 +127,7 @@ func (fs *Files) maybeStartDownload(ctx context.Context, src *source.Source, che
 	go func() {
 		// Spawn a goroutine to execute the download process.
 		// The handler will be called before Get returns.
-		cacheFile := dldr.Get(ctx, h)
+		cacheFile := dldr.Get(ctx)
 		if cacheFile == "" {
 			// Either the download failed, or cache update failed.
 			return

--- a/libsq/files/files.go
+++ b/libsq/files/files.go
@@ -167,11 +167,6 @@ func (fs *Files) Filesize(ctx context.Context, src *source.Source) (size int64, 
 
 		return ioz.Filesize(dlFile)
 
-		// dl.Filesize will fail if the file has not been downloaded yet, which
-		// means that the source has not been ingested; but Files.Filesize should
-		// not have been invoked before ingestion.
-		// return dl.Filesize(ctx)
-
 	case location.TypeSQL:
 		// Should be impossible.
 		return 0, errz.Errorf("invalid to get size of SQL source: %s", src.Handle)

--- a/libsq/files/files_test.go
+++ b/libsq/files/files_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
 
-	"github.com/neilotoole/sq/libsq/core/ioz"
 	"github.com/neilotoole/sq/libsq/core/lg"
 	"github.com/neilotoole/sq/libsq/core/lg/lgt"
 	"github.com/neilotoole/sq/libsq/core/stringz"
@@ -267,7 +266,8 @@ func TestFiles_Filesize(t *testing.T) {
 	// Files.Filesize will block until the stream is fully read.
 	r, err := fs.NewReader(th.Context, stdinSrc, false)
 	require.NoError(t, err)
-	require.NoError(t, ioz.Drain(r))
+	_, err = io.Copy(io.Discard, r)
+	require.NoError(t, err)
 
 	gotSize2, err := fs.Filesize(th.Context, stdinSrc)
 	require.NoError(t, err)

--- a/libsq/files/files_test.go
+++ b/libsq/files/files_test.go
@@ -101,11 +101,18 @@ func TestFiles_DriverType(t *testing.T) {
 		t.Run(tu.Name(location.Redact(tc.loc)), func(t *testing.T) {
 			ctx := lg.NewContext(context.Background(), lgt.New(t))
 
-			fs, err := files.New(ctx, nil, testh.TempLockFunc(t), tu.TempDir(t, true), tu.CacheDir(t, true))
+			fs, err := files.New(
+				ctx,
+				nil,
+				testh.TempLockFunc(t),
+				tu.TempDir(t, false),
+				tu.CacheDir(t, false),
+			)
 			require.NoError(t, err)
+			defer func() { assert.NoError(t, fs.Close()) }()
 			fs.AddDriverDetectors(testh.DriverDetectors()...)
 
-			gotType, gotErr := fs.DetectType(context.Background(), "@test_"+stringz.Uniq8(), tc.loc)
+			gotType, gotErr := fs.DetectType(ctx, "@test_"+stringz.Uniq8(), tc.loc)
 			if tc.wantErr {
 				require.Error(t, gotErr)
 				return

--- a/libsq/files/internal/downloader/cache.go
+++ b/libsq/files/internal/downloader/cache.go
@@ -237,8 +237,8 @@ func (c *cache) clear(ctx context.Context) error {
 	return nil
 }
 
-// write updates the cache header from resp. The response body is not
-// written to the cache, nor is resp.Body closed.
+// writeHeader updates the main cache header file from resp. The response body
+// is not written to the cache, nor is resp.Body closed.
 func (c *cache) writeHeader(ctx context.Context, resp *http.Response) (err error) {
 	header, err := httputil.DumpResponse(resp, false)
 	if err != nil {

--- a/libsq/files/internal/downloader/cache.go
+++ b/libsq/files/internal/downloader/cache.go
@@ -389,7 +389,9 @@ func (r *responseCacher) write(p []byte, n int) error {
 
 // Read implements io.Reader. It reads into p from the response body,
 // writes the received bytes to the cache, and returns the number of
-// bytes read and any error. If
+// bytes read and any error.
+//
+// FIXME: comment this properly.
 func (r *responseCacher) Read(p []byte) (n int, err error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -430,7 +432,6 @@ func (r *responseCacher) Read(p []byte) (n int, err error) {
 	}
 
 	return n, err
-
 }
 
 func (r *responseCacher) finalize() error {

--- a/libsq/files/internal/downloader/cache.go
+++ b/libsq/files/internal/downloader/cache.go
@@ -320,8 +320,9 @@ type responseCacher struct {
 // Read implements [io.Reader]. It reads into p from the wrapped response body,
 // appends the received bytes to the staging cache, and returns the number of
 // bytes read, and any error. When Read encounters [io.EOF] from the response
-// body, it finalizes the cache, and on success returns [io.EOF]. If an error
-// occurs during cache finalization, Read returns that error instead of io.EOF.
+// body, it promotes the staging cache to main, and on success returns [io.EOF].
+// If an error occurs during cache promotion, Read returns that promotion error
+// instead of [io.EOF].
 func (r *responseCacher) Read(p []byte) (n int, err error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()

--- a/libsq/files/internal/downloader/cache.go
+++ b/libsq/files/internal/downloader/cache.go
@@ -364,12 +364,12 @@ func (c *cache) newResponseCacher(ctx context.Context, resp *http.Response) (*re
 var _ io.ReadCloser = (*responseCacher)(nil)
 
 type responseCacher struct {
-	mu         sync.Mutex
+	body       io.ReadCloser
 	closeErr   *error
+	f          *os.File
 	mainDir    string
 	stagingDir string
-	body       io.ReadCloser
-	f          *os.File
+	mu         sync.Mutex
 }
 
 func (r *responseCacher) write(p []byte, n int) error {

--- a/libsq/files/internal/downloader/downloader.go
+++ b/libsq/files/internal/downloader/downloader.go
@@ -346,7 +346,7 @@ func (dl *Downloader) get(req *http.Request) (dlFile string, //nolint:gocognit,f
 		}
 
 		if resp == cachedResp {
-			err = dl.cache.write(ctx, resp, true)
+			err = dl.cache.writeHeader(ctx, resp)
 			lg.WarnIfCloseError(log, lgm.CloseHTTPResponseBody, resp.Body)
 			if err != nil {
 				log.Error("Failed to update cache header", lga.Dir, dl.cache.dir, lga.Err, err)

--- a/libsq/files/internal/downloader/downloader.go
+++ b/libsq/files/internal/downloader/downloader.go
@@ -113,7 +113,8 @@ type Downloader struct {
 
 	// workingCh is re-created on each call to Downloader.Get, and is closed
 	// when Get returns.
-	workingCh chan struct{}
+	// Deprecated: using new responseCacher mechanism.
+	//workingCh chan struct{}
 
 	// cache implements the on-disk cache. If nil, caching is disabled.
 	// It will be created in dlDir.
@@ -165,12 +166,12 @@ func New(name string, c *http.Client, dlURL, dlDir string) (*Downloader, error) 
 		markCachedResponses: true,
 		continueOnError:     true,
 		dlDir:               dlDir,
-		workingCh:           make(chan struct{}),
+		//workingCh:           make(chan struct{}),
 	}
 
 	// Downloader is not initially working, so the channel should be closed.
 	// It will be reset to open on each call to Downloader.Get.
-	close(dl.workingCh)
+	//close(dl.workingCh)
 
 	return dl, nil
 }
@@ -195,7 +196,7 @@ func New(name string, c *http.Client, dlURL, dlDir string) (*Downloader, error) 
 //
 // Get consults the context for options. In particular, it makes
 // use of OptCache and OptContinueOnError.
-func (dl *Downloader) Get(ctx context.Context, h Handler) (cacheFile string) {
+func (dl *Downloader) Get(ctx context.Context) (dlFile string, dlStream *streamcache.Stream, err error) {
 	dl.mu.Lock()
 	defer dl.mu.Unlock()
 
@@ -207,22 +208,22 @@ func (dl *Downloader) Get(ctx context.Context, h Handler) (cacheFile string) {
 
 	req := dl.mustRequest(ctx)
 	lg.FromContext(ctx).Debug("Get download", lga.URL, dl.url)
-	cacheFile = dl.get(req, h)
-	return cacheFile
+	return dl.get(req)
+	//return dlFile
 }
 
 // get contains the main logic for getting the download.
 // It invokes Handler as appropriate, and on success returns the
 // filepath of the valid cached download ›file.
-func (dl *Downloader) get(req *http.Request, h Handler) (cacheFile string) { //nolint:gocognit,funlen,cyclop
+func (dl *Downloader) get(req *http.Request) (dlFile string, dlStream *streamcache.Stream, err error) { //nolint:gocognit,funlen,cyclop
 	ctx := req.Context()
 	log := lg.FromContext(ctx)
 
 	dl.dlStream = nil
 
-	defer func() {
-		close(dl.workingCh)
-	}()
+	//defer func() {
+	//	close(dl.workingCh)
+	//}()
 
 	var fpBody string
 	if dl.cache != nil {
@@ -232,12 +233,12 @@ func (dl *Downloader) get(req *http.Request, h Handler) (cacheFile string) { //n
 	state := dl.state(req)
 	if state == Fresh && fpBody != "" {
 		// The cached response is fresh, so we can return it.
-		h.Cached(fpBody)
-		return fpBody
+		//h.Cached(fpBody)
+		return fpBody, nil, nil
 	}
 
 	cacheable := dl.isCacheable(req)
-	var err error
+	//var err error
 	var cachedResp *http.Response
 	if cacheable {
 		cachedResp, err = dl.cache.get(req.Context(), req) //nolint:bodyclose
@@ -254,8 +255,8 @@ func (dl *Downloader) get(req *http.Request, h Handler) (cacheFile string) { //n
 			freshness := getFreshness(cachedResp.Header, req.Header)
 			if freshness == Fresh && fpBody != "" {
 				lg.WarnIfCloseError(log, lgm.CloseHTTPResponseBody, cachedResp.Body)
-				h.Cached(fpBody)
-				return fpBody
+				//h.Cached(fpBody)
+				return fpBody, nil, nil
 			}
 
 			if freshness == Stale {
@@ -296,8 +297,8 @@ func (dl *Downloader) get(req *http.Request, h Handler) (cacheFile string) { //n
 			// when available.
 			lg.WarnIfCloseError(log, lgm.CloseHTTPResponseBody, cachedResp.Body)
 			log.Warn("Returning cached response due to transport failure", lga.Err, err)
-			h.Cached(fpBody)
-			return fpBody
+			//h.Cached(fpBody)
+			return fpBody, nil, nil
 
 		default:
 			if err != nil && resp != nil && resp.StatusCode != http.StatusOK {
@@ -306,31 +307,31 @@ func (dl *Downloader) get(req *http.Request, h Handler) (cacheFile string) { //n
 
 				if fp := dl.cacheFileOnError(req, err); fp != "" {
 					lg.WarnIfCloseError(log, lgm.CloseHTTPResponseBody, resp.Body)
-					h.Cached(fp)
-					return fp
+					//h.Cached(fp)
+					return fp, nil, nil
 				}
 			}
 
 			if err != nil {
 				lg.WarnIfCloseError(log, lgm.CloseHTTPResponseBody, resp.Body)
 				if fp := dl.cacheFileOnError(req, err); fp != "" {
-					h.Cached(fp)
-					return fp
+					//h.Cached(fp)
+					return fp, nil, nil
 				}
-				h.Error(err)
-				return ""
+				//h.Error(err)
+				return "", nil, err
 			}
 
 			if resp.StatusCode != http.StatusOK {
 				lg.WarnIfCloseError(log, lgm.CloseHTTPResponseBody, resp.Body)
 				err = errz.Errorf("download: unexpected HTTP status: %s", httpz.StatusText(resp.StatusCode))
 				if fp := dl.cacheFileOnError(req, err); fp != "" {
-					h.Cached(fp)
-					return fp
+					//h.Cached(fp)
+					return fp, nil, nil
 				}
 
-				h.Error(err)
-				return ""
+				//h.Error(err)
+				return "", nil, err
 			}
 		}
 	} else {
@@ -341,11 +342,11 @@ func (dl *Downloader) get(req *http.Request, h Handler) (cacheFile string) { //n
 			resp, err = dl.do(req) //nolint:bodyclose
 			if err != nil {
 				if fp := dl.cacheFileOnError(req, err); fp != "" {
-					h.Cached(fp)
-					return fp
+					//h.Cached(fp)
+					return fp, nil, nil
 				}
-				h.Error(err)
-				return ""
+				//h.Error(err)
+				return "", nil, err
 			}
 		}
 	}
@@ -366,58 +367,66 @@ func (dl *Downloader) get(req *http.Request, h Handler) (cacheFile string) { //n
 			if err != nil {
 				log.Error("Failed to update cache header", lga.Dir, dl.cache.dir, lga.Err, err)
 				if fp := dl.cacheFileOnError(req, err); fp != "" {
-					h.Cached(fp)
-					return fp
+					//h.Cached(fp)
+					return fp, nil, nil
 				}
-				h.Error(err)
-				return ""
+				//h.Error(err)
+				return "", nil, err
+
 			}
 
 			if fpBody != "" {
-				h.Cached(fpBody)
-				return fpBody
+				//h.Cached(fpBody)
+				return fpBody, nil, nil
 			}
 		} else if cachedResp != nil && cachedResp.Body != nil {
 			lg.WarnIfCloseError(log, lgm.CloseHTTPResponseBody, cachedResp.Body)
 		}
+		//
+		//var cacheErr error
+		//cacheWait := make(chan struct{})
 
-		var cacheErr error
-		cacheWait := make(chan struct{})
-
-		dl.dlStream = streamcache.New(resp.Body)
-		resp.Body = dl.dlStream.NewReader(ctx)
-		h.Uncached(dl.dlStream)
-		cacheErr = dl.cache.write(req.Context(), resp, false)
-		close(cacheWait)
-		if cacheErr != nil {
-			// We don't explicitly call Handler.Error: it would be "illegal" to do so
-			// anyway, because the Handler docs state that at most one Handler callback
-			// func is ever invoked.
-			//
-			// The cache write could fail for one of two reasons:
-			//
-			// - The download didn't complete successfully: that is, there was an error
-			//   reading from resp.Body. In this case, that same error will be propagated
-			//   to the Handler via the streamcache.Stream that was provided to Handler.Uncached.
-			// - The download completed, but there was a problem writing out the cache
-			//   files (header, body, checksum). This is likely a very rare occurrence.
-			//   In that case, any previous cache files are left untouched by cache.write,
-			//   and all we do is log the error. If the cache is inconsistent, it will
-			//   repair itself on next invocation, so it's not a big deal.
-			log.Warn("Failed to write download cache", lga.Dir, dl.cache.dir, lga.Err, cacheErr)
-			lg.WarnIfCloseError(log, lgm.CloseHTTPResponseBody, resp.Body)
-			return ""
+		var respCacher *responseCacher
+		if respCacher, err = dl.cache.newResponseCacher(ctx, resp); err != nil {
+			//h.Error(err)
+			return "", nil, err
 		}
-		lg.WarnIfCloseError(log, lgm.CloseHTTPResponseBody, resp.Body)
-		return fpBody
+
+		dl.dlStream = streamcache.New(respCacher)
+		//resp.Body = dl.dlStream.NewReader(ctx)
+		//h.Uncached(dl.dlStream)
+		return "", dl.dlStream, nil
+		//cacheErr = dl.cache.write(req.Context(), resp, false)
+		//close(cacheWait)
+		//if cacheErr != nil {
+		//	// We don't explicitly call Handler.Error: it would be "illegal" to do so
+		//	// anyway, because the Handler docs state that at most one Handler callback
+		//	// func is ever invoked.
+		//	//
+		//	// The cache write could fail for one of two reasons:
+		//	//
+		//	// - The download didn't complete successfully: that is, there was an error
+		//	//   reading from resp.Body. In this case, that same error will be propagated
+		//	//   to the Handler via the streamcache.Stream that was provided to Handler.Uncached.
+		//	// - The download completed, but there was a problem writing out the cache
+		//	//   files (header, body, checksum). This is likely a very rare occurrence.
+		//	//   In that case, any previous cache files are left untouched by cache.write,
+		//	//   and all we do is log the error. If the cache is inconsistent, it will
+		//	//   repair itself on next invocation, so it's not a big deal.
+		//	log.Warn("Failed to write download cache", lga.Dir, dl.cache.dir, lga.Err, cacheErr)
+		//	lg.WarnIfCloseError(log, lgm.CloseHTTPResponseBody, resp.Body)
+		//	return ""
+		//}
+		//lg.WarnIfCloseError(log, lgm.CloseHTTPResponseBody, resp.Body)
+		//return fpBody
 	}
 
 	// It's not cacheable, so we can just wrap resp.Body in a streamcache
 	// and return it.
 	dl.dlStream = streamcache.New(resp.Body)
 	resp.Body = nil // Unnecessary, but just to be explicit.
-	h.Uncached(dl.dlStream)
-	return ""
+	//h.Uncached(dl.dlStream)
+	return "", dl.dlStream, nil
 }
 
 // do executes the request.
@@ -548,9 +557,9 @@ func (dl *Downloader) Filesize(ctx context.Context) (int64, error) {
 // Working returns a channel that is closed when Downloader.Get returns.
 // Each new call to Downloader.Get creates a new channel, so don't hold
 // on to the returned channel across multiple calls to Get.
-func (dl *Downloader) Working() <-chan struct{} {
-	return dl.workingCh
-}
+//func (dl *Downloader) Working() <-chan struct{} {
+//	return dl.workingCh
+//}
 
 // CacheFile returns the path to the cached file, if it exists and has
 // been fully downloaded.

--- a/libsq/files/internal/downloader/downloader_test.go
+++ b/libsq/files/internal/downloader/downloader_test.go
@@ -248,10 +248,7 @@ func TestCachePreservedOnFailedRefresh(t *testing.T) {
 	require.Equal(t, len(sentBody), gotN)
 
 	require.True(t, errors.Is(gotStream.Err(), io.EOF))
-	var gotFilesize int64
-	gotFilesize, err = dl.Filesize(ctx)
 	require.NoError(t, err)
-	require.Equal(t, len(sentBody), int(gotFilesize))
 	require.Equal(t, len(sentBody), gotStream.Size())
 
 	fpBody, err := dl.CacheFile(ctx)

--- a/libsq/source/location/location.go
+++ b/libsq/source/location/location.go
@@ -1,6 +1,9 @@
 // Package location contains functionality related to source location.
 package location
 
+// NOTE: This package contains code from several eras. There's a bunch of
+// overlap and duplication. It should be consolidated.
+
 import (
 	"net/url"
 	"path"
@@ -327,11 +330,11 @@ func isFpath(loc string) (fpath string, ok bool) {
 type Type string
 
 const (
-	TypeStdin      = "stdin"
-	TypeLocalFile  = "local_file"
-	TypeSQL        = "sql"
-	TypeRemoteFile = "remote_file"
-	TypeUnknown    = "unknown"
+	TypeStdin   = "stdin"
+	TypeFile    = "local_file"
+	TypeSQL     = "sql"
+	TypeHTTP    = "http_file"
+	TypeUnknown = "unknown"
 )
 
 // TypeOf returns the type of loc, or locTypeUnknown if it
@@ -345,14 +348,14 @@ func TypeOf(loc string) Type {
 		return TypeSQL
 	case strings.HasPrefix(loc, "http://"),
 		strings.HasPrefix(loc, "https://"):
-		return TypeRemoteFile
+		return TypeHTTP
 	default:
 	}
 
 	if _, err := filepath.Abs(loc); err != nil {
 		return TypeUnknown
 	}
-	return TypeLocalFile
+	return TypeFile
 }
 
 // isHTTP tests if s is a well-structured HTTP or HTTPS url, and

--- a/testh/tu/tu.go
+++ b/testh/tu/tu.go
@@ -376,32 +376,44 @@ func MustStat(tb testing.TB, fp string) os.FileInfo {
 	return fi
 }
 
-// MustDrain drains r, failing t on error. If arg close is true,
-// r is closed if it's an io.Closer.
-func MustDrain(tb testing.TB, r io.Reader, close bool) {
+// MustDrain drains r, failing t on error. If arg cloze is true,
+// r is closed if it's an io.Closer, even if the drain fails.
+// FIXME: delete this func.
+func MustDrain(tb testing.TB, r io.Reader, cloze bool) {
 	tb.Helper()
-	_, err := io.Copy(io.Discard, r)
-	require.NoError(tb, err)
-	if !close {
+	_, cpErr := io.Copy(io.Discard, r)
+	if !cloze {
+		require.NoError(tb, cpErr)
 		return
 	}
+
+	var closeErr error
 	if rc, ok := r.(io.Closer); ok {
-		require.NoError(tb, rc.Close())
+		closeErr = rc.Close()
 	}
+
+	require.NoError(tb, cpErr)
+	require.NoError(tb, closeErr)
 }
 
 // MustDrainN is like MustDrain, but also reports the number of bytes
-// drained. If arg close is true, r is closed if it's an io.Closer.
-func MustDrainN(tb testing.TB, r io.Reader, close bool) int {
+// drained. If arg cloze is true, r is closed if it's an io.Closer,
+// even if the drain fails.
+func MustDrainN(tb testing.TB, r io.Reader, cloze bool) int {
 	tb.Helper()
-	n, err := io.Copy(io.Discard, r)
-	require.NoError(tb, err)
-	if !close {
+	n, cpErr := io.Copy(io.Discard, r)
+	if !cloze {
+		require.NoError(tb, cpErr)
 		return int(n)
 	}
+
+	var closeErr error
 	if rc, ok := r.(io.Closer); ok {
-		require.NoError(tb, rc.Close())
+		closeErr = rc.Close()
 	}
+
+	require.NoError(tb, cpErr)
+	require.NoError(tb, closeErr)
 	return int(n)
 }
 


### PR DESCRIPTION
- See https://github.com/neilotoole/sq/actions/runs/7688809566/job/20950448990#step:6:3024
- Refactored `downloader.Downloader.Get`... no longer uses the `Handler` callback mechanism. The logic should be much clearer now.