### PR TITLE
Fix ClickHouse SourceMetadata missing Catalog field (#555)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,18 @@ Breaking changes are annotated with ☢️, and alpha/beta features with 🐥.
 > `v0.18.2`. This typically means that there was some CI/tooling mishap. Ignore
 > those gaps.
 
+## Unreleased
+
+### Fixed
+
+- [#555]: ClickHouse driver now populates `md.Catalog` in `SourceMetadata`,
+  matching the current ClickHouse database. Previously the field was left
+  empty, which caused `TestSQLDriver_CurrentSchemaCatalog` to fail for the
+  ClickHouse sakila source.
+
+[#555]: https://github.com/neilotoole/sq/issues/555
+
+
 ## [v0.50.0] - 2026-02-16
 
 ### Added

--- a/drivers/clickhouse/metadata.go
+++ b/drivers/clickhouse/metadata.go
@@ -56,6 +56,7 @@ func getSourceMetadata(ctx context.Context, src *source.Source, db sqlz.DB, noSc
 	md.DBVersion = version
 	md.DBProduct = "ClickHouse " + version
 	md.Schema = database
+	md.Catalog = database
 	md.Name = database
 	md.FQName = database
 	md.User = user

--- a/drivers/clickhouse/metadata.go
+++ b/drivers/clickhouse/metadata.go
@@ -32,7 +32,9 @@ import (
 //   - Driver/DBDriver: drivertype.ClickHouse
 //   - DBVersion: ClickHouse server version from version()
 //   - DBProduct: "ClickHouse" plus version string
-//   - Schema/Name/FQName: Current database from currentDatabase()
+//   - Schema/Catalog/Name/FQName: Current database from currentDatabase().
+//     ClickHouse uses a single "database" concept that maps to both schema
+//     and catalog in sq's model.
 //   - User: Current user from currentUser()
 //   - Size: Total database size from system.tables
 //   - Tables: Table metadata with TableCount/ViewCount (if noSchema is false)

--- a/libsq/driver/driver_test.go
+++ b/libsq/driver/driver_test.go
@@ -671,8 +671,8 @@ func TestSQLDriver_CurrentSchemaCatalog(t *testing.T) {
 			md, err := grip.SourceMetadata(th.Context, false)
 			require.NoError(t, err)
 			require.NotNil(t, md)
-			require.Equal(t, md.Schema, tc.wantSchema)
-			require.Equal(t, md.Catalog, tc.wantCatalog)
+			require.Equal(t, tc.wantSchema, md.Schema)
+			require.Equal(t, tc.wantCatalog, md.Catalog)
 
 			gotSchemas, err := drvr.ListSchemas(th.Context, db)
 			require.NoError(t, err)


### PR DESCRIPTION
Fixes #555.

## Summary

- `drivers/clickhouse/metadata.go` — `getSourceMetadata` now sets `md.Catalog = database` alongside `md.Schema = database`. For ClickHouse, `currentDatabase()` maps to both schema and catalog (per `drivers/clickhouse/README.md`), mirroring the pattern used by the `postgres` and `sqlite3` drivers.
- `libsq/driver/driver_test.go` — hygiene fix: swap `require.Equal` argument order at lines 669 and 675 so the "expected" / "actual" labels in failure output are correct (issue AC #5).
- `CHANGELOG.md` — new `Unreleased > Fixed` entry.

## Test plan

- [x] `go test ./libsq/driver/ -run TestSQLDriver_CurrentSchemaCatalog -v` — `@sakila_ch25` passes (previously failed)
- [x] `go test ./...` — full suite passes
- [x] `make lint` — 0 issues