### PR TITLE
(Fix) Usage of netlify-cli in site-dependabot skill.

### DIFF
--- a/.agents/skills/sq-site-dependabot/SKILL.md
+++ b/.agents/skills/sq-site-dependabot/SKILL.md
@@ -39,12 +39,17 @@ Default to **Audit** unless the user says "merge", "clear them", or "full".
 Run first in every mode. Stop on failure.
 
 ```bash
-# gh auth + site tooling (see site/Makefile: make check)
+# gh auth + site deps (bun install if needed) + make check
 .agents/skills/sq-site-dependabot/scripts/check-tools.sh
 # Full / Layer B (+ NETLIFY_* via make check-netlify):
 .agents/skills/sq-site-dependabot/scripts/check-tools.sh --netlify
-# Or: gh api user -q .login && cd site && make check-netlify
+# Or: gh api user -q .login && cd site && bun install && make check-netlify
 ```
+
+`check-tools.sh` runs `bun install` in `site/` when `bun x netlify-cli` is missing
+(fresh clone, agent sandbox). Needs network. `SKIP_SITE_DEPS=1` skips that step.
+Layer B (`site-netlify-validate`) always uses `bun x netlify-cli` — a global/brew
+CLI does not replace `bun install`.
 
 Details: [references/tool-bootstrap.md](references/tool-bootstrap.md).
 

--- a/.agents/skills/sq-site-dependabot/references/tool-bootstrap.md
+++ b/.agents/skills/sq-site-dependabot/references/tool-bootstrap.md
@@ -9,6 +9,20 @@ fails and install or authenticate before continuing.
 - **Site tools** — `cd site && make check`. Validate, Full.
 - **Netlify env** — `cd site && make check-netlify`. Layer B, Full only.
 
+### Agents and fresh checkouts
+
+`check-tools.sh` runs `bun install` in `site/` when `bun x netlify-cli` is not
+available (common in sandboxes without `node_modules`). Requires network access.
+
+- **Do not rely on `brew install netlify-cli` alone** — `make site-netlify-validate`
+  invokes `bun x netlify-cli` (lockfile-pinned devDependency).
+- `make check` may warn if only a global `netlify` is on PATH; install site deps
+  before Full mode.
+- `SKIP_SITE_DEPS=1` — skip auto `bun install` when deps are already present.
+- **Cursor / agent sandbox:** `make check` runs `bun x netlify-cli`. If Phase 0
+  fails after `bun install`, re-run with permissions that allow executing
+  `site/node_modules` binaries (not only `brew install netlify-cli`).
+
 ## Netlify credentials (Validate Layer B / Full only)
 
 Maintainers store credentials in **`site/.env`** (gitignored). Template:
