### PR TITLE
Bump codeql-action to v4 and actions/cache to v5 (Node 24)

### DIFF
--- a/.github/workflows/codeql-site.yml
+++ b/.github/workflows/codeql-site.yml
@@ -39,12 +39,12 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v3
+        uses: github/codeql-action/autobuild@v4
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -55,7 +55,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@v4
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -69,7 +69,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, Go, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v3
+      uses: github/codeql-action/autobuild@v4
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
@@ -82,6 +82,6 @@ jobs:
     #   ./location_of_script_within_repo/buildscript.sh
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@v4
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/site-ci.yml
+++ b/.github/workflows/site-ci.yml
@@ -33,7 +33,7 @@ jobs:
           bun-version: 1.2
 
       - name: Cache Bun dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.bun/install/cache

--- a/.github/workflows/site-links-nightly.yml
+++ b/.github/workflows/site-links-nightly.yml
@@ -27,7 +27,7 @@ jobs:
           bun-version: 1.2
 
       - name: Cache Bun dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.bun/install/cache


### PR DESCRIPTION
## Summary

Follow-up to #596. That PR resolved the Node.js 20 deprecation warnings emitted by `goreleaser-action@v6` on the release pipeline. After merge, the same deprecation surfaced on regular master runs from two other actions:

- `github/codeql-action/{init,autobuild,analyze}@v3` → `@v4` in `codeql.yml` and `codeql-site.yml` (latest `v4.35.4`, declares `using: node24`).
- `actions/cache@v4` → `@v5` in `site-ci.yml` and `site-links-nightly.yml` (latest `v5.0.5`, declares `using: node24`).

Both upgrades are drop-in for the current usage — no input/output changes that this repo's workflows rely on.

Ref: <https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/>

## Test plan

- [ ] `Site CI` run on this PR shows no Node.js 20 deprecation annotations.
- [ ] `CodeQL site` run on this PR shows no Node.js 20 deprecation annotations.
- [ ] `CodeQL` (Go) — only triggers on changes under `**/*.go` / `go.mod` / `go.sum`, so won't fire on this PR; confirm at next Go-touching push.
- [ ] `site-links-nightly` — scheduled workflow; confirm at next nightly run.