### PR TITLE
Fix/site dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,8 +10,8 @@ updates:
     schedule:
       interval: "weekly"
 
-  # Bun lockfile under site/ (Dependabot uses the npm ecosystem for lockfiles).
-  - package-ecosystem: "npm"
+  # Bun lockfile under site/ (use the bun ecosystem so Dependabot reads bun.lock).
+  - package-ecosystem: "bun"
     directory: "/site"
     schedule:
       interval: "weekly"

--- a/site/netlify.toml
+++ b/site/netlify.toml
@@ -9,8 +9,9 @@
   force = true
 
 [build.environment]
+  # Pinned releases (not "latest") for security and reproducible, reviewable upgrades.
   NODE_VERSION = "22"
-  BUN_VERSION = "latest"
+  BUN_VERSION = "1.3.13"
   HUGO_VERSION = "0.139.2"
 
 [context.production]

--- a/site/netlify.toml
+++ b/site/netlify.toml
@@ -10,7 +10,7 @@
 
 [build.environment]
   # Pinned releases (not "latest") for security and reproducible, reviewable upgrades.
-  NODE_VERSION = "22"
+  NODE_VERSION = "22.13.1"
   BUN_VERSION = "1.3.13"
   HUGO_VERSION = "0.139.2"
 


### PR DESCRIPTION
This pull request updates configuration files to improve dependency management and build reproducibility for the `site` directory. The main changes are switching Dependabot to use the Bun ecosystem for lockfile updates and pinning the Bun version in the Netlify build environment.

**Dependency management improvements:**

* Updated `.github/dependabot.yml` to use the `bun` ecosystem for the `/site` directory, ensuring Dependabot reads and updates `bun.lock` files correctly.

**Build environment reproducibility:**

* Changed `site/netlify.toml` to pin `BUN_VERSION` to `1.3.13` instead of using `latest`, improving build security and reproducibility.