### PR TITLE
Add regression tests for SQLite missing functions (#527)

### DIFF
--- a/drivers/sqlite3/functions_test.go
+++ b/drivers/sqlite3/functions_test.go
@@ -1,0 +1,103 @@
+package sqlite3_test
+
+// TODO(gh527): Expand this file into a broader SQLite built-in function
+// smoke suite (math, json, fts5, date/time, etc.) so future amalgamation
+// drift surfaces quickly rather than as a user-reported missing-function bug.
+
+import (
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/neilotoole/sq/libsq/core/stringz"
+	"github.com/neilotoole/sq/testh"
+	"github.com/neilotoole/sq/testh/sakila"
+)
+
+// minSQLiteMajor and minSQLiteMinor define the minimum embedded SQLite
+// version required to satisfy GH #527: unistr() was added in 3.47.0, and
+// if (as an inline alias of iif) is also available from that line forward.
+const (
+	minSQLiteMajor = 3
+	minSQLiteMinor = 47
+)
+
+// TestSQLiteVersionFloor asserts that the SQLite version bundled via
+// mattn/go-sqlite3 is at least 3.47.0. If this test fails, a dependency
+// downgrade has re-introduced the missing-function regressions tracked
+// in GH #527 (unistr, if/iif).
+func TestSQLiteVersionFloor(t *testing.T) {
+	t.Parallel()
+
+	th := testh.New(t)
+	src := th.Source(sakila.SL3)
+	sink, err := th.QuerySQL(src, nil, "SELECT sqlite_version()")
+	require.NoError(t, err)
+	require.Equal(t, 1, len(sink.Recs))
+
+	got, ok := stringz.Val(sink.Recs[0][0]).(string)
+	require.True(t, ok, "sqlite_version() should return a string")
+
+	parts := strings.Split(got, ".")
+	require.GreaterOrEqual(t, len(parts), 2, "unexpected sqlite_version format: %q", got)
+
+	major, err := strconv.Atoi(parts[0])
+	require.NoError(t, err, "parsing sqlite_version major: %q", got)
+	minor, err := strconv.Atoi(parts[1])
+	require.NoError(t, err, "parsing sqlite_version minor: %q", got)
+
+	ok = major > minSQLiteMajor || (major == minSQLiteMajor && minor >= minSQLiteMinor)
+	require.Truef(t, ok,
+		"SQLite %s is below the %d.%d.0 floor; unistr() and if/iif() will regress (see GH #527)",
+		got, minSQLiteMajor, minSQLiteMinor)
+}
+
+// TestSQLiteMissingFunctions_gh527 is a regression test for GH #527,
+// which reported that unistr() and if() were unavailable in sq. Both are
+// provided by SQLite 3.47.0+; this test asserts each function executes
+// and returns the expected value.
+func TestSQLiteMissingFunctions_gh527(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name  string
+		query string
+		want  string
+	}{
+		{
+			name:  "unistr",
+			query: `SELECT unistr('\2728')`,
+			want:  "\u2728",
+		},
+		{
+			name:  "iif",
+			query: `SELECT iif(1=1, 'yes', 'no')`,
+			want:  "yes",
+		},
+		{
+			name:  "if",
+			query: `SELECT if(1=1, 'yes', 'no')`,
+			want:  "yes",
+		},
+	}
+
+	th := testh.New(t)
+	src := th.Source(sakila.SL3)
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			sink, err := th.QuerySQL(src, nil, tc.query)
+			require.NoErrorf(t, err, "function %q failed; see GH #527", tc.name)
+			require.Equal(t, 1, len(sink.Recs))
+
+			got, ok := stringz.Val(sink.Recs[0][0]).(string)
+			require.Truef(t, ok, "function %q returned non-string value: %T",
+				tc.name, sink.Recs[0][0])
+			require.Equalf(t, tc.want, got, "function %q", tc.name)
+		})
+	}
+}

--- a/drivers/sqlite3/functions_test.go
+++ b/drivers/sqlite3/functions_test.go
@@ -83,13 +83,12 @@ func TestSQLiteMissingFunctions_gh527(t *testing.T) {
 		},
 	}
 
-	th := testh.New(t)
-	src := th.Source(sakila.SL3)
-
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
+			th := testh.New(t)
+			src := th.Source(sakila.SL3)
 			sink, err := th.QuerySQL(src, nil, tc.query)
 			require.NoErrorf(t, err, "function %q failed; see GH #527", tc.name)
 			require.Equal(t, 1, len(sink.Recs))


### PR DESCRIPTION
## Summary

- Adds regression tests in `drivers/sqlite3/functions_test.go` covering
  the functions reported as missing in #527 (`unistr`, `if`) plus `iif`
  for completeness.
- Adds `TestSQLiteVersionFloor` asserting the bundled SQLite is
  `>= 3.47.0`, so a future dependency downgrade below that line fails
  loudly rather than silently reintroducing the missing-function bug.
- No production code changes: #527 is already resolved on master by the
  transitive `mattn/go-sqlite3` bump in #557 / #558, which moved the
  embedded SQLite from 3.46.1 to 3.51.3.

## Background

#527 was reported against `sq` v0.48.10, which bundled SQLite 3.46.1
via `go-sqlite3` v1.14.24. `unistr()` was added in SQLite 3.47.0, and
`if` is registered as an inline alias of `iif` in current SQLite
releases. Both now work on master — this PR pins that as a test
invariant.

A `TODO(gh527)` is left at the top of the new file noting that a
broader SQLite built-in smoke suite (math / json / fts5 / date-time)
would be a good follow-up so future amalgamation drift surfaces in CI
rather than via user reports.

Closes #527.

## Test plan

- [x] `go test -tags "$(BUILD_TAGS)" ./drivers/sqlite3/...` passes
- [x] `make lint` clean
- [ ] Reviewer sanity-check of the version-floor logic and the chosen
      floor (3.47.0)