### PR TITLE
Improve FAQ formatting on agent-skills page

### DIFF
--- a/site/content/en/docs/agent-skills.md
+++ b/site/content/en/docs/agent-skills.md
@@ -98,7 +98,7 @@ disclosure**:
   database or file format (see the table in `SKILL.md`).
 
 The skill intentionally defers to **`sq help`**, **`sq <cmd> --help`**, and
-[sq.io](https://sq.io) rather than duplicating full reference material.
+[sq.io](https://sq.io/) rather than duplicating full reference material.
 For the raw source, see [`SKILL.md` on GitHub](https://github.com/neilotoole/sq/blob/master/skills/sq/SKILL.md).
 
 ## Updating

--- a/site/content/en/docs/agent-skills.md
+++ b/site/content/en/docs/agent-skills.md
@@ -98,8 +98,8 @@ disclosure**:
   database or file format (see the table in `SKILL.md`).
 
 The skill intentionally defers to **`sq help`**, **`sq <cmd> --help`**, and
-sq.io rather than duplicating full reference material. For the raw source, see
-[`SKILL.md` on GitHub](https://github.com/neilotoole/sq/blob/master/skills/sq/SKILL.md).
+[sq.io](https://sq.io) rather than duplicating full reference material.
+For the raw source, see [`SKILL.md` on GitHub](https://github.com/neilotoole/sq/blob/master/skills/sq/SKILL.md).
 
 ## Updating
 
@@ -115,16 +115,20 @@ sq.io rather than duplicating full reference material. For the raw source, see
 
 ## FAQ
 
-**Does the skill replace reading sq.io?**
-No. It steers assistants toward official docs and `--help` output.
+### Does the skill replace reading the docs?
 
-**Do I need the skill to use sq?**
+No. It steers assistants toward this website and `sq --help` output.
+
+### Do I need the skill to use sq?
+
 No. It is optional context for AI-assisted workflows.
 
-**Air-gapped or offline?**
+### Air-gapped or offline?
+
 Copy `skills/sq/` from a release tarball or clone; you do not need `npx` if you
 install manually.
 
-**Forks**
-Point `npx skills add` and marketplace URLs at your fork’s GitHub URL or
+### Can I use a fork?
+
+Yes. Point `npx skills add` and marketplace URLs at your fork’s GitHub URL or
 local path.


### PR DESCRIPTION
## Summary

- Convert the FAQ on `site/content/en/docs/agent-skills.md` from a bold-prefix Q/A pattern (which renders question and answer on the same line) to `### H3` headings, so each question gets its own line, an auto-generated anchor, and a TOC entry.
- Reword the "Forks" entry as "Can I use a fork?" with a leading "Yes." for parallel structure with the other questions.
- Link `sq.io` in the Usage section while we're here.

## Test plan

- [ ] Run `bun start` and visually confirm the FAQ section at `/docs/agent-skills/#faq` renders with each question as its own heading.
- [ ] Confirm the new auto-anchors (e.g. `#does-the-skill-replace-reading-the-docs`) work as deep links.
- [ ] `bun run lint:markdown` passes (no new errors; pre-existing `#install-the-skill` fragment errors are unrelated to this change).