### PR TITLE
Document --render-sql, regen cmd help, adopt US English

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,11 +23,11 @@ Breaking changes are annotated with ☢️, and alpha/beta features with 🐥.
   See the [driver docs](https://sq.io/docs/drivers/duckdb).
 - [#602]: [`sq`](https://sq.io/docs/cmd/sq) now features a [`--render-sql`](https://sq.io/docs/cmd/sq/#render-sql)
   flag, which prints the SQL (derived from `SLQ` input) that would be
-  executed against the target database, _instead_ of running it. Honours `--format` with:
+  executed against the target database, _instead_ of running it. Honors `--format` with:
   - `text` or `raw`: the rendered SQL is printed.
   - `json` or `yaml`: a structured payload is printed containing the
-    original SLQ, the rendered SQL, the dialect and information about the
-    sources that the query touches.
+    original SLQ, the rendered SQL, any [`--args`](https://sq.io/docs/cmd/sq/#predefined-variables),
+    the dialect and information about the sources that the query touches.
     ```yaml
     # $ sq --render-sql --yaml '@sakila/pg.actor | join(@sakila/my.film_actor, .actor_id) | .first_name, .last_name, .film_id | .[0:5]'
     slq: "@sakila/pg.actor | join(@sakila/my.film_actor, .actor_id) | .first_name, .last_name, .film_id | .[0:5]"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ Breaking changes are annotated with ☢️, and alpha/beta features with 🐥.
   executed against the target database, _instead_ of running it. Honors `--format` with:
   - `text` or `raw`: the rendered SQL is printed.
   - `json` or `yaml`: a structured payload is printed containing the
-    original SLQ, the rendered SQL, any [`--args`](https://sq.io/docs/cmd/sq/#predefined-variables),
+    original SLQ, the rendered SQL, any [`--arg`](https://sq.io/docs/cmd/sq/#predefined-variables),
     the dialect and information about the sources that the query touches.
     ```yaml
     # $ sq --render-sql --yaml '@sakila/pg.actor | join(@sakila/my.film_actor, .actor_id) | .first_name, .last_name, .film_id | .[0:5]'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,23 +21,23 @@ Breaking changes are annotated with ☢️, and alpha/beta features with 🐥.
   extensions (`json`, `parquet`, `icu`, `fts`, `httpfs`, `excel`, `inet`,
   `autocomplete`, `tpch`, `tpcds`).
   See the [driver docs](https://sq.io/docs/drivers/duckdb).
-- [#602]: [`sq`](https://sq.io/docs/cmd/sq) now features a `--render-sql` flag, which prints the SQL (derived from
-  `SLQ` input, e.g. `.actor | .[0:2]`) that would be
+- [#602]: [`sq`](https://sq.io/docs/cmd/sq) now features a [`--render-sql`](https://sq.io/docs/cmd/sq/#render-sql)
+  flag, which prints the SQL (derived from `SLQ` input) that would be
   executed against the target database, _instead_ of running it. Honours `--format` with:
   - `text` or `raw`: the rendered SQL is printed.
-  - `json`, `jsonl`, or `yaml`: a structured payload is printed containing the
+  - `json` or `yaml`: a structured payload is printed containing the
     original SLQ, the rendered SQL, the dialect and information about the
     sources that the query touches.
     ```yaml
-    # sq --render-sql --yaml '@sakila/local/pg.actor | join(@sakila/local/my.film_actor, .actor_id) | .first_name, .last_name, .film_id | .[0:5]'
-    slq: "@sakila/local/pg.actor | join(@sakila/local/my.film_actor, .actor_id) | .first_name, .last_name, .film_id | .[0:5]"
+    # $ sq --render-sql --yaml '@sakila/pg.actor | join(@sakila/my.film_actor, .actor_id) | .first_name, .last_name, .film_id | .[0:5]'
+    slq: "@sakila/pg.actor | join(@sakila/my.film_actor, .actor_id) | .first_name, .last_name, .film_id | .[0:5]"
     sql: SELECT "first_name", "last_name", "film_id" FROM "actor" INNER JOIN "film_actor" ON "actor"."actor_id" = "film_actor"."actor_id" LIMIT 5 OFFSET 0
     dialect: sqlite3
     sources:
       target: "@join_xukcx3ye"
       inputs:
-      - "@sakila/local/pg"
-      - "@sakila/local/my"
+      - "@sakila/pg"
+      - "@sakila/my"
     ```
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,6 +84,13 @@ so they're skipped under `go test -short`. See
 [`CONTRIBUTING.md`](./CONTRIBUTING.md#test-handles) for driver test handle
 conventions.
 
+### English spelling
+
+Use US English in all prose: code comments, godoc, user-facing strings,
+commit messages, PR descriptions, CHANGELOG entries, and site docs. For
+example, "honors" not "honours", "color" not "colour", "behavior" not
+"behaviour", "optimize" not "optimise".
+
 ### Markdown
 
 - Wrap lines at 80 characters where feasible.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -197,6 +197,7 @@ helpful:
 - Provide concrete examples with shell commands
 - Link to documentation for detailed features
 - Be specific about what changed and why
+- Use US English (e.g. "honors" not "honours", "color" not "colour")
 
 ### Version Links
 

--- a/cli/cmd_config_get.go
+++ b/cli/cmd_config_get.go
@@ -11,7 +11,7 @@ import (
 
 func newConfigGetCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "get",
+		Use:   "get OPTION",
 		Short: "Show config option",
 		Long: `Show config option. By default, only explicitly set options are shown.
 Use the -v flag to see all options. When flag --src is provided, show config

--- a/cli/cmd_slq.go
+++ b/cli/cmd_slq.go
@@ -206,7 +206,7 @@ func execSLQPrint(ctx context.Context, ru *run.Run, mArgs map[string]string) err
 // execSLQRenderSQL renders the SLQ query as SQL and writes the result via
 // ru.Writers.SQL, without executing the SQL.
 //
-// Honoured --format values:
+// Honored --format values:
 //   - text (default), raw: plain SQL; on a color-enabled TTY the SQL
 //     is syntax-highlighted via chroma using sq's palette.
 //   - json, jsonl, yaml: structured payload (see [output.SQLPayload]).

--- a/cli/cmd_tbl.go
+++ b/cli/cmd_tbl.go
@@ -247,7 +247,7 @@ only applies to SQL sources.`,
   $ sq tbl drop .payment
 
   # drop multiple tables
-  $ sq drop .payment @sakila_sl3.actor`,
+  $ sq tbl drop .payment @sakila_sl3.actor`,
 	}
 
 	return cmd

--- a/cli/flag/flag.go
+++ b/cli/flag/flag.go
@@ -47,13 +47,7 @@ const (
 	InsertUsage = "Insert query results into @HANDLE.TABLE; if not existing, TABLE will be created"
 
 	RenderSQL      = "render-sql"
-	RenderSQLUsage = "Render the SLQ to SQL without executing it. " +
-		"For cross-source queries, renders the final SQL that would run against the join database " +
-		"(no cross-source join data is staged, though referenced sources are still opened — " +
-		"and document sources may still be ingested into the scratch DB — to determine the dialect). " +
-		"With --format=json, --format=jsonl, or --format=yaml, prints a structured payload containing " +
-		"the SLQ, the SQL, the dialect, the sources, and any --arg values. " +
-		"Other formats (csv, html, markdown, etc.) fall back to plain text."
+	RenderSQLUsage = `Render the SLQ to SQL without executing it`
 
 	JSON       = "json"
 	JSONShort  = "j"

--- a/cli/output/jsonw/jsonw.go
+++ b/cli/output/jsonw/jsonw.go
@@ -11,7 +11,7 @@ import (
 )
 
 // WriteJSON prints a JSON representation of v to out, using specs
-// from pr. It honours pr.Compact, pr.Indent, and the colour palette
+// from pr. It honors pr.Compact, pr.Indent, and the color palette
 // derived from pr. The underlying [jcolorenc.Encoder.Encode] always
 // appends a trailing newline, so callers do not (and must not) write
 // one themselves.

--- a/cli/output/sqlw/json.go
+++ b/cli/output/sqlw/json.go
@@ -10,16 +10,16 @@ import (
 // NewJSONWriter returns an output.SQLWriter that emits an SQLPayload
 // as JSON, pretty-printed by default but compact when pr.Compact is
 // true. For unconditionally single-line output (e.g. for jsonl
-// pipelines), use [NewJSONLWriter] instead. Output honours the colour
-// palette in pr when colour is enabled, matching the rest of sq's
+// pipelines), use [NewJSONLWriter] instead. Output honors the color
+// palette in pr when color is enabled, matching the rest of sq's
 // JSON output.
 func NewJSONWriter(out io.Writer, pr *output.Printing) *JSONWriter {
 	return &JSONWriter{out: out, pr: pr, compact: pr.Compact}
 }
 
 // NewJSONLWriter returns an output.SQLWriter that emits an SQLPayload as
-// compact one-line JSON, suitable for jsonl pipelines. Colour is honoured
-// when pr has colour enabled.
+// compact one-line JSON, suitable for jsonl pipelines. Color is honored
+// when pr has color enabled.
 func NewJSONLWriter(out io.Writer, pr *output.Printing) *JSONWriter {
 	return &JSONWriter{out: out, pr: pr, compact: true}
 }

--- a/cli/output/sqlw/sqlw_test.go
+++ b/cli/output/sqlw/sqlw_test.go
@@ -221,7 +221,7 @@ func TestJSONLWriter_Color(t *testing.T) {
 	got := buf.String()
 	require.Contains(t, got, "\x1b[", "expected ANSI escape codes in colored JSONL output")
 	// JSONL stays single-line (one trailing newline, no internal newlines)
-	// even after colourising.
+	// even after colorizing.
 	stripped := stripANSI(got)
 	require.Equal(t, 1, strings.Count(stripped, "\n"))
 	require.True(t, strings.HasSuffix(stripped, "\n"))

--- a/cli/output/sqlw/yaml.go
+++ b/cli/output/sqlw/yaml.go
@@ -9,7 +9,7 @@ import (
 )
 
 // NewYAMLWriter returns an output.SQLWriter that emits an SQLPayload as
-// YAML. Output is colourised via yamlw to match sq's other YAML output.
+// YAML. Output is colorized via yamlw to match sq's other YAML output.
 func NewYAMLWriter(out io.Writer, pr *output.Printing) *YAMLWriter {
 	return &YAMLWriter{out: out, pr: pr}
 }

--- a/drivers/duckdb/create.go
+++ b/drivers/duckdb/create.go
@@ -25,9 +25,9 @@ var createTblKindDefaults = map[kind.Kind]string{ //nolint:exhaustive // kind.Nu
 }
 
 // buildCreateTableStmt builds a DuckDB CREATE TABLE statement from tblDef.
-// It honours PKColName, NotNull, HasDefault, and Unique. AutoIncrement is
+// It honors PKColName, NotNull, HasDefault, and Unique. AutoIncrement is
 // intentionally ignored: DuckDB has no AUTOINCREMENT keyword (callers wanting
-// SERIAL-style behaviour use SEQUENCE objects), and a PRIMARY KEY alone is
+// SERIAL-style behavior use SEQUENCE objects), and a PRIMARY KEY alone is
 // sufficient for sq's use cases. Foreign-key constraints are deliberately
 // omitted for now.
 func buildCreateTableStmt(tblDef *schema.Table) string {

--- a/drivers/duckdb/testdata/README.md
+++ b/drivers/duckdb/testdata/README.md
@@ -50,7 +50,7 @@ Available fixture names: `sakila`, `sakila-whitespace`, `sakila_diff`, `empty`,
   topologically) keeps every other constraint intact. `ON DELETE
   CASCADE`, `SET NULL`, and `SET DEFAULT` clauses are stripped from FKs
   too (DuckDB only supports the default `NO ACTION`); sq's read-mostly
-  tests do not exercise cascade behaviour, so this is invisible in
+  tests do not exercise cascade behavior, so this is invisible in
   practice. The `sakila-whitespace.duckdb` variant strips FKs entirely
   because DuckDB rejects `ALTER` on tables with dependent constraints.
 - **No `BLOB SUB_TYPE TEXT`.** This Firebird-heritage type alias is

--- a/drivers/oracle/orshared/wrap.go
+++ b/drivers/oracle/orshared/wrap.go
@@ -18,7 +18,7 @@ const (
 )
 
 // errCode reports the ORA-NNNNN code carried by err, or 0 if err does not
-// originate from a recognised Oracle wire driver.
+// originate from a recognized Oracle wire driver.
 //
 // go-ora exposes the code as the exported field network.OracleError.ErrCode
 // (no Code() accessor), so a method-set type assertion does not match.

--- a/drivers/sqlserver/db_type_test.go
+++ b/drivers/sqlserver/db_type_test.go
@@ -323,7 +323,7 @@ func Test_MSSQLDB_DriverIssue196(t *testing.T) {
 	t.Parallel()
 
 	// Note that although this test only checks BINARY, the same
-	// behaviour is expected of VARBINARY.
+	// behavior is expected of VARBINARY.
 	const (
 		canonicalTblName = "type_test_issue_196"
 		insertTpl        = "INSERT INTO %s (col_binary_n) VALUES %s"

--- a/grammar/README.md
+++ b/grammar/README.md
@@ -13,7 +13,7 @@ The grammar is **not yet stable**: it may change in any new `sq` release.
 - [SLQ at a glance](#slq-at-a-glance)
 - [How SLQ becomes SQL](#how-slq-becomes-sql)
 - [Query structure](#query-structure)
-- [Element catalogue](#element-catalogue)
+- [Element catalog](#element-catalog)
 - [Lexical layer](#lexical-layer)
 - [Operator precedence](#operator-precedence)
 - [Working with the grammar](#working-with-the-grammar)
@@ -157,7 +157,7 @@ A few enforced rules:
 - The first segment's selector is interpreted as a table selector, not a
   column selector (`narrowTblSel`).
 
-## Element catalogue
+## Element catalog
 
 Quick reference for every element kind. See [`SLQ.g4`](./SLQ.g4) for the
 exact grammar and the sample queries in `testdata/` for live examples.

--- a/site/content/en/docs/cmd/add.help.txt
+++ b/site/content/en/docs/cmd/add.help.txt
@@ -76,12 +76,21 @@ minimum, the following drivers are bundled:
   postgres   PostgreSQL
   sqlserver  Microsoft SQL Server / Azure SQL Edge
   mysql      MySQL
+  clickhouse ClickHouse
+  oracle     Oracle Database (experimental)
   csv        Comma-Separated Values
   tsv        Tab-Separated Values
   json       JSON
   jsona      JSON Array: LF-delimited JSON arrays
   jsonl      JSON Lines: LF-delimited JSON objects
   xlsx       Microsoft Excel XLSX
+
+DRIVER NOTES:
+
+The clickhouse driver will automatically apply a default port if not
+specified: 9000 for non-secure, or 9440 for secure (when "secure=true"
+is in the connection string). This differs from the underlying clickhouse-go
+library, which does not apply a default port.
 
 If there isn't already an active source, the newly added source becomes the
 active source (but the active group does not change). Otherwise you can
@@ -107,6 +116,9 @@ More examples:
 
   # Add a SQL Server source; will have generated handle @sakila
   $ sq add 'sqlserver://user:pass@localhost?database=sakila'
+
+  # Add an Oracle source (experimental)
+  $ sq add 'oracle://user:pass@localhost:1521/ORCLPDB1'
 
   # Add a SQLite DB, and immediately make it the active source
   $ sq add ./testdata/sqlite1.db --active
@@ -149,7 +161,7 @@ Global Flags:
       --error.format string   Error output format (default "text")
   -E, --error.stack           Print error stack trace to stderr
       --log                   Enable logging
-      --log.file string       Log file path (default "/Users/neilotoole/Library/Logs/sq/sq.log")
+      --log.file string       Log file path (default "$HOME/Library/Logs/sq/sq.log")
       --log.format string     Log output format (text or json) (default "text")
       --log.level string      Log level, one of: DEBUG, INFO, WARN, ERROR (default "DEBUG")
   -M, --monochrome            Don't print color output

--- a/site/content/en/docs/cmd/cache-clear.help.txt
+++ b/site/content/en/docs/cmd/cache-clear.help.txt
@@ -19,7 +19,7 @@ Global Flags:
       --error.format string   Error output format (default "text")
   -E, --error.stack           Print error stack trace to stderr
       --log                   Enable logging
-      --log.file string       Log file path (default "/Users/neilotoole/Library/Logs/sq/sq.log")
+      --log.file string       Log file path (default "$HOME/Library/Logs/sq/sq.log")
       --log.format string     Log output format (text or json) (default "text")
       --log.level string      Log level, one of: DEBUG, INFO, WARN, ERROR (default "DEBUG")
   -M, --monochrome            Don't print color output

--- a/site/content/en/docs/cmd/cache-disable.help.txt
+++ b/site/content/en/docs/cmd/cache-disable.help.txt
@@ -19,7 +19,7 @@ Global Flags:
       --error.format string   Error output format (default "text")
   -E, --error.stack           Print error stack trace to stderr
       --log                   Enable logging
-      --log.file string       Log file path (default "/Users/neilotoole/Library/Logs/sq/sq.log")
+      --log.file string       Log file path (default "$HOME/Library/Logs/sq/sq.log")
       --log.format string     Log output format (text or json) (default "text")
       --log.level string      Log level, one of: DEBUG, INFO, WARN, ERROR (default "DEBUG")
   -M, --monochrome            Don't print color output

--- a/site/content/en/docs/cmd/cache-enable.help.txt
+++ b/site/content/en/docs/cmd/cache-enable.help.txt
@@ -19,7 +19,7 @@ Global Flags:
       --error.format string   Error output format (default "text")
   -E, --error.stack           Print error stack trace to stderr
       --log                   Enable logging
-      --log.file string       Log file path (default "/Users/neilotoole/Library/Logs/sq/sq.log")
+      --log.file string       Log file path (default "$HOME/Library/Logs/sq/sq.log")
       --log.format string     Log output format (text or json) (default "text")
       --log.level string      Log level, one of: DEBUG, INFO, WARN, ERROR (default "DEBUG")
   -M, --monochrome            Don't print color output

--- a/site/content/en/docs/cmd/cache-location.help.txt
+++ b/site/content/en/docs/cmd/cache-location.help.txt
@@ -5,7 +5,7 @@ Usage:
 
 Examples:
   $ sq cache location
-  /Users/neilotoole/Library/Caches/sq/f36ac695
+  $HOME/Library/Caches/sq/f36ac695
 
 Flags:
   -t, --text        Output text
@@ -21,7 +21,7 @@ Global Flags:
       --error.format string   Error output format (default "text")
   -E, --error.stack           Print error stack trace to stderr
       --log                   Enable logging
-      --log.file string       Log file path (default "/Users/neilotoole/Library/Logs/sq/sq.log")
+      --log.file string       Log file path (default "$HOME/Library/Logs/sq/sq.log")
       --log.format string     Log output format (text or json) (default "text")
       --log.level string      Log level, one of: DEBUG, INFO, WARN, ERROR (default "DEBUG")
   -M, --monochrome            Don't print color output

--- a/site/content/en/docs/cmd/cache-stat.help.txt
+++ b/site/content/en/docs/cmd/cache-stat.help.txt
@@ -5,7 +5,7 @@ Usage:
 
 Examples:
   $ sq cache stat
-  /Users/neilotoole/Library/Caches/sq/f36ac695  enabled  (472.8MB)
+  $HOME/Library/Caches/sq/f36ac695  enabled  (472.8MB)
 
 Flags:
   -t, --text        Output text
@@ -21,7 +21,7 @@ Global Flags:
       --error.format string   Error output format (default "text")
   -E, --error.stack           Print error stack trace to stderr
       --log                   Enable logging
-      --log.file string       Log file path (default "/Users/neilotoole/Library/Logs/sq/sq.log")
+      --log.file string       Log file path (default "$HOME/Library/Logs/sq/sq.log")
       --log.format string     Log output format (text or json) (default "text")
       --log.level string      Log level, one of: DEBUG, INFO, WARN, ERROR (default "DEBUG")
   -M, --monochrome            Don't print color output

--- a/site/content/en/docs/cmd/cache-tree.help.txt
+++ b/site/content/en/docs/cmd/cache-tree.help.txt
@@ -20,7 +20,7 @@ Global Flags:
       --error.format string   Error output format (default "text")
   -E, --error.stack           Print error stack trace to stderr
       --log                   Enable logging
-      --log.file string       Log file path (default "/Users/neilotoole/Library/Logs/sq/sq.log")
+      --log.file string       Log file path (default "$HOME/Library/Logs/sq/sq.log")
       --log.format string     Log output format (text or json) (default "text")
       --log.level string      Log level, one of: DEBUG, INFO, WARN, ERROR (default "DEBUG")
   -M, --monochrome            Don't print color output

--- a/site/content/en/docs/cmd/completion-bash.help.txt
+++ b/site/content/en/docs/cmd/completion-bash.help.txt
@@ -29,7 +29,7 @@ Global Flags:
   -E, --error.stack           Print error stack trace to stderr
       --help                  Show help
       --log                   Enable logging
-      --log.file string       Log file path (default "/Users/neilotoole/Library/Logs/sq/sq.log")
+      --log.file string       Log file path (default "$HOME/Library/Logs/sq/sq.log")
       --log.format string     Log output format (text or json) (default "text")
       --log.level string      Log level, one of: DEBUG, INFO, WARN, ERROR (default "DEBUG")
   -M, --monochrome            Don't print color output

--- a/site/content/en/docs/cmd/completion-fish.help.txt
+++ b/site/content/en/docs/cmd/completion-fish.help.txt
@@ -20,7 +20,7 @@ Global Flags:
   -E, --error.stack           Print error stack trace to stderr
       --help                  Show help
       --log                   Enable logging
-      --log.file string       Log file path (default "/Users/neilotoole/Library/Logs/sq/sq.log")
+      --log.file string       Log file path (default "$HOME/Library/Logs/sq/sq.log")
       --log.format string     Log output format (text or json) (default "text")
       --log.level string      Log level, one of: DEBUG, INFO, WARN, ERROR (default "DEBUG")
   -M, --monochrome            Don't print color output

--- a/site/content/en/docs/cmd/completion-powershell.help.txt
+++ b/site/content/en/docs/cmd/completion-powershell.help.txt
@@ -17,7 +17,7 @@ Global Flags:
   -E, --error.stack           Print error stack trace to stderr
       --help                  Show help
       --log                   Enable logging
-      --log.file string       Log file path (default "/Users/neilotoole/Library/Logs/sq/sq.log")
+      --log.file string       Log file path (default "$HOME/Library/Logs/sq/sq.log")
       --log.format string     Log output format (text or json) (default "text")
       --log.level string      Log level, one of: DEBUG, INFO, WARN, ERROR (default "DEBUG")
   -M, --monochrome            Don't print color output

--- a/site/content/en/docs/cmd/completion-zsh.help.txt
+++ b/site/content/en/docs/cmd/completion-zsh.help.txt
@@ -31,7 +31,7 @@ Global Flags:
   -E, --error.stack           Print error stack trace to stderr
       --help                  Show help
       --log                   Enable logging
-      --log.file string       Log file path (default "/Users/neilotoole/Library/Logs/sq/sq.log")
+      --log.file string       Log file path (default "$HOME/Library/Logs/sq/sq.log")
       --log.format string     Log output format (text or json) (default "text")
       --log.level string      Log level, one of: DEBUG, INFO, WARN, ERROR (default "DEBUG")
   -M, --monochrome            Don't print color output

--- a/site/content/en/docs/cmd/completion.help.txt
+++ b/site/content/en/docs/cmd/completion.help.txt
@@ -17,7 +17,7 @@ Global Flags:
   -E, --error.stack           Print error stack trace to stderr
       --help                  Show help
       --log                   Enable logging
-      --log.file string       Log file path (default "/Users/neilotoole/Library/Logs/sq/sq.log")
+      --log.file string       Log file path (default "$HOME/Library/Logs/sq/sq.log")
       --log.format string     Log output format (text or json) (default "text")
       --log.level string      Log level, one of: DEBUG, INFO, WARN, ERROR (default "DEBUG")
   -M, --monochrome            Don't print color output

--- a/site/content/en/docs/cmd/config-edit.help.txt
+++ b/site/content/en/docs/cmd/config-edit.help.txt
@@ -29,7 +29,7 @@ Global Flags:
       --error.format string   Error output format (default "text")
   -E, --error.stack           Print error stack trace to stderr
       --log                   Enable logging
-      --log.file string       Log file path (default "/Users/neilotoole/Library/Logs/sq/sq.log")
+      --log.file string       Log file path (default "$HOME/Library/Logs/sq/sq.log")
       --log.format string     Log output format (text or json) (default "text")
       --log.level string      Log level, one of: DEBUG, INFO, WARN, ERROR (default "DEBUG")
   -M, --monochrome            Don't print color output

--- a/site/content/en/docs/cmd/config-get.help.txt
+++ b/site/content/en/docs/cmd/config-get.help.txt
@@ -3,7 +3,7 @@ Use the -v flag to see all options. When flag --src is provided, show config
 just for that source.
 
 Usage:
-  sq config get
+  sq config get OPTION
 
 Examples:
   # Show individual base option

--- a/site/content/en/docs/cmd/config-get.help.txt
+++ b/site/content/en/docs/cmd/config-get.help.txt
@@ -3,7 +3,7 @@ Use the -v flag to see all options. When flag --src is provided, show config
 just for that source.
 
 Usage:
-  sq config get OPTION
+  sq config get
 
 Examples:
   # Show individual base option
@@ -31,7 +31,7 @@ Global Flags:
       --error.format string   Error output format (default "text")
   -E, --error.stack           Print error stack trace to stderr
       --log                   Enable logging
-      --log.file string       Log file path (default "/Users/neilotoole/Library/Logs/sq/sq.log")
+      --log.file string       Log file path (default "$HOME/Library/Logs/sq/sq.log")
       --log.format string     Log output format (text or json) (default "text")
       --log.level string      Log level, one of: DEBUG, INFO, WARN, ERROR (default "DEBUG")
   -M, --monochrome            Don't print color output

--- a/site/content/en/docs/cmd/config-location.help.txt
+++ b/site/content/en/docs/cmd/config-location.help.txt
@@ -6,11 +6,11 @@ Usage:
 Examples:
   # Print config location
   $ sq config location
-  /Users/neilotoole/.config/sq
+  $HOME/.config/sq
 
   # Print location, also show origin (flag, env, default)
   $ sq config location -v
-  /Users/neilotoole/.config/sq
+  $HOME/.config/sq
   Origin: env
 
 Flags:
@@ -27,7 +27,7 @@ Global Flags:
       --error.format string   Error output format (default "text")
   -E, --error.stack           Print error stack trace to stderr
       --log                   Enable logging
-      --log.file string       Log file path (default "/Users/neilotoole/Library/Logs/sq/sq.log")
+      --log.file string       Log file path (default "$HOME/Library/Logs/sq/sq.log")
       --log.format string     Log output format (text or json) (default "text")
       --log.level string      Log level, one of: DEBUG, INFO, WARN, ERROR (default "DEBUG")
   -M, --monochrome            Don't print color output

--- a/site/content/en/docs/cmd/config-ls.help.txt
+++ b/site/content/en/docs/cmd/config-ls.help.txt
@@ -40,7 +40,7 @@ Global Flags:
       --error.format string   Error output format (default "text")
   -E, --error.stack           Print error stack trace to stderr
       --log                   Enable logging
-      --log.file string       Log file path (default "/Users/neilotoole/Library/Logs/sq/sq.log")
+      --log.file string       Log file path (default "$HOME/Library/Logs/sq/sq.log")
       --log.format string     Log output format (text or json) (default "text")
       --log.level string      Log level, one of: DEBUG, INFO, WARN, ERROR (default "DEBUG")
   -M, --monochrome            Don't print color output

--- a/site/content/en/docs/cmd/config-set.help.txt
+++ b/site/content/en/docs/cmd/config-set.help.txt
@@ -38,7 +38,7 @@ Global Flags:
       --error.format string   Error output format (default "text")
   -E, --error.stack           Print error stack trace to stderr
       --log                   Enable logging
-      --log.file string       Log file path (default "/Users/neilotoole/Library/Logs/sq/sq.log")
+      --log.file string       Log file path (default "$HOME/Library/Logs/sq/sq.log")
       --log.format string     Log output format (text or json) (default "text")
       --log.level string      Log level, one of: DEBUG, INFO, WARN, ERROR (default "DEBUG")
   -M, --monochrome            Don't print color output

--- a/site/content/en/docs/cmd/diff.help.txt
+++ b/site/content/en/docs/cmd/diff.help.txt
@@ -113,7 +113,7 @@ Global Flags:
       --error.format string   Error output format (default "text")
   -E, --error.stack           Print error stack trace to stderr
       --log                   Enable logging
-      --log.file string       Log file path (default "/Users/neilotoole/Library/Logs/sq/sq.log")
+      --log.file string       Log file path (default "$HOME/Library/Logs/sq/sq.log")
       --log.format string     Log output format (text or json) (default "text")
       --log.level string      Log level, one of: DEBUG, INFO, WARN, ERROR (default "DEBUG")
   -M, --monochrome            Don't print color output

--- a/site/content/en/docs/cmd/driver-ls.help.txt
+++ b/site/content/en/docs/cmd/driver-ls.help.txt
@@ -18,7 +18,7 @@ Global Flags:
       --error.format string   Error output format (default "text")
   -E, --error.stack           Print error stack trace to stderr
       --log                   Enable logging
-      --log.file string       Log file path (default "/Users/neilotoole/Library/Logs/sq/sq.log")
+      --log.file string       Log file path (default "$HOME/Library/Logs/sq/sq.log")
       --log.format string     Log output format (text or json) (default "text")
       --log.level string      Log level, one of: DEBUG, INFO, WARN, ERROR (default "DEBUG")
   -M, --monochrome            Don't print color output

--- a/site/content/en/docs/cmd/driver-ls.output.txt
+++ b/site/content/en/docs/cmd/driver-ls.output.txt
@@ -1,13 +1,16 @@
-DRIVER     DESCRIPTION                            USER-DEFINED  DOC
-sqlite3    SQLite                                 false         https://github.com/mattn/go-sqlite3
-postgres   PostgreSQL                             false         https://github.com/jackc/pgx
-sqlserver  Microsoft SQL Server / Azure SQL Edge  false         https://github.com/microsoft/go-mssqldb
-mysql      MySQL                                  false         https://github.com/go-sql-driver/mysql
-csv        Comma-Separated Values                 false         https://en.wikipedia.org/wiki/Comma-separated_values
-tsv        Tab-Separated Values                   false         https://en.wikipedia.org/wiki/Tab-separated_values
-json       JSON                                   false         https://en.wikipedia.org/wiki/JSON
-jsona      JSON Array: LF-delimited JSON arrays   false         https://en.wikipedia.org/wiki/JSON
-jsonl      JSON Lines: LF-delimited JSON objects  false         https://en.wikipedia.org/wiki/JSON_streaming#Line-delimited_JSON
-xlsx       Microsoft Excel XLSX                   false         https://en.wikipedia.org/wiki/Microsoft_Excel
-ppl        People                                 true          
-rss        RSS (Really Simple Syndication)        true          https://en.wikipedia.org/wiki/RSS#Example
+DRIVER      DESCRIPTION                            USER-DEFINED  DOC
+sqlite3     SQLite                                 false         https://github.com/mattn/go-sqlite3
+duckdb      DuckDB                                 false         https://duckdb.org
+postgres    PostgreSQL                             false         https://github.com/jackc/pgx
+sqlserver   Microsoft SQL Server / Azure SQL Edge  false         https://github.com/microsoft/go-mssqldb
+mysql       MySQL                                  false         https://github.com/go-sql-driver/mysql
+clickhouse  ClickHouse                             false         https://github.com/ClickHouse/clickhouse-go
+oracle      Oracle                                 false         https://github.com/sijms/go-ora
+csv         Comma-Separated Values                 false         https://en.wikipedia.org/wiki/Comma-separated_values
+tsv         Tab-Separated Values                   false         https://en.wikipedia.org/wiki/Tab-separated_values
+json        JSON                                   false         https://en.wikipedia.org/wiki/JSON
+jsona       JSON Array: LF-delimited JSON arrays   false         https://en.wikipedia.org/wiki/JSON
+jsonl       JSON Lines: LF-delimited JSON objects  false         https://en.wikipedia.org/wiki/JSON_streaming#Line-delimited_JSON
+xlsx        Microsoft Excel XLSX                   false         https://en.wikipedia.org/wiki/Microsoft_Excel
+ppl         People                                 true          
+rss         RSS (Really Simple Syndication)        true          https://en.wikipedia.org/wiki/RSS#Example

--- a/site/content/en/docs/cmd/group.help.txt
+++ b/site/content/en/docs/cmd/group.help.txt
@@ -35,7 +35,7 @@ Global Flags:
       --error.format string   Error output format (default "text")
   -E, --error.stack           Print error stack trace to stderr
       --log                   Enable logging
-      --log.file string       Log file path (default "/Users/neilotoole/Library/Logs/sq/sq.log")
+      --log.file string       Log file path (default "$HOME/Library/Logs/sq/sq.log")
       --log.format string     Log output format (text or json) (default "text")
       --log.level string      Log level, one of: DEBUG, INFO, WARN, ERROR (default "DEBUG")
   -M, --monochrome            Don't print color output

--- a/site/content/en/docs/cmd/help.help.txt
+++ b/site/content/en/docs/cmd/help.help.txt
@@ -10,7 +10,7 @@ Global Flags:
   -E, --error.stack           Print error stack trace to stderr
       --help                  Show help
       --log                   Enable logging
-      --log.file string       Log file path (default "/Users/neilotoole/Library/Logs/sq/sq.log")
+      --log.file string       Log file path (default "$HOME/Library/Logs/sq/sq.log")
       --log.format string     Log output format (text or json) (default "text")
       --log.level string      Log level, one of: DEBUG, INFO, WARN, ERROR (default "DEBUG")
   -M, --monochrome            Don't print color output

--- a/site/content/en/docs/cmd/inspect.help.txt
+++ b/site/content/en/docs/cmd/inspect.help.txt
@@ -85,7 +85,7 @@ Global Flags:
       --error.format string   Error output format (default "text")
   -E, --error.stack           Print error stack trace to stderr
       --log                   Enable logging
-      --log.file string       Log file path (default "/Users/neilotoole/Library/Logs/sq/sq.log")
+      --log.file string       Log file path (default "$HOME/Library/Logs/sq/sq.log")
       --log.format string     Log output format (text or json) (default "text")
       --log.level string      Log level, one of: DEBUG, INFO, WARN, ERROR (default "DEBUG")
   -M, --monochrome            Don't print color output

--- a/site/content/en/docs/cmd/ls.help.txt
+++ b/site/content/en/docs/cmd/ls.help.txt
@@ -42,7 +42,7 @@ Global Flags:
       --error.format string   Error output format (default "text")
   -E, --error.stack           Print error stack trace to stderr
       --log                   Enable logging
-      --log.file string       Log file path (default "/Users/neilotoole/Library/Logs/sq/sq.log")
+      --log.file string       Log file path (default "$HOME/Library/Logs/sq/sq.log")
       --log.format string     Log output format (text or json) (default "text")
       --log.level string      Log level, one of: DEBUG, INFO, WARN, ERROR (default "DEBUG")
   -M, --monochrome            Don't print color output

--- a/site/content/en/docs/cmd/mv.help.txt
+++ b/site/content/en/docs/cmd/mv.help.txt
@@ -38,7 +38,7 @@ Global Flags:
       --error.format string   Error output format (default "text")
   -E, --error.stack           Print error stack trace to stderr
       --log                   Enable logging
-      --log.file string       Log file path (default "/Users/neilotoole/Library/Logs/sq/sq.log")
+      --log.file string       Log file path (default "$HOME/Library/Logs/sq/sq.log")
       --log.format string     Log output format (text or json) (default "text")
       --log.level string      Log level, one of: DEBUG, INFO, WARN, ERROR (default "DEBUG")
   -M, --monochrome            Don't print color output

--- a/site/content/en/docs/cmd/options/log.file.help.txt
+++ b/site/content/en/docs/cmd/options/log.file.help.txt
@@ -1,4 +1,4 @@
 Usage:
-  sq config set log.file /Users/neilotoole/Library/Logs/sq/sq.log
+  sq config set log.file $HOME/Library/Logs/sq/sq.log
 
 Path to log file. Empty value disables logging.

--- a/site/content/en/docs/cmd/ping.help.txt
+++ b/site/content/en/docs/cmd/ping.help.txt
@@ -43,7 +43,7 @@ Global Flags:
       --error.format string   Error output format (default "text")
   -E, --error.stack           Print error stack trace to stderr
       --log                   Enable logging
-      --log.file string       Log file path (default "/Users/neilotoole/Library/Logs/sq/sq.log")
+      --log.file string       Log file path (default "$HOME/Library/Logs/sq/sq.log")
       --log.format string     Log output format (text or json) (default "text")
       --log.level string      Log level, one of: DEBUG, INFO, WARN, ERROR (default "DEBUG")
   -M, --monochrome            Don't print color output

--- a/site/content/en/docs/cmd/rm.help.txt
+++ b/site/content/en/docs/cmd/rm.help.txt
@@ -33,7 +33,7 @@ Global Flags:
       --error.format string   Error output format (default "text")
   -E, --error.stack           Print error stack trace to stderr
       --log                   Enable logging
-      --log.file string       Log file path (default "/Users/neilotoole/Library/Logs/sq/sq.log")
+      --log.file string       Log file path (default "$HOME/Library/Logs/sq/sq.log")
       --log.format string     Log output format (text or json) (default "text")
       --log.level string      Log level, one of: DEBUG, INFO, WARN, ERROR (default "DEBUG")
   -M, --monochrome            Don't print color output

--- a/site/content/en/docs/cmd/sq.help.txt
+++ b/site/content/en/docs/cmd/sq.help.txt
@@ -129,7 +129,7 @@ Flags:
       --no-cache                       Don't cache ingest data
       --driver.csv.delim string        Delimiter for ingest CSV data (default "comma")
       --driver.csv.empty-as-null       Treat ingest empty CSV fields as NULL (default true)
-      --render-sql                     Render the SLQ to SQL without executing it. For cross-source queries, renders the final SQL that would run against the join database (no cross-source join data is staged, though referenced sources are still opened — and document sources may still be ingested into the scratch DB — to determine the dialect). With --format=json, --format=jsonl, or --format=yaml, prints a structured payload containing the SLQ, the SQL, the dialect, the sources, and any --arg values. Other formats (csv, html, markdown, etc.) fall back to plain text.
+      --render-sql                     Render the SLQ to SQL without executing it
       --version                        Print version info
   -M, --monochrome                     Don't print color output
       --no-progress                    Don't show progress bar

--- a/site/content/en/docs/cmd/sq.help.txt
+++ b/site/content/en/docs/cmd/sq.help.txt
@@ -129,6 +129,7 @@ Flags:
       --no-cache                       Don't cache ingest data
       --driver.csv.delim string        Delimiter for ingest CSV data (default "comma")
       --driver.csv.empty-as-null       Treat ingest empty CSV fields as NULL (default true)
+      --render-sql                     Render the SLQ to SQL without executing it. For cross-source queries, renders the final SQL that would run against the join database (no cross-source join data is staged, though referenced sources are still opened — and document sources may still be ingested into the scratch DB — to determine the dialect). With --format=json, --format=jsonl, or --format=yaml, prints a structured payload containing the SLQ, the SQL, the dialect, the sources, and any --arg values. Other formats (csv, html, markdown, etc.) fall back to plain text.
       --version                        Print version info
   -M, --monochrome                     Don't print color output
       --no-progress                    Don't show progress bar
@@ -137,7 +138,7 @@ Flags:
       --debug.pprof string             pprof profiling mode (default "off")
       --config string                  Load config from here
       --log                            Enable logging
-      --log.file string                Log file path (default "/Users/neilotoole/Library/Logs/sq/sq.log")
+      --log.file string                Log file path (default "$HOME/Library/Logs/sq/sq.log")
       --log.level string               Log level, one of: DEBUG, INFO, WARN, ERROR (default "DEBUG")
       --log.format string              Log output format (text or json) (default "text")
       --error.format string            Error output format (default "text")

--- a/site/content/en/docs/cmd/sq.md
+++ b/site/content/en/docs/cmd/sq.md
@@ -100,8 +100,24 @@ sources:
 
 For cross-source queries, the rendered SQL targets the synthetic join
 database; `sources.target` is the synthetic handle, and `sources.inputs`
-lists the user sources that would be staged into it. Other output
-formats (`csv`, `html`, `markdown`, etc.) fall back to plain text.
+lists each user source that would be staged into it. For example, joining
+the `actor` table from a Postgres Sakila against the `film_actor` table
+from a MySQL Sakila:
+
+```yaml
+# $ sq --render-sql --yaml '@sakila/pg.actor | join(@sakila/my.film_actor, .actor_id) | .first_name, .last_name, .film_id | .[0:5]'
+slq: "@sakila/pg.actor | join(@sakila/my.film_actor, .actor_id) | .first_name, .last_name, .film_id | .[0:5]"
+sql: SELECT "first_name", "last_name", "film_id" FROM "actor" INNER JOIN "film_actor" ON "actor"."actor_id" = "film_actor"."actor_id" LIMIT 5 OFFSET 0
+dialect: sqlite3
+sources:
+  target: "@join_xukcx3ye"
+  inputs:
+  - "@sakila/pg"
+  - "@sakila/my"
+```
+
+`sources.target` is the synthesized SQLite join DB into which both
+inputs are staged before the rendered SQL runs against it.
 
 ## Override active source
 

--- a/site/content/en/docs/cmd/sq.md
+++ b/site/content/en/docs/cmd/sq.md
@@ -72,7 +72,7 @@ $ sq --csv .actor -o actor.csv
 ## Render SQL
 
 Use `--render-sql` to print the SQL that `sq` would execute against the
-target database, instead of running the query. Handy for debugging,
+target database, instead of running the SLQ query. Handy for debugging,
 learning the SLQ-to-SQL mapping, or piping the rendered SQL into another
 tool.
 

--- a/site/content/en/docs/cmd/sq.md
+++ b/site/content/en/docs/cmd/sq.md
@@ -69,6 +69,40 @@ But you can also use `--output` (`-o`) to specify a file:
 $ sq --csv .actor -o actor.csv
 ```
 
+## Render SQL
+
+Use `--render-sql` to print the SQL that `sq` would execute against the
+target database, instead of running the query. Handy for debugging,
+learning the SLQ-to-SQL mapping, or piping the rendered SQL into another
+tool.
+
+```sql
+-- $ sq --render-sql '.actor | .[0:2]'
+SELECT * FROM "actor" LIMIT 2 OFFSET 0
+```
+
+With `--json` or `--yaml`, `sq` prints a
+structured payload containing the original SLQ, the rendered SQL, the
+dialect, the sources the query touches, and any `--arg` values:
+
+```yaml
+# $ sq --render-sql --yaml --arg first TOM '.actor | where(.first_name == $first) | .[0:2]'
+args:
+  first: TOM
+slq: .actor | where(.first_name == $first) | .[0:2]
+sql: SELECT * FROM "actor" WHERE "first_name" = 'TOM' LIMIT 2 OFFSET 0
+dialect: sqlite3
+sources:
+  target: "@sakila"
+  inputs:
+  - "@sakila"
+```
+
+For cross-source queries, the rendered SQL targets the synthetic join
+database; `sources.target` is the synthetic handle, and `sources.inputs`
+lists the user sources that would be staged into it. Other output
+formats (`csv`, `html`, `markdown`, etc.) fall back to plain text.
+
 ## Override active source
 
 As explained in the [sources](/docs/source#active-source) section,
@@ -143,38 +177,6 @@ projects   apollo
 
 Note that not every database implements catalog support (this includes MySQL
 and SQLite). See the driver support [matrix](/docs/concepts#catalog-schema-support).
-
-## Render SQL
-
-Use `--render-sql` to print the SQL that `sq` would execute against the
-target database, instead of running SLQthe query. Handy for debugging,
-learning the SLQ-to-SQL mapping, or piping the rendered SQL into another
-tool.
-
-```shell
-$ sq --render-sql '.actor | .[0:2]'
-SELECT * FROM "actor" LIMIT 2 OFFSET 0
-```
-
-With `--json` or `--yaml`, `sq` prints a
-structured payload containing the original SLQ, the rendered SQL, the
-dialect, the sources the query touches, and any `--arg` values:
-
-```shell
-$ sq --render-sql --yaml '.actor | .[0:2]'
-slq: ".actor | .[0:2]"
-sql: SELECT * FROM "actor" LIMIT 2 OFFSET 0
-dialect: sqlite3
-sources:
-  target: "@sakila"
-  inputs:
-  - "@sakila"
-```
-
-For cross-source queries, the rendered SQL targets the synthetic join
-database; `sources.target` is the synthetic handle, and `sources.inputs`
-lists the user sources that would be staged into it. Other output
-formats (`csv`, `html`, `markdown`, etc.) fall back to plain text.
 
 ## Reference
 

--- a/site/content/en/docs/cmd/sq.md
+++ b/site/content/en/docs/cmd/sq.md
@@ -12,7 +12,6 @@ url: /docs/cmd/sq
 ---
 Use the root `sq` cmd to execute queries against data sources.
 
-
 ## Pipe Data
 
 For file-based sources (such as CSV or XLSX), you can [`sq add`](/docs/cmd/add) the source file,
@@ -33,7 +32,7 @@ $ cat ./example.xlsx | sq inspect
 The `--arg` flag passes a value to `sq` as a [predefined variable](/docs/query/#predefined-variables):
 
 ```shell
-$ sq --arg first "TOM" '.actor | .first_name == $first'
+$ sq --arg first "TOM" '.actor | where(.first_name == $first)'
 actor_id  first_name  last_name  last_update
 38        TOM         MCKELLEN   2020-06-11T02:50:54Z
 42        TOM         MIRANDA    2020-06-11T02:50:54Z
@@ -145,6 +144,37 @@ projects   apollo
 Note that not every database implements catalog support (this includes MySQL
 and SQLite). See the driver support [matrix](/docs/concepts#catalog-schema-support).
 
+## Render SQL
+
+Use `--render-sql` to print the SQL that `sq` would execute against the
+target database, instead of running SLQthe query. Handy for debugging,
+learning the SLQ-to-SQL mapping, or piping the rendered SQL into another
+tool.
+
+```shell
+$ sq --render-sql '.actor | .[0:2]'
+SELECT * FROM "actor" LIMIT 2 OFFSET 0
+```
+
+With `--json` or `--yaml`, `sq` prints a
+structured payload containing the original SLQ, the rendered SQL, the
+dialect, the sources the query touches, and any `--arg` values:
+
+```shell
+$ sq --render-sql --yaml '.actor | .[0:2]'
+slq: ".actor | .[0:2]"
+sql: SELECT * FROM "actor" LIMIT 2 OFFSET 0
+dialect: sqlite3
+sources:
+  target: "@sakila"
+  inputs:
+  - "@sakila"
+```
+
+For cross-source queries, the rendered SQL targets the synthetic join
+database; `sources.target` is the synthetic handle, and `sources.inputs`
+lists the user sources that would be staged into it. Other output
+formats (`csv`, `html`, `markdown`, etc.) fall back to plain text.
 
 ## Reference
 

--- a/site/content/en/docs/cmd/sql.help.txt
+++ b/site/content/en/docs/cmd/sql.help.txt
@@ -61,7 +61,7 @@ Global Flags:
       --error.format string   Error output format (default "text")
   -E, --error.stack           Print error stack trace to stderr
       --log                   Enable logging
-      --log.file string       Log file path (default "/Users/neilotoole/Library/Logs/sq/sq.log")
+      --log.file string       Log file path (default "$HOME/Library/Logs/sq/sq.log")
       --log.format string     Log output format (text or json) (default "text")
       --log.level string      Log level, one of: DEBUG, INFO, WARN, ERROR (default "DEBUG")
   -M, --monochrome            Don't print color output

--- a/site/content/en/docs/cmd/src.help.txt
+++ b/site/content/en/docs/cmd/src.help.txt
@@ -26,7 +26,7 @@ Global Flags:
       --error.format string   Error output format (default "text")
   -E, --error.stack           Print error stack trace to stderr
       --log                   Enable logging
-      --log.file string       Log file path (default "/Users/neilotoole/Library/Logs/sq/sq.log")
+      --log.file string       Log file path (default "$HOME/Library/Logs/sq/sq.log")
       --log.format string     Log output format (text or json) (default "text")
       --log.level string      Log level, one of: DEBUG, INFO, WARN, ERROR (default "DEBUG")
   -M, --monochrome            Don't print color output

--- a/site/content/en/docs/cmd/tbl-copy.help.txt
+++ b/site/content/en/docs/cmd/tbl-copy.help.txt
@@ -31,7 +31,7 @@ Global Flags:
       --error.format string   Error output format (default "text")
   -E, --error.stack           Print error stack trace to stderr
       --log                   Enable logging
-      --log.file string       Log file path (default "/Users/neilotoole/Library/Logs/sq/sq.log")
+      --log.file string       Log file path (default "$HOME/Library/Logs/sq/sq.log")
       --log.format string     Log output format (text or json) (default "text")
       --log.level string      Log level, one of: DEBUG, INFO, WARN, ERROR (default "DEBUG")
   -M, --monochrome            Don't print color output

--- a/site/content/en/docs/cmd/tbl-drop.help.txt
+++ b/site/content/en/docs/cmd/tbl-drop.help.txt
@@ -12,7 +12,7 @@ Examples:
   $ sq tbl drop .payment
 
   # drop multiple tables
-  $ sq drop .payment @sakila_sl3.actor
+  $ sq tbl drop .payment @sakila_sl3.actor
 
 Flags:
       --help   help for drop

--- a/site/content/en/docs/cmd/tbl-drop.help.txt
+++ b/site/content/en/docs/cmd/tbl-drop.help.txt
@@ -12,7 +12,7 @@ Examples:
   $ sq tbl drop .payment
 
   # drop multiple tables
-  $ sq tbl drop .payment @sakila_sl3.actor
+  $ sq drop .payment @sakila_sl3.actor
 
 Flags:
       --help   help for drop
@@ -23,7 +23,7 @@ Global Flags:
       --error.format string   Error output format (default "text")
   -E, --error.stack           Print error stack trace to stderr
       --log                   Enable logging
-      --log.file string       Log file path (default "/Users/neilotoole/Library/Logs/sq/sq.log")
+      --log.file string       Log file path (default "$HOME/Library/Logs/sq/sq.log")
       --log.format string     Log output format (text or json) (default "text")
       --log.level string      Log level, one of: DEBUG, INFO, WARN, ERROR (default "DEBUG")
   -M, --monochrome            Don't print color output

--- a/site/content/en/docs/cmd/tbl-truncate.help.txt
+++ b/site/content/en/docs/cmd/tbl-truncate.help.txt
@@ -27,7 +27,7 @@ Global Flags:
       --error.format string   Error output format (default "text")
   -E, --error.stack           Print error stack trace to stderr
       --log                   Enable logging
-      --log.file string       Log file path (default "/Users/neilotoole/Library/Logs/sq/sq.log")
+      --log.file string       Log file path (default "$HOME/Library/Logs/sq/sq.log")
       --log.format string     Log output format (text or json) (default "text")
       --log.level string      Log level, one of: DEBUG, INFO, WARN, ERROR (default "DEBUG")
   -M, --monochrome            Don't print color output

--- a/site/content/en/docs/cmd/version.help.txt
+++ b/site/content/en/docs/cmd/version.help.txt
@@ -59,7 +59,7 @@ Global Flags:
       --error.format string   Error output format (default "text")
   -E, --error.stack           Print error stack trace to stderr
       --log                   Enable logging
-      --log.file string       Log file path (default "/Users/neilotoole/Library/Logs/sq/sq.log")
+      --log.file string       Log file path (default "$HOME/Library/Logs/sq/sq.log")
       --log.format string     Log output format (text or json) (default "text")
       --log.level string      Log level, one of: DEBUG, INFO, WARN, ERROR (default "DEBUG")
   -M, --monochrome            Don't print color output

--- a/site/content/en/docs/drivers/oracle.md
+++ b/site/content/en/docs/drivers/oracle.md
@@ -120,23 +120,23 @@ required.
 
 #### Source-level fields
 
-| Field | Source |
-| --- | --- |
-| `name`, `schema` | `SYS_CONTEXT('USERENV', 'CURRENT_SCHEMA')` |
-| `catalog` | `SYS_CONTEXT('USERENV', 'DB_NAME')` (PDB name in multitenant; database name otherwise) |
-| `user` | `SYS_CONTEXT('USERENV', 'SESSION_USER')` |
-| `db_product` | `BANNER` from `V$VERSION` (the full descriptive string, e.g. `Oracle Database 23ai Free Release …`) |
-| `db_version` | `VERSION_FULL` from `PRODUCT_COMPONENT_VERSION` (e.g. `23.26.1.0.0`); falls back to `V$INSTANCE.VERSION` (DBA-only) and finally to the banner |
-| `size` | `SUM(bytes)` over `USER_SEGMENTS` — bytes occupied by segments owned by the connected user. The PDB- or database-wide equivalents (`DBA_DATA_FILES`) require DBA privileges and are not used. |
+| Field            | Source                                                                                                                                                                                        |
+|------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `name`, `schema` | `SYS_CONTEXT('USERENV', 'CURRENT_SCHEMA')`                                                                                                                                                    |
+| `catalog`        | `SYS_CONTEXT('USERENV', 'DB_NAME')` (PDB name in multitenant; database name otherwise)                                                                                                        |
+| `user`           | `SYS_CONTEXT('USERENV', 'SESSION_USER')`                                                                                                                                                      |
+| `db_product`     | `BANNER` from `V$VERSION` (the full descriptive string, e.g. `Oracle Database 23ai Free Release …`)                                                                                           |
+| `db_version`     | `VERSION_FULL` from `PRODUCT_COMPONENT_VERSION` (e.g. `23.26.1.0.0`); falls back to `V$INSTANCE.VERSION` (DBA-only) and finally to the banner                                                 |
+| `size`           | `SUM(bytes)` over `USER_SEGMENTS` — bytes occupied by segments owned by the connected user. The PDB- or database-wide equivalents (`DBA_DATA_FILES`) require DBA privileges and are not used. |
 
 #### Per-table fields
 
-| Field | Source |
-| --- | --- |
+| Field                                    | Source                                                                                                                                                                         |
+|------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `row_count` (tables, materialized views) | `NUM_ROWS` from `USER_TABLES` / `USER_MVIEWS`, with a live `SELECT COUNT(*)` fallback when the dictionary value is NULL (it stays NULL until `DBMS_STATS` / `ANALYZE` has run) |
-| `row_count` (views) | always live `SELECT COUNT(*)` — `USER_VIEWS` carries no row count |
-| `size` (tables, materialized views) | `SUM(bytes)` from `USER_SEGMENTS` for the matching segment name |
-| `size` (views) | not reported — views have no underlying segment |
+| `row_count` (views)                      | always live `SELECT COUNT(*)` — `USER_VIEWS` carries no row count                                                                                                              |
+| `size` (tables, materialized views)      | `SUM(bytes)` from `USER_SEGMENTS` for the matching segment name                                                                                                                |
+| `size` (views)                           | not reported — views have no underlying segment                                                                                                                                |
 
 ### SQL rendering
 
@@ -170,15 +170,15 @@ Oracle SQL rendering differs from several other SQL drivers:
 
 Common Oracle types map to `sq` kinds as follows:
 
-| Oracle type | `sq` kind |
-| --- | --- |
-| `VARCHAR2`, `NVARCHAR2`, `CHAR`, `NCHAR`, `CLOB`, `NCLOB`, `ROWID` | `text` |
-| `NUMBER(p,0)` where `p` is 1-19 | `int` |
-| Other `NUMBER` values | `decimal` |
-| `BINARY_FLOAT`, `BINARY_DOUBLE`, `FLOAT` | `float` |
-| `DATE`, `TIMESTAMP`, `TIMESTAMP WITH TIME ZONE` | `datetime` |
-| `BLOB`, `RAW`, `LONG RAW` | `bytes` |
-| Interval types | `text` |
+| Oracle type                                                        | `sq` kind  |
+|--------------------------------------------------------------------|------------|
+| `VARCHAR2`, `NVARCHAR2`, `CHAR`, `NCHAR`, `CLOB`, `NCLOB`, `ROWID` | `text`     |
+| `NUMBER(p,0)` where `p` is 1-19                                    | `int`      |
+| Other `NUMBER` values                                              | `decimal`  |
+| `BINARY_FLOAT`, `BINARY_DOUBLE`, `FLOAT`                           | `float`    |
+| `DATE`, `TIMESTAMP`, `TIMESTAMP WITH TIME ZONE`                    | `datetime` |
+| `BLOB`, `RAW`, `LONG RAW`                                          | `bytes`    |
+| Interval types                                                     | `text`     |
 
 When `sq` creates Oracle tables, it uses Oracle-native equivalents such as
 `NUMBER(19,0)` for `int`, `NUMBER(1,0)` for `bool`, `TIMESTAMP` for

--- a/site/content/en/docs/query/index.md
+++ b/site/content/en/docs/query/index.md
@@ -347,7 +347,7 @@ whitespace, shell tokens, long strings, etc..
 $ sq --arg last "O'Toole" '.actor | where(.last_name == $last)'
 
 # Value containing double-quote
-sq --arg first 'Elvis "The King"' '.actor | .first_name == $first'
+sq --arg first 'Elvis "The King"' '.actor | where(.first_name == $first)'
 ```
 
 It's common to combine `sq --arg` with shell variables:


### PR DESCRIPTION
## Summary

- **Document `--render-sql`** on the [sq cmd page](site/content/en/docs/cmd/sq.md): a new "Render SQL" section covering the plain-SQL output, the structured `--json`/`--yaml` payload (with `--arg` example), and a cross-source Postgres↔MySQL join example showing the synthesized join-DB handle and multiple `sources.inputs` entries. Also wraps two stale implicit-filter examples (`.actor | .first_name == $first`) in `where(...)` to match current SLQ syntax.
- **Regenerate `site/content/en/docs/cmd/*.help.txt`** to pick up the current driver list (`clickhouse`, `oracle`), the `$HOME`-normalized log-file path, and the new `--render-sql` flag. Also picks up Hugo-formatter-driven table changes in `site/content/en/docs/drivers/oracle.md`.
- **Tighten `cli/flag/flag.go` `RenderSQLUsage`** down to a one-line raw string literal; the long form lives in `sq.md` instead. CHANGELOG entry for `#602` rewritten to be more compact and link directly to the new `#render-sql` anchor.
- **Adopt US English** as the project standard: new `### English spelling` subsection in `CLAUDE.md`, matching bullet in `CONTRIBUTING.md`'s CHANGELOG `### Writing Style` block, and a sweep of existing UK spellings in Go comments and project READMEs (`honours`→`honors`, `colour(ised|ising)`→`color(ized|izing)`, `behaviour`→`behavior`, `recognised`→`recognized`, `catalogue`→`catalog`, including the `grammar/README.md` heading + TOC anchor). Vendored trees (`go-udiff`, `jcolorenc`) are left untouched.

## Test plan

- [ ] `make test-short` passes
- [ ] `make lint` passes (golangci-lint)
- [ ] `cd site && bun test` passes (markdownlint, stylelint, etc.)
- [ ] `cd site && bun run build` builds the Hugo site without errors
- [ ] Manual: `sq --render-sql --help` shows the trimmed flag help text matching `sq.help.txt`
- [ ] Manual: render the cmd page locally (`cd site && bun start`) and verify the "Render SQL" section anchor (`/docs/cmd/sq/#render-sql`) resolves and the YAML examples display correctly
- [ ] `grep -rniE '\b(honour|colour|behaviour|recognis|catalogu)\w*'` returns only vendored / CLAUDE.md / CONTRIBUTING.md matches