### PR TITLE
Pipe sqlite DB file on stdin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,11 +25,33 @@ This release features significant improvements to [`sq diff`](https://sq.io/docs
   # Stop after 5 differences, using the -n shorthand flag
   $ sq diff @prod.actor @staging.actor --data -n5
   ```
+
 - [#353]: The performance of `sq diff` has been significantly improved. There's still more to do.
+
 - Previously, `sq diff --data` compared the rendered (text) representation of each value. This could
   lead to inaccurate results, for example with two timestamp values in different time zones, but the text
   rendering omitted the time zone. Now, `sq diff --data` compares the raw values, not the rendered text.
   Note in particular with time values that both time and location components are compared.
+
+- `sq` can now handle a SQLite DB on `stdin`. This is useful for testing, or for
+  working with SQLite DBs in a pipeline.
+
+  ```shell
+  $ cat sakila.db | sq '.actor | .first_name, .last_name'
+  ```
+
+  It's also surprisingly handy in daily life, because there are sneaky SQLite DBs
+  all around us. Let's see how many text messages I've sent and received over the years:
+
+  ```shell
+  $ cat ~/Library/Messages/chat.db | sq '.message | count'
+  count
+  215439
+  ```
+  I'm sure that number makes me an amateur with these millenials 👴🏻. 
+  
+  > Note that you'll need to enable macOS [Full Disk Access](https://spin.atomicobject.com/search-imessage-sql/) to read the `chat.db` file.
+
 
 ## Changed
 

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -4,13 +4,14 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"github.com/neilotoole/sq/libsq/source"
-	"github.com/neilotoole/sq/libsq/source/drivertype"
 	"image/gif"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/neilotoole/sq/libsq/source"
+	"github.com/neilotoole/sq/libsq/source/drivertype"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -265,5 +266,4 @@ func TestSQLiteStdin(t *testing.T) {
 	require.Equal(t, drivertype.SQLite.String(), gotMap["db_driver"])
 	require.Equal(t, source.StdinHandle, gotMap["handle"])
 	require.Len(t, gotMap["tables"], 21)
-
 }

--- a/libsq/files/files.go
+++ b/libsq/files/files.go
@@ -395,7 +395,7 @@ func (fs *Files) Close() error {
 	return err
 }
 
-// CreateTemp creates a new temporary file fs's temp dir with the given
+// CreateTemp creates a new temporary file in fs's temp dir with the given
 // filename pattern, as per the os.CreateTemp docs. If arg clean is
 // true, the file is added to the cleanup sequence invoked by fs.Close.
 // It is the callers responsibility to close the returned file.


### PR DESCRIPTION
You can now pipe a SQLite file on stdin, e.g.

```shell
$ cat sakila.db | sq inspect
```