### PR TITLE
Add install support for nixos

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -183,6 +183,14 @@ if command_exists brew; then
   exit
 fi
 
+# nix
+if command_exists nix-shell; then
+  set -e
+  printf "Using nix to install sq...\n\n"
+
+  nix-shell -p sq
+  exit
+fi
 
 printf "\nCould not find a suitable install mechanism to install sq.\n"
 printf "\nVisit https://github.com/neilotoole/sq for more installation options.\n"


### PR DESCRIPTION
Adding support for installing `sq` into NixOS. 

`install.sh` now tests whether `nix-shell` is present. If so, install `sq` as a package.