### PR TITLE
slq: drop ESCAPE '|' from like/ilike for uniform cross-driver behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,18 @@ Breaking changes are annotated with ☢️, and alpha/beta features with 🐥.
 
 ## Unreleased
 
+### Changed
+
+- [#629]: [`like`](https://sq.io/docs/query#like) and
+  [`ilike`](https://sq.io/docs/query#ilike) no longer emit a trailing
+  `ESCAPE '|'` clause. `|` is now a normal literal character on every
+  driver, removing the pre-#629 cross-driver divergence (runtime error
+  on Postgres/Oracle/SQLite/SQL Server, silent drop on MySQL). For
+  literal `%`/`_` matching, use [`contains`](https://sq.io/docs/query#contains)
+  / [`icontains`](https://sq.io/docs/query#icontains), which
+  auto-escape wildcards. The [`contains`](https://sq.io/docs/query#contains)
+  family is unchanged and still emits `ESCAPE '|'`.
+
 ### Added
 
 - [#601]: New SLQ functions for substring matching: `contains(col, str)`,
@@ -1479,6 +1491,7 @@ make working with lots of sources much easier.
 [#601]: https://github.com/neilotoole/sq/issues/601
 [#602]: https://github.com/neilotoole/sq/pull/602
 [#615]: https://github.com/neilotoole/sq/issues/615
+[#629]: https://github.com/neilotoole/sq/issues/629
 
 
 [v0.15.2]: https://github.com/neilotoole/sq/releases/tag/v0.15.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,12 +18,14 @@ Breaking changes are annotated with ☢️, and alpha/beta features with 🐥.
 
 - [#629]: [`like`](https://sq.io/docs/query#like) and
   [`ilike`](https://sq.io/docs/query#ilike) no longer emit a trailing
-  `ESCAPE '|'` clause. `|` is now a normal literal character on every
-  driver, removing the pre-#629 cross-driver divergence (runtime error
-  on Postgres/Oracle/SQLite/SQL Server, silent drop on MySQL). For
-  literal `%`/`_` matching, use [`contains`](https://sq.io/docs/query#contains)
-  / [`icontains`](https://sq.io/docs/query#icontains), which
-  auto-escape wildcards. The [`contains`](https://sq.io/docs/query#contains)
+  `ESCAPE '|'` clause. `|` is now a literal character on every driver,
+  removing the pre-#629 cross-driver divergence (runtime error on
+  Postgres/DuckDB/Oracle/SQLite/SQL Server, silent drop on MySQL).
+  Other engine-default escape semantics (e.g. MySQL's default
+  backslash escape) remain driver-specific. For literal `%`/`_`
+  matching, use [`contains`](https://sq.io/docs/query#contains) /
+  [`icontains`](https://sq.io/docs/query#icontains), which auto-escape
+  wildcards. The [`contains`](https://sq.io/docs/query#contains)
   family is unchanged and still emits `ESCAPE '|'`.
 
 ### Added

--- a/drivers/clickhouse/clickhouse.go
+++ b/drivers/clickhouse/clickhouse.go
@@ -289,7 +289,10 @@ func (d *driveri) Renderer() *render.Renderer {
 	r.FunctionOverrides[ast.FuncNameIContains] = renderFuncIContains
 	r.FunctionOverrides[ast.FuncNameIStartsWith] = renderFuncIStartsWith
 	r.FunctionOverrides[ast.FuncNameIEndsWith] = renderFuncIEndsWith
-	r.FunctionOverrides[ast.FuncNameLike] = renderFuncLike
+	// FuncNameLike falls through to the default doFuncLike: ClickHouse's
+	// LIKE matches the default RenderLikeRaw shape exactly. ILike needs
+	// an override because the default emits LOWER(col) LIKE LOWER(pat),
+	// whereas ClickHouse supports native ILIKE.
 	r.FunctionOverrides[ast.FuncNameILike] = renderFuncILike
 	return r
 }

--- a/drivers/clickhouse/render.go
+++ b/drivers/clickhouse/render.go
@@ -309,12 +309,8 @@ func renderFuncIEndsWith(rc *render.Context, fn *ast.FuncNode) (string, error) {
 	return "endsWithCaseInsensitive(" + colSQL + ", " + stringz.SingleQuote(lit) + ")", nil
 }
 
-// renderFuncLike uses ClickHouse's native LIKE.
-func renderFuncLike(rc *render.Context, fn *ast.FuncNode) (string, error) {
-	return render.RenderLikeRaw(rc, fn, render.LikeRawOpts{})
-}
-
-// renderFuncILike uses ClickHouse's native ILIKE.
+// renderFuncILike uses ClickHouse's native ILIKE rather than the
+// default LOWER(col) LIKE LOWER(pat) shape.
 func renderFuncILike(rc *render.Context, fn *ast.FuncNode) (string, error) {
 	return render.RenderLikeRaw(rc, fn, render.LikeRawOpts{Op: "ILIKE"})
 }

--- a/drivers/clickhouse/render.go
+++ b/drivers/clickhouse/render.go
@@ -309,15 +309,12 @@ func renderFuncIEndsWith(rc *render.Context, fn *ast.FuncNode) (string, error) {
 	return "endsWithCaseInsensitive(" + colSQL + ", " + stringz.SingleQuote(lit) + ")", nil
 }
 
-// renderFuncLike uses ClickHouse's native LIKE. ClickHouse's LIKE
-// does not support an ESCAPE clause, so RenderLikeRaw is called
-// with OmitEscape=true.
+// renderFuncLike uses ClickHouse's native LIKE.
 func renderFuncLike(rc *render.Context, fn *ast.FuncNode) (string, error) {
-	return render.RenderLikeRaw(rc, fn, render.LikeRawOpts{OmitEscape: true})
+	return render.RenderLikeRaw(rc, fn, render.LikeRawOpts{})
 }
 
-// renderFuncILike uses ClickHouse's native ILIKE. Like LIKE, ILIKE
-// does not support ESCAPE.
+// renderFuncILike uses ClickHouse's native ILIKE.
 func renderFuncILike(rc *render.Context, fn *ast.FuncNode) (string, error) {
-	return render.RenderLikeRaw(rc, fn, render.LikeRawOpts{Op: "ILIKE", OmitEscape: true})
+	return render.RenderLikeRaw(rc, fn, render.LikeRawOpts{Op: "ILIKE"})
 }

--- a/libsq/ast/render/function_like.go
+++ b/libsq/ast/render/function_like.go
@@ -250,11 +250,6 @@ type LikeRawOpts struct {
 	// space). Callers must include the leading space.
 	ColCollate string
 
-	// OmitEscape, when true, suppresses the trailing " ESCAPE '|'"
-	// clause. Used for drivers (e.g. ClickHouse) that don't support
-	// an ESCAPE clause on LIKE.
-	OmitEscape bool
-
 	// IgnoreCase, when true, wraps the column and literal in LOWER(...).
 	// IgnoreCase is mutually exclusive with non-empty Op and ColCollate:
 	// LOWER-wrapping handles case-insensitivity portably without needing
@@ -269,7 +264,11 @@ type LikeRawOpts struct {
 // like / ilike functions. Unlike [RenderLikeOp], the literal pattern
 // is bound verbatim: % and _ are wildcards, not escaped. Single
 // quotes inside the literal are still properly escaped by
-// SingleQuote.
+// SingleQuote. No ESCAPE clause is emitted, so the engine has no
+// reserved escape character; `|` (and every other character) is a
+// normal literal. Users who need literal `%` / `_` matching should
+// use [RenderLikeOp] (SLQ's contains family), which auto-escapes
+// wildcards in the pattern.
 //
 // opts.IgnoreCase is mutually exclusive with opts.Op and opts.ColCollate:
 // the LOWER-wrapping strategy stands alone, and combining it with a
@@ -291,9 +290,5 @@ func RenderLikeRaw(rc *Context, fn *ast.FuncNode, opts LikeRawOpts) (string, err
 		colSQL = "LOWER(" + colSQL + ")"
 		litSQL = "LOWER(" + litSQL + ")"
 	}
-	out := colSQL + opts.ColCollate + " " + op + " " + litSQL
-	if !opts.OmitEscape {
-		out += likeEscapeClause
-	}
-	return out, nil
+	return colSQL + opts.ColCollate + " " + op + " " + litSQL, nil
 }

--- a/libsq/ast/render/function_like.go
+++ b/libsq/ast/render/function_like.go
@@ -264,11 +264,13 @@ type LikeRawOpts struct {
 // like / ilike functions. Unlike [RenderLikeOp], the literal pattern
 // is bound verbatim: % and _ are wildcards, not escaped. Single
 // quotes inside the literal are still properly escaped by
-// SingleQuote. No ESCAPE clause is emitted, so the engine has no
-// reserved escape character; `|` (and every other character) is a
-// normal literal. Users who need literal `%` / `_` matching should
-// use [RenderLikeOp] (SLQ's contains family), which auto-escapes
-// wildcards in the pattern.
+// SingleQuote. No `ESCAPE '|'` clause is emitted, so `|` is a literal
+// character on every driver. Other engine-default escape semantics
+// remain driver-specific — notably MySQL's default backslash escape
+// (`\`) still applies in `LIKE` patterns unless the session sets the
+// `NO_BACKSLASH_ESCAPES` SQL mode. Users who need literal `%` / `_`
+// matching should use [RenderLikeOp] (SLQ's contains family), which
+// auto-escapes wildcards in the pattern.
 //
 // opts.IgnoreCase is mutually exclusive with opts.Op and opts.ColCollate:
 // the LOWER-wrapping strategy stands alone, and combining it with a

--- a/libsq/query_string_test.go
+++ b/libsq/query_string_test.go
@@ -720,13 +720,14 @@ func TestQuery_string_like(t *testing.T) {
 			wantRecCount: 0,
 		},
 		{
-			// `|` is a normal literal character on every driver: no ESCAPE
-			// clause is emitted, so the engine has no reserved escape
-			// character and `a|b` matches the literal substring `a|b`
-			// (no sakila actor first_name contains it → 0 rows). Pinning
-			// this shape guards against the pre-#629 regression where
-			// `ESCAPE '|'` made bare `|` either a runtime error or a
-			// silently-dropped character depending on the driver.
+			// `|` is a literal character on every driver: no `ESCAPE '|'`
+			// clause is emitted, so `a|b` matches the literal substring
+			// `a|b` (no sakila actor first_name contains it → 0 rows).
+			// Pinning this shape guards against the pre-#629 regression
+			// where `ESCAPE '|'` made bare `|` either a runtime error
+			// or a silently-dropped character depending on the driver.
+			// Other driver-default escape semantics (e.g. MySQL's `\`)
+			// are out of scope and unchanged.
 			name:    "like/bare-pipe-is-literal",
 			in:      `@sakila | .actor | where(like(.first_name, "a|b"))`,
 			wantSQL: `SELECT * FROM "actor" WHERE "first_name" LIKE 'a|b'`,
@@ -734,6 +735,26 @@ func TestQuery_string_like(t *testing.T) {
 				drivertype.MySQL:      "SELECT * FROM `actor` WHERE `first_name` LIKE BINARY 'a|b'",
 				drivertype.MSSQL:      `SELECT * FROM "actor" WHERE "first_name" COLLATE Latin1_General_BIN2 LIKE 'a|b'`,
 				drivertype.ClickHouse: "SELECT * FROM `actor` WHERE `first_name` LIKE 'a|b'",
+			},
+			wantRecCount: 0,
+		},
+		{
+			// Stronger discriminator than like/bare-pipe-is-literal: this
+			// pattern would have returned 4 rows on pre-#629 MySQL (the
+			// lenient driver, which silently dropped a bare `|` not
+			// followed by a meta-char), because `|PEN%` collapsed to
+			// `PEN%` and matched the 4 PENELOPEs. Post-#629 every driver
+			// treats `|` as literal, so `|PEN%` only matches names
+			// starting with `|PEN` — none in sakila → 0 rows. Pre-#629
+			// strict drivers (PG/DuckDB/Oracle/SQLite/SQL Server) would
+			// have raised a runtime "invalid escape sequence" here.
+			name:    "like/literal-pipe-prefix",
+			in:      `@sakila | .actor | where(like(.first_name, "|PEN%"))`,
+			wantSQL: `SELECT * FROM "actor" WHERE "first_name" LIKE '|PEN%'`,
+			override: driverMap{
+				drivertype.MySQL:      "SELECT * FROM `actor` WHERE `first_name` LIKE BINARY '|PEN%'",
+				drivertype.MSSQL:      `SELECT * FROM "actor" WHERE "first_name" COLLATE Latin1_General_BIN2 LIKE '|PEN%'`,
+				drivertype.ClickHouse: "SELECT * FROM `actor` WHERE `first_name` LIKE '|PEN%'",
 			},
 			wantRecCount: 0,
 		},
@@ -827,6 +848,25 @@ func TestQuery_string_ilike(t *testing.T) {
 				drivertype.MySQL:      "SELECT * FROM `actor` WHERE LOWER(`first_name`) LIKE LOWER('')",
 				drivertype.MSSQL:      `SELECT * FROM "actor" WHERE "first_name" COLLATE Latin1_General_CI_AS LIKE ''`,
 				drivertype.ClickHouse: "SELECT * FROM `actor` WHERE `first_name` ILIKE ''",
+			},
+			wantRecCount: 0,
+		},
+		{
+			// ILIKE-renderer mirror of like/literal-pipe-prefix. Catches
+			// any future re-introduction of a default `ESCAPE '|'` on the
+			// ILIKE path (which would silently drop the leading `|` on
+			// MySQL via the LOWER-wrap default renderer and surface 4
+			// PENELOPEs instead of 0).
+			name:    "ilike/literal-pipe-prefix",
+			in:      `@sakila | .actor | where(ilike(.first_name, "|pen%"))`,
+			wantSQL: `SELECT * FROM "actor" WHERE LOWER("first_name") LIKE LOWER('|pen%')`,
+			override: driverMap{
+				drivertype.Pg:         `SELECT * FROM "actor" WHERE "first_name" ILIKE '|pen%'`,
+				drivertype.DuckDB:     `SELECT * FROM "actor" WHERE "first_name" ILIKE '|pen%'`,
+				drivertype.SQLite:     `SELECT * FROM "actor" WHERE "first_name" LIKE '|pen%'`,
+				drivertype.MySQL:      "SELECT * FROM `actor` WHERE LOWER(`first_name`) LIKE LOWER('|pen%')",
+				drivertype.MSSQL:      `SELECT * FROM "actor" WHERE "first_name" COLLATE Latin1_General_CI_AS LIKE '|pen%'`,
+				drivertype.ClickHouse: "SELECT * FROM `actor` WHERE `first_name` ILIKE '|pen%'",
 			},
 			wantRecCount: 0,
 		},

--- a/libsq/query_string_test.go
+++ b/libsq/query_string_test.go
@@ -663,10 +663,10 @@ func TestQuery_string_like(t *testing.T) {
 			// same 4 rows (see SQLite-quirk pair test below).
 			name:    "like/wildcard-prefix-uppercase",
 			in:      `@sakila | .actor | where(like(.first_name, "PEN%"))`,
-			wantSQL: `SELECT * FROM "actor" WHERE "first_name" LIKE 'PEN%' ESCAPE '|'`,
+			wantSQL: `SELECT * FROM "actor" WHERE "first_name" LIKE 'PEN%'`,
 			override: driverMap{
-				drivertype.MySQL:      "SELECT * FROM `actor` WHERE `first_name` LIKE BINARY 'PEN%' ESCAPE '|'",
-				drivertype.MSSQL:      `SELECT * FROM "actor" WHERE "first_name" COLLATE Latin1_General_BIN2 LIKE 'PEN%' ESCAPE '|'`,
+				drivertype.MySQL:      "SELECT * FROM `actor` WHERE `first_name` LIKE BINARY 'PEN%'",
+				drivertype.MSSQL:      `SELECT * FROM "actor" WHERE "first_name" COLLATE Latin1_General_BIN2 LIKE 'PEN%'`,
 				drivertype.ClickHouse: "SELECT * FROM `actor` WHERE `first_name` LIKE 'PEN%'",
 			},
 			wantRecCount: 4,
@@ -676,7 +676,7 @@ func TestQuery_string_like(t *testing.T) {
 			// a lowercase pattern matches uppercase data.
 			name:         "like/sqlite-ascii-ci-quirk",
 			in:           `@sakila | .actor | where(like(.first_name, "pen%"))`,
-			wantSQL:      `SELECT * FROM "actor" WHERE "first_name" LIKE 'pen%' ESCAPE '|'`,
+			wantSQL:      `SELECT * FROM "actor" WHERE "first_name" LIKE 'pen%'`,
 			onlyFor:      []drivertype.Type{drivertype.SQLite},
 			wantRecCount: 4,
 		},
@@ -697,10 +697,10 @@ func TestQuery_string_like(t *testing.T) {
 			// `_` is treated as a wildcard, not auto-escaped.
 			name:    "like/single-char-wildcard",
 			in:      `@sakila | .actor | where(like(.first_name, "PEN_LOPE"))`,
-			wantSQL: `SELECT * FROM "actor" WHERE "first_name" LIKE 'PEN_LOPE' ESCAPE '|'`,
+			wantSQL: `SELECT * FROM "actor" WHERE "first_name" LIKE 'PEN_LOPE'`,
 			override: driverMap{
-				drivertype.MySQL:      "SELECT * FROM `actor` WHERE `first_name` LIKE BINARY 'PEN_LOPE' ESCAPE '|'",
-				drivertype.MSSQL:      `SELECT * FROM "actor" WHERE "first_name" COLLATE Latin1_General_BIN2 LIKE 'PEN_LOPE' ESCAPE '|'`,
+				drivertype.MySQL:      "SELECT * FROM `actor` WHERE `first_name` LIKE BINARY 'PEN_LOPE'",
+				drivertype.MSSQL:      `SELECT * FROM "actor" WHERE "first_name" COLLATE Latin1_General_BIN2 LIKE 'PEN_LOPE'`,
 				drivertype.ClickHouse: "SELECT * FROM `actor` WHERE `first_name` LIKE 'PEN_LOPE'",
 			},
 			wantRecCount: 4,
@@ -711,30 +711,31 @@ func TestQuery_string_like(t *testing.T) {
 			// non-NULL row. Sakila has no empty first_names → 0 rows.
 			name:    "like/empty-pattern-matches-empty-strings-only",
 			in:      `@sakila | .actor | where(like(.first_name, ""))`,
-			wantSQL: `SELECT * FROM "actor" WHERE "first_name" LIKE '' ESCAPE '|'`,
+			wantSQL: `SELECT * FROM "actor" WHERE "first_name" LIKE ''`,
 			override: driverMap{
-				drivertype.MySQL:      "SELECT * FROM `actor` WHERE `first_name` LIKE BINARY '' ESCAPE '|'",
-				drivertype.MSSQL:      `SELECT * FROM "actor" WHERE "first_name" COLLATE Latin1_General_BIN2 LIKE '' ESCAPE '|'`,
+				drivertype.MySQL:      "SELECT * FROM `actor` WHERE `first_name` LIKE BINARY ''",
+				drivertype.MSSQL:      `SELECT * FROM "actor" WHERE "first_name" COLLATE Latin1_General_BIN2 LIKE ''`,
 				drivertype.ClickHouse: "SELECT * FROM `actor` WHERE `first_name` LIKE ''",
 			},
 			wantRecCount: 0,
 		},
 		{
-			// Pin the SQL shape for `|` in the pattern. The engine reserves
-			// `|` as the ESCAPE character on every driver except ClickHouse,
-			// which omits the ESCAPE clause entirely. Runtime behavior of
-			// a bare `|` diverges (silently dropped on lenient drivers,
-			// "invalid escape sequence" runtime error on Postgres/Oracle),
-			// so we don't exec — see the v1-limitation note in the docs.
-			name:    "like/escape-char-in-pattern-pins-shape",
+			// `|` is a normal literal character on every driver: no ESCAPE
+			// clause is emitted, so the engine has no reserved escape
+			// character and `a|b` matches the literal substring `a|b`
+			// (no sakila actor first_name contains it → 0 rows). Pinning
+			// this shape guards against the pre-#629 regression where
+			// `ESCAPE '|'` made bare `|` either a runtime error or a
+			// silently-dropped character depending on the driver.
+			name:    "like/bare-pipe-is-literal",
 			in:      `@sakila | .actor | where(like(.first_name, "a|b"))`,
-			wantSQL: `SELECT * FROM "actor" WHERE "first_name" LIKE 'a|b' ESCAPE '|'`,
+			wantSQL: `SELECT * FROM "actor" WHERE "first_name" LIKE 'a|b'`,
 			override: driverMap{
-				drivertype.MySQL:      "SELECT * FROM `actor` WHERE `first_name` LIKE BINARY 'a|b' ESCAPE '|'",
-				drivertype.MSSQL:      `SELECT * FROM "actor" WHERE "first_name" COLLATE Latin1_General_BIN2 LIKE 'a|b' ESCAPE '|'`,
+				drivertype.MySQL:      "SELECT * FROM `actor` WHERE `first_name` LIKE BINARY 'a|b'",
+				drivertype.MSSQL:      `SELECT * FROM "actor" WHERE "first_name" COLLATE Latin1_General_BIN2 LIKE 'a|b'`,
 				drivertype.ClickHouse: "SELECT * FROM `actor` WHERE `first_name` LIKE 'a|b'",
 			},
-			skipExec: true,
+			wantRecCount: 0,
 		},
 		{
 			name:            "like/wrong-arg-count",
@@ -755,7 +756,7 @@ func TestQuery_string_like(t *testing.T) {
 	}
 }
 
-//nolint:exhaustive,lll
+//nolint:exhaustive
 func TestQuery_string_ilike(t *testing.T) {
 	testCases := []queryTestCase{
 		{
@@ -764,13 +765,13 @@ func TestQuery_string_ilike(t *testing.T) {
 			// matching.
 			name:    "ilike/wildcard-prefix-lowercase-match",
 			in:      `@sakila | .actor | where(ilike(.first_name, "pen%"))`,
-			wantSQL: `SELECT * FROM "actor" WHERE LOWER("first_name") LIKE LOWER('pen%') ESCAPE '|'`,
+			wantSQL: `SELECT * FROM "actor" WHERE LOWER("first_name") LIKE LOWER('pen%')`,
 			override: driverMap{
-				drivertype.Pg:         `SELECT * FROM "actor" WHERE "first_name" ILIKE 'pen%' ESCAPE '|'`,
-				drivertype.DuckDB:     `SELECT * FROM "actor" WHERE "first_name" ILIKE 'pen%' ESCAPE '|'`,
-				drivertype.SQLite:     `SELECT * FROM "actor" WHERE "first_name" LIKE 'pen%' ESCAPE '|'`,
-				drivertype.MySQL:      "SELECT * FROM `actor` WHERE LOWER(`first_name`) LIKE LOWER('pen%') ESCAPE '|'",
-				drivertype.MSSQL:      `SELECT * FROM "actor" WHERE "first_name" COLLATE Latin1_General_CI_AS LIKE 'pen%' ESCAPE '|'`,
+				drivertype.Pg:         `SELECT * FROM "actor" WHERE "first_name" ILIKE 'pen%'`,
+				drivertype.DuckDB:     `SELECT * FROM "actor" WHERE "first_name" ILIKE 'pen%'`,
+				drivertype.SQLite:     `SELECT * FROM "actor" WHERE "first_name" LIKE 'pen%'`,
+				drivertype.MySQL:      "SELECT * FROM `actor` WHERE LOWER(`first_name`) LIKE LOWER('pen%')",
+				drivertype.MSSQL:      `SELECT * FROM "actor" WHERE "first_name" COLLATE Latin1_General_CI_AS LIKE 'pen%'`,
 				drivertype.ClickHouse: "SELECT * FROM `actor` WHERE `first_name` ILIKE 'pen%'",
 			},
 			wantRecCount: 4,
@@ -780,13 +781,13 @@ func TestQuery_string_ilike(t *testing.T) {
 			// same 4 PENELOPEs.
 			name:    "ilike/wildcard-prefix-uppercase-match",
 			in:      `@sakila | .actor | where(ilike(.first_name, "PEN%"))`,
-			wantSQL: `SELECT * FROM "actor" WHERE LOWER("first_name") LIKE LOWER('PEN%') ESCAPE '|'`,
+			wantSQL: `SELECT * FROM "actor" WHERE LOWER("first_name") LIKE LOWER('PEN%')`,
 			override: driverMap{
-				drivertype.Pg:         `SELECT * FROM "actor" WHERE "first_name" ILIKE 'PEN%' ESCAPE '|'`,
-				drivertype.DuckDB:     `SELECT * FROM "actor" WHERE "first_name" ILIKE 'PEN%' ESCAPE '|'`,
-				drivertype.SQLite:     `SELECT * FROM "actor" WHERE "first_name" LIKE 'PEN%' ESCAPE '|'`,
-				drivertype.MySQL:      "SELECT * FROM `actor` WHERE LOWER(`first_name`) LIKE LOWER('PEN%') ESCAPE '|'",
-				drivertype.MSSQL:      `SELECT * FROM "actor" WHERE "first_name" COLLATE Latin1_General_CI_AS LIKE 'PEN%' ESCAPE '|'`,
+				drivertype.Pg:         `SELECT * FROM "actor" WHERE "first_name" ILIKE 'PEN%'`,
+				drivertype.DuckDB:     `SELECT * FROM "actor" WHERE "first_name" ILIKE 'PEN%'`,
+				drivertype.SQLite:     `SELECT * FROM "actor" WHERE "first_name" LIKE 'PEN%'`,
+				drivertype.MySQL:      "SELECT * FROM `actor` WHERE LOWER(`first_name`) LIKE LOWER('PEN%')",
+				drivertype.MSSQL:      `SELECT * FROM "actor" WHERE "first_name" COLLATE Latin1_General_CI_AS LIKE 'PEN%'`,
 				drivertype.ClickHouse: "SELECT * FROM `actor` WHERE `first_name` ILIKE 'PEN%'",
 			},
 			wantRecCount: 4,
@@ -802,13 +803,13 @@ func TestQuery_string_ilike(t *testing.T) {
 			// 4 PENELOPEs on every driver under CI.
 			name:    "ilike/single-char-wildcard-mixed-case",
 			in:      `@sakila | .actor | where(ilike(.first_name, "pen_LOPE"))`,
-			wantSQL: `SELECT * FROM "actor" WHERE LOWER("first_name") LIKE LOWER('pen_LOPE') ESCAPE '|'`,
+			wantSQL: `SELECT * FROM "actor" WHERE LOWER("first_name") LIKE LOWER('pen_LOPE')`,
 			override: driverMap{
-				drivertype.Pg:         `SELECT * FROM "actor" WHERE "first_name" ILIKE 'pen_LOPE' ESCAPE '|'`,
-				drivertype.DuckDB:     `SELECT * FROM "actor" WHERE "first_name" ILIKE 'pen_LOPE' ESCAPE '|'`,
-				drivertype.SQLite:     `SELECT * FROM "actor" WHERE "first_name" LIKE 'pen_LOPE' ESCAPE '|'`,
-				drivertype.MySQL:      "SELECT * FROM `actor` WHERE LOWER(`first_name`) LIKE LOWER('pen_LOPE') ESCAPE '|'",
-				drivertype.MSSQL:      `SELECT * FROM "actor" WHERE "first_name" COLLATE Latin1_General_CI_AS LIKE 'pen_LOPE' ESCAPE '|'`,
+				drivertype.Pg:         `SELECT * FROM "actor" WHERE "first_name" ILIKE 'pen_LOPE'`,
+				drivertype.DuckDB:     `SELECT * FROM "actor" WHERE "first_name" ILIKE 'pen_LOPE'`,
+				drivertype.SQLite:     `SELECT * FROM "actor" WHERE "first_name" LIKE 'pen_LOPE'`,
+				drivertype.MySQL:      "SELECT * FROM `actor` WHERE LOWER(`first_name`) LIKE LOWER('pen_LOPE')",
+				drivertype.MSSQL:      `SELECT * FROM "actor" WHERE "first_name" COLLATE Latin1_General_CI_AS LIKE 'pen_LOPE'`,
 				drivertype.ClickHouse: "SELECT * FROM `actor` WHERE `first_name` ILIKE 'pen_LOPE'",
 			},
 			wantRecCount: 4,
@@ -818,13 +819,13 @@ func TestQuery_string_ilike(t *testing.T) {
 			// semantics). Sakila has no empty first_names → 0 rows.
 			name:    "ilike/empty-pattern-matches-empty-strings-only",
 			in:      `@sakila | .actor | where(ilike(.first_name, ""))`,
-			wantSQL: `SELECT * FROM "actor" WHERE LOWER("first_name") LIKE LOWER('') ESCAPE '|'`,
+			wantSQL: `SELECT * FROM "actor" WHERE LOWER("first_name") LIKE LOWER('')`,
 			override: driverMap{
-				drivertype.Pg:         `SELECT * FROM "actor" WHERE "first_name" ILIKE '' ESCAPE '|'`,
-				drivertype.DuckDB:     `SELECT * FROM "actor" WHERE "first_name" ILIKE '' ESCAPE '|'`,
-				drivertype.SQLite:     `SELECT * FROM "actor" WHERE "first_name" LIKE '' ESCAPE '|'`,
-				drivertype.MySQL:      "SELECT * FROM `actor` WHERE LOWER(`first_name`) LIKE LOWER('') ESCAPE '|'",
-				drivertype.MSSQL:      `SELECT * FROM "actor" WHERE "first_name" COLLATE Latin1_General_CI_AS LIKE '' ESCAPE '|'`,
+				drivertype.Pg:         `SELECT * FROM "actor" WHERE "first_name" ILIKE ''`,
+				drivertype.DuckDB:     `SELECT * FROM "actor" WHERE "first_name" ILIKE ''`,
+				drivertype.SQLite:     `SELECT * FROM "actor" WHERE "first_name" LIKE ''`,
+				drivertype.MySQL:      "SELECT * FROM `actor` WHERE LOWER(`first_name`) LIKE LOWER('')",
+				drivertype.MSSQL:      `SELECT * FROM "actor" WHERE "first_name" COLLATE Latin1_General_CI_AS LIKE ''`,
 				drivertype.ClickHouse: "SELECT * FROM `actor` WHERE `first_name` ILIKE ''",
 			},
 			wantRecCount: 0,

--- a/site/content/en/docs/query/index.md
+++ b/site/content/en/docs/query/index.md
@@ -946,9 +946,9 @@ Per-driver implementation:
 - **SQLite:** plain `LIKE` (already ASCII-CI by default).
 - **ClickHouse:** native `ILIKE`.
 
-No `ESCAPE` clause is emitted on any driver — see [`like`](#like)
-for escape behavior and the [`icontains`](#icontains) cross-reference
-for literal `%` / `_` matching.
+No `ESCAPE '|'` clause is emitted on any driver — see [`like`](#like)
+for escape behavior. For literal `%` / `_` matching, use
+[`icontains`](#icontains), which auto-escapes wildcards.
 
 ### `istartswith`
 
@@ -998,11 +998,14 @@ overriding them globally via `PRAGMA case_sensitive_like`.
 Non-ASCII characters are not case-folded unless the ICU extension is
 loaded — same caveat as [`icontains`](#icontains).
 
-No `ESCAPE` clause is emitted on any driver, so `|` (and every other
-character) is a literal in the pattern. If you need to match a
-literal `%` or `_` rather than treat them as wildcards, use
-[`contains`](#contains), which auto-escapes wildcards in the
-pattern. For column-as-pattern (`like(.col_a, .col_b)`), see
+No `ESCAPE '|'` clause is emitted on any driver, so `|` is a literal
+character in the pattern. Other engine-default escape semantics remain
+driver-specific — notably MySQL's default backslash escape (`\`) still
+applies in `LIKE` patterns unless the session sets the
+`NO_BACKSLASH_ESCAPES` SQL mode. If you need to match a literal `%` or
+`_` rather than treat them as wildcards, use [`contains`](#contains),
+which auto-escapes wildcards in the pattern. For column-as-pattern
+(`like(.col_a, .col_b)`), see
 [issue #628](https://github.com/neilotoole/sq/issues/628).
 
 An empty pattern matches only empty strings (`col = ''`) — not every

--- a/site/content/en/docs/query/index.md
+++ b/site/content/en/docs/query/index.md
@@ -941,10 +941,14 @@ $ sq '.actor | where(ilike(.first_name, "pen%"))'
 Per-driver implementation:
 
 - **Postgres / DuckDB:** native `ILIKE`.
-- **MySQL / Oracle:** `LOWER(col) LIKE LOWER(pat) ESCAPE '|'`.
+- **MySQL / Oracle:** `LOWER(col) LIKE LOWER(pat)`.
 - **SQL Server:** `LIKE` with `COLLATE Latin1_General_CI_AS`.
-- **SQLite:** `LIKE ... ESCAPE '|'` (already ASCII-CI by default).
-- **ClickHouse:** native `ILIKE` (no `ESCAPE` clause).
+- **SQLite:** plain `LIKE` (already ASCII-CI by default).
+- **ClickHouse:** native `ILIKE`.
+
+No `ESCAPE` clause is emitted on any driver — see [`like`](#like)
+for escape behavior and the [`icontains`](#icontains) cross-reference
+for literal `%` / `_` matching.
 
 ### `istartswith`
 
@@ -994,29 +998,12 @@ overriding them globally via `PRAGMA case_sensitive_like`.
 Non-ASCII characters are not case-folded unless the ICU extension is
 loaded — same caveat as [`icontains`](#icontains).
 
-**v1 limitation — engine escape character:** every driver except
-ClickHouse emits a trailing `ESCAPE '|'` clause, reserving `|` as the
-LIKE escape character. Practical consequences:
-
-- On Postgres, DuckDB, Oracle, SQLite, and SQL Server (strict
-  drivers), a pattern containing `|` not followed by `%`, `_`, `[`,
-  `]`, or another `|` raises a runtime error (e.g. "invalid escape
-  sequence").
-- On MySQL (the only lenient driver), `|` followed by `%`, `_`, or
-  another `|` matches that character literally — i.e.
-  `like(.col, "10|%")` matches the substring `10%`. A bare `|` not
-  followed by an escape target is silently dropped. Don't rely on
-  this; behavior may differ between MySQL versions.
-- On ClickHouse, the `ESCAPE` clause is omitted entirely, so `|` is
-  always a literal character with no special meaning.
-
-If you need portable literal-`%` / literal-`_` matching, use
-[`contains`](#contains) (which auto-escapes wildcards in the
-literal). The current `like` / `ilike` ESCAPE semantics may be
-revisited in a future version; see issue
-[#629](https://github.com/neilotoole/sq/issues/629). A separate
-follow-up, [#628](https://github.com/neilotoole/sq/issues/628),
-tracks column-as-pattern support.
+No `ESCAPE` clause is emitted on any driver, so `|` (and every other
+character) is a literal in the pattern. If you need to match a
+literal `%` or `_` rather than treat them as wildcards, use
+[`contains`](#contains), which auto-escapes wildcards in the
+pattern. For column-as-pattern (`like(.col_a, .col_b)`), see
+[issue #628](https://github.com/neilotoole/sq/issues/628).
 
 An empty pattern matches only empty strings (`col = ''`) — not every
 non-NULL row, in contrast with [`contains`](#contains)`(.col, "")`.


### PR DESCRIPTION
## Summary

Closes [#629](https://github.com/neilotoole/sq/issues/629). Follow-up
to [#627](https://github.com/neilotoole/sq/pull/627) (case-insensitive
SLQ family + `like` / `ilike`). Removes the trailing `ESCAPE '|'`
clause that `like` / `ilike` emitted on every driver except
ClickHouse, producing inconsistent cross-driver behavior around a bare
`|`:

| Driver | Pre-#629 behavior of bare `\|` |
|---|---|
| Postgres, Oracle, SQLite, SQL Server | runtime "invalid escape sequence" error |
| MySQL | silently dropped |
| ClickHouse | literal character (no clause emitted) |

After this PR, `|` is a normal literal character on every driver. The
`contains` family is **unchanged** and still emits `ESCAPE '|'` — its
auto-escape of user input into the LIKE pattern still does real work
there.

Sequencing note: `like` / `ilike` shipped in #627 under `Unreleased`
and have not been published in any tagged release, so this change
lands before any user has seen the inconsistent escape behavior.

## Changes

- **`libsq/ast/render/function_like.go`**: `RenderLikeRaw` no longer
  appends ` ESCAPE '|'`. `LikeRawOpts.OmitEscape` removed (the new
  default is "no ESCAPE"). Godoc updated.
- **`drivers/clickhouse/render.go`**: `like`/`ilike` overrides drop
  `OmitEscape: true` and the stale "ClickHouse doesn't support
  ESCAPE" comments. Behavior unchanged for ClickHouse.
- **`libsq/query_string_test.go`**: stripped ` ESCAPE '|'` from
  `wantSQL` and per-driver overrides in `TestQuery_string_like` /
  `TestQuery_string_ilike`. The `like/escape-char-in-pattern-pins-shape`
  test (previously `skipExec: true` because of the divergent runtime
  behavior) is **repurposed as `like/bare-pipe-is-literal`**: drops
  `skipExec`, expects 0 rows, and now runs end-to-end across every
  driver as a positive demonstration that bare `\|` is a literal. One
  unused `lll` nolint directive removed.
- **`site/content/en/docs/query/index.md`**: `ilike` per-driver
  bullets drop ` ESCAPE '|'`; the `like` v1-limitation paragraph
  (23 lines describing the pre-#629 divergence) is replaced with a
  brief `contains` cross-reference. The `#628` column-as-pattern
  follow-up pointer is retained.
- **`CHANGELOG.md`**: `### Changed` entry under `## Unreleased`.

## Test plan

- [x] `make lint` clean (0 issues).
- [x] `TestQuery_string_like` passes against all 6 configured drivers
  (sqlite3, postgres, mysql, sqlserver, clickhouse, oracle), including
  the newly-exec-tested `like/bare-pipe-is-literal`.
- [x] `TestQuery_string_ilike` passes against all 6 drivers.
- [x] `TestQuery_string_{contains,icontains,startswith,istartswith,endswith,iendswith}`
  pass — regression check that the `contains` family still emits
  `ESCAPE '|'` correctly.
- [x] `grep -rn OmitEscape **/*.go` → 0 matches.