### PR TITLE
Moved time/tzdata import to main

### DIFF
--- a/drivers/csv/csv_test.go
+++ b/drivers/csv/csv_test.go
@@ -441,7 +441,7 @@ func TestGenerateTimestampVals(t *testing.T) {
 	names := maps.Keys(timez.TimestampLayouts)
 	slices.Sort(names)
 
-	for _, loc := range []*time.Location{time.UTC, timez.LosAngeles, timez.Denver} {
+	for _, loc := range []*time.Location{time.UTC, fixt.LosAngeles, fixt.Denver} {
 		fmt.Fprintf(os.Stdout, "\n\n%s\n\n", loc.String())
 		tm := canonicalTimeUTC.In(loc)
 

--- a/libsq/core/timez/timez.go
+++ b/libsq/core/timez/timez.go
@@ -4,7 +4,6 @@ package timez
 import (
 	"strings"
 	"time"
-	_ "time/tzdata" // Load tzdata: it's not included in all distros, e.g. Alpine.
 
 	"github.com/neilotoole/sq/libsq/core/errz"
 )
@@ -178,17 +177,4 @@ var TimestampLayouts = map[string]string{
 	"DateHourMinute":            DateHourMinute,
 	"ExcelDatetimeMDYSeconds":   ExcelDatetimeMDYSeconds,
 	"ExcelDatetimeMDYNoSeconds": ExcelDatetimeMDYNoSeconds,
-}
-
-var (
-	LosAngeles = mustLoadLocation("America/Los_Angeles")
-	Denver     = mustLoadLocation("America/Denver")
-)
-
-func mustLoadLocation(name string) *time.Location {
-	loc, err := time.LoadLocation(name)
-	if err != nil {
-		panic(err)
-	}
-	return loc
 }

--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/signal"
 	"time"
+	_ "time/tzdata"
 
 	"github.com/neilotoole/sq/cli"
 	"github.com/neilotoole/sq/libsq/core/errz"

--- a/testh/fixt/fixt.go
+++ b/testh/fixt/fixt.go
@@ -103,3 +103,16 @@ const (
 	// in the "blobs" table.
 	BlobDBPath = "drivers/sqlite3/testdata/blob.db"
 )
+
+var (
+	LosAngeles = mustLoadLocation("America/Los_Angeles")
+	Denver     = mustLoadLocation("America/Denver")
+)
+
+func mustLoadLocation(name string) *time.Location {
+	loc, err := time.LoadLocation(name)
+	if err != nil {
+		panic(err)
+	}
+	return loc
+}


### PR DESCRIPTION
- Some test fixtures for tz locations were included in pkg `timez`, instead of being in the test code.
- Moved import of `time/tzdata` to `main.go`.