### PR TITLE
fix: columns too wide with --no-header

### DIFF
--- a/cli/output/tablew/internal/texttable.go
+++ b/cli/output/tablew/internal/texttable.go
@@ -185,7 +185,11 @@ func (t *Table) RenderAll(ctx context.Context) error {
 func (t *Table) SetHeader(keys []string) {
 	t.colSize = len(keys)
 	for i, v := range keys {
-		t.parseDimension(v, i, -1)
+		if !t.hdrDisable {
+			// Only include header text in column width calculation
+			// if the header row will actually be displayed.
+			t.parseDimension(v, i, -1)
+		}
 		t.headers = append(t.headers, v)
 	}
 }


### PR DESCRIPTION
Fixes #469

## Changes
- Skip header text from column width calculation when `--no-header` flag is used
- Column widths are now determined solely by data content when headers are disabled