### PR TITLE
Bump goreleaser-action from v6 to v7 (Node 24)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -151,7 +151,7 @@ jobs:
           go-version-file: go.mod
 
       - name: GoReleaser (build darwin binaries)
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@v7
         with:
           distribution: goreleaser-pro
           version: ${{ env.GORELEASER_VERSION }}
@@ -182,7 +182,7 @@ jobs:
           go-version-file: go.mod
 
       - name: GoReleaser (build linux-amd64 binaries)
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@v7
         with:
           distribution: goreleaser-pro
           version: ${{ env.GORELEASER_VERSION }}
@@ -218,7 +218,7 @@ jobs:
           sudo apt install -y gcc-aarch64-linux-gnu
 
       - name: GoReleaser (build linux-arm64 binaries)
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@v7
         with:
           distribution: goreleaser-pro
           version: ${{ env.GORELEASER_VERSION }}
@@ -250,7 +250,7 @@ jobs:
           go-version-file: go.mod
 
       - name: GoReleaser (build windows binaries)
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@v7
         with:
           distribution: goreleaser-pro
           version: ${{ env.GORELEASER_VERSION }}
@@ -314,7 +314,7 @@ jobs:
 
 
       - name: GoReleaser (publish)
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@v7
         with:
           distribution: goreleaser-pro
           version: ${{ env.GORELEASER_VERSION }}

--- a/site/content/en/docs/drivers/oracle.md
+++ b/site/content/en/docs/drivers/oracle.md
@@ -31,7 +31,7 @@ Use [`sq add`](/docs/cmd/add) to add an Oracle source.
 sq add 'oracle://user:password@host:1521/service_name'
 ```
 
-For the Sakila Oracle test image:
+For the [Sakila Oracle test image](https://hub.docker.com/repository/docker/sakiladb/oracle/general):
 
 ```shell
 sq add 'oracle://sakila:p_ssW0rd@localhost:1521/SAKILA' --handle @sakila_ora


### PR DESCRIPTION
## Summary

- Bumps `goreleaser/goreleaser-action` from `v6` to `v7` in `.github/workflows/main.yml` (5 occurrences).
- `v6` runs on Node.js 20, which GitHub is deprecating: forced to Node 24 on **2026-06-02** and fully removed on **2026-09-16**. CI currently emits a deprecation warning on every run of `binaries-{darwin,linux-amd64,linux-arm64,windows}` and the publish job.
- `v7.2.1` (latest) declares `using: 'node24'` in its `action.yml`. The only v7 breaking change is dropping support for GoReleaser < v2, and this repo is already on GoReleaser v2.

Ref: <https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/>

## Test plan

- [ ] CI passes on this branch with no Node.js 20 deprecation annotations.
- [ ] `binaries-*` jobs continue to produce artifacts (`dist-linux-amd64`, `dist-linux-arm64`, `dist-windows`, `dist-darwin`).
- [ ] Publish job's GoReleaser step still runs (note: this only fires on tag pushes, so it won't exercise on a PR — confirm at next release).