@@ -69,7 +83,8 @@ cd site && make check-netlify
   `PAGER=less` does not pause at `(END)` mid-run.
 - **Bun:** [bun.sh](https://bun.sh) — pin to `site/netlify.toml` /
   [site-ci.yml](../../../../.github/workflows/site-ci.yml)
-- **Netlify CLI:** `cd site && bun install` (devDependency)
+- **Netlify CLI:** `cd site && bun install` then `bun x netlify-cli --version`
+  (not brew-only for Layer B)
 - **checkenv:** `site/scripts/checkenv.bash` (via `make check-env --merge`)
 
 ## Working directory

--- a/.agents/skills/sq-site-dependabot/references/tool-bootstrap.md
+++ b/.agents/skills/sq-site-dependabot/references/tool-bootstrap.md
@@ -14,10 +14,9 @@ fails and install or authenticate before continuing.
 `check-tools.sh` runs `bun install` in `site/` when `bun x netlify-cli` is not
 available (common in sandboxes without `node_modules`). Requires network access.
 
-- **Do not rely on `brew install netlify-cli` alone** — `make site-netlify-validate`
-  invokes `bun x netlify-cli` (lockfile-pinned devDependency).
-- `make check` may warn if only a global `netlify` is on PATH; install site deps
-  before Full mode.
+- **Do not rely on `brew install netlify-cli` alone** — `make check` and
+  `make site-netlify-validate` require `bun x netlify-cli` (lockfile devDependency).
+  A global/brew `netlify` on PATH does not satisfy the check.
 - `SKIP_SITE_DEPS=1` — skip auto `bun install` when deps are already present.
 - **Cursor / agent sandbox:** `make check` runs `bun x netlify-cli`. If Phase 0
   fails after `bun install`, re-run with permissions that allow executing

--- a/.agents/skills/sq-site-dependabot/scripts/check-tools.sh
+++ b/.agents/skills/sq-site-dependabot/scripts/check-tools.sh
@@ -22,11 +22,41 @@ fi
 gh_login=$(gh api user -q .login)
 echo "Logged in as ${gh_login}"
 
-echo "==> Site tooling (make check)"
 if [ ! -d "${SITE_DIR}" ]; then
 	echo "site/ not found at ${SITE_DIR}" >&2
 	exit 1
 fi
+
+# Netlify CLI is a site devDependency (bun x netlify-cli). Agents and fresh
+# checkouts often lack node_modules; install before make check. Layer B also
+# requires bun x (brew netlify alone is not enough for site-netlify-validate).
+netlify_cli_in_node_modules() {
+	[ -f "${SITE_DIR}/node_modules/netlify-cli/package.json" ]
+}
+
+ensure_site_deps() {
+	if [ "${SKIP_SITE_DEPS:-}" = "1" ]; then
+		echo "==> Site dependencies (skipped: SKIP_SITE_DEPS=1)"
+		return 0
+	fi
+	echo "==> Site dependencies"
+	if netlify_cli_in_node_modules; then
+		echo "netlify-cli present in site/node_modules"
+		return 0
+	fi
+	echo "netlify-cli not in node_modules; running bun install (needs network)…"
+	(cd "${SITE_DIR}" && bun install)
+	if ! netlify_cli_in_node_modules; then
+		echo "error: netlify-cli still missing after bun install" >&2
+		echo "From site/: bun install. Full mode requires bun x, not only brew netlify-cli." >&2
+		exit 1
+	fi
+	echo "netlify-cli installed (verify with: cd site && bun x netlify-cli --version)"
+}
+
+ensure_site_deps
+
+echo "==> Site tooling (make check)"
 if [ "${1:-}" = "--netlify" ]; then
 	(cd "${SITE_DIR}" && make check-netlify)
 else

--- a/site/Common.make
+++ b/site/Common.make
@@ -112,13 +112,16 @@ check_docker:
 		exit 1; \
 	fi
 
-# Check Netlify CLI (site devDependency; run from site/ after bun install)
+# Check Netlify CLI (site devDependency; Layer B uses bun x — brew alone is not enough)
 check_netlify_cli:
 	@if bun x netlify-cli --version >/dev/null 2>&1; then \
 		NETLIFY_VER=$$(bun x netlify-cli --version 2>/dev/null | head -1); \
 		$(LOGGER) log_info_dim "Netlify CLI $$NETLIFY_VER (via bun x)."; \
+	elif command -v netlify >/dev/null 2>&1 && netlify --version >/dev/null 2>&1; then \
+		NETLIFY_VER=$$(netlify --version 2>/dev/null | head -1); \
+		$(LOGGER) log_warning "Netlify CLI $$NETLIFY_VER on PATH only; run 'bun install' in site/ for lockfile CLI (required for site-netlify-validate)."; \
 	else \
-		$(LOGGER) log_error "Netlify CLI not available. Run: bun install"; \
+		$(LOGGER) log_error "Netlify CLI not available. From site/: bun install"; \
 		exit 1; \
 	fi
 

--- a/site/Common.make
+++ b/site/Common.make
@@ -112,16 +112,16 @@ check_docker:
 		exit 1; \
 	fi
 
-# Check Netlify CLI (site devDependency; Layer B uses bun x — brew alone is not enough)
+# Check lockfile-pinned Netlify CLI (site-netlify-validate uses bun x; PATH/brew is not accepted)
 check_netlify_cli:
 	@if bun x netlify-cli --version >/dev/null 2>&1; then \
 		NETLIFY_VER=$$(bun x netlify-cli --version 2>/dev/null | head -1); \
 		$(LOGGER) log_info_dim "Netlify CLI $$NETLIFY_VER (via bun x)."; \
-	elif command -v netlify >/dev/null 2>&1 && netlify --version >/dev/null 2>&1; then \
-		NETLIFY_VER=$$(netlify --version 2>/dev/null | head -1); \
-		$(LOGGER) log_warning "Netlify CLI $$NETLIFY_VER on PATH only; run 'bun install' in site/ for lockfile CLI (required for site-netlify-validate)."; \
 	else \
-		$(LOGGER) log_error "Netlify CLI not available. From site/: bun install"; \
+		$(LOGGER) log_error "Netlify CLI not available via bun x. From site/: bun install"; \
+		if command -v netlify >/dev/null 2>&1; then \
+			$(LOGGER) log_error "A global/brew netlify CLI is on PATH but Layer B requires site/node_modules (lockfile)."; \
+		fi; \
 		exit 1; \
 	fi
 

--- a/site/scripts/netlify-deploy-validate.sh
+++ b/site/scripts/netlify-deploy-validate.sh
@@ -45,6 +45,14 @@ if ! command -v jq >/dev/null 2>&1; then
 	exit 1
 fi
 
+if ! bun x netlify-cli --version >/dev/null 2>&1; then
+	log_error "netlify-cli not available via bun x (run: cd site && bun install)."
+	if command -v netlify >/dev/null 2>&1; then
+		log_error "A global/brew netlify CLI is on PATH; site-netlify-validate requires the lockfile devDependency."
+	fi
+	exit 1
+fi
+
 DEPLOY_MESSAGE="${MESSAGE:-dependabot-validate $(date -u +%Y-%m-%dT%H:%MZ)}"
 deploy_json=$(mktemp)
 trap 'rm -f "${deploy_json}"' EXIT


### PR DESCRIPTION
This pull request improves the reliability of Netlify CLI usage in local and agent environments by ensuring that `bun install` is used to install the lockfile-pinned Netlify CLI as a site devDependency, rather than relying on a globally installed version. The documentation and tooling scripts are updated to clarify and enforce this requirement, reducing issues in fresh checkouts and CI sandboxes.

**Tooling improvements:**

* Updated `check-tools.sh` to automatically run `bun install` in `site/` if `netlify-cli` is missing from `node_modules`, unless `SKIP_SITE_DEPS=1` is set. This ensures the correct CLI is available before running `make check` or `make check-netlify`.
* Improved `check_netlify_cli` target in `site/Common.make` to warn if only a global `netlify` is present, and to require the lockfile-pinned CLI for validation steps.

**Documentation updates:**

* Updated `.agents/skills/sq-site-dependabot/SKILL.md` to clarify that `check-tools.sh` installs site dependencies with `bun install` if needed, and that Layer B always uses the lockfile-pinned CLI, not a global/brew install.
* Expanded `.agents/skills/sq-site-dependabot/references/tool-bootstrap.md` with details on agent/fresh checkout behavior, the importance of using `bun install` for Netlify CLI, and the use of `SKIP_SITE_DEPS=1`. [[1]](diffhunk://#diff-019bbc123a5c7b0f6ac31d967e3c661622f000e93f1345ab0153baee7ab3ae91R12-R25) [[2]](diffhunk://#diff-019bbc123a5c7b0f6ac31d967e3c661622f000e93f1345ab0153baee7ab3ae91L72-R87)

These changes ensure that all environments use the correct Netlify CLI version and reduce confusion or errors related to dependency management.