### PR TITLE
docs(grammar): extensively document SLQ.g4 and grammar/README

### DIFF
--- a/grammar/README.md
+++ b/grammar/README.md
@@ -1,37 +1,443 @@
 # SLQ Grammar
 
-The query language used by `sq` is formally known as _SLQ_. The
-grammar is defined in `SLQ.g4`, which is an [ANTLR4](https://www.antlr.org/) grammar.
+The query language used by [`sq`](https://sq.io) is formally known as **SLQ**.
+This directory contains the formal grammar (`SLQ.g4`, written in
+[ANTLR4](https://www.antlr.org/) syntax) and the tooling that turns it into a
+Go parser. This README is the high-level companion to [`SLQ.g4`](./SLQ.g4):
+read this first, then dive into the grammar file for the rule-by-rule detail.
 
-There's a bunch of valid sample input in the `testdata` dir.
+The grammar is **not yet stable**: it may change in any new `sq` release.
 
-The `antlr4` tool generates the parser / lexer files from the grammar.
-Being that `antlr4` is Java-based, Java must be installed to regenerate
-from the grammar. The process is encapsulated in `generate.sh` (or execute
-`go generate ./...`). 
+## Contents
 
-The generated `.go` files ultimately end up in package `libsq/ast/internal/slq`. Files
-in this directory should not be directly edited.
+- [SLQ at a glance](#slq-at-a-glance)
+- [How SLQ becomes SQL](#how-slq-becomes-sql)
+- [Query structure](#query-structure)
+- [Element catalogue](#element-catalogue)
+- [Lexical layer](#lexical-layer)
+- [Operator precedence](#operator-precedence)
+- [Working with the grammar](#working-with-the-grammar)
+- [Common pitfalls](#common-pitfalls)
+- [Further reading](#further-reading)
 
-The `libsq/ast.Parse` function takes a `SLQ` input string and returns an `*ast.AST`.
-The entrypoint that accepts the SLQ string is `libsq.ExecSLQ`, which ultimately
-invokes `ast.Parse`.
+## SLQ at a glance
+
+SLQ is a pipeline language. A query is a chain of *segments* separated by `|`,
+each transforming the previous one — the same mental model as Unix pipelines
+or `jq`. The renderer maps each segment to (part of) a SQL clause.
+
+```text
+@sakila | .actor | .first_name, .last_name | .[0:10]
+└──────┘   └────┘   └─────────────────────┘   └────┘
+ source     table     projection              row range
+
+≈   SELECT "first_name", "last_name"
+    FROM   "actor"
+    LIMIT  10 OFFSET 0
+```
+
+Three things to internalize before reading the grammar:
+
+1. **Segments are pipes.** `|` separates segments; `,` separates elements
+   *inside* a segment.
+2. **Selectors are dotted.** `.actor`, `.first_name`, `.actor.first_name` —
+   the leading dot is part of the token.
+3. **Handles are sources.** `@sakila` (or `@work/acme/sakila`) names a
+   registered data source. `@sakila.actor` is shorthand for
+   `@sakila | .actor`.
+
+## How SLQ becomes SQL
+
+The path from query text to executed SQL spans three packages. The generated
+parser lives in `libsq/ast/internal/slq`, the AST lives in `libsq/ast`, and
+the dialect-specific renderer lives in `libsq/ast/render`.
+
+```mermaid
+flowchart LR
+    Q["SLQ query text<br/>(e.g. @sakila | .actor)"]
+    L["ANTLR Lexer<br/>(slq_lexer.go)"]
+    P["ANTLR Parser<br/>(slq_parser.go)"]
+    V["parseTreeVisitor<br/>(libsq/ast)"]
+    N["Narrowing passes<br/>(narrowTblSel,<br/>narrowColSel, ...)"]
+    A["*ast.AST"]
+    R["SQL Renderer<br/>(libsq/ast/render)"]
+    S["Dialect SQL<br/>(Postgres, SQLite, ...)"]
+
+    Q --> L --> P --> V --> N --> A --> R --> S
+```
+
+| Stage | Input | Output | Where it lives |
+| --- | --- | --- | --- |
+| Lex | text | token stream | `slq.SLQLexer` (generated) |
+| Parse | tokens | parse tree | `slq.SLQParser` (generated) |
+| Build | parse tree | initial AST | `parseTreeVisitor` (`libsq/ast`) |
+| Narrow | initial AST | typed AST | `narrow*` passes (see `process.go`) |
+| Verify | typed AST | typed AST | `verify` |
+| Render | typed AST | SQL string | `libsq/ast/render` (per-dialect) |
+
+The grammar is the *contract* between lex/parse and everything downstream.
+Changing it is a downstream-ripple operation: the parser must be regenerated
+**and** the AST builder usually needs adjusting to match.
+
+### Public entry points
+
+- [`libsq/ast.Parse(log, input)`](../libsq/ast/parser.go) — turn SLQ text
+  into an `*ast.AST`. This is what consumers of the language should call.
+- [`libsq.ExecSLQ`](../libsq/libsq.go) — the top-level "run a query"
+  entry. It calls `ast.Parse` internally.
+
+The generated Go sources land in `libsq/ast/internal/slq/` and **must not be
+hand-edited** — they will be overwritten the next time the grammar is
+regenerated.
+
+## Query structure
+
+The parser's view of a query is a small tree:
+
+```mermaid
+flowchart TD
+    stmtList --> query1[query]
+    stmtList --> query2[query ...]
+    query1 --> seg1[segment]
+    query1 --> seg2[segment]
+    query1 --> segN[...]
+    seg1 --> elem1[element]
+    seg1 --> elem2[element ...]
+    elem1 --> kind{{kind?}}
+    kind --> handle
+    kind --> handleTable
+    kind --> selectorElement
+    kind --> join
+    kind --> where
+    kind --> groupBy
+    kind --> having
+    kind --> orderBy
+    kind --> rowRange
+    kind --> uniqueFunc
+    kind --> countFunc
+    kind --> funcElement
+    kind --> exprElement
+```
+
+Concretely: a `stmtList` is one or more `query`s separated by `;`. A `query`
+is one or more `segment`s separated by `|`. A `segment` is one or more
+`element`s separated by `,`. An `element` is one of the thirteen kinds in
+the diagram above. The thirteen-way fan-out is where the grammar's
+expressive power lives.
+
+### Where each element legally appears
+
+Most elements can appear in any segment, but a few have positional rules
+that the AST builder enforces:
+
+```mermaid
+stateDiagram-v2
+    direction LR
+    [*] --> Source: handle / handleTable
+    Source --> Table: selectorElement (table)
+    Table --> Table: join
+    Table --> Filtered: where
+    Filtered --> Grouped: group_by
+    Grouped --> HavingFiltered: having
+    Filtered --> Projected: projection
+    Table --> Projected: projection
+    HavingFiltered --> Projected: projection
+    Projected --> Ordered: order_by
+    Ordered --> Ranged: rowRange
+    Projected --> Ranged: rowRange
+    Ranged --> [*]
+    Projected --> [*]
+```
+
+A few enforced rules:
+
+- **`having` requires `group_by`** — checked by AST verification, not the
+  grammar.
+- **At most one `rowRange`** per query (`verifyRowRange`).
+- The first segment's selector is interpreted as a table selector, not a
+  column selector (`narrowTblSel`).
+
+## Element catalogue
+
+Quick reference for every element kind. See [`SLQ.g4`](./SLQ.g4) for the
+exact grammar and the sample queries in `testdata/` for live examples.
+
+**`handle`** — `@sakila`. Names a registered data source. Aliasing is not
+allowed at the handle level.
+
+**`handleTable`** — `@sakila.actor`. Source + table in one element.
+Shorthand for `@sakila | .actor`.
+
+**`selectorElement`** — `.first_name:given_name`. A dotted selector with
+optional alias. Role (table vs. column vs. table-column) is decided by
+position via the narrowing passes.
+
+**`join`** — `join(.film, .actor.id == .film.id)`. Maps to `JOIN ... ON
+...`. Thirteen kinds including `cross_join`; `NATURAL JOIN` is excluded
+by design.
+
+**`where`** — `where(.id > 10)`. Maps to `WHERE`. Also spelled
+`select(...)` (the `jq` form); the two are equivalent at the parser
+level.
+
+**`groupBy`** — `group_by(.customer_id)`. Maps to `GROUP BY`. Aliases:
+`group_by`, `gb`.
+
+**`having`** — `having(sum(.amount) > 100)`. Maps to `HAVING`. Must follow
+a `group_by` (enforced at AST verification, not parse).
+
+**`orderBy`** — `order_by(.last_name-)`. Maps to `ORDER BY ... ASC/DESC`;
+`+` / `-` suffix per term selects direction. Aliases: `order_by`,
+`sort_by`, `ob`.
+
+**`rowRange`** — `.[10:15]`. Maps to `LIMIT` / `OFFSET`. `jq`-style slice
+syntax; see [Row ranges](#row-ranges).
+
+**`uniqueFunc`** — `unique`. Maps to `DISTINCT`. Bare keyword, no parens.
+Alias: `uniq`.
+
+**`countFunc`** — `count`, `count(*)`, `count(.id):n`. Maps to
+`COUNT(...)`. Special-cased because of the bare form (no parens).
+
+**`funcElement`** — `sum(.amount):total`. Generic `<fn>(...) AS <alias>`.
+For portable functions listed in `funcName` and proprietary `_fn` calls.
+
+**`exprElement`** — `(1+2):total`. Arbitrary expression as a result
+column with an optional alias.
+
+### Selector resolution
+
+A `selector` in the grammar is just `.name` or `.name1.name2`. Whether it
+refers to a table, a column, or a `table.column` pair is decided after
+parsing by the *narrowing* passes:
+
+```mermaid
+flowchart TD
+    A[SelectorNode] --> Q{Position in query?}
+    Q -->|first segment| T[TblSelectorNode]
+    Q -->|after handle| T
+    Q -->|after final table segment<br/>and has two name parts| TC[TblColSelectorNode]
+    Q -->|otherwise, inside func/expr<br/>and has two name parts| TC
+    Q -->|otherwise, single part| C[ColSelectorNode]
+```
+
+This two-step approach — keep the grammar deliberately ambiguous, then
+disambiguate using context — keeps the grammar small. The trade-off is
+that some "obvious" errors are caught at AST-build time, not parse time.
+
+### Row ranges
+
+`jq`-style slice forms map to SQL `LIMIT`/`OFFSET` as follows:
+
+| SLQ | Meaning | SQL |
+| --- | --- | --- |
+| `.[]` | all rows | *(no LIMIT/OFFSET)* |
+| `.[10]` | row index 10 | `LIMIT 1 OFFSET 10` |
+| `.[10:15]` | rows 10–15 | `LIMIT 5 OFFSET 10` |
+| `.[0:15]` / `.[:15]` | first 15 rows | `LIMIT 15 OFFSET 0` |
+| `.[10:]` | from row 10 onwards | `OFFSET 10` |
+
+The grammar admits all five forms in a single rule; the conversion to
+`{offset, limit}` happens in [`VisitRowRange`](../libsq/ast/range.go).
+
+## Lexical layer
+
+A few tokens deserve special attention because they cross-cut the grammar.
+
+```mermaid
+flowchart LR
+    subgraph Identifiers
+        ID["ID<br/>actor, first_name, _x"]
+        IDNUM["IDNUM<br/>007bond, 123abc"]
+        DIGITS["DIGITS<br/>007, 00123"]
+    end
+    subgraph Selectors_and_handles[Selectors & handles]
+        NAME[".name<br/>.actor, .'my col'"]
+        HANDLE["@source<br/>@work/acme/sakila"]
+        ARG["$var<br/>argument reference"]
+    end
+    subgraph Literals
+        NN["NN<br/>natural ints"]
+        NUMBER["NUMBER<br/>signed / float / exp"]
+        STRING["STRING<br/>\"...\""]
+        BOOL["BOOL: true / false"]
+        NULL["NULL: null"]
+    end
+    NAME --> ID
+    NAME --> IDNUM
+    NAME --> DIGITS
+    NAME --> STRING
+    NAME --> ARG
+    HANDLE --> ID
+```
+
+### Identifier rules and the issue-470 trio
+
+For numeric-prefixed schema/catalog names (issue #470), the lexer
+distinguishes three identifier-like token families:
+
+- **`ID`** — `[a-zA-Z_][a-zA-Z0-9_]*`. The classic identifier; cannot start
+  with a digit.
+- **`IDNUM`** — `[0-9]+[a-zA-Z_][a-zA-Z0-9_]*`. Digits followed by at least
+  one letter or underscore. Matches `007bond`.
+- **`DIGITS`** — `[0-9]+`. Pure digit runs, including leading zeros.
+  Matches `007`.
+
+These all feed into `NAME`. The interaction with `NN` (natural number,
+no leading zeros) is subtle:
+
+- For `42`, the lexer must choose `NN` over `DIGITS` so that numeric
+  literals don't become identifiers. **Definition order** breaks the tie:
+  `NN` is defined before `DIGITS`.
+- For `007bond`, ANTLR's **maximal munch** rule prefers `IDNUM` (the
+  longest match) over `DIGITS` followed by stray `bond`.
+
+If you reorder these lexer rules, expect numeric-literal regressions.
+
+### The `ALIAS_RESERVED` hack
+
+`alias` allows `:` + identifier/string. But what if the alias *text* is a
+SLQ keyword? For example:
+
+```text
+.actor | count:count
+```
+
+The bare `count` after the colon would be lexed as the `count` keyword,
+not as an alias name, and parsing fails. `ALIAS_RESERVED` is the
+workaround: for each problematic keyword, the literal `:keyword` is
+pre-baked as a single token. The AST builder then strips the leading
+colon (see [`alias.go`](../libsq/ast/alias.go)). The list is small
+(`:count`, `:avg`, `:min`, `:max`, `:group_by`, `:order_by`, `:unique`,
+`:count_unique`) and needs to be kept in sync as new keywords are added.
+
+This is acknowledged as a wart and could likely be refactored away with
+a redesigned `alias` rule.
+
+### Comments and whitespace
+
+- Whitespace (`\t`, `\r`, `\n`, space) is skipped.
+- `#` starts a comment that runs to end of line; also skipped.
+
+## Operator precedence
+
+`expr` is a left-recursive rule. ANTLR resolves precedence by alternative
+order — earlier alternatives bind tighter. The full ladder, tight → loose:
+
+```text
+        (expr)                     -- parens (tightest)
+        selector / literal / arg
+        unary  -x  +x  ~x  !x
+        ||                          -- SQL string concat (NOT logical-or)
+        *  /  %
+        +  -
+        <<  >>  &                   -- bitwise
+        <  <=  >  >=
+        ==  !=
+        &&                          -- logical-and (loosest)
+        func(...)                   -- function call
+```
+
+**Watch out:** in SLQ, `||` means SQL string concatenation (as in SQLite
+and Postgres), **not** logical-or. Boolean disjunction is currently not a
+first-class operator; users typically rewrite with multiple `where`
+clauses or use database-specific tricks via `_proprietary` functions.
 
 ## Working with the grammar
 
-You probably should install the [antlr tools](https://github.com/antlr/antlr4-tools).
+### Regenerating the parser
+
+Regeneration runs the bundled `antlr4` JAR (under `tools/`) and writes Go
+sources to `libsq/ast/internal/slq/`:
 
 ```shell
-pip install antlr4-tools
+# either:
+go generate ./...
+
+# or, directly:
+cd grammar && ./generate.sh
 ```
 
-You may also find [antlr4ts](https://github.com/tunnelvisionlabs/antlr4ts) useful.
+You need Java to be available, because `antlr4` is Java-based. The exact
+JAR is committed in `tools/antlr-4.13.0-complete.jar`, so no separate
+ANTLR install is required.
 
-```shell
-npm install antlr4ts
-```
+The generated files MUST NOT be hand-edited — they are wholly derived
+from `SLQ.g4` and will be overwritten on the next regeneration.
 
-And there are various [IDE plugins](https://github.com/antlr/antlr4-tools) available.
+### Recommended local tooling
 
-In particular, note the [VS Code extension](https://github.com/mike-lischke/vscode-antlr4).
+For grammar authoring you'll want:
 
+- The [antlr4 tools](https://github.com/antlr/antlr4-tools) for testing
+  grammars from the command line:
+
+  ```shell
+  pip install antlr4-tools
+  ```
+
+- Optionally, [antlr4ts](https://github.com/tunnelvisionlabs/antlr4ts):
+
+  ```shell
+  npm install antlr4ts
+  ```
+
+- The
+  [VS Code ANTLR4 extension](https://github.com/mike-lischke/vscode-antlr4)
+  for in-editor diagnostics, railroad diagrams, and parse-tree previews.
+
+### Sample inputs
+
+`testdata/` contains a corpus of valid SLQ snippets. `all-valid.slq` is a
+broad smoke test; the `*.test.slq` files exercise specific element kinds
+(`join-*`, `range-*`, `column-alias`, `select-*`). When evolving the
+grammar, extend these alongside your changes.
+
+### Editing checklist
+
+Before sending a grammar change:
+
+1. Update [`SLQ.g4`](./SLQ.g4) — keep comments adjacent to the rules they
+   describe.
+2. Regenerate: `go generate ./...`.
+3. Build: `go build ./libsq/ast/internal/slq` (the `generate.sh` script
+   does this automatically as a sanity check).
+4. Update [`libsq/ast`](../libsq/ast) visitors / narrowing passes if you
+   touched any rule that produces a new shape of parse tree.
+5. Add or extend sample inputs under `testdata/`.
+6. Run `make test` (or `make test-short` to skip Docker-backed tests).
+
+## Common pitfalls
+
+A non-exhaustive list of things that have bitten contributors:
+
+- **Element-order ambiguity.** `handleTable` must come before `handle`
+  in the `element` alternative list, or `@sakila.actor` would be parsed
+  as `@sakila` followed by mystery input.
+- **`NN` vs `DIGITS` order.** Reordering these lexer rules silently
+  changes how integer literals tokenize.
+- **`select` vs `where`.** Both spellings work for filtering. Don't
+  confuse `select(...)` (a `WHERE`) with a SQL `SELECT` list — the
+  projection in SLQ is just a comma-separated selector list.
+- **`||` is concat, not OR.** See [Operator precedence](#operator-precedence).
+- **Aliasing a keyword.** Always works via the `:keyword` form thanks to
+  `ALIAS_RESERVED`, but only for the keywords listed there. New
+  keywords need to be added.
+- **`narrowing` passes can reject grammatically-valid input.** Some
+  errors only surface at AST-build time (e.g. `having` without
+  `group_by`, multiple row ranges). Grep `libsq/ast` for `verify*` /
+  `narrow*` if a query parses but fails downstream.
+
+## Further reading
+
+- [`SLQ.g4`](./SLQ.g4) — the grammar itself, extensively commented.
+- [`libsq/ast`](../libsq/ast) — AST types, the parse-tree visitor, and
+  narrowing/verification passes.
+- [`libsq/ast/render`](../libsq/ast/render) — dialect-specific SQL
+  rendering.
+- [sq.io](https://sq.io) — end-user docs (query syntax, command
+  reference).
+- [ANTLR4 reference](https://github.com/antlr/antlr4/blob/master/doc/index.md)
+  — definitive guide to the grammar metalanguage used in `SLQ.g4`.
+- [`jq` manual](https://jqlang.github.io/jq/manual/) — SLQ's primary
+  syntactic inspiration.

--- a/grammar/SLQ.g4
+++ b/grammar/SLQ.g4
@@ -1,13 +1,117 @@
-// This is the grammar for SLQ, the query language used by sq (https://sq.io).
-// The grammar is not yet finalized; it is subject to change in any new sq release.
+// =============================================================================
+// SLQ.g4 -- the ANTLR4 grammar for SLQ, the sq query language.
+// =============================================================================
+//
+// SLQ is the query language used by `sq` (https://sq.io). It is a
+// pipeline-oriented language strongly inspired by `jq`, but with semantics
+// that map cleanly onto SQL. A simple SLQ query looks like this:
+//
+//     @sakila | .actor | .first_name, .last_name | .[0:10]
+//
+// which, when run against a Postgres source, is rendered as approximately:
+//
+//     SELECT "first_name", "last_name" FROM "actor" LIMIT 10 OFFSET 0
+//
+// The grammar is NOT stable: it is subject to change in any new sq release.
+// Companion documentation lives in `README.md` next to this file, and the
+// `testdata/` directory has a corpus of sample queries that exercise the
+// grammar.
+//
+// -----------------------------------------------------------------------------
+// Language tour (for grammar readers)
+// -----------------------------------------------------------------------------
+//
+// A query is a sequence of *segments* separated by the pipe operator `|`.
+// Each segment contains one or more *elements* separated by commas.
+//
+//     @sakila    |    .actor    |    .first_name, .last_name    |    .[0:10]
+//     └────────┘    └──────┘    └─────────────────────────┘    └─────┘
+//      handle      table-sel      column selectors             row-range
+//      segment     segment        segment                       segment
+//
+// Most segments map directly to a clause of the eventual SQL statement:
+//
+//     element kind         purpose                            SQL analogue
+//     ─────────────────    ────────────────────────────────   ──────────────
+//     handle               choose the data source             (source pick)
+//     handleTable          handle + table in one token        FROM <table>
+//     selectorElement      pick a table or column             FROM / SELECT
+//     join                 join two tables                    JOIN ... ON ...
+//     where                filter predicate                   WHERE
+//     groupBy              grouping                           GROUP BY
+//     having               group filter                       HAVING
+//     orderBy              sort                               ORDER BY
+//     rowRange             limit/offset                       LIMIT / OFFSET
+//     uniqueFunc           dedupe                             DISTINCT
+//     countFunc            count rows                         COUNT(...)
+//     funcElement          generic function call              <fn>(...)
+//     exprElement          expression as a result column      <expr> AS <a>
+//
+// -----------------------------------------------------------------------------
+// Where this file fits
+// -----------------------------------------------------------------------------
+//
+// 1. `antlr4` (Java) reads this `.g4` file and generates Go sources for the
+//    lexer, parser, listener, and visitor. Generation is wired through
+//    `generate.sh` / `generate.go` (`go generate ./...`). The output lands
+//    in `libsq/ast/internal/slq/`; those files MUST NOT be hand-edited.
+//
+// 2. `libsq/ast.Parse` is the public entry point. It wraps the generated
+//    lexer/parser, walks the resulting parse tree with `parseTreeVisitor`,
+//    and produces an `*ast.AST` (in package `libsq/ast`).
+//
+// 3. A SQL renderer (`libsq/ast/render`) then walks the AST and emits a
+//    dialect-specific SQL statement.
+//
+// See `README.md` for diagrams of these stages.
+// =============================================================================
+
 grammar SLQ;
 
+// -----------------------------------------------------------------------------
+// PARSER RULES
+// -----------------------------------------------------------------------------
+//
+// ANTLR convention: rule names that start with a lower-case letter are
+// PARSER rules; ALL_CAPS names are LEXER (token) rules. The parser rules
+// below define the tree structure; the lexer rules at the bottom of the
+// file define the alphabet of tokens that the parser sees.
+
+// stmtList is the top-level entry point: zero or more queries separated by
+// semicolons. Leading and trailing semicolons are tolerated, and runs of
+// consecutive semicolons are collapsed. This permits scripts like:
+//
+//     ; @sakila | .actor ;; @sakila | .film ;
+//
+// although in practice nearly all SLQ inputs are a single query and the
+// semicolon machinery is rarely used. `libsq/ast` builds an AST per query.
 stmtList: ';'* query ( ';'+ query)* ';'*;
 
+// query is a sequence of segments joined by the pipe operator. The pipe
+// is the defining feature of SLQ: each segment receives "what the previous
+// segment produced" and transforms it further, mirroring `jq` and Unix
+// shell pipelines. The pipe has no associativity issue because segments
+// are simply concatenated left-to-right.
+//
+//     @sakila | .actor | .first_name
+//     └──┬──┘   └──┬──┘   └────┬───┘
+//       seg0      seg1        seg2
 query: segment ('|' segment)*;
 
+// segment is a comma-separated list of elements. Most segments contain a
+// single element (e.g. a `where(...)` or an `order_by(...)`). The comma
+// is mainly used for projections — `.first_name, .last_name` — and for
+// listing tables before a join: `.actor, .film | join(...)`.
 segment: (element) (',' element)*;
 
+// element is the heart of the parser: each alternative names one kind of
+// thing that can appear inside a segment. Order matters here only when
+// alternatives would otherwise be ambiguous; ANTLR uses the first match.
+//
+// Note that `handleTable` MUST come before `handle`: an input like
+// `@sakila.actor` is a `handleTable` (handle + table), but the prefix
+// `@sakila` on its own is a `handle`. Listing `handleTable` first ensures
+// the longer match wins.
 element
   : handleTable
 	| handle
@@ -25,8 +129,27 @@ element
 
 
 
+// -----------------------------------------------------------------------------
+// Function calls (generic)
+// -----------------------------------------------------------------------------
+
+// funcElement wraps a function call so that it can be used as a result
+// column with an optional alias:
+//
+//     .payment | sum(.amount):total
+//
+// `sum(.amount)` is the `func`; `:total` is the `alias`.
 funcElement: func (alias)?;
+
+// func is the syntactic form `name(arg, arg, ...)`. The single-argument
+// form `name(*)` is also accepted (e.g. `count(*)`). Empty parens are
+// permitted: `name()`.
 func: funcName '(' ( expr ( ',' expr)* | '*')? ')';
+
+// funcName is the closed set of "portable" function names known to SLQ,
+// plus the open-ended `PROPRIETARY_FUNC_NAME` for DB-native escapes.
+// Adding a new portable function requires (a) adding the literal here and
+// (b) implementing/handling it in `libsq/ast` and the SQL renderer.
 funcName
   : 'sum'
 	| 'avg'
@@ -38,34 +161,46 @@ funcName
 	| PROPRIETARY_FUNC_NAME
   ;
 
-// PROPRIETARY_FUNC_NAME is a DB-native func, which is invoked by prefixing
-// an underscore to the func name, e.g. _date(xyz).
+// PROPRIETARY_FUNC_NAME is the escape hatch for invoking a function that
+// is specific to a particular database, e.g. SQLite's `strftime`. The
+// convention is to prefix the underscore: `_strftime(...)`. The renderer
+// passes proprietary calls through verbatim (minus the leading `_`) and
+// it is the user's responsibility to ensure the function exists on the
+// active source. See `ast.FuncNode.IsProprietary`.
 PROPRIETARY_FUNC_NAME: '_' ID;
 
-/*
-join
-----
 
-join implements SQL's JOIN mechanism.
-
-    @sakila_pg | .actor | join(.film_actor, .actor_id)
-    @sakila_pg | .actor | join(@sakila_my.film_actor, .actor_id)
-    @sakila_pg | .actor | join(.film_actor, .actor.actor_id == .film_actor.actor_id)
-    @sakila_pg | .actor:a | join(.film_actor:fa, .a.actor_id == .fa.actor_id)
-    @sakila_pg.actor:a | join(@sakila_my.film_actor:fa, .a.actor_id == .fa.actor_id)
-
-See:
-- https://www.sqlite.org/syntax/join-clause.html
-- https://www.sqlite.org/syntax/join-operator.html
-*/
-join: JOIN_TYPE '(' joinTable (',' expr)? ')';
-joinTable: (HANDLE)? NAME (alias)?;
-// JOIN_TYPE is the set of join types, and their aliases.
-// Note that not every database may support every join type, but
-// this is not the concern of the grammar.
+// -----------------------------------------------------------------------------
+// join
+// -----------------------------------------------------------------------------
 //
-// Note that NATURAL JOIN is not supported, as its implementation
-// is spotty in various DBs, and it's often considered an anti-pattern.
+// `join` implements SQL's JOIN. The shape is `<join-kind>(table, predicate)`,
+// optionally with cross-source handles and aliases.
+//
+//     @sakila_pg | .actor | join(.film_actor, .actor_id)
+//     @sakila_pg | .actor | join(@sakila_my.film_actor, .actor_id)
+//     @sakila_pg | .actor | join(.film_actor, .actor.actor_id == .film_actor.actor_id)
+//     @sakila_pg | .actor:a | join(.film_actor:fa, .a.actor_id == .fa.actor_id)
+//     @sakila_pg.actor:a | join(@sakila_my.film_actor:fa, .a.actor_id == .fa.actor_id)
+//
+// The second-argument expression may be omitted for the few join types
+// (e.g. `cross_join`) that don't require a predicate.
+//
+// See:
+// - https://www.sqlite.org/syntax/join-clause.html
+// - https://www.sqlite.org/syntax/join-operator.html
+join: JOIN_TYPE '(' joinTable (',' expr)? ')';
+
+// joinTable is the table being joined to. The optional leading `HANDLE`
+// supports cross-source joins (e.g. `@sakila_my.film_actor`). The trailing
+// `alias` provides a short name for use in the join predicate.
+joinTable: (HANDLE)? NAME (alias)?;
+
+// JOIN_TYPE is the closed set of join keywords plus short aliases.
+// `NATURAL JOIN` is intentionally absent: its implementation differs
+// across DBs and it is widely considered an anti-pattern. Not every
+// listed kind is supported by every backing database, but that is the
+// renderer/driver's problem to detect, not the grammar's.
 JOIN_TYPE
  : 'join'
  | 'inner_join'
@@ -84,145 +219,186 @@ JOIN_TYPE
  ;
 
 
-/*
-uniqueFunc
-----------
-
-uniqueFunc implements SQL's DISTINCT mechanism.
-
-    .actor | .first_name | unique
-    .actor | unique
-
-The func takes zero args.
-*/
+// -----------------------------------------------------------------------------
+// uniqueFunc -- DISTINCT
+// -----------------------------------------------------------------------------
+//
+// `unique` (or its short alias `uniq`) implements SQL's `DISTINCT`. It
+// takes zero arguments and applies to the current projection:
+//
+//     .actor | .first_name | unique     -- SELECT DISTINCT first_name FROM actor
+//     .actor | unique                   -- SELECT DISTINCT * FROM actor
+//
+// Note that `unique` is a *segment-level* element (sibling to `where`,
+// `group_by`, etc.), not a function call: there are no parentheses.
 uniqueFunc: 'unique' | 'uniq';
 
-/*
 
-countFunc
----------
-
-This implements SQL's COUNT function. It has special handling vs other
-funcs because of the several forms it can take.
-
-    .actor | count
-    .actor | count:quantity                 # alias
-    .actor | count()
-    .actor | count(*)
-    .actor | count(.first_name):quanity     # alias
-
- */
+// -----------------------------------------------------------------------------
+// countFunc -- COUNT
+// -----------------------------------------------------------------------------
+//
+// `count` has bespoke grammar because it accepts several distinct shapes,
+// some of which would conflict with the generic `func` rule:
+//
+//     .actor | count                          -- bare keyword form
+//     .actor | count:quantity                 -- bare form with alias
+//     .actor | count()                        -- empty-paren form
+//     .actor | count(*)                       -- COUNT(*)
+//     .actor | count(.first_name):quantity    -- COUNT(<col>) with alias
+//
+// In particular, the bare form `count` (no parens) is the reason this
+// can't just live under `funcName`/`func`.
 countFunc: 'count' (LPAR (selector)? RPAR)? (alias)?;
 
 
-/*
-where
------
-The "where" mechanism implements SQL's WHERE clause.
+// -----------------------------------------------------------------------------
+// where -- WHERE
+// -----------------------------------------------------------------------------
+//
+// `where` filters rows, exactly like SQL's `WHERE` clause:
+//
+//     .actor | where(.actor_id > 10 && .first_name == "TOM")
+//
+// Naming note: this construct is called both `where` (the SQL term) and
+// `select` (the `jq` term -- see `jq`'s `select(boolean_expression)`).
+// `sq`'s design principle is to mirror `jq` syntax where possible, but
+// for SQL audiences "select" means "pick these columns", which conflicts.
+// For now BOTH spellings are accepted; one is expected to be deprecated
+// after user feedback settles the question.
 
-  .actor | where(.actor_id > 10 && .first_name == "TOM")
-
-From a SQL perspective, "where" is the natural name to use. However,
-and inconveniently, jq uses "select" for this purpose.
-
- https://jqlang.github.io/jq/manual/v1.6/#select(boolean_expression)
-
-One of sq's design principles is to adhere to jq syntax whenver possible.
-Alas, for SQL users, "select" means "SELECT these columns", not "select
-the matching rows".
-
-It's unclear what the best approach is here, so for now, we will allow
-both "where" and "select", and plan to deprecate one of these after user
-feedback.
-*/
-
+// WHERE is the lexer rule that captures whichever spelling the user used.
+// The parser rule below sees a single `WHERE` token either way.
 WHERE: 'where' | 'select';
 where: WHERE LPAR (expr)? RPAR;
 
 
-/*
-group_by
---------
-
-The 'group_by' construct implments the SQL "GROUP BY" clause.
-
-    .payment | .customer_id, sum(.amount) | group_by(.customer_id)
-
-Syonyms:
-- 'group_by' for jq interoperability.
-  https://jqlang.github.io/jq/manual/v1.6/#group_by(path_expression)
-- 'gb' for brevity.
-*/
+// -----------------------------------------------------------------------------
+// group_by -- GROUP BY
+// -----------------------------------------------------------------------------
+//
+// `group_by` implements SQL `GROUP BY`. It is typically paired with
+// aggregate functions in the preceding projection:
+//
+//     .payment | .customer_id, sum(.amount) | group_by(.customer_id)
+//
+// Spellings:
+// - `group_by` (the `jq` form; see
+//   https://jqlang.github.io/jq/manual/v1.6/#group_by(path_expression))
+// - `gb`        (brevity alias)
 
 GROUP_BY: 'group_by' | 'gb';
+
+// groupByTerm is what may appear inside `group_by(...)`: either a column
+// selector or a function call (so that you can group by an expression).
 groupByTerm: selector | func;
+
 groupBy: GROUP_BY '(' groupByTerm (',' groupByTerm)* ')';
 
 
-/*
-having
-------
-
-The 'having' construct implements the SQL "HAVING" clause.
-It is a top-level segment clause, and must be preceded by a 'group_by' clause.
-
-    .payment | .customer_id, sum(.amount) |
-      group_by(.customer_id) | having(sum(.amount) > 100)
-*/
+// -----------------------------------------------------------------------------
+// having -- HAVING
+// -----------------------------------------------------------------------------
+//
+// `having` filters grouped results -- SQL's `HAVING`. It is a top-level
+// segment element, and (per SQL semantics) must follow a `group_by`:
+//
+//     .payment | .customer_id, sum(.amount) |
+//       group_by(.customer_id) | having(sum(.amount) > 100)
+//
+// The grammar does not enforce the "must follow group_by" rule -- that
+// constraint is checked by AST verification in `libsq/ast`.
 
 HAVING: 'having';
 having: HAVING '(' expr ')';
 
-/*
-order_by
-------
 
-The 'order_by' construct implements the SQL "ORDER BY" clause.
-
-    .actor | order_by(.first_name, .last_name)
-    .actor | order_by(.first_name+)
-    .actor | order_by(.actor.first_name-)
-
-The optional plus/minus tokens specify ASC or DESC order.
-
-Synonyms:
-
-- 'sort_by' for jq interoperability.
-  https://jqlang.github.io/jq/manual/v1.6/#sort,sort_by(path_expression)
-- 'ob' for brevity.
-
-We do not implement a 'sort' synonym for the jq 'sort' function, because SQL
-results are inherently sorted. Although perhaps it should be implemented
-as a no-op.
-*/
+// -----------------------------------------------------------------------------
+// order_by -- ORDER BY
+// -----------------------------------------------------------------------------
+//
+// `order_by` implements SQL `ORDER BY`. Trailing `+` and `-` on a term
+// select ASC / DESC respectively (default is ASC).
+//
+//     .actor | order_by(.first_name, .last_name)
+//     .actor | order_by(.first_name+)
+//     .actor | order_by(.actor.first_name-)
+//
+// Spellings:
+// - `order_by` (canonical)
+// - `sort_by`  (the `jq` form; see
+//   https://jqlang.github.io/jq/manual/v1.6/#sort,sort_by(path_expression))
+// - `ob`       (brevity alias)
+//
+// Note: there is NO `sort` synonym for `jq`'s `sort`. SQL results are
+// inherently ordered when an ORDER BY is present, so a bare `sort` with
+// no key has no obvious mapping. It could conceivably be added as a
+// no-op, but that has not been done.
 
 ORDER_BY: 'order_by' | 'sort_by' | 'ob';
+
+// orderByTerm is a selector with an optional direction suffix.
 orderByTerm: selector ('+' | '-')?;
+
 orderBy: ORDER_BY '(' orderByTerm (',' orderByTerm)* ')';
 
-// selector specfies a table name, a column name, or table.column.
-// - .first_name
-// - ."first name"
-// - .actor
-// - ."actor"
-// - .actor.first_name
+
+// -----------------------------------------------------------------------------
+// Selectors -- pick a table/column
+// -----------------------------------------------------------------------------
+//
+// A "selector" is a dotted path that names either a table, a column, or
+// a table-qualified column:
+//
+//     .first_name              -- column
+//     ."first name"            -- column (quoted, allows spaces/keywords)
+//     .actor                   -- table
+//     ."actor"                 -- table (quoted)
+//     .actor.first_name        -- table-qualified column
+//
+// The grammar permits ONE or TWO name parts. Whether a single-part
+// selector resolves to a column or a table is decided by `libsq/ast`
+// based on position in the query (see `narrowTblSel`, `narrowColSel`,
+// `narrowTblColSel` in `libsq/ast`).
 selector: NAME (NAME)?;
 
-// selector is a selector element.
-// - .first_name
-// - ."first name"
-// - .first_name:given_name
-// - ."first name":given_name
-// - .actor.first_name
-// - .actor.first_name:given_name
-// - ."actor".first_name
+// selectorElement wraps a selector so it can carry an alias when used as
+// a projection result column:
+//
+//     .first_name:given_name
+//     ."first name":given_name
+//     .actor.first_name:given_name
+//     ."actor".first_name
+//
+// `:given_name` is the alias part (see `alias` rule).
 selectorElement: (selector) (alias)?;
 
+
+// -----------------------------------------------------------------------------
+// Aliases
+// -----------------------------------------------------------------------------
+//
+// An alias attaches a name to a column/expression/table -- the SQL `AS`.
+// The canonical form is a colon followed by an identifier, argument, or
+// quoted string:
+//
+//     .first_name:given_name        -- alias = "given_name"
+//     .actor:a                      -- table alias
+//     (1+2):total                   -- expression alias
+//     .first_name:"given name"      -- alias with spaces
+//
+// `ALIAS_RESERVED` is a wart: see comment on that lexer rule below.
 alias: ALIAS_RESERVED | ':' (ARG | ID | STRING);
-// The grammar has problems dealing with "reserved" lexer tokens.
-// Basically, there's a problem with using "column:KEYWORD".
-// ALIAS_RESERVED is a hack to deal with those cases.
-// The grammar could probably be refactored to not need this.
+
+// ALIAS_RESERVED works around an ANTLR pain point: when an alias text
+// happens to be a reserved keyword (e.g. `:count` after a `count`
+// function), the lexer would otherwise tokenize the keyword and the
+// parser would get confused. Each entry here is a literal `:keyword`
+// pre-baked as a single token, sidestepping the conflict.
+//
+// This list must be kept in sync as new keywords are added. The grammar
+// could likely be refactored to eliminate the need for this, but that
+// has not been done.
 ALIAS_RESERVED
     // TODO: Update ALIAS_RESERVED with all "keywords"
     : ':count'
@@ -235,27 +411,54 @@ ALIAS_RESERVED
     | ':unique'
     ;
 
+// ARG is a `$`-prefixed argument reference. Arguments are bound from
+// outside the query (e.g. CLI flags) and substituted at evaluation time.
 ARG: '$' ID;
 
 arg : ARG;
 
-// handleTable is a handle.table pair.
-// - @my1.user
+
+// -----------------------------------------------------------------------------
+// Source handles & handle-table pairs
+// -----------------------------------------------------------------------------
+//
+// A "handle" identifies a data source registered in `sq`'s configuration.
+// Handles begin with `@` and may use `/` separators for hierarchical
+// organization:
+//
+//     @sakila
+//     @work/acme/sakila
+//     @home/csv/actor
+//
+// A "handle-table" jams a handle and a table into one element, allowing
+// the source segment to be elided:
+//
+//     @sakila.actor             -- equivalent to: @sakila | .actor
+//     @sakila.actor:a           -- with alias on the table (in handleTable's
+//                                   parent context, not in the lexer itself)
+
+// handleTable is `@source.table`.
 handleTable: HANDLE NAME;
 
-// handle is a source handle.
-// - @sakila
-// - @work/acme/sakila
-// - @home/csv/actor
+// handle is a bare source handle: `@source`.
 handle: HANDLE;
 
-// rowRange specifies a range of rows. It gets turned into
-// a SQL "LIMIT x OFFSET y".
-// - [] select all rows
-// - [10] select row 10
-// - [10:15] select rows 10 thru 15
-// - [0:15] select rows 0 thru 15
-// - [:15] same as above (0 thru 15) [10:] select all rows from 10 onwards
+
+// -----------------------------------------------------------------------------
+// rowRange -- LIMIT / OFFSET
+// -----------------------------------------------------------------------------
+//
+// Row ranges use `jq`-style bracket slicing. The forms are:
+//
+//     .[]         no range -- select all rows (no LIMIT, no OFFSET)
+//     .[10]       single row at index 10 -- LIMIT 1 OFFSET 10
+//     .[10:15]    rows 10 through 15 -- LIMIT (15-10) OFFSET 10
+//     .[0:15]     first 15 rows -- LIMIT 15 OFFSET 0
+//     .[:15]      same as .[0:15]
+//     .[10:]      from row 10 onwards -- OFFSET 10, no LIMIT
+//
+// The translation from slice form to {offset, limit} happens in
+// `libsq/ast.VisitRowRange`.
 rowRange:
 	'.[' (
 		NN COLON NN // [10:15]
@@ -265,8 +468,42 @@ rowRange:
 	)? ']';
 
 
+// -----------------------------------------------------------------------------
+// Expressions
+// -----------------------------------------------------------------------------
+//
+// exprElement is an expression used as a result column (with optional
+// alias):
+//
+//     .actor | (1+2):total
+//
+// See `ast.ExprElementNode`.
 exprElement: expr (alias)?;
 
+// expr is the expression grammar. ANTLR resolves operator precedence by
+// the *order* in which alternatives are listed: earlier rules bind
+// tighter. The order below matches SQL/C-family precedence, from
+// tightest to loosest:
+//
+//     1.  '(' expr ')'         -- parenthesized
+//     2.  selector             -- column reference
+//     3.  literal              -- number / string / bool / null
+//     4.  arg                  -- $param reference
+//     5.  unary  -x  +x  ~x  !x
+//     6.  ||                   -- string concat (NOT logical-or)
+//     7.  *  /  %
+//     8.  +  -
+//     9.  <<  >>  &            -- bitwise
+//     10. <  <=  >  >=
+//     11. ==  !=
+//     12. &&                   -- logical-and (and logical-or sibling)
+//     13. func                 -- function call
+//
+// IMPORTANT: `||` here is the SQL string-concatenation operator (as in
+// SQLite/Postgres `'a' || 'b' = 'ab'`), NOT logical-or. Logical-or, if
+// needed, is generally expressed via separate `where` calls or rewritten
+// by callers; the grammar tier does not currently introduce a dedicated
+// logical-or token.
 expr:
 	'(' expr ')'
 	| selector
@@ -283,20 +520,48 @@ expr:
 	| func
 	;
 
+// literal is the set of scalar literals admitted by an expression.
 literal: NN | NUMBER | BOOL | STRING | NULL;
 
+// unaryOperator -- standard set, including bitwise-not (`~`) and
+// logical-not (`!`).
 unaryOperator: '-' | '+' | '~' | '!';
 
+
+// =============================================================================
+// LEXER RULES
+// =============================================================================
+//
+// Lexer rules (ALL_CAPS) match raw character sequences and produce tokens
+// for the parser. Order MATTERS when two rules can match the same input:
+// ANTLR prefers (1) the longer match, and (2) on a tie, the rule defined
+// earlier. Several rules below comment on that ordering explicitly.
+// =============================================================================
+
+// BOOL captures `true`/`false`. Note that this matches before `ID`
+// because lexer rules are tried in definition order on equal-length
+// matches and `ID` is defined later.
 BOOL: 'true' | 'false';
+
+// NULL captures `null`. Same ordering note as BOOL.
 NULL: 'null';
+
+// ID -- standard identifier. Letters, digits, underscores; cannot start
+// with a digit. Examples: `actor`, `first_name`, `_private`.
 ID: [a-zA-Z_][a-zA-Z0-9_]*;
 
-// IDNUM matches numeric-prefixed identifiers that start with digits followed
-// by at least one letter or underscore. Examples: 123abc, 007bond, 456_schema.
-// This token was added to support numeric schema/catalog names (issue #470).
+// IDNUM matches numeric-prefixed identifiers: digits followed by at
+// least one letter or underscore. Examples: `123abc`, `007bond`,
+// `456_schema`. Added for issue #470 (numeric schema/catalog names).
 IDNUM: [0-9]+ [a-zA-Z_] [a-zA-Z0-9_]*;
 
+// WS -- whitespace is skipped entirely; SLQ is not whitespace-sensitive
+// (except inside quoted strings).
 WS: [ \t\r\n]+ -> skip;
+
+// Punctuation tokens. Naming these explicitly lets parser rules
+// reference them by name in addition to literal form, and helps when
+// inspecting generated parse trees.
 LPAR: '(';
 RPAR: ')';
 LBRA: '[';
@@ -306,29 +571,49 @@ PIPE: '|';
 COLON: ':';
 
 
-// NN: Natural Number {0,1,2,3, ...}
+// NN -- natural number {0, 1, 2, ...}. Used for row-range indices and
+// other non-negative-integer-only contexts. Defined BEFORE `DIGITS` so
+// that on equal-length matches `NN` wins for plain integers without
+// leading zeros.
 NN: INTF;
 
+// NUMBER -- signed numeric literal, possibly fractional and possibly
+// with exponent. Examples:
+//
+//     45         1e10       -3e4
+//     -3         1.35       -4.5
+//     0.3        1.35E-9
 NUMBER:
 	NN
 	| '-'? INTF '.' [0-9]+ EXP? // 1.35, 1.35E-9, 0.3, -4.5
 	| '-'? INTF EXP // 1e10 -3e4
 	| '-'? INTF ; // -3, 45
 
-fragment INTF: '0' | [1-9] [0-9]*; // no leading zeros
+// INTF is a fragment used by NN and NUMBER: an integer literal with no
+// leading zeros. (`fragment` means it does not produce a token by
+// itself; it only contributes to other rules.)
+fragment INTF: '0' | [1-9] [0-9]*;
 
-// DIGITS matches pure digit sequences including those with leading zeros.
-// Examples: 007, 00123, 42. Used in NAME rule for numeric schema/catalog names.
-// Note: This is separate from INTF which disallows leading zeros (for NUMBER).
-// IMPORTANT: DIGITS must be defined AFTER NN to ensure that standard numbers
-// (without leading zeros) are matched by NN first. ANTLR gives priority to
-// tokens defined earlier when lengths are equal.
-// See issue #470.
+// DIGITS matches pure digit sequences INCLUDING those with leading
+// zeros. Examples: `007`, `00123`, `42`. Used inside the `NAME` rule
+// for numeric schema/catalog names (issue #470). This is separate from
+// `INTF`, which disallows leading zeros so that numeric literals don't
+// accidentally accept `007` and the like.
+//
+// IMPORTANT: `DIGITS` must be defined AFTER `NN` so that for inputs
+// without leading zeros (e.g. `42`) the lexer picks `NN`. ANTLR breaks
+// equal-length ties by definition order, earliest wins.
 DIGITS: [0-9]+;
 
+// EXP is the exponent fragment used by NUMBER. `\-` inside the bracket
+// class is needed because `-` denotes a range otherwise.
 fragment EXP:
-	[Ee] [+\-]? INTF; // \- since "-" means "range" inside [...]
+	[Ee] [+\-]? INTF;
 
+// Comparison operators. Defined as named tokens so parser rules can
+// reference them symbolically. Note that the parser rule `expr` above
+// happens to use the literal forms (`'<'`, `'=='`, etc.) directly; both
+// styles are interchangeable in ANTLR.
 LT_EQ: '<=';
 LT: '<';
 GT_EQ: '>=';
@@ -337,27 +622,47 @@ NEQ: '!=';
 EQ: '==';
 
 
-// NAME matches a dot followed by an identifier (table name, column name, or schema name).
-// The alternatives are:
-//   - ARG:    Argument reference, e.g., .$var
-//   - ID:     Standard identifier starting with letter/underscore, e.g., .actor, ._private
-//   - STRING: Quoted identifier, e.g., ."my table"
-//   - DIGITS: Pure digit sequence including leading zeros, e.g., .007, .00123 (issue #470)
-//   - IDNUM:  Numeric-prefixed identifier, e.g., .123abc, .007bond (issue #470)
+// NAME matches a leading dot plus an identifier-like payload, modeling
+// the `.thing` syntax used throughout SLQ. Alternatives, in priority
+// order (ANTLR's maximal munch chooses the longest match):
 //
-// Note: ANTLR's maximal munch rule ensures that inputs like "007bond" match IDNUM (the
-// longest possible token) rather than DIGITS followed by something else.
+//   - ARG:    argument reference, e.g. `.$var`
+//   - ID:     standard identifier, e.g. `.actor`, `._private`
+//   - STRING: quoted identifier, e.g. `."my table"`
+//   - DIGITS: pure digit sequence including leading zeros, e.g. `.007`
+//             (issue #470 -- numeric schema/catalog names)
+//   - IDNUM:  numeric-prefixed identifier, e.g. `.123abc`, `.007bond`
+//             (issue #470)
+//
+// Maximal-munch matters here: for input `.007bond`, the lexer must
+// produce a single `NAME` whose payload matches `IDNUM` (`007bond`),
+// NOT a `NAME` containing only `DIGITS` (`007`) followed by stray
+// `bond`. ANTLR's longest-match rule handles this automatically.
 NAME: '.' (ARG | ID | STRING | DIGITS | IDNUM);
 
-// SEL can be .THING or .THING.OTHERTHING.
-// It can also be ."some name".OTHERTHING, etc.
+// (Old SEL idea kept for reference -- a fully-dotted multi-segment
+// selector matched in the lexer rather than the parser. Not used today
+// because two-part selectors are handled in the parser `selector` rule
+// instead.)
 //SEL: '.' (ID | STRING) ('.' (ID | STRING))*;
 
-// HANDLE: @mydb1 or @postgres_db2 etc.
 
+// HANDLE matches a source handle: `@` plus identifier, optionally with
+// `/`-separated path segments. Examples:
+//
+//     @mydb1
+//     @postgres_db2
+//     @work/acme/sakila
 HANDLE: '@' ID ('/' ID)*;
 
+// STRING is a JSON-style double-quoted string with backslash escapes.
+// SLQ uses `STRING` both for string LITERALS in expressions and for
+// QUOTED IDENTIFIERS inside `NAME` (e.g. `."my table"`). The AST layer
+// strips the surrounding quotes (`stringz.StripDoubleQuote`).
 STRING: '"' (ESC | ~["\\])* '"';
+
+// Escape sequences supported inside STRING: standard JSON-style plus a
+// `\uXXXX` Unicode escape.
 fragment ESC: '\\' (["\\/bfnrt] | UNICODE);
 fragment UNICODE: 'u' HEX HEX HEX HEX;
 fragment HEX: [0-9a-fA-F];
@@ -365,8 +670,15 @@ fragment HEX: [0-9a-fA-F];
 //NUMERIC_LITERAL
 // : DIGIT+ ( '.' DIGIT* )? ( E [-+]? DIGIT+ )? | '.' DIGIT+ ( E [-+]? DIGIT+ )? ;
 
+// DIGIT -- single decimal digit fragment, used by various number rules.
 fragment DIGIT: [0-9];
 
+// Case-insensitive letter fragments. These are kept around for use by
+// any future rule that wants to match keywords case-insensitively
+// (`A B C ...` -> `[aA][bB][cC]...`). They are not currently referenced,
+// but are preserved both for convenience and because they appear in the
+// grammar's upstream lineage (see the SQLite grammar reference at the
+// bottom of this file).
 fragment A: [aA];
 fragment B: [bB];
 fragment C: [cC];
@@ -394,6 +706,7 @@ fragment X: [xX];
 fragment Y: [yY];
 fragment Z: [zZ];
 
+// LINECOMMENT -- `#` to end-of-line. Skipped, like whitespace.
 LINECOMMENT: '#' .*? '\n' -> skip;
 
 //// From https://github.com/antlr/grammars-v4/blob/master/sql/sqlite/SQLiteLexer.g4
@@ -403,4 +716,3 @@ LINECOMMENT: '#' .*? '\n' -> skip;
 //    | '[' ~']'* ']'
 //    | [A-Z_] [A-Z_0-9]*
 //; // TODO check: needs more chars in set
-


### PR DESCRIPTION
## Summary

- Expands inline comments throughout `grammar/SLQ.g4` so each rule
  carries its purpose, SQL mapping, and known design quirks (`||` as
  string-concat, the `ALIAS_RESERVED` hack, the `NN`/`DIGITS`/`IDNUM`
  ordering from issue #470, etc.). The grammar text itself is unchanged
  — the regenerated parser is equivalent.
- Rewrites `grammar/README.md` as the high-level companion: opens with
  a language tour, then walks the lex → parse → build → narrow → render
  pipeline. Adds Mermaid diagrams for the pipeline, parse-tree shape,
  segment progression, selector narrowing, and the lexical token map;
  plus tables for the element catalogue, row-range forms, operator
  precedence, and a "common pitfalls" section.
- No code changes — purely documentation.

## Test plan

- [ ] `grammar/README.md` renders correctly on GitHub (Mermaid diagrams visible)
- [ ] `go generate ./...` runs cleanly against the (unchanged) `SLQ.g4`
- [ ] `markdownlint grammar/README.md` is clean
- [ ] `go test -short ./libsq/ast/...` passes