### PR TITLE
Add Codacy config to exclude testdata from scanning

### DIFF
--- a/.codacy.yaml
+++ b/.codacy.yaml
@@ -1,0 +1,9 @@
+---
+# Codacy configuration.
+# See: https://docs.codacy.com/repositories-configure/codacy-configuration-file/
+#
+# Test fixtures contain fake credentials (e.g. the Sakila sample DB user) and
+# intentionally malformed inputs that trigger false positives from Checkov's
+# secret scanner and other linters. Exclude them from all engines.
+exclude_paths:
+  - "**/testdata/**"


### PR DESCRIPTION
## Summary

- Adds `.codacy.yaml` at the repo root that excludes `**/testdata/**` from all Codacy-managed engines.
- Silences the 8 error-severity Checkov `CKV_SECRET_4` ("Basic Auth Credentials") alerts, all of which are false positives flagging fake credentials in test fixtures — e.g. the Sakila sample DB user `postgres://sakila:p_ssW0rd@localhost/sakila` in `cli/config/yamlstore/upgrades/v0.34.0/testdata/want.sq.yml:14`.
- Also suppresses analogous lint noise from Revive, Markdownlint, etc. inside testdata, where such rules are not meaningful.

## Test plan

- [ ] Confirm Codacy picks up `.codacy.yaml` on next scan of `master` after merge.
- [ ] Verify the 8 Checkov alerts (#747–#754) transition to `fixed` / `dismissed` state on the Security tab.
- [ ] Spot-check that non-testdata findings are still reported.