### PR TITLE
Update footer styles and Netlify badge visibility for dark mode support

### DIFF
--- a/site/assets/scss/common/_custom.scss
+++ b/site/assets/scss/common/_custom.scss
@@ -424,12 +424,24 @@ footer {
 
   li.netlify-logo img {
     scale: 75%;
-    opacity: 50%;
+    opacity: 75%;
+  }
+
+  li.netlify-logo .netlify-badge-dark {
+    display: none;
   }
 }
 
 [data-dark-mode] footer {
   background-color: darken($gray-800, 5%);
+
+  li.netlify-logo .netlify-badge-light {
+    display: none;
+  }
+
+  li.netlify-logo .netlify-badge-dark {
+    display: inline;
+  }
 }
 
 div.asciinema-player-wrapper {

--- a/site/layouts/partials/footer/footer.html
+++ b/site/layouts/partials/footer/footer.html
@@ -3,7 +3,10 @@
     <div class="row">
       <div class="col-lg-8 order-last order-lg-first">
         <ul class="list-inline">
-          <li class="list-inline-item netlify-logo"><a href="https://www.netlify.com"> <img src="https://www.netlify.com/assets/badges/netlify-badge-color-bg.svg" alt="Deploys by Netlify" /> </a>
+          <li class="list-inline-item netlify-logo"><a href="https://www.netlify.com">
+            <img class="netlify-badge-light" src="https://www.netlify.com/assets/badges/netlify-badge-color-bg.svg" alt="Deploys by Netlify" />
+            <img class="netlify-badge-dark" src="https://www.netlify.com/assets/badges/netlify-badge-light.svg" alt="Deploys by Netlify" />
+          </a>
           </li>
         </ul>
       </div>


### PR DESCRIPTION
This pull request updates how the Netlify badge is displayed in the site footer to better support light and dark modes. The main change is that the footer now shows a different Netlify badge image depending on the user's theme, ensuring optimal visibility and branding.

**Dark/Light mode support for Netlify badge:**

* Updated `footer.html` to include both light and dark versions of the Netlify badge, each with their own CSS class (`netlify-badge-light` and `netlify-badge-dark`).
* Modified `_custom.scss` to show only the appropriate badge for the current theme: the light badge in normal mode and the dark badge in dark mode.

**Visual adjustments:**

* Increased the opacity of the Netlify badge for better visibility.