### PR TITLE
Fix/site footer and nav links

### DIFF
--- a/site/assets/scss/common/_dark.scss
+++ b/site/assets/scss/common/_dark.scss
@@ -305,6 +305,11 @@ $navbar-dark-active-color:          $link-color-dark;
   border-top: 1px solid $border-dark;
 }
 
+[data-dark-mode] body .docs-navigation a .card,
+[data-dark-mode] body .docs-navigation a .card .card-body {
+  color: $link-color-dark;
+}
+
 [data-dark-mode] body pre code::-webkit-scrollbar-thumb {
   background: $gray-400;
 }

--- a/site/layouts/partials/footer/footer.html
+++ b/site/layouts/partials/footer/footer.html
@@ -3,10 +3,8 @@
     <div class="row">
       <div class="col-lg-8 order-last order-lg-first">
         <ul class="list-inline">
-          {{ if not (hasPrefix .Site.BaseURL "http://localhost") -}}
-          <li class="list-inline-item netlify-logo"><a href="https://www.netlify.com"> <img src="https://www.netlify.com/v3/img/components/netlify-dark.svg" alt="Deploys by Netlify" /> </a>
+          <li class="list-inline-item netlify-logo"><a href="https://www.netlify.com"> <img src="https://www.netlify.com/assets/badges/netlify-badge-color-bg.svg" alt="Deploys by Netlify" /> </a>
           </li>
-          {{ end -}}
         </ul>
       </div>
 <!--      <div class="col-lg-8 order-first order-lg-last text-lg-end">-->


### PR DESCRIPTION
This pull request introduces a minor update to the website's dark mode styling and updates the Netlify badge in the footer. The changes improve the visual consistency of the documentation navigation in dark mode and ensure the Netlify badge uses the latest official asset.

Visual and styling improvements:

* Updated the `.docs-navigation` card and card body text color in dark mode to use `$link-color-dark` for better readability and consistency. (`site/assets/scss/common/_dark.scss`)

Footer update:

* Replaced the Netlify badge image with the latest official badge and removed the conditional that hid it on localhost, ensuring the badge always displays. (`site/layouts/partials/footer/footer.html`)