### PR TITLE
slq(like,ilike): accept column selector as pattern argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,16 @@ Breaking changes are annotated with ☢️, and alpha/beta features with 🐥.
   [`ilike`](https://sq.io/docs/query#ilike) (`%` and `_` are
   wildcards). See [Query language](https://sq.io/docs/query) for
   per-driver behavior and SQLite ASCII-CI quirks.
+- [#628]: [`like`](https://sq.io/docs/query#like) and
+  [`ilike`](https://sq.io/docs/query#ilike) now accept a column
+  selector as the pattern argument (in addition to the existing
+  quoted-literal form), enabling column-vs-column matching such as
+  `where(like(.events.message, .rules.pattern))`. NULL values on
+  the RHS yield NULL from `LIKE`, which `WHERE` treats as false
+  (standard SQL semantics). The [`contains`](https://sq.io/docs/query#contains)
+  family stays literal-only by design: its auto-escape of wildcards
+  in the user pattern cannot be performed when the pattern is
+  resolved at execution time.
 
 ### Changed
 
@@ -1515,6 +1525,7 @@ make working with lots of sources much easier.
 [#601]: https://github.com/neilotoole/sq/issues/601
 [#602]: https://github.com/neilotoole/sq/pull/602
 [#615]: https://github.com/neilotoole/sq/issues/615
+[#628]: https://github.com/neilotoole/sq/issues/628
 [#629]: https://github.com/neilotoole/sq/issues/629
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,9 +38,10 @@ Breaking changes are annotated with ☢️, and alpha/beta features with 🐥.
   `where(like(.events.message, .rules.pattern))`. NULL values on
   the RHS yield NULL from `LIKE`, which `WHERE` treats as false
   (standard SQL semantics). The [`contains`](https://sq.io/docs/query#contains)
-  family stays literal-only by design: its auto-escape of wildcards
-  in the user pattern cannot be performed when the pattern is
-  resolved at execution time.
+  family stays literal-only: its render-time auto-escape of `%`/`_`
+  in the user pattern doesn't extend to a runtime column value, and
+  the per-driver SQL-level escaping that would replace it is out of
+  scope for v1.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,9 +32,9 @@ Breaking changes are annotated with ☢️, and alpha/beta features with 🐥.
   wildcards). See [Query language](https://sq.io/docs/query) for
   per-driver behavior and SQLite ASCII-CI quirks.
 - [#628]: [`like`](https://sq.io/docs/query#like) and
-  [`ilike`](https://sq.io/docs/query#ilike) now accept a column
-  selector as the pattern argument (in addition to the existing
-  quoted-literal form), enabling column-vs-column matching such as
+  [`ilike`](https://sq.io/docs/query#ilike) now accept either a
+  quoted string literal or a column selector as the pattern argument,
+  enabling column-vs-column matching such as
   `where(like(.events.message, .rules.pattern))`. NULL values on
   the RHS yield NULL from `LIKE`, which `WHERE` treats as false
   (standard SQL semantics). The [`contains`](https://sq.io/docs/query#contains)

--- a/libsq/ast/render/function_like.go
+++ b/libsq/ast/render/function_like.go
@@ -70,11 +70,14 @@ func buildLikePattern(s string, mode LikeMode, extraMeta string) string {
 }
 
 // ParseLikeArgs validates the shape of a substring-matching function call
-// (contains/startswith/endswith and their case-insensitive companions,
-// plus like/ilike) and returns the rendered column SQL and the unquoted
-// literal value. The first argument must be a column selector; the second
-// must be a quoted string literal. Other shapes are rejected with a clear
-// error. Exported for use by driver-specific overrides.
+// (contains/startswith/endswith and their case-insensitive companions)
+// and returns the rendered column SQL and the unquoted literal value.
+// The first argument must be a column selector; the second must be a
+// quoted string literal. Other shapes are rejected with a clear error.
+// Exported for use by driver-specific overrides.
+//
+// For like / ilike, which additionally accept a column selector as the
+// second argument, use [ParseLikePatternArgs].
 func ParseLikeArgs(rc *Context, fn *ast.FuncNode) (colSQL, literal string, err error) {
 	children := fn.Children()
 	if len(children) != 2 {
@@ -112,6 +115,63 @@ func ParseLikeArgs(rc *Context, fn *ast.FuncNode) (colSQL, literal string, err e
 			fn.FuncName())
 	}
 	return colSQL, val, nil
+}
+
+// ParseLikePatternArgs is the like / ilike companion to [ParseLikeArgs].
+// It validates the shape of a user-controlled-wildcard function call and
+// returns the rendered column SQL for the first argument plus the
+// rendered SQL for the second argument, which may be either a quoted
+// string literal (returned single-quoted, ready to splice into the
+// emitted LIKE clause) or a column selector (rendered via the dialect's
+// selector renderer). Mixed-form calls — like(.col, "lit") and
+// like(.col, .other_col) — are both accepted and dispatch on the
+// second-argument node type at parse time. Exported for use by
+// driver-specific overrides.
+func ParseLikePatternArgs(rc *Context, fn *ast.FuncNode) (colSQL, rhsSQL string, err error) {
+	children := fn.Children()
+	if len(children) != 2 {
+		return "", "", errz.Errorf(
+			"%s() requires exactly 2 arguments (column, pattern), got %d",
+			fn.FuncName(), len(children))
+	}
+
+	colNode, ok := ast.NodeUnwrap[ast.Node](children[0])
+	if !ok {
+		return "", "", errz.Errorf(
+			"%s() first argument must be a column selector", fn.FuncName())
+	}
+	colSQL, err = renderSelectorNode(rc.Dialect, colNode)
+	if err != nil {
+		return "", "", errz.Wrapf(err, "%s() first argument", fn.FuncName())
+	}
+
+	rhsNode, ok := ast.NodeUnwrap[ast.Node](children[1])
+	if !ok {
+		return "", "", errz.Errorf(
+			"%s() second argument must be a string literal or column selector",
+			fn.FuncName())
+	}
+
+	if lit, isLit := rhsNode.(*ast.LiteralNode); isLit {
+		val, wasQuoted, errLit := unquoteLiteral(lit.Text())
+		if errLit != nil {
+			return "", "", errz.Wrapf(errLit, "%s() second argument", fn.FuncName())
+		}
+		if !wasQuoted {
+			return "", "", errz.Errorf(
+				"%s() second argument must be a quoted string literal or column selector",
+				fn.FuncName())
+		}
+		return colSQL, stringz.SingleQuote(val), nil
+	}
+
+	rhsSQL, err = renderSelectorNode(rc.Dialect, rhsNode)
+	if err != nil {
+		return "", "", errz.Errorf(
+			"%s() second argument must be a string literal or column selector",
+			fn.FuncName())
+	}
+	return colSQL, rhsSQL, nil
 }
 
 // LikeOpts configures [RenderLikeOp]. Only Mode is required.
@@ -261,13 +321,16 @@ type LikeRawOpts struct {
 }
 
 // RenderLikeRaw renders the user-controlled LIKE shape used by SLQ's
-// like / ilike functions. Unlike [RenderLikeOp], the literal pattern
-// is bound verbatim: % and _ are wildcards, not escaped. Single
-// quotes inside the literal are still properly escaped by
-// SingleQuote. No `ESCAPE '|'` clause is emitted, so `|` is a literal
-// character on every driver. Other engine-default escape semantics
-// remain driver-specific — notably MySQL's default backslash escape
-// (`\`) still applies in `LIKE` patterns unless the session sets the
+// like / ilike functions. Unlike [RenderLikeOp], the pattern is bound
+// verbatim: % and _ are wildcards, not auto-escaped. The pattern may
+// be either a quoted string literal (single quotes inside are escaped
+// by SingleQuote) or a column selector (resolved per-row at execution
+// time). See [ParseLikePatternArgs] for the dispatch.
+//
+// No `ESCAPE '|'` clause is emitted, so `|` is a literal character on
+// every driver. Other engine-default escape semantics remain
+// driver-specific — notably MySQL's default backslash escape (`\`)
+// still applies in `LIKE` patterns unless the session sets the
 // `NO_BACKSLASH_ESCAPES` SQL mode. Users who need literal `%` / `_`
 // matching should use [RenderLikeOp] (SLQ's contains family), which
 // auto-escapes wildcards in the pattern.
@@ -279,7 +342,7 @@ func RenderLikeRaw(rc *Context, fn *ast.FuncNode, opts LikeRawOpts) (string, err
 	if opts.IgnoreCase && (opts.Op != "" || opts.ColCollate != "") {
 		panic("RenderLikeRaw: IgnoreCase is mutually exclusive with Op and ColCollate")
 	}
-	colSQL, lit, err := ParseLikeArgs(rc, fn)
+	colSQL, rhsSQL, err := ParseLikePatternArgs(rc, fn)
 	if err != nil {
 		return "", err
 	}
@@ -287,10 +350,9 @@ func RenderLikeRaw(rc *Context, fn *ast.FuncNode, opts LikeRawOpts) (string, err
 	if op == "" {
 		op = "LIKE"
 	}
-	litSQL := stringz.SingleQuote(lit)
 	if opts.IgnoreCase {
 		colSQL = "LOWER(" + colSQL + ")"
-		litSQL = "LOWER(" + litSQL + ")"
+		rhsSQL = "LOWER(" + rhsSQL + ")"
 	}
-	return colSQL + opts.ColCollate + " " + op + " " + litSQL, nil
+	return colSQL + opts.ColCollate + " " + op + " " + rhsSQL, nil
 }

--- a/libsq/ast/render/function_like.go
+++ b/libsq/ast/render/function_like.go
@@ -167,7 +167,7 @@ func ParseLikePatternArgs(rc *Context, fn *ast.FuncNode) (colSQL, rhsSQL string,
 
 	rhsSQL, err = renderSelectorNode(rc.Dialect, rhsNode)
 	if err != nil {
-		return "", "", errz.Errorf(
+		return "", "", errz.Wrapf(err,
 			"%s() second argument must be a string literal or column selector",
 			fn.FuncName())
 	}

--- a/libsq/ast/render/function_like.go
+++ b/libsq/ast/render/function_like.go
@@ -69,6 +69,36 @@ func buildLikePattern(s string, mode LikeMode, extraMeta string) string {
 	}
 }
 
+// parseLikeColArg is the shared LHS parser for the LIKE-family
+// arg-validation helpers. It checks the arg count, renders the first
+// argument (which must be a column selector), and returns the raw RHS
+// child node for the caller to unwrap and dispatch on. The two callers
+// (ParseLikeArgs and ParseLikePatternArgs) have different RHS contracts,
+// so RHS handling stays in each caller.
+//
+// SLQ parses function arguments as expression trees, so each child is
+// typically wrapped in an *ast.ExprNode. NodeUnwrap peels those
+// single-child wrappers to reach the underlying selector / literal
+// leaves; nodes with internal branching are rejected.
+func parseLikeColArg(rc *Context, fn *ast.FuncNode) (colSQL string, rhsChild ast.Node, err error) {
+	children := fn.Children()
+	if len(children) != 2 {
+		return "", nil, errz.Errorf(
+			"%s() requires exactly 2 arguments (column, pattern), got %d",
+			fn.FuncName(), len(children))
+	}
+	colNode, ok := ast.NodeUnwrap[ast.Node](children[0])
+	if !ok {
+		return "", nil, errz.Errorf(
+			"%s() first argument must be a column selector", fn.FuncName())
+	}
+	colSQL, err = renderSelectorNode(rc.Dialect, colNode)
+	if err != nil {
+		return "", nil, errz.Wrapf(err, "%s() first argument", fn.FuncName())
+	}
+	return colSQL, children[1], nil
+}
+
 // ParseLikeArgs validates the shape of a substring-matching function call
 // (contains/startswith/endswith and their case-insensitive companions)
 // and returns the rendered column SQL and the unquoted literal value.
@@ -79,28 +109,11 @@ func buildLikePattern(s string, mode LikeMode, extraMeta string) string {
 // For like / ilike, which additionally accept a column selector as the
 // second argument, use [ParseLikePatternArgs].
 func ParseLikeArgs(rc *Context, fn *ast.FuncNode) (colSQL, literal string, err error) {
-	children := fn.Children()
-	if len(children) != 2 {
-		return "", "", errz.Errorf(
-			"%s() requires exactly 2 arguments (column, pattern), got %d",
-			fn.FuncName(), len(children))
-	}
-
-	// SLQ parses function arguments as expression trees, so each child is
-	// typically wrapped in an *ast.ExprNode. Peel through single-child
-	// wrappers to reach the underlying selector and literal leaves; reject
-	// anything with internal branching.
-	colNode, ok := ast.NodeUnwrap[ast.Node](children[0])
-	if !ok {
-		return "", "", errz.Errorf(
-			"%s() first argument must be a column selector", fn.FuncName())
-	}
-	colSQL, err = renderSelectorNode(rc.Dialect, colNode)
+	colSQL, rhsChild, err := parseLikeColArg(rc, fn)
 	if err != nil {
-		return "", "", errz.Wrapf(err, "%s() first argument", fn.FuncName())
+		return "", "", err
 	}
-
-	litNode, ok := ast.NodeUnwrap[*ast.LiteralNode](children[1])
+	litNode, ok := ast.NodeUnwrap[*ast.LiteralNode](rhsChild)
 	if !ok {
 		return "", "", errz.Errorf(
 			"%s() second argument must be a string literal", fn.FuncName())
@@ -128,24 +141,11 @@ func ParseLikeArgs(rc *Context, fn *ast.FuncNode) (colSQL, literal string, err e
 // second-argument node type at parse time. Exported for use by
 // driver-specific overrides.
 func ParseLikePatternArgs(rc *Context, fn *ast.FuncNode) (colSQL, rhsSQL string, err error) {
-	children := fn.Children()
-	if len(children) != 2 {
-		return "", "", errz.Errorf(
-			"%s() requires exactly 2 arguments (column, pattern), got %d",
-			fn.FuncName(), len(children))
-	}
-
-	colNode, ok := ast.NodeUnwrap[ast.Node](children[0])
-	if !ok {
-		return "", "", errz.Errorf(
-			"%s() first argument must be a column selector", fn.FuncName())
-	}
-	colSQL, err = renderSelectorNode(rc.Dialect, colNode)
+	colSQL, rhsChild, err := parseLikeColArg(rc, fn)
 	if err != nil {
-		return "", "", errz.Wrapf(err, "%s() first argument", fn.FuncName())
+		return "", "", err
 	}
-
-	rhsNode, ok := ast.NodeUnwrap[ast.Node](children[1])
+	rhsNode, ok := ast.NodeUnwrap[ast.Node](rhsChild)
 	if !ok {
 		return "", "", errz.Errorf(
 			"%s() second argument must be a string literal or column selector",

--- a/libsq/query_string_test.go
+++ b/libsq/query_string_test.go
@@ -759,14 +759,67 @@ func TestQuery_string_like(t *testing.T) {
 			wantRecCount: 0,
 		},
 		{
+			// Column-as-pattern (#628): RHS is a column selector, not a
+			// quoted literal. No actor in sakila has first_name equal to
+			// last_name (pattern has no wildcards, so plain LIKE is an
+			// exact match on case-sensitive drivers; SQLite's default
+			// LIKE is ASCII-CI but still no exact case-insensitive
+			// match exists either) → 0 rows on every driver.
+			name:    "like/column-rhs",
+			in:      `@sakila | .actor | where(like(.first_name, .last_name))`,
+			wantSQL: `SELECT * FROM "actor" WHERE "first_name" LIKE "last_name"`,
+			override: driverMap{
+				drivertype.MySQL:      "SELECT * FROM `actor` WHERE `first_name` LIKE BINARY `last_name`",
+				drivertype.MSSQL:      `SELECT * FROM "actor" WHERE "first_name" COLLATE Latin1_General_BIN2 LIKE "last_name"`,
+				drivertype.ClickHouse: "SELECT * FROM `actor` WHERE `first_name` LIKE `last_name`",
+			},
+			wantRecCount: 0,
+		},
+		{
+			// Column-as-pattern with table-qualified selectors. Pins
+			// that *ast.TblColSelectorNode renders correctly on the RHS
+			// (not just the LHS, which the literal-pattern tests above
+			// already covered implicitly).
+			name:    "like/column-rhs-table-prefixed",
+			in:      `@sakila | .actor | where(like(.actor.first_name, .actor.last_name))`,
+			wantSQL: `SELECT * FROM "actor" WHERE "actor"."first_name" LIKE "actor"."last_name"`,
+			override: driverMap{
+				drivertype.MySQL:      "SELECT * FROM `actor` WHERE `actor`.`first_name` LIKE BINARY `actor`.`last_name`",
+				drivertype.MSSQL:      `SELECT * FROM "actor" WHERE "actor"."first_name" COLLATE Latin1_General_BIN2 LIKE "actor"."last_name"`,
+				drivertype.ClickHouse: "SELECT * FROM `actor` WHERE `actor`.`first_name` LIKE `actor`.`last_name`",
+			},
+			wantRecCount: 0,
+		},
+		{
+			// NULL semantics for column-RHS: sakila's address.address2
+			// is nullable and mostly NULL. `col LIKE NULL` returns NULL
+			// on every driver, and WHERE treats NULL as false, so those
+			// rows are filtered out. Non-NULL address2 values never
+			// equal their address column either → 0 rows total.
+			// Documents standard SQL behavior (issue #628 open
+			// question 3) and pins that column-RHS doesn't error on
+			// NULL pattern values.
+			name:    "like/column-rhs-null-handling",
+			in:      `@sakila | .address | where(like(.address, .address2))`,
+			wantSQL: `SELECT * FROM "address" WHERE "address" LIKE "address2"`,
+			override: driverMap{
+				drivertype.MySQL:      "SELECT * FROM `address` WHERE `address` LIKE BINARY `address2`",
+				drivertype.MSSQL:      `SELECT * FROM "address" WHERE "address" COLLATE Latin1_General_BIN2 LIKE "address2"`,
+				drivertype.ClickHouse: "SELECT * FROM `address` WHERE `address` LIKE `address2`",
+			},
+			wantRecCount: 0,
+		},
+		{
 			name:            "like/wrong-arg-count",
 			in:              `@sakila | .actor | where(like(.first_name))`,
 			wantErrContains: "like() requires exactly 2 arguments",
 		},
 		{
-			name:            "like/non-literal-pattern",
-			in:              `@sakila | .actor | where(like(.first_name, .last_name))`,
-			wantErrContains: "like() second argument must be a string literal",
+			// Numeric (unquoted) literal RHS is still rejected post-#628;
+			// only string literals and column selectors are accepted.
+			name:            "like/numeric-rhs-rejected",
+			in:              `@sakila | .actor | where(like(.first_name, 42))`,
+			wantErrContains: "like() second argument must be a quoted string literal or column selector",
 		},
 	}
 
@@ -777,7 +830,7 @@ func TestQuery_string_like(t *testing.T) {
 	}
 }
 
-//nolint:exhaustive
+//nolint:exhaustive,lll
 func TestQuery_string_ilike(t *testing.T) {
 	testCases := []queryTestCase{
 		{
@@ -871,14 +924,70 @@ func TestQuery_string_ilike(t *testing.T) {
 			wantRecCount: 0,
 		},
 		{
+			// Column-as-pattern (#628) for ilike. Case-insensitive
+			// column-vs-column comparison: no actor has first_name
+			// matching last_name case-insensitively → 0 rows on
+			// every driver. Pins the LOWER-wrap on both sides
+			// (default / MySQL / Oracle paths) and the native
+			// ILIKE variants (PG / DuckDB / ClickHouse).
+			name:    "ilike/column-rhs",
+			in:      `@sakila | .actor | where(ilike(.first_name, .last_name))`,
+			wantSQL: `SELECT * FROM "actor" WHERE LOWER("first_name") LIKE LOWER("last_name")`,
+			override: driverMap{
+				drivertype.Pg:         `SELECT * FROM "actor" WHERE "first_name" ILIKE "last_name"`,
+				drivertype.DuckDB:     `SELECT * FROM "actor" WHERE "first_name" ILIKE "last_name"`,
+				drivertype.SQLite:     `SELECT * FROM "actor" WHERE "first_name" LIKE "last_name"`,
+				drivertype.MySQL:      "SELECT * FROM `actor` WHERE LOWER(`first_name`) LIKE LOWER(`last_name`)",
+				drivertype.MSSQL:      `SELECT * FROM "actor" WHERE "first_name" COLLATE Latin1_General_CI_AS LIKE "last_name"`,
+				drivertype.ClickHouse: "SELECT * FROM `actor` WHERE `first_name` ILIKE `last_name`",
+			},
+			wantRecCount: 0,
+		},
+		{
+			// Column-as-pattern with table-qualified selectors for ilike.
+			// Pins TblColSelectorNode rendering on the RHS under LOWER
+			// wrap (where applicable) and inside the COLLATE clause.
+			name:    "ilike/column-rhs-table-prefixed",
+			in:      `@sakila | .actor | where(ilike(.actor.first_name, .actor.last_name))`,
+			wantSQL: `SELECT * FROM "actor" WHERE LOWER("actor"."first_name") LIKE LOWER("actor"."last_name")`,
+			override: driverMap{
+				drivertype.Pg:         `SELECT * FROM "actor" WHERE "actor"."first_name" ILIKE "actor"."last_name"`,
+				drivertype.DuckDB:     `SELECT * FROM "actor" WHERE "actor"."first_name" ILIKE "actor"."last_name"`,
+				drivertype.SQLite:     `SELECT * FROM "actor" WHERE "actor"."first_name" LIKE "actor"."last_name"`,
+				drivertype.MySQL:      "SELECT * FROM `actor` WHERE LOWER(`actor`.`first_name`) LIKE LOWER(`actor`.`last_name`)",
+				drivertype.MSSQL:      `SELECT * FROM "actor" WHERE "actor"."first_name" COLLATE Latin1_General_CI_AS LIKE "actor"."last_name"`,
+				drivertype.ClickHouse: "SELECT * FROM `actor` WHERE `actor`.`first_name` ILIKE `actor`.`last_name`",
+			},
+			wantRecCount: 0,
+		},
+		{
+			// NULL semantics for ilike column-RHS, mirroring the like
+			// equivalent. Most address2 values are NULL → ILIKE NULL
+			// is NULL → WHERE filters → 0 rows.
+			name:    "ilike/column-rhs-null-handling",
+			in:      `@sakila | .address | where(ilike(.address, .address2))`,
+			wantSQL: `SELECT * FROM "address" WHERE LOWER("address") LIKE LOWER("address2")`,
+			override: driverMap{
+				drivertype.Pg:         `SELECT * FROM "address" WHERE "address" ILIKE "address2"`,
+				drivertype.DuckDB:     `SELECT * FROM "address" WHERE "address" ILIKE "address2"`,
+				drivertype.SQLite:     `SELECT * FROM "address" WHERE "address" LIKE "address2"`,
+				drivertype.MySQL:      "SELECT * FROM `address` WHERE LOWER(`address`) LIKE LOWER(`address2`)",
+				drivertype.MSSQL:      `SELECT * FROM "address" WHERE "address" COLLATE Latin1_General_CI_AS LIKE "address2"`,
+				drivertype.ClickHouse: "SELECT * FROM `address` WHERE `address` ILIKE `address2`",
+			},
+			wantRecCount: 0,
+		},
+		{
 			name:            "ilike/wrong-arg-count",
 			in:              `@sakila | .actor | where(ilike(.first_name))`,
 			wantErrContains: "ilike() requires exactly 2 arguments",
 		},
 		{
-			name:            "ilike/non-literal-pattern",
-			in:              `@sakila | .actor | where(ilike(.first_name, .last_name))`,
-			wantErrContains: "ilike() second argument must be a string literal",
+			// Numeric (unquoted) literal RHS is still rejected post-#628;
+			// only string literals and column selectors are accepted.
+			name:            "ilike/numeric-rhs-rejected",
+			in:              `@sakila | .actor | where(ilike(.first_name, 42))`,
+			wantErrContains: "ilike() second argument must be a quoted string literal or column selector",
 		},
 	}
 

--- a/libsq/query_string_test.go
+++ b/libsq/query_string_test.go
@@ -776,6 +776,24 @@ func TestQuery_string_like(t *testing.T) {
 			wantRecCount: 0,
 		},
 		{
+			// Positive-match column-RHS: every row matches itself. No
+			// wildcards, so plain LIKE is an exact match — and a row's
+			// first_name is always exactly equal to its own first_name
+			// → all 200 sakila actors match on every driver. Catches
+			// regressions where column-RHS renders syntactically valid
+			// SQL but evaluates false for every row (which the 0-row
+			// tests above could not distinguish from "feature broken").
+			name:    "like/column-rhs-self-reference-matches-all",
+			in:      `@sakila | .actor | where(like(.first_name, .first_name))`,
+			wantSQL: `SELECT * FROM "actor" WHERE "first_name" LIKE "first_name"`,
+			override: driverMap{
+				drivertype.MySQL:      "SELECT * FROM `actor` WHERE `first_name` LIKE BINARY `first_name`",
+				drivertype.MSSQL:      `SELECT * FROM "actor" WHERE "first_name" COLLATE Latin1_General_BIN2 LIKE "first_name"`,
+				drivertype.ClickHouse: "SELECT * FROM `actor` WHERE `first_name` LIKE `first_name`",
+			},
+			wantRecCount: 200,
+		},
+		{
 			// Column-as-pattern with table-qualified selectors. Pins
 			// that *ast.TblColSelectorNode renders correctly on the RHS
 			// (not just the LHS, which the literal-pattern tests above
@@ -972,6 +990,25 @@ func TestQuery_string_ilike(t *testing.T) {
 				drivertype.ClickHouse: "SELECT * FROM `actor` WHERE `first_name` ILIKE `last_name`",
 			},
 			wantRecCount: 0,
+		},
+		{
+			// Positive-match column-RHS for ilike (mirror of the like
+			// equivalent). Every row matches itself case-insensitively
+			// → all 200 actors. Catches the same regression class on
+			// the ILIKE renderer path: column-RHS renders valid SQL
+			// but evaluates false for every row.
+			name:    "ilike/column-rhs-self-reference-matches-all",
+			in:      `@sakila | .actor | where(ilike(.first_name, .first_name))`,
+			wantSQL: `SELECT * FROM "actor" WHERE LOWER("first_name") LIKE LOWER("first_name")`,
+			override: driverMap{
+				drivertype.Pg:         `SELECT * FROM "actor" WHERE "first_name" ILIKE "first_name"`,
+				drivertype.DuckDB:     `SELECT * FROM "actor" WHERE "first_name" ILIKE "first_name"`,
+				drivertype.SQLite:     `SELECT * FROM "actor" WHERE "first_name" LIKE "first_name"`,
+				drivertype.MySQL:      "SELECT * FROM `actor` WHERE LOWER(`first_name`) LIKE LOWER(`first_name`)",
+				drivertype.MSSQL:      `SELECT * FROM "actor" WHERE "first_name" COLLATE Latin1_General_CI_AS LIKE "first_name"`,
+				drivertype.ClickHouse: "SELECT * FROM `actor` WHERE `first_name` ILIKE `first_name`",
+			},
+			wantRecCount: 200,
 		},
 		{
 			// Column-as-pattern with table-qualified selectors for ilike.

--- a/libsq/query_string_test.go
+++ b/libsq/query_string_test.go
@@ -821,6 +821,36 @@ func TestQuery_string_like(t *testing.T) {
 			in:              `@sakila | .actor | where(like(.first_name, 42))`,
 			wantErrContains: "like() second argument must be a quoted string literal or column selector",
 		},
+		{
+			// A binary-expression RHS (here, a comparison) is rejected:
+			// NodeUnwrap sees branching and the parser surfaces the
+			// expected-shape error. Pins the !ok branch of the
+			// ParseLikePatternArgs RHS dispatch — the numeric test above
+			// only covers the unquoted-literal branch.
+			name:            "like/expression-rhs-rejected",
+			in:              `@sakila | .actor | where(like(.first_name, .last_name == .first_name))`,
+			wantErrContains: "like() second argument must be a string literal or column selector",
+		},
+		{
+			// *ast.TblSelectorNode RHS (`.actor` — bare table, not a
+			// column) is silently accepted: renderSelectorNode renders
+			// it as a quoted identifier, producing nonsensical-but-valid
+			// SQL. The current lenient stance is consistent with where /
+			// orderby, which use the same selector helper. We pin the
+			// SQL shape (skipExec since the resulting query references
+			// an identifier that doesn't resolve to a column at runtime)
+			// so any future stricter dispatch in ParseLikePatternArgs is
+			// a deliberate change, not silent drift.
+			name:    "like/table-selector-rhs-renders-as-identifier",
+			in:      `@sakila | .actor | where(like(.first_name, .actor))`,
+			wantSQL: `SELECT * FROM "actor" WHERE "first_name" LIKE "actor"`,
+			override: driverMap{
+				drivertype.MySQL:      "SELECT * FROM `actor` WHERE `first_name` LIKE BINARY `actor`",
+				drivertype.MSSQL:      `SELECT * FROM "actor" WHERE "first_name" COLLATE Latin1_General_BIN2 LIKE "actor"`,
+				drivertype.ClickHouse: "SELECT * FROM `actor` WHERE `first_name` LIKE `actor`",
+			},
+			skipExec: true,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -988,6 +1018,13 @@ func TestQuery_string_ilike(t *testing.T) {
 			name:            "ilike/numeric-rhs-rejected",
 			in:              `@sakila | .actor | where(ilike(.first_name, 42))`,
 			wantErrContains: "ilike() second argument must be a quoted string literal or column selector",
+		},
+		{
+			// Mirror of like/expression-rhs-rejected for the ILIKE
+			// renderer path.
+			name:            "ilike/expression-rhs-rejected",
+			in:              `@sakila | .actor | where(ilike(.first_name, .last_name == .first_name))`,
+			wantErrContains: "ilike() second argument must be a string literal or column selector",
 		},
 	}
 

--- a/site/content/en/docs/query/index.md
+++ b/site/content/en/docs/query/index.md
@@ -1034,9 +1034,11 @@ false (row excluded); this matches standard SQL semantics. Wildcards
 pattern — they are not auto-escaped, since the value isn't known
 until execution.
 
-The [`contains`](#contains) family stays literal-only by design: its
-auto-escape of wildcards in the user pattern can't be performed when
-the pattern is a column reference resolved at query time.
+The [`contains`](#contains) family stays literal-only by design. Its
+auto-escape of wildcards in the user pattern is performed at SLQ-render
+time over a known string; extending it to a column RHS would require
+emitting per-driver SQL-level escaping (e.g. nested `REPLACE` chains)
+that's out of scope for v1.
 
 ### `max`
 

--- a/site/content/en/docs/query/index.md
+++ b/site/content/en/docs/query/index.md
@@ -949,9 +949,9 @@ Per-driver implementation:
 - **ClickHouse:** native `ILIKE`.
 
 No `ESCAPE '|'` clause is emitted on any driver — see [`like`](#like)
-for escape behavior and column-as-pattern semantics. For literal
-`%` / `_` matching, use [`icontains`](#icontains), which auto-escapes
-wildcards.
+for escape behavior and [Column as pattern](#column-as-pattern) for
+column-RHS semantics. For literal `%` / `_` matching, use
+[`icontains`](#icontains), which auto-escapes wildcards.
 
 ### `istartswith`
 
@@ -1022,16 +1022,17 @@ The pattern argument can be a column selector instead of a quoted
 string literal, enabling column-vs-column matching:
 
 ```shell
-$ sq '.events | where(like(.message, .pattern))'
 $ sq '.actor | where(ilike(.first_name, .last_name))'
+$ sq '.events | where(like(.message, .pattern))'
 ```
 
-Useful for fuzzy joins, matching stored rules against incoming data,
-and similar data-wrangling workflows. NULL values in the RHS column
-yield NULL from `LIKE`, which `WHERE` treats as false (row excluded);
-this matches standard SQL semantics. Wildcards (`%`, `_`) in the RHS
-column's data behave exactly as in a literal pattern — they are not
-auto-escaped, since the value isn't known until execution.
+Useful for matching stored rules against incoming data, correlated
+pattern lookups, and similar data-wrangling workflows. NULL values
+in the RHS column yield NULL from `LIKE`, which `WHERE` treats as
+false (row excluded); this matches standard SQL semantics. Wildcards
+(`%`, `_`) in the RHS column's data behave exactly as in a literal
+pattern — they are not auto-escaped, since the value isn't known
+until execution.
 
 The [`contains`](#contains) family stays literal-only by design: its
 auto-escape of wildcards in the user pattern can't be performed when

--- a/site/content/en/docs/query/index.md
+++ b/site/content/en/docs/query/index.md
@@ -932,10 +932,12 @@ matches every non-NULL row.
 
 `ilike(col, pattern)` is the case-insensitive counterpart to
 [`like`](#like). `%` and `_` are wildcards in `pattern` and are not
-auto-escaped.
+auto-escaped. As with `like`, `pattern` may be either a quoted string
+literal or a column selector.
 
 ```shell
 $ sq '.actor | where(ilike(.first_name, "pen%"))'
+$ sq '.actor | where(ilike(.first_name, .last_name))'
 ```
 
 Per-driver implementation:
@@ -947,8 +949,9 @@ Per-driver implementation:
 - **ClickHouse:** native `ILIKE`.
 
 No `ESCAPE '|'` clause is emitted on any driver — see [`like`](#like)
-for escape behavior. For literal `%` / `_` matching, use
-[`icontains`](#icontains), which auto-escapes wildcards.
+for escape behavior and column-as-pattern semantics. For literal
+`%` / `_` matching, use [`icontains`](#icontains), which auto-escapes
+wildcards.
 
 ### `istartswith`
 
@@ -970,7 +973,9 @@ matches every non-NULL row.
 `like(col, pattern)` exposes raw `LIKE`-pattern matching, where `%`
 matches any sequence and `_` matches any single character. Unlike
 [`contains`](#contains) and friends, wildcards in `pattern` are
-**not** auto-escaped: the user controls them.
+**not** auto-escaped: the user controls them. `pattern` may be either
+a quoted string literal or a column selector — see [Column as
+pattern](#column-as-pattern) below.
 
 ```shell
 $ sq '.actor | where(like(.first_name, "Pen%"))'
@@ -1004,14 +1009,33 @@ driver-specific — notably MySQL's default backslash escape (`\`) still
 applies in `LIKE` patterns unless the session sets the
 `NO_BACKSLASH_ESCAPES` SQL mode. If you need to match a literal `%` or
 `_` rather than treat them as wildcards, use [`contains`](#contains),
-which auto-escapes wildcards in the pattern. For column-as-pattern
-(`like(.col_a, .col_b)`), see
-[issue #628](https://github.com/neilotoole/sq/issues/628).
+which auto-escapes wildcards in the pattern.
 
 An empty pattern matches only empty strings (`col = ''`) — not every
 non-NULL row, in contrast with [`contains`](#contains)`(.col, "")`.
 That difference is intentional and matches standard SQL `LIKE`
 semantics.
+
+#### Column as pattern
+
+The pattern argument can be a column selector instead of a quoted
+string literal, enabling column-vs-column matching:
+
+```shell
+$ sq '.events | where(like(.message, .pattern))'
+$ sq '.actor | where(ilike(.first_name, .last_name))'
+```
+
+Useful for fuzzy joins, matching stored rules against incoming data,
+and similar data-wrangling workflows. NULL values in the RHS column
+yield NULL from `LIKE`, which `WHERE` treats as false (row excluded);
+this matches standard SQL semantics. Wildcards (`%`, `_`) in the RHS
+column's data behave exactly as in a literal pattern — they are not
+auto-escaped, since the value isn't known until execution.
+
+The [`contains`](#contains) family stays literal-only by design: its
+auto-escape of wildcards in the user pattern can't be performed when
+the pattern is a column reference resolved at query time.
 
 ### `max`
 


### PR DESCRIPTION
## Summary

Closes [#628](https://github.com/neilotoole/sq/issues/628). `like` and
`ilike` now accept a column reference as the pattern argument, enabling
column-vs-column matching:

```shell
$ sq '.events | where(like(.message, .rules.pattern))'
$ sq '.actor  | where(ilike(.first_name, .last_name))'
```

The existing literal-pattern form is unchanged; the two are
interchangeable per call. The `contains` family stays literal-only by
design — its auto-escape of wildcards in the user pattern cannot be
performed when the pattern is resolved at execution time (explicit
non-goal in the issue).

NULL on the RHS yields NULL from `LIKE`, which `WHERE` treats as false
(standard SQL behavior, issue's open question 3). Wildcards (`%`, `_`)
in the RHS column's *data* behave exactly as in a literal pattern —
they are not auto-escaped.

## Changes

- **`libsq/ast/render/function_like.go`**: new `ParseLikePatternArgs`
  forks the literal/column dispatch out of `ParseLikeArgs` (which
  stays unchanged and continues serving `RenderLikeOp` / the
  `contains` family). The new parser tries `*ast.LiteralNode` first
  (existing path → `stringz.SingleQuote`); otherwise delegates to
  `renderSelectorNode` to accept `*ast.ColSelectorNode` /
  `*ast.TblColSelectorNode` / `*ast.TblSelectorNode`. Anything else
  errors with `"<fn>() second argument must be a string literal or
  column selector"`. Unquoted-literal RHS (e.g. numeric `42`) gets
  the parallel `"quoted string literal or column selector"` message.
  `RenderLikeRaw` swaps to the new parser; the LOWER-wrap for
  `IgnoreCase` composes identically over either form.
- **No per-driver code changes.** Every `like`/`ilike` override
  (MySQL `LIKE BINARY`, SQL Server `COLLATE`, SQLite, ClickHouse
  `ILIKE`, default LOWER-wrap) routes through `RenderLikeRaw` and
  inherits the new behavior. Verified by re-running the full
  like-family suite against all 6 configured drivers.
- **`libsq/query_string_test.go`**: 6 new sub-tests across
  `TestQuery_string_like` / `TestQuery_string_ilike`:
  - `{like,ilike}/column-rhs` — bare column selector on RHS;
    `.first_name` vs `.last_name` on actor; 0 rows; per-driver SQL
    pinned (MySQL `LIKE BINARY`, MSSQL `COLLATE …`, ClickHouse ILIKE,
    default LOWER-wrap, etc.).
  - `{like,ilike}/column-rhs-table-prefixed` — `*ast.TblColSelectorNode`
    on RHS; pins the qualified-column rendering inside LOWER-wrap and
    COLLATE clauses.
  - `{like,ilike}/column-rhs-null-handling` — `address.address2`
    (mostly NULL) as RHS; documents that `col LIKE NULL → NULL →
    false under WHERE` works without erroring.

  The existing `{like,ilike}/non-literal-pattern` error tests are
  replaced with `{like,ilike}/numeric-rhs-rejected`, which pin the
  new error message for unquoted-literal RHS.
- **`site/content/en/docs/query/index.md`**: updates the `like` /
  `ilike` signature paragraphs; adds a "Column as pattern"
  subsection under `like` with the motivating example, NULL
  semantics note, and the rationale for keeping `contains`
  literal-only.
- **`CHANGELOG.md`**: entry under `## Unreleased > ### Added`.

## Out of scope

- Column-RHS for the `contains` family (explicit non-goal in #628).
- Arbitrary SQL expressions on the RHS — e.g. `like(.col, concat(...))`
  — issue's open question 2; tracked as future work.

## Test plan

- [x] `make lint` clean (0 issues).
- [x] All 8 like-family tests (`TestQuery_string_{contains,startswith,endswith,icontains,istartswith,iendswith,like,ilike}`)
  pass against all 6 configured drivers (sqlite3, postgres, mysql,
  sqlserver, clickhouse, oracle).
- [x] 6 new column-RHS sub-tests pass per driver — total 36 driver
  matrix passes for the new feature.
- [x] Contains family unchanged (still uses `ParseLikeArgs`, still
  literal-only): regression-tested.