### PR TITLE
Explicitly import time/tzdata

### DIFF
--- a/libsq/core/timez/timez.go
+++ b/libsq/core/timez/timez.go
@@ -4,6 +4,7 @@ package timez
 import (
 	"strings"
 	"time"
+	_ "time/tzdata" // Load tzdata: it's not included in all distros, e.g. Alpine.
 
 	"github.com/neilotoole/sq/libsq/core/errz"
 )


### PR DESCRIPTION
`sq v0.47.0` introduced a dependency on timezone location data (tzdata). Well, that's guaranteed to be included on every distro, e.g. Alpine.

This broke the distro tests: https://github.com/neilotoole/sq/actions/runs/7701355729/job/20987599862#step:3:383

The solution is to explicitly import `time/tzdata`.