### PR TITLE
Track memory usage

### DIFF
--- a/cli/options.go
+++ b/cli/options.go
@@ -201,6 +201,7 @@ func RegisterDefaultOpts(reg *options.Registry) {
 		driver.OptIngestSampleSize,
 		csv.OptDelim,
 		csv.OptEmptyAsNull,
+		OptDebugTrackMemory,
 		progress.OptDebugSleep,
 	)
 }

--- a/cli/options_test.go
+++ b/cli/options_test.go
@@ -19,7 +19,7 @@ func TestRegisterDefaultOpts(t *testing.T) {
 	log.Debug("options.Registry (after)", "reg", reg)
 
 	keys := reg.Keys()
-	require.Len(t, keys, 50)
+	require.Len(t, keys, 51)
 
 	for _, opt := range reg.Opts() {
 		opt := opt

--- a/cli/output.go
+++ b/cli/output.go
@@ -120,6 +120,16 @@ command, sq falls back to "text". Available formats:
 		`Delay before showing a progress bar.`,
 	)
 
+	OptDebugTrackMemory = options.NewDuration(
+		"debug.stats.frequency",
+		"",
+		0,
+		0,
+		"Memory usage sampling interval.",
+		`Memory usage sampling interval. If non-zero, peak memory usage is periodically
+sampled, and reported on exit. If zero, memory usage sampling is disabled.`,
+	)
+
 	OptCompact = options.NewBool(
 		"compact",
 		"",

--- a/libsq/core/ioz/ioz.go
+++ b/libsq/core/ioz/ioz.go
@@ -11,12 +11,15 @@ import (
 	mrand "math/rand"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/a8m/tree"
 	"github.com/a8m/tree/ostree"
+	"github.com/c2h5oh/datasize"
 	yaml "github.com/goccy/go-yaml"
 
 	"github.com/neilotoole/sq/libsq/core/errz"
@@ -791,4 +794,43 @@ func countNonDirs(entries []os.DirEntry) (count int) {
 		}
 	}
 	return count
+}
+
+// PeakMemory is an [atomic.Uint64] that tracks the peak memory usage.
+type PeakMemory struct {
+	atomic.Uint64
+}
+
+// String returns a human-friendly representation.
+func (p *PeakMemory) String() string {
+	v := p.Load()
+	return datasize.ByteSize(v).HR()
+}
+
+// StartPeakMemoryTracker starts a goroutine that tracks the peak memory usage,
+// per [runtime.MemStats.Sys] and [runtime.ReadMemStats]. The goroutine sleeps
+// for sampleFreq between each sample and exits when ctx is done.
+func StartPeakMemoryTracker(ctx context.Context, sampleFreq time.Duration) *PeakMemory {
+	peakMem := &PeakMemory{}
+	go func() {
+		ticker := time.NewTicker(sampleFreq)
+		defer ticker.Stop()
+
+		var peak uint64
+		stats := &runtime.MemStats{}
+		for {
+			runtime.ReadMemStats(stats)
+			peak = peakMem.Load()
+			if stats.Sys > peak {
+				peakMem.Store(stats.Sys)
+			}
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+			}
+		}
+	}()
+
+	return peakMem
 }


### PR DESCRIPTION
Add config option `debug.stats.frequency` to log peak memory usage.