### PR TITLE
Add file buffers to diff

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -106,11 +106,12 @@ func ExecuteWith(ctx context.Context, ru *run.Run, args []string) (err error) {
 		// runtimez.MemStatsRefresh = memStatRefreshFreq
 
 		// Debug setting to log peak memory usage on exit.
-		peakSys, peakAllocs, gcPause := runtimez.StartMemStatsTracker(ctx)
+		peakSys, peakAllocs, totalAllocs, gcPause := runtimez.StartMemStatsTracker(ctx)
 		defer func() {
-			log.Info("Peak memory stats",
-				"sys", datasize.ByteSize(peakSys.Load()).HR(),
-				"heap", datasize.ByteSize(peakAllocs.Load()).HR(),
+			log.Info("Memory stats",
+				"sys_peak", datasize.ByteSize(peakSys.Load()).HR(),
+				"heap_peak", datasize.ByteSize(peakAllocs.Load()).HR(),
+				"heap_total", datasize.ByteSize(totalAllocs.Load()).HR(),
 				"gc_pause", time.Duration(gcPause.Load()).String(),
 			)
 		}()

--- a/cli/diff/diff.go
+++ b/cli/diff/diff.go
@@ -59,3 +59,17 @@ type Modes struct {
 	// Data compares each row in a table. Caution: this can be slow.
 	Data bool
 }
+
+// getBufferFactor returns a diffdoc.Opt for use with [diffdoc.NewUnifiedDoc]
+// or [diffdoc.NewHunkDoc] that configures the [diffdoc.Doc] to use buffers
+// created by cfg.Run.Files. These buffers spill over to disk after a size
+// threshold, which is helpful when diffing large files.
+func getBufFactory(cfg *Config) diffdoc.Opt {
+	if cfg == nil || cfg.Run == nil || cfg.Run.Files == nil {
+		return diffdoc.OptBufferFactory(diffdoc.DefaultBufferFactory)
+	}
+
+	return diffdoc.OptBufferFactory(func() diffdoc.Buffer {
+		return cfg.Run.Files.NewBuffer()
+	})
+}

--- a/cli/diff/diff.go
+++ b/cli/diff/diff.go
@@ -6,6 +6,7 @@ import (
 	"github.com/neilotoole/sq/cli/output"
 	"github.com/neilotoole/sq/cli/run"
 	"github.com/neilotoole/sq/libsq/core/diffdoc"
+	"github.com/neilotoole/sq/libsq/core/ioz"
 )
 
 // Config contains parameters to control diff behavior.
@@ -66,10 +67,8 @@ type Modes struct {
 // threshold, which is helpful when diffing large files.
 func getBufFactory(cfg *Config) diffdoc.Opt {
 	if cfg == nil || cfg.Run == nil || cfg.Run.Files == nil {
-		return diffdoc.OptBufferFactory(diffdoc.DefaultBufferFactory)
+		return diffdoc.OptBufferFactory(ioz.NewDefaultBuffer)
 	}
 
-	return diffdoc.OptBufferFactory(func() diffdoc.Buffer {
-		return cfg.Run.Files.NewBuffer()
-	})
+	return diffdoc.OptBufferFactory(cfg.Run.Files.NewBuffer)
 }

--- a/cli/diff/exec_source.go
+++ b/cli/diff/exec_source.go
@@ -17,16 +17,20 @@ func ExecSourceDiff(ctx context.Context, cfg *Config, src1, src2 *source.Source)
 	var differs []*diffdoc.Differ
 
 	if modes.Overview {
-		doc := diffdoc.NewUnifiedDoc(diffdoc.Titlef(cfg.Colors,
-			"sq diff --overview %s %s", src1.Handle, src2.Handle))
+		doc := diffdoc.NewUnifiedDoc(
+			diffdoc.Titlef(cfg.Colors, "sq diff --overview %s %s", src1.Handle, src2.Handle),
+			getBufFactory(cfg),
+		)
 		differs = append(differs, diffdoc.NewDiffer(doc, func(ctx context.Context, _ func(error)) {
 			diffOverview(ctx, cfg, src1, src2, doc)
 		}))
 	}
 
 	if modes.DBProperties {
-		doc := diffdoc.NewUnifiedDoc(diffdoc.Titlef(cfg.Colors,
-			"sq diff --dbprops %s %s", src1.Handle, src2.Handle))
+		doc := diffdoc.NewUnifiedDoc(
+			diffdoc.Titlef(cfg.Colors, "sq diff --dbprops %s %s", src1.Handle, src2.Handle),
+			getBufFactory(cfg),
+		)
 		differs = append(differs, diffdoc.NewDiffer(doc, func(ctx context.Context, _ func(error)) {
 			diffDBProps(ctx, cfg, src1, src2, doc)
 		}))

--- a/cli/diff/exec_table.go
+++ b/cli/diff/exec_table.go
@@ -25,8 +25,10 @@ func ExecTableDiff(ctx context.Context, cfg *Config, src1 *source.Source, table1
 	)
 
 	if elems.Schema {
-		doc := diffdoc.NewUnifiedDoc(diffdoc.Titlef(cfg.Colors,
-			"sq diff --schema %s %s", td1.String(), td2.String()))
+		doc := diffdoc.NewUnifiedDoc(
+			diffdoc.Titlef(cfg.Colors, "sq diff --schema %s %s", td1.String(), td2.String()),
+			getBufFactory(cfg),
+		)
 		differs = append(differs, diffdoc.NewDiffer(doc, func(ctx context.Context, _ func(error)) {
 			diffTableSchema(ctx, cfg, elems.RowCount, td1, td2, doc)
 		}))

--- a/cli/diff/schema.go
+++ b/cli/diff/schema.go
@@ -39,7 +39,10 @@ func differsForSchema(ctx context.Context, cfg *Config, showRowCounts bool,
 		td1 := source.Table{Handle: src1.Handle, Name: tblName}
 		td2 := source.Table{Handle: src2.Handle, Name: tblName}
 
-		doc := diffdoc.NewUnifiedDoc(diffdoc.Titlef(cfg.Colors, "sq diff %s %s", td1, td2))
+		doc := diffdoc.NewUnifiedDoc(
+			diffdoc.Titlef(cfg.Colors, "sq diff %s %s", td1, td2),
+			getBufFactory(cfg),
+		)
 		differs = append(differs, diffdoc.NewDiffer(doc, func(ctx context.Context, _ func(error)) {
 			diffTableSchema(ctx, cfg, showRowCounts, td1, td2, doc)
 		}))

--- a/cli/diff/tabledata.go
+++ b/cli/diff/tabledata.go
@@ -62,7 +62,10 @@ func differForTableData(cfg *Config, title bool, td1, td2 source.Table) *diffdoc
 
 	doc := diffdoc.NewHunkDoc(
 		cmdTitle,
-		diffdoc.Headerf(cfg.Colors, td1.String(), td2.String()))
+		diffdoc.Headerf(cfg.Colors, td1.String(), td2.String()),
+		getBufFactory(cfg),
+	)
+
 	differ := diffdoc.NewDiffer(doc, func(ctx context.Context, cancelFn func(error)) {
 		diffTableData(ctx, cancelFn, cfg, td1, td2, doc)
 		if doc.Err() != nil {
@@ -85,8 +88,9 @@ func diffTableData(ctx context.Context, cancelFn context.CancelCauseFunc, //noli
 	log := lg.FromContext(ctx).With(lga.Left, td1.String(), lga.Right, td2.String())
 	log.Info("Diffing table data")
 
-	bar := progress.FromContext(ctx).NewWaiter(
-		fmt.Sprintf("Diff table data %s, %s", td1.String(), td2.String()),
+	bar := progress.FromContext(ctx).NewUnitCounter(
+		fmt.Sprintf("Diff data %s, %s", td1.String(), td2.String()),
+		"rec",
 		progress.OptMemUsage,
 	)
 
@@ -239,6 +243,7 @@ func diffTableData(ctx context.Context, cancelFn context.CancelCauseFunc, //noli
 			if !rp.Equal() {
 				diffCount++
 			}
+			bar.Incr(1)
 
 			recPairsCh <- rp
 

--- a/cli/diff/tabledata.go
+++ b/cli/diff/tabledata.go
@@ -240,10 +240,10 @@ func diffTableData(ctx context.Context, cancelFn context.CancelCauseFunc, //noli
 			}
 
 			rp := record.NewPair(i, rec1, rec2)
+			bar.Incr(1)
 			if !rp.Equal() {
 				diffCount++
 			}
-			bar.Incr(1)
 
 			recPairsCh <- rp
 

--- a/cli/error.go
+++ b/cli/error.go
@@ -96,7 +96,7 @@ func PrintError(ctx context.Context, ru *run.Run, err error) {
 	var errOut io.Writer
 	var pr *output.Printing
 	if ru != nil && ru.Stdout != nil && ru.Stderr != nil {
-		outCfg := getOutputConfig(cmd, clnup, fm, opts, ru.Stdout, ru.Stderr)
+		outCfg := getOutputConfig(cmd, ru.Files, clnup, fm, opts, ru.Stdout, ru.Stderr)
 		if outCfg != nil {
 			errOut, pr = outCfg.errOut, outCfg.errOutPr
 		}

--- a/cli/options.go
+++ b/cli/options.go
@@ -202,6 +202,7 @@ func RegisterDefaultOpts(reg *options.Registry) {
 		tuning.OptErrgroupLimit,
 		tuning.OptRecBufSize,
 		tuning.OptFlushThreshold,
+		tuning.OptBufMemLimit,
 		driver.OptIngestHeader,
 		driver.OptIngestCache,
 		files.OptCacheLockTimeout,

--- a/cli/options_test.go
+++ b/cli/options_test.go
@@ -16,7 +16,7 @@ func TestRegisterDefaultOpts(t *testing.T) {
 	lgt.New(t).Debug("options.Registry (after)", "reg", reg)
 
 	keys := reg.Keys()
-	require.Len(t, keys, 59)
+	require.Len(t, keys, 60)
 
 	for _, opt := range reg.Opts() {
 		opt := opt

--- a/cli/output.go
+++ b/cli/output.go
@@ -543,12 +543,6 @@ func getOutputConfig(cmd *cobra.Command, fs *files.Files, clnup *cleanup.Cleanup
 		prog = nil // Set to nil just to be explicit.
 	}
 
-	if prog != nil {
-		clnup.Add(func() {
-			lg.FromContext(ctx).Info("Progress closing stats", "progress", prog)
-		})
-	}
-
 	switch {
 	case cmdFlagChanged(cmd, flag.FileOutput) || fm == format.Raw:
 		// For file or raw output, we don't decorate stdout with

--- a/cli/output/jsonw/internal/benchmark_test.go
+++ b/cli/output/jsonw/internal/benchmark_test.go
@@ -7,7 +7,7 @@ import (
 
 	segmentj "github.com/segmentio/encoding/json"
 
-	jcolorenc "github.com/neilotoole/sq/cli/output/jsonw/internal/jcolorenc" //nolint:revive
+	"github.com/neilotoole/sq/cli/output/jsonw/internal/jcolorenc"
 	"github.com/neilotoole/sq/testh"
 	"github.com/neilotoole/sq/testh/sakila"
 )

--- a/cli/output/jsonw/internal/internal_test.go
+++ b/cli/output/jsonw/internal/internal_test.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/neilotoole/sq/cli/output"
 	"github.com/neilotoole/sq/cli/output/jsonw/internal"
-	jcolorenc "github.com/neilotoole/sq/cli/output/jsonw/internal/jcolorenc" //nolint:revive
+	"github.com/neilotoole/sq/cli/output/jsonw/internal/jcolorenc"
 )
 
 // Encoder encapsulates the methods of a JSON encoder.

--- a/cli/output/jsonw/internal/jcolorenc/codec.go
+++ b/cli/output/jsonw/internal/jcolorenc/codec.go
@@ -1,4 +1,4 @@
-package json
+package jcolorenc
 
 import (
 	"encoding"

--- a/cli/output/jsonw/internal/jcolorenc/decode.go
+++ b/cli/output/jsonw/internal/jcolorenc/decode.go
@@ -1,4 +1,4 @@
-package json
+package jcolorenc
 
 import (
 	"bytes"

--- a/cli/output/jsonw/internal/jcolorenc/encode.go
+++ b/cli/output/jsonw/internal/jcolorenc/encode.go
@@ -1,4 +1,4 @@
-package json
+package jcolorenc
 
 import (
 	"bytes"

--- a/cli/output/jsonw/internal/jcolorenc/golang_bench_test.go
+++ b/cli/output/jsonw/internal/jcolorenc/golang_bench_test.go
@@ -8,7 +8,7 @@
 // We benchmark converting between the JSON form
 // and in-memory data structures.
 
-package json
+package jcolorenc
 
 import (
 	"bytes"

--- a/cli/output/jsonw/internal/jcolorenc/golang_decode_test.go
+++ b/cli/output/jsonw/internal/jcolorenc/golang_decode_test.go
@@ -2253,7 +2253,7 @@ func TestUnmarshalEmbeddedUnexported(t *testing.T) {
 		in:  `{"R":2,"Q":1}`,
 		ptr: new(S1),
 		out: &S1{R: 2},
-		err: fmt.Errorf("json: cannot set embedded pointer to unexported struct: json.embed1"),
+		err: fmt.Errorf("json: cannot set embedded pointer to unexported struct: jcolorenc.embed1"),
 	}, {
 		// The top level Q field takes precedence.
 		in:  `{"Q":1}`,
@@ -2275,7 +2275,7 @@ func TestUnmarshalEmbeddedUnexported(t *testing.T) {
 		in:  `{"R":2,"Q":1}`,
 		ptr: new(S5),
 		out: &S5{R: 2},
-		err: fmt.Errorf("json: cannot set embedded pointer to unexported struct: json.embed3"),
+		err: fmt.Errorf("json: cannot set embedded pointer to unexported struct: jcolorenc.embed3"),
 	}, {
 		// Issue 24152, ensure decodeState.indirect does not panic.
 		in:  `{"embed1": {"Q": 1}}`,

--- a/cli/output/jsonw/internal/jcolorenc/golang_decode_test.go
+++ b/cli/output/jsonw/internal/jcolorenc/golang_decode_test.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-package json
+package jcolorenc
 
 import (
 	"bytes"

--- a/cli/output/jsonw/internal/jcolorenc/golang_encode_test.go
+++ b/cli/output/jsonw/internal/jcolorenc/golang_encode_test.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-package json
+package jcolorenc
 
 import (
 	"bytes"

--- a/cli/output/jsonw/internal/jcolorenc/golang_example_marshaling_test.go
+++ b/cli/output/jsonw/internal/jcolorenc/golang_example_marshaling_test.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-package json_test
+package jcolorenc_test
 
 import (
 	"encoding/json"

--- a/cli/output/jsonw/internal/jcolorenc/golang_example_test.go
+++ b/cli/output/jsonw/internal/jcolorenc/golang_example_test.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-package json_test
+package jcolorenc_test
 
 import (
 	"bytes"

--- a/cli/output/jsonw/internal/jcolorenc/golang_number_test.go
+++ b/cli/output/jsonw/internal/jcolorenc/golang_number_test.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-package json
+package jcolorenc
 
 import (
 	"regexp"

--- a/cli/output/jsonw/internal/jcolorenc/golang_scanner_test.go
+++ b/cli/output/jsonw/internal/jcolorenc/golang_scanner_test.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-package json
+package jcolorenc
 
 import (
 	"bytes"

--- a/cli/output/jsonw/internal/jcolorenc/golang_shim_test.go
+++ b/cli/output/jsonw/internal/jcolorenc/golang_shim_test.go
@@ -1,6 +1,6 @@
 // This file is a shim for dependencies of golang_*_test.go files that are normally provided by the standard library.
 // It helps importing those files with minimal changes.
-package json
+package jcolorenc
 
 import (
 	"bytes"

--- a/cli/output/jsonw/internal/jcolorenc/golang_tagkey_test.go
+++ b/cli/output/jsonw/internal/jcolorenc/golang_tagkey_test.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-package json
+package jcolorenc
 
 import (
 	"testing"

--- a/cli/output/jsonw/internal/jcolorenc/json.go
+++ b/cli/output/jsonw/internal/jcolorenc/json.go
@@ -1,4 +1,4 @@
-package json
+package jcolorenc
 
 import (
 	"bytes"

--- a/cli/output/jsonw/internal/jcolorenc/json_test.go
+++ b/cli/output/jsonw/internal/jcolorenc/json_test.go
@@ -1,4 +1,4 @@
-package json
+package jcolorenc
 
 import (
 	"bytes"

--- a/cli/output/jsonw/internal/jcolorenc/parse.go
+++ b/cli/output/jsonw/internal/jcolorenc/parse.go
@@ -1,4 +1,4 @@
-package json
+package jcolorenc
 
 import (
 	"bytes"

--- a/cli/output/jsonw/internal/jcolorenc/parse_test.go
+++ b/cli/output/jsonw/internal/jcolorenc/parse_test.go
@@ -1,4 +1,4 @@
-package json
+package jcolorenc
 
 import (
 	"bytes"

--- a/cli/output/jsonw/internal/jcolorenc/reflect.go
+++ b/cli/output/jsonw/internal/jcolorenc/reflect.go
@@ -1,7 +1,7 @@
 //go:build go1.15
 // +build go1.15
 
-package json
+package jcolorenc
 
 import (
 	"reflect"

--- a/cli/output/jsonw/internal/jcolorenc/reflect_optimize.go
+++ b/cli/output/jsonw/internal/jcolorenc/reflect_optimize.go
@@ -1,7 +1,7 @@
 //go:build !go1.15
 // +build !go1.15
 
-package json
+package jcolorenc
 
 import (
 	"reflect"

--- a/cli/output/jsonw/internal/jcolorenc/token.go
+++ b/cli/output/jsonw/internal/jcolorenc/token.go
@@ -1,4 +1,4 @@
-package json
+package jcolorenc
 
 // Tokenizer is an iterator-style type which can be used to progressively parse
 // through a json input.

--- a/cli/output/jsonw/internal/jcolorenc/token_test.go
+++ b/cli/output/jsonw/internal/jcolorenc/token_test.go
@@ -1,4 +1,4 @@
-package json
+package jcolorenc
 
 import (
 	"reflect"

--- a/cli/output/jsonw/jsonw.go
+++ b/cli/output/jsonw/jsonw.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/neilotoole/sq/cli/output"
 	"github.com/neilotoole/sq/cli/output/jsonw/internal"
-	jcolorenc "github.com/neilotoole/sq/cli/output/jsonw/internal/jcolorenc" //nolint:revive
+	"github.com/neilotoole/sq/cli/output/jsonw/internal/jcolorenc"
 	"github.com/neilotoole/sq/libsq/core/errz"
 )
 

--- a/cli/output/jsonw/pingwriter.go
+++ b/cli/output/jsonw/pingwriter.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/neilotoole/sq/cli/output"
 	"github.com/neilotoole/sq/cli/output/jsonw/internal"
-	jcolorenc "github.com/neilotoole/sq/cli/output/jsonw/internal/jcolorenc" //nolint:revive
+	"github.com/neilotoole/sq/cli/output/jsonw/internal/jcolorenc"
 	"github.com/neilotoole/sq/libsq/core/errz"
 	"github.com/neilotoole/sq/libsq/source"
 )

--- a/cli/output/printing.go
+++ b/cli/output/printing.go
@@ -4,6 +4,8 @@ import (
 	"log/slog"
 	"time"
 
+	"github.com/neilotoole/sq/libsq/core/ioz"
+
 	"github.com/fatih/color"
 	"github.com/samber/lo"
 
@@ -103,6 +105,10 @@ type Printing struct {
 	// Warning is the color for warning elements.
 	Warning *color.Color
 
+	// NewBufferFn returns a new [ioz.Buffer] instance, whose use should be
+	// preferred over [bytes.Buffer] in large data situations.
+	NewBufferFn func() ioz.Buffer
+
 	// Indent is the indent string to use when pretty-printing,
 	// typically two spaces.
 	Indent string
@@ -163,6 +169,7 @@ type Printing struct {
 // are enabled. The default indent is two spaces.
 func NewPrinting() *Printing {
 	pr := &Printing{
+		NewBufferFn:            ioz.NewDefaultBuffer,
 		ShowHeader:             true,
 		Verbose:                false,
 		Compact:                false,

--- a/cli/output/printing.go
+++ b/cli/output/printing.go
@@ -105,8 +105,8 @@ type Printing struct {
 	// Warning is the color for warning elements.
 	Warning *color.Color
 
-	// NewBufferFn returns a new [ioz.Buffer] instance, whose use should be
-	// preferred over [bytes.Buffer] in large data situations.
+	// NewBufferFn returns a new [ioz.Buffer] instance; it should be preferred
+	// over [bytes.Buffer] when dealing large/unbounded data.
 	NewBufferFn func() ioz.Buffer
 
 	// Indent is the indent string to use when pretty-printing,
@@ -218,6 +218,7 @@ func NewPrinting() *Printing {
 // Clone returns a clone of pr.
 func (pr *Printing) Clone() *Printing {
 	pr2 := &Printing{
+		NewBufferFn:            pr.NewBufferFn,
 		monochrome:             pr.monochrome,
 		FlushThreshold:         pr.FlushThreshold,
 		ShowHeader:             pr.ShowHeader,

--- a/cli/run.go
+++ b/cli/run.go
@@ -193,14 +193,14 @@ func preRun(cmd *cobra.Command, ru *run.Run) error {
 		return err
 	}
 
-	var outCfg *outputConfig
-	ru.Writers, outCfg = newWriters(ru.Cmd, ru.Cleanup, cmdOpts, ru.Stdout, ru.Stderr)
-	ru.Out = outCfg.out
-	ru.ErrOut = outCfg.errOut
-
 	if err = FinishRunInit(ctx, ru); err != nil {
 		return err
 	}
+
+	var outCfg *outputConfig
+	ru.Writers, outCfg = newWriters(ru.Cmd, ru.Files, ru.Cleanup, cmdOpts, ru.Stdout, ru.Stderr)
+	ru.Out = outCfg.out
+	ru.ErrOut = outCfg.errOut
 
 	if cmdRequiresConfigLock(cmd) {
 		var unlock func()

--- a/go.mod
+++ b/go.mod
@@ -61,6 +61,7 @@ require (
 	github.com/VividCortex/ewma v1.2.0 // indirect
 	github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/djherbis/buffer v1.2.0 // indirect
 	github.com/felixge/fgprof v0.9.4 // indirect
 	github.com/golang-sql/civil v0.0.0-20220223132316-b832511892a9 // indirect
 	github.com/golang-sql/sqlexp v0.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -47,6 +47,8 @@ github.com/creack/pty v1.1.18/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/djherbis/buffer v1.2.0 h1:PH5Dd2ss0C7CRRhQCZ2u7MssF+No9ide8Ye71nPHcrQ=
+github.com/djherbis/buffer v1.2.0/go.mod h1:fjnebbZjCUpPinBRD+TDwXSOeNQ7fPQWLfGQqiAiUyE=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/ecnepsnai/osquery v1.0.1 h1:i96n/3uqcafKZtRYmXVNqekKbfrIm66q179mWZ/Y2Aw=

--- a/libsq/core/diffdoc/diffdoc.go
+++ b/libsq/core/diffdoc/diffdoc.go
@@ -87,6 +87,7 @@ type UnifiedDoc struct {
 
 // Close implements io.Closer.
 func (d *UnifiedDoc) Close() error {
+	d.bodyBuf.Reset()
 	d.bodyBuf = nil
 	return nil
 }

--- a/libsq/core/ioz/buffer.go
+++ b/libsq/core/ioz/buffer.go
@@ -1,0 +1,186 @@
+package ioz
+
+import (
+	"bytes"
+	"io"
+	"math"
+	"os"
+	"sync"
+
+	"github.com/djherbis/buffer"
+
+	"github.com/neilotoole/sq/libsq/core/errz"
+)
+
+// Buffer extracts the methods of [bytes.Buffer] to allow for alternative
+// buffering strategies, such as file-backed buffers for large files. It also
+// adds a [Buffer.Close] method that the caller MUST invoke when done.
+type Buffer interface {
+	io.Reader
+	io.Writer
+
+	// Len returns the number of bytes of the unread portion of the buffer;
+	Len() int64
+
+	// Cap returns the capacity of the buffer.
+	Cap() int64
+
+	// Reset resets the buffer to be empty.
+	Reset()
+
+	// Close MUST be invoked when done with the buffer, or resources may leak.
+	Close() error
+}
+
+// NewDefaultBuffer returns a [Buffer] backed by a [bytes.Buffer].
+var NewDefaultBuffer = func() Buffer {
+	return &bytesBuffer{buf: &bytes.Buffer{}}
+}
+
+var _ Buffer = (*bytesBuffer)(nil)
+
+// bytesBuffer adapts [bytes.Buffer] to the [Buffer] interface used by
+// pkg djherbis/buffer, as see in the [Buffers] type.
+type bytesBuffer struct {
+	buf *bytes.Buffer
+}
+
+func (b *bytesBuffer) Read(p []byte) (n int, err error) {
+	return b.buf.Read(p)
+}
+
+func (b *bytesBuffer) Write(p []byte) (n int, err error) {
+	return b.buf.Write(p)
+}
+
+func (b *bytesBuffer) Reset() {
+	b.buf.Reset()
+}
+
+func (b *bytesBuffer) Close() error {
+	b.buf.Reset()
+	b.buf = nil
+	return nil
+}
+
+func (b *bytesBuffer) Cap() int64 {
+	return int64(b.buf.Cap())
+}
+
+func (b *bytesBuffer) Len() int64 {
+	return int64(b.buf.Len())
+}
+
+// NewBuffers returns a new [Buffers] instance. The caller must invoke
+// [Buffers.Close] when done. Arg dir is the directory in which file-backed
+// buffers will be stored; the dir will be created if necessary, and is deleted
+// by [Buffers.Close]. Arg memBufSize is the maximum size of in-memory buffers;
+// if a buffer exceeds this size, it will be backed by a file.
+func NewBuffers(dir string, memBufSize int) (*Buffers, error) {
+	if err := RequireDir(dir); err != nil {
+		return nil, err
+	}
+
+	bf := &Buffers{
+		dir:            dir,
+		spillThreshold: int64(memBufSize),
+		fileBufPool:    buffer.NewFilePool(math.MaxInt, dir),
+	}
+
+	// Now is a good time to test if the pool works.
+	if f, err := bf.fileBufPool.Get(); err != nil {
+		return nil, errz.Wrapf(err, "failed to get file buffer from pool")
+	} else {
+		f.Reset()
+	}
+
+	b2 := bf.NewMem2Disk()
+	_, err := io.Copy(b2, LimitRandReader(100000)) // FIXME: delete
+	if err != nil {
+		return nil, errz.Err(err)
+	}
+	b2.Reset()
+
+	return bf, nil
+}
+
+// Buffers is a factory for creating buffers that overflow to disk. This is
+// useful when dealing with large data that may not fit in memory.
+type Buffers struct {
+	fileBufPool    buffer.Pool
+	dir            string
+	spillThreshold int64
+}
+
+// Close removes the directory used for file-backed buffers.
+func (bs *Buffers) Close() error {
+	return errz.Wrap(os.RemoveAll(bs.dir), "failed to remove file buffer dir")
+}
+
+// NewMem2Disk returns a [Buffer] whose head is in-memory, but overflows to disk
+// when it reaches a threshold. The caller MUST invoke [Buffer.Close] when done,
+// or resources may be leaked.
+func (bs *Buffers) NewMem2Disk() Buffer {
+	lz := &lazyFileBuffer{pool: bs.fileBufPool}
+	multi := buffer.NewMulti(buffer.New(bs.spillThreshold), lz)
+	return &mem2DiskBuffer{fileBuf: lz, Buffer: multi}
+}
+
+var _ Buffer = (*mem2DiskBuffer)(nil)
+
+type mem2DiskBuffer struct {
+	fileBuf *lazyFileBuffer
+	buffer.Buffer
+}
+
+func (m *mem2DiskBuffer) Close() error {
+	if m.fileBuf.buf != nil {
+		return errz.Err(m.fileBuf.pool.Put(m.fileBuf.buf))
+	}
+	return nil
+}
+
+var _ buffer.Buffer = (*lazyFileBuffer)(nil)
+
+// lazyFileBuffer is a [Buffer] that lazily initializes a file-backed buffer.
+type lazyFileBuffer struct {
+	pool buffer.Pool
+	buf  buffer.Buffer
+	once sync.Once
+}
+
+func (lz *lazyFileBuffer) init() {
+	lz.once.Do(func() {
+		var err error
+		if lz.buf, err = lz.pool.Get(); err != nil {
+			// Shouldn't happen
+			panic(errz.Wrap(err, "failed to get file buffer from pool"))
+		}
+	})
+}
+
+func (lz *lazyFileBuffer) Len() int64 {
+	lz.init()
+	return lz.buf.Len()
+}
+
+func (lz *lazyFileBuffer) Cap() int64 {
+	lz.init()
+	return lz.buf.Cap()
+}
+
+func (lz *lazyFileBuffer) Read(p []byte) (n int, err error) {
+	lz.init()
+	return lz.buf.Read(p)
+}
+
+func (lz *lazyFileBuffer) Write(p []byte) (n int, err error) {
+	lz.init()
+	return lz.buf.Write(p)
+}
+
+func (lz *lazyFileBuffer) Reset() {
+	if lz.buf != nil {
+		lz.buf.Reset()
+	}
+}

--- a/libsq/core/ioz/buffer.go
+++ b/libsq/core/ioz/buffer.go
@@ -87,20 +87,6 @@ func NewBuffers(dir string, memBufSize int) (*Buffers, error) {
 		fileBufPool:    buffer.NewFilePool(math.MaxInt, dir),
 	}
 
-	// Now is a good time to test if the pool works.
-	if f, err := bf.fileBufPool.Get(); err != nil {
-		return nil, errz.Wrapf(err, "failed to get file buffer from pool")
-	} else {
-		f.Reset()
-	}
-
-	b2 := bf.NewMem2Disk()
-	_, err := io.Copy(b2, LimitRandReader(100000)) // FIXME: delete
-	if err != nil {
-		return nil, errz.Err(err)
-	}
-	b2.Reset()
-
 	return bf, nil
 }
 
@@ -142,7 +128,8 @@ func (m *mem2DiskBuffer) Close() error {
 
 var _ buffer.Buffer = (*lazyFileBuffer)(nil)
 
-// lazyFileBuffer is a [Buffer] that lazily initializes a file-backed buffer.
+// lazyFileBuffer is a [buffer.Buffer] that lazily initializes a file-backed
+// buffer.
 type lazyFileBuffer struct {
 	pool buffer.Pool
 	buf  buffer.Buffer

--- a/libsq/core/ioz/checksum/checksum_test.go
+++ b/libsq/core/ioz/checksum/checksum_test.go
@@ -1,6 +1,9 @@
 package checksum_test
 
 import (
+	"bytes"
+	"io"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -16,4 +19,36 @@ func TestSum(t *testing.T) {
 	require.Equal(t, "", got)
 	got = checksum.Sum([]byte("hello world"))
 	assert.Equal(t, "d4a1185", got)
+}
+
+func TestChecksums(t *testing.T) {
+	f, err := os.CreateTemp(t.TempDir(), "sq-test-*")
+	require.NoError(t, err)
+	_, err = io.WriteString(f, "huzzah")
+	require.NoError(t, err)
+	assert.NoError(t, f.Close())
+
+	buf := &bytes.Buffer{}
+
+	gotSum1, err := checksum.ForFile(f.Name())
+	require.NoError(t, err)
+	t.Logf("gotSum1: %s  %s", gotSum1, f.Name())
+	require.NoError(t, checksum.Write(buf, gotSum1, f.Name()))
+
+	gotSums, err := checksum.Read(bytes.NewReader(buf.Bytes()))
+	require.NoError(t, err)
+	require.Len(t, gotSums, 1)
+	require.Equal(t, gotSum1, gotSums[f.Name()])
+
+	// Make some changes to the file and verify that the checksums differ.
+	f, err = os.OpenFile(f.Name(), os.O_APPEND|os.O_WRONLY, 0o600)
+	require.NoError(t, err)
+	_, err = io.WriteString(f, "more huzzah")
+	require.NoError(t, err)
+	assert.NoError(t, f.Close())
+	gotSum2, err := checksum.ForFile(f.Name())
+	require.NoError(t, err)
+	t.Logf("gotSum2: %s  %s", gotSum2, f.Name())
+	require.NoError(t, checksum.Write(buf, gotSum1, f.Name()))
+	require.NotEqual(t, gotSum1, gotSum2)
 }

--- a/libsq/core/ioz/ioz_test.go
+++ b/libsq/core/ioz/ioz_test.go
@@ -1,7 +1,6 @@
 package ioz_test
 
 import (
-	"bytes"
 	"context"
 	"io"
 	"os"
@@ -11,11 +10,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/neilotoole/sq/libsq/core/ioz"
-	"github.com/neilotoole/sq/libsq/core/ioz/checksum"
 )
 
 func TestMarshalYAML(t *testing.T) {
@@ -26,38 +23,6 @@ func TestMarshalYAML(t *testing.T) {
 	b, err := ioz.MarshalYAML(m)
 	require.NoError(t, err)
 	require.NotNil(t, b)
-}
-
-func TestChecksums(t *testing.T) {
-	f, err := os.CreateTemp(t.TempDir(), "sq-test-*")
-	require.NoError(t, err)
-	_, err = io.WriteString(f, "huzzah")
-	require.NoError(t, err)
-	assert.NoError(t, f.Close())
-
-	buf := &bytes.Buffer{}
-
-	gotSum1, err := checksum.ForFile(f.Name())
-	require.NoError(t, err)
-	t.Logf("gotSum1: %s  %s", gotSum1, f.Name())
-	require.NoError(t, checksum.Write(buf, gotSum1, f.Name()))
-
-	gotSums, err := checksum.Read(bytes.NewReader(buf.Bytes()))
-	require.NoError(t, err)
-	require.Len(t, gotSums, 1)
-	require.Equal(t, gotSum1, gotSums[f.Name()])
-
-	// Make some changes to the file and verify that the checksums differ.
-	f, err = os.OpenFile(f.Name(), os.O_APPEND|os.O_WRONLY, 0o600)
-	require.NoError(t, err)
-	_, err = io.WriteString(f, "more huzzah")
-	require.NoError(t, err)
-	assert.NoError(t, f.Close())
-	gotSum2, err := checksum.ForFile(f.Name())
-	require.NoError(t, err)
-	t.Logf("gotSum2: %s  %s", gotSum2, f.Name())
-	require.NoError(t, checksum.Write(buf, gotSum1, f.Name()))
-	require.NotEqual(t, gotSum1, gotSum2)
 }
 
 func TestDelayReader(t *testing.T) {
@@ -86,7 +51,7 @@ func TestDelayReader(t *testing.T) {
 }
 
 func TestWriteToFile(t *testing.T) {
-	const val = `In Zanadu did Kubla Khan a stately pleasure dome decree`
+	const val = `In Xanadu did Kubla Khan a stately pleasure dome decree`
 	ctx := context.Background()
 	dir := t.TempDir()
 

--- a/libsq/core/lg/lgm/lgm.go
+++ b/libsq/core/lg/lgm/lgm.go
@@ -10,6 +10,7 @@ const (
 	CloseDBStmt           = "Close DB stmt"
 	CloseHTTPResponseBody = "Close HTTP response body"
 	CloseFileReader       = "Close file reader"
+	CloseBuffer           = "Close buffer"
 	CloseFileWriter       = "Close file writer"
 	CloseOutputFile       = "Close output file"
 	CloseDiffDoc          = "Close diff doc"

--- a/libsq/core/progress/progress.go
+++ b/libsq/core/progress/progress.go
@@ -17,7 +17,6 @@ package progress
 import (
 	"context"
 	"io"
-	"log/slog"
 	"slices"
 	"sync"
 	"time"
@@ -267,26 +266,6 @@ func (p *Progress) HideOnWriter(w io.Writer) io.Writer {
 		// Note that it's safe to invoke p.life.kill on a nil pcLifecycle.
 		p.life.kill()
 	})
-}
-
-// LogValue reports some stats.
-func (p *Progress) LogValue() slog.Value {
-	var barCount int
-	var barsIncrByCallTotal int64
-	p.mu.Lock()
-	barCount = len(p.allBars)
-	for _, bar := range p.allBars {
-		if bar == nil {
-			continue
-		}
-		barsIncrByCallTotal += bar.incrByCalls.Load()
-	}
-	p.mu.Unlock()
-
-	return slog.GroupValue(
-		slog.Int("bars", barCount),
-		slog.Int("incr_by_total", int(barsIncrByCallTotal)),
-	)
 }
 
 // destroy is probably needlessly complex, but at the time it was written,

--- a/libsq/core/progress/virtualbar.go
+++ b/libsq/core/progress/virtualbar.go
@@ -51,7 +51,6 @@ func newVirtualBar(p *Progress, cfg *barConfig, opts []BarOpt) *virtualBar {
 
 	vb := &virtualBar{
 		p:           p,
-		incrByCalls: &atomic.Int64{},
 		incrTotal:   &atomic.Int64{},
 		destroyOnce: &sync.Once{},
 		notBefore:   time.Now().Add(p.renderDelay),
@@ -88,10 +87,6 @@ type virtualBar struct {
 
 	// incrTotal holds the cumulative value of virtualBar.Incr.
 	incrTotal *atomic.Int64
-
-	// incrByCalls is a count of virtualBar.Incr invocations. It's used for
-	// logging stats.
-	incrByCalls *atomic.Int64
 
 	// destroyOnce is used within virtualBar.destroy.
 	destroyOnce *sync.Once
@@ -134,7 +129,6 @@ func (vb *virtualBar) Incr(n int) {
 	}
 
 	vb.incrTotal.Add(int64(n))
-	vb.incrByCalls.Add(1)
 }
 
 // refresh is called by the Progress's refresh goroutine, potentially creating,

--- a/libsq/core/sqlz/sqlz.go
+++ b/libsq/core/sqlz/sqlz.go
@@ -6,10 +6,9 @@ import (
 	"database/sql"
 	"log/slog"
 
-	"github.com/neilotoole/sq/libsq/core/lg/lga"
-
 	"github.com/neilotoole/sq/libsq/core/errz"
 	"github.com/neilotoole/sq/libsq/core/lg"
+	"github.com/neilotoole/sq/libsq/core/lg/lga"
 	"github.com/neilotoole/sq/libsq/core/lg/lgm"
 )
 

--- a/libsq/core/tuning/tuning.go
+++ b/libsq/core/tuning/tuning.go
@@ -44,11 +44,20 @@ var OptRecBufSize = options.NewInt(
 )
 
 var OptFlushThreshold = options.NewInt(
-	"tuning.flush-threshold",
+	"tuning.output-flush-threshold",
 	nil,
 	1000,
 	"Output writer buffer flush threshold in bytes",
 	`Size in bytes after which output writers should flush any internal buffer.
 Generally, it is not necessary to fiddle this knob.`,
+	options.TagTuning,
+)
+
+var OptBufMemLimit = options.NewInt(
+	"tuning.buffer-mem-limit",
+	nil,
+	1024*32, // 32KB
+	"Buffer swap file memory limit",
+	`Size in bytes after which in-memory temp buffers overflow to disk.`,
 	options.TagTuning,
 )

--- a/libsq/core/tuning/tuning.go
+++ b/libsq/core/tuning/tuning.go
@@ -56,7 +56,7 @@ Generally, it is not necessary to fiddle this knob.`,
 var OptBufMemLimit = options.NewInt(
 	"tuning.buffer-mem-limit",
 	nil,
-	1024*32, // 32KB
+	1024*1000, // 1MB
 	"Buffer swap file memory limit",
 	`Size in bytes after which in-memory temp buffers overflow to disk.`,
 	options.TagTuning,

--- a/libsq/core/tuning/tuning.go
+++ b/libsq/core/tuning/tuning.go
@@ -56,7 +56,7 @@ Generally, it is not necessary to fiddle this knob.`,
 var OptBufMemLimit = options.NewInt(
 	"tuning.buffer-mem-limit",
 	nil,
-	1024*1000, // 1MB
+	1000*1000, // 1MB
 	"Buffer swap file memory limit",
 	`Size in bytes after which in-memory temp buffers overflow to disk.`,
 	options.TagTuning,

--- a/libsq/files/files.go
+++ b/libsq/files/files.go
@@ -88,12 +88,27 @@ type Files struct {
 	mu sync.Mutex
 }
 
-// NewBuffer returns a new [buffer.Buffer] instance which may be in-memory or
-// on-disk, or both, for use as a temporary buffer for potentially large buffers
-// that may not fit in memory. The caller must invoke [buffer.Buffer.Reset] on
-// the returned buffer when done with it.
-func (fs *Files) NewBuffer() buffer.Buffer {
+// NewBuffer returns a new [Buffer] instance which may be in-memory or on-disk,
+// or both, for use as a temporary buffer for potentially large buffers that may
+// not fit in memory. The caller must invoke [Buffer.Reset] on the returned
+// buffer when done with it.
+func (fs *Files) NewBuffer() Buffer {
 	return buffer.NewMulti(buffer.New(fs.memBufSize), buffer.NewPartition(fs.fileBufPool))
+}
+
+// Buffer extracts the methods of [bytes.Buffer] to allow for alternative
+// buffering strategies, such as file-backed buffers for large files.
+type Buffer interface {
+	// Len returns the number of bytes of the unread portion of the buffer;
+	Len() int64
+
+	// Cap returns the capacity of the buffer.
+	Cap() int64
+	io.Reader
+	io.Writer
+
+	// Reset resets the buffer to be empty.
+	Reset()
 }
 
 // New returns a new Files instance. The caller must invoke Files.Close

--- a/libsq/files/files_test.go
+++ b/libsq/files/files_test.go
@@ -292,3 +292,19 @@ func TestFiles_Filesize(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, wantSize, gotSize2)
 }
+
+func TestFiles_NewBuffer(t *testing.T) {
+	th := testh.New(t)
+	fs := th.Files()
+
+	want := []byte("hello world")
+	buf := fs.NewBuffer()
+	n, err := buf.Write(want)
+	require.NoError(t, err)
+	require.Equal(t, len(want), n)
+
+	got, err := io.ReadAll(buf)
+	require.NoError(t, err)
+	require.Equal(t, want, got)
+	buf.Reset()
+}

--- a/libsq/files/files_test.go
+++ b/libsq/files/files_test.go
@@ -307,4 +307,5 @@ func TestFiles_NewBuffer(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, want, got)
 	buf.Reset()
+	require.NoError(t, buf.Close())
 }


### PR DESCRIPTION
`sq diff` uses `bytes.Buffer` in several places. For large data, this can consume a lot of mem. This PR adds the `ioz.Buffer` mechanism, which enables memory spillover to disk after a threshold.