### PR TITLE
(agents) Add contributor agent skills scaffold and agent agnostic AGENTS.md

### DIFF
--- a/.agents/skills/sq-gomod-dependabot/SKILL.md
+++ b/.agents/skills/sq-gomod-dependabot/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: sq-gomod-dependabot
+description: >-
+  Reviews and merges Dependabot pull requests for Go modules (gomod) at the sq
+  repo root. Use for dependabot gomod PRs, go.mod/go.sum updates, and Go module
+  security bumps—not site/ Bun PRs.
+license: MIT
+compatibility: >-
+  Requires gh CLI (authenticated), Go toolchain, make test-short, and network
+  access to GitHub.
+metadata:
+  author: Todd Papaioannou
+  homepage: https://sq.io
+  version: "0.1.0"
+---
+
+# sq-gomod-dependabot
+
+Placeholder skill for Go module Dependabot PRs. Expand when gomod PR volume
+warrants a detailed workflow.
+
+## When to use
+
+- Dependabot PRs updating `go.mod` / `go.sum` at the repository root
+- Not for [`site/`](../../../site/) Bun/Hugo dependency PRs (use
+  `sq-site-dependabot`)
+
+## Minimal workflow
+
+1. `gh auth status` — GitHub CLI required.
+2. Review the diff: direct vs indirect dependency, security advisory if any.
+3. `make test-short` (or `make test` for broader coverage).
+4. `gh pr merge --squash --delete-branch` after required checks pass.
+
+No `bun.lock` sequencing issue; multiple gomod PRs are less coupled than site
+PRs.
+
+See [AGENTS.md](../../../AGENTS.md#agent-skills-contributors).

--- a/.agents/skills/sq-site-dependabot/SKILL.md
+++ b/.agents/skills/sq-site-dependabot/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: sq-site-dependabot
+description: >-
+  Reviews, validates, and safely merges Dependabot pull requests for the sq.io
+  site (site/, Bun lockfile). Use when clearing site dependency PRs, triaging
+  Dependabot failures, or checking Lighthouse impact before merge.
+license: MIT
+compatibility: >-
+  Requires gh CLI (authenticated), Bun 1.2+, make, and network access to GitHub
+  and Netlify deploy previews.
+metadata:
+  author: Todd Papaioannou
+  homepage: https://sq.io
+  version: "0.1.0"
+---
+
+# sq-site-dependabot
+
+Scaffold only in this PR. A follow-up PR adds the full workflow (tool bootstrap,
+risk tiers, Netlify validation, merge scripts, and references).
+
+## When to use
+
+- Open Dependabot PRs touching [`site/`](../../../site/) or `site/bun.lock`
+- Clearing a backlog of site dependency updates
+- Investigating Site CI vs Netlify deploy-preview failures on dependabot branches
+
+## Until the full skill ships
+
+1. Read [AGENTS.md](../../../AGENTS.md#agent-skills-contributors) for skill paths
+   and `npx skills add` usage.
+2. From `site/`, run `make ci` before merging any site dependency PR.
+3. Confirm the Netlify deploy preview is green on the PR’s current head SHA
+   before approve/merge.
+
+Do not merge site Dependabot PRs in bulk without rebasing between merges (shared
+`bun.lock`).

--- a/.agents/skills/sq-site-dependabot/SKILL.md
+++ b/.agents/skills/sq-site-dependabot/SKILL.md
@@ -31,7 +31,7 @@ risk tiers, Netlify validation, merge scripts, and references).
    and `npx skills add` usage.
 2. From `site/`, run `make ci` before merging any site dependency PR.
 3. Confirm the Netlify deploy preview is green on the PR’s current head SHA
-   before approve/merge.
+   before approving or merging.
 
 Do not merge site Dependabot PRs in bulk without rebasing between merges (shared
 `bun.lock`).

--- a/.claude/skills
+++ b/.claude/skills
@@ -1,0 +1,1 @@
+../.agents/skills

--- a/.gitignore
+++ b/.gitignore
@@ -73,7 +73,8 @@ sakila_b*
 
 ## AI stuff
 CLAUDE.local.md
-/.claude
+/.claude/*
+!.claude/skills
 /docs/superpowers/
 
 ## Hugo site (site/)

--- a/.gitignore
+++ b/.gitignore
@@ -74,7 +74,7 @@ sakila_b*
 ## AI stuff
 CLAUDE.local.md
 /.claude/*
-!.claude/skills
+!/.claude/skills
 /docs/superpowers/
 
 ## Hugo site (site/)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,11 +1,10 @@
-# CLAUDE.md
+# AGENTS.md
 
-Guidance for AI coding assistants (Claude Code, Copilot, Cursor, etc.) and
+Guidance for AI coding assistants (Claude Code, Copilot, Cursor, Codex, etc.) and
 human contributors working in this repo.
 
-For **agent skills** (Dependabot triage under `.agents/skills/`), `npx skills`
-install, symlink layout, and expanded cross-agent notes, see
-[AGENTS.md](./AGENTS.md).
+For Claude Code, [`CLAUDE.md`](./CLAUDE.md) mirrors the essentials here and links
+to this file for expanded contributor content.
 
 ## About `sq`
 
@@ -146,3 +145,64 @@ dialect configuration, test handles, and the SQL-vs-document driver split.
 For a visual map of the driver interfaces (`driver.Driver`,
 `driver.SQLDriver`, `driver.Grip`, `driver.Registry`) and how they relate to
 the rest of the system, see [`ARCHITECTURE.md`](./ARCHITECTURE.md).
+
+## Agent skills (contributors)
+
+This repo ships [Agent Skills](https://agentskills.io/specification) for
+**maintainer** workflows. They live under [`.agents/skills/`](.agents/skills/).
+
+| Location | Audience |
+|----------|----------|
+| [`.agents/skills/`](.agents/skills/) | Contributors (Dependabot triage, etc.) |
+| [`skills/sq/`](skills/sq/SKILL.md) | End users of the `sq` CLI (distribution; not repo auto-discovery) |
+
+Claude Code discovers the same tree via [`.claude/skills`](.claude/skills)
+(symlink to `.agents/skills`). Cursor and Codex load `.agents/skills/`
+directly. On Windows, if symlinks are unavailable, use WSL or duplicate the
+tree as documented in [`CONTRIBUTING.md`](./CONTRIBUTING.md).
+
+### Skills in this repo
+
+| Skill | Use when |
+|-------|----------|
+| [`sq-site-dependabot`](.agents/skills/sq-site-dependabot/) | Triaging or merging Dependabot PRs for [`site/`](site/) (Bun / Hugo). |
+| [`sq-gomod-dependabot`](.agents/skills/sq-gomod-dependabot/) | Dependabot PRs for Go modules at repo root (placeholder). |
+
+Invoke explicitly when your agent supports it (e.g. `/sq-site-dependabot` in
+Cursor, `$sq-site-dependabot` in Codex) or ask to “clear site dependabot PRs”.
+
+Full site-dependabot workflow content lands in a follow-up PR; this scaffold
+adds directories and docs only.
+
+### Installing and verifying skills (`npx skills`)
+
+Use the [Skills CLI](https://skills.sh/docs/cli) (no global install required):
+
+```bash
+npx skills add <owner/repo> --skill <skill-name>
+```
+
+**From this repository on GitHub** (install into your agent’s skill directories):
+
+```bash
+npx skills add neilotoole/sq --skill sq-site-dependabot
+npx skills add neilotoole/sq --skill sq-gomod-dependabot
+```
+
+**From a local checkout** (verify before opening a PR that touches skills):
+
+```bash
+npx skills add . -l
+npx skills add . --skill sq-site-dependabot -y
+```
+
+The `-l` / `--list` flag prints discoverable skills and descriptions without
+installing. Use `-y` to skip prompts in CI or scripts.
+
+**In-repo discovery (no install):** Cursor and Codex load
+[`.agents/skills/`](.agents/skills/) from the working tree. Claude Code also
+reads [`.claude/skills`](.claude/skills) when the symlink to `.agents/skills`
+is present.
+
+Optional: set `DISABLE_TELEMETRY=1` to opt out of anonymous Skills CLI
+telemetry ([docs](https://skills.sh/docs/cli)).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,6 +5,15 @@ and [discussion](https://github.com/neilotoole/sq/discussions).
 
 For user documentation, see [sq.io](https://sq.io).
 
+For AI coding assistants working in this repo, see [AGENTS.md](./AGENTS.md)
+(cross-agent guidance and contributor [Agent Skills](https://agentskills.io/specification)
+under [`.agents/skills/`](./.agents/skills/)). Install into your agent with
+`npx skills add neilotoole/sq --skill <name>` (see
+[AGENTS.md](./AGENTS.md#installing-and-verifying-skills-npx-skills)). Claude Code
+also uses [`.claude/skills`](./.claude/skills) (symlink to `.agents/skills`
+when checked out). On Windows, if symlinks are unavailable, use WSL, `npx skills
+add`, or copy `.agents/skills` under `.claude/skills`.
+
 ## Documentation site (`site/`)
 
 The [sq.io](https://sq.io) website is a [Hugo](https://gohugo.io) project in [`site/`](./site/). From `site/`, use **`make`** for the usual workflow (`make deps`, `make site-local`, `make site-test`, `make site-build`, or `make ci` to match CI). Bun equivalents are in [`site/README.md`](./site/README.md).
@@ -14,6 +23,11 @@ first: it explains the **stable** vs **full** link-check split, what PR CI block
 on, and what runs as informational/nightly follow-up.
 
 Changes under `site/` are validated by [`.github/workflows/site-ci.yml`](./.github/workflows/site-ci.yml).
+
+To triage or merge a batch of **Dependabot PRs** for `site/`, use the
+[`sq-site-dependabot`](./.agents/skills/sq-site-dependabot/) agent skill (invoke
+explicitly in your agent, e.g. `/sq-site-dependabot` in Cursor). Full workflow
+content may still be expanding across PRs; see [AGENTS.md](./AGENTS.md#agent-skills-contributors).
 
 ### `site/` import background (maintainers)
 


### PR DESCRIPTION
This pull request introduces initial support and documentation for "**Agent Skills**" to help contributors and AI coding assistants triage and merge Dependabot pull requests in the repository. It adds two new skill scaffolds for handling Go module and site/Bun dependency updates, and provides comprehensive guidance for contributors and agents on using, installing, and verifying these skills. The changes also update contributor documentation to reference these new workflows and skill locations.

Adds scaffold Agent Skills under `.agents/skills/` for `sq-site-dependabot` and `sq-gomod-dependabot` (spec-compliant `SKILL.md` placeholders; full workflows land in a follow-up PR). Track `.claude/skills` as a symlink to `.agents/skills` for Claude Code, with a `.gitignore` exception so local `.claude` settings stay ignored.

User-facing sq CLI skill remains at `skills/sq/` for distribution, separate from contributor skills in `.agents/skills/`.

**Agent Skills: New Scaffolds and Documentation**

* Added `.agents/skills/sq-gomod-dependabot/SKILL.md`: Introduces a placeholder skill for reviewing and merging Dependabot PRs that update Go modules at the repo root. Provides minimal workflow steps and usage guidance.
* Added `.agents/skills/sq-site-dependabot/SKILL.md`: Adds a scaffold for a skill to handle Dependabot PRs for the `site/` directory (Bun/Hugo dependencies). Details when and how to use, with a note that a full workflow will follow in a subsequent PR.
* Added `.claude/skills`: Points to `.agents/skills` to enable Claude Code agent skill discovery.

**Contributor and Agent Guidance Updates**

* [`AGENTS.md`](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9R1-R208): New document providing detailed guidance for both human and AI contributors, including skill usage, installation, conventions, and driver development notes. Explains agent skill discovery and installation across different coding assistants.
* [`CLAUDE.md`](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7R6-R9): Updated to reference `AGENTS.md` for expanded agent skill documentation and installation instructions.
* [`CONTRIBUTING.md`](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055R8-R16): Now references `AGENTS.md` and the new agent skills for contributors and AI assistants, with installation instructions and cross-platform notes. Adds a section on using `sq-site-dependabot` for triaging/merging site Dependabot PRs. [[1]](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055R8-R16) [[2]](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055R27-R31)