### PR TITLE
(agents) Enable skill to debug Netlify build failures 

### DIFF
--- a/.agents/skills/sq-site-dependabot/SKILL.md
+++ b/.agents/skills/sq-site-dependabot/SKILL.md
@@ -105,8 +105,9 @@ After `make ci` on the PR branch:
 3. Open deploy-preview URL; confirm published (not building/failed)
 4. T1+: review `@netlify/plugin-lighthouse` on preview if available
 
-If pending: poll ~5 min. If failed: do not merge; see
-[references/merge-failures.md](references/merge-failures.md).
+If pending: poll ~5 min. If failed: do not merge; run
+`debug-netlify-pr.sh <n>` or see [references/netlify-build-debug.md](references/netlify-build-debug.md);
+recovery steps in [references/merge-failures.md](references/merge-failures.md).
 
 ### Layer B — Netlify CLI (required in Full mode)
 
@@ -197,3 +198,4 @@ Per PR (GitHub comment or chat):
 - [ci-and-checks.md](references/ci-and-checks.md)
 - [netlify-cli-validate.md](references/netlify-cli-validate.md)
 - [merge-failures.md](references/merge-failures.md)
+- [netlify-build-debug.md](references/netlify-build-debug.md)

--- a/.agents/skills/sq-site-dependabot/references/ci-and-checks.md
+++ b/.agents/skills/sq-site-dependabot/references/ci-and-checks.md
@@ -39,7 +39,9 @@ See [site/README.md](../../../../site/README.md#site-testing).
 
 **Pending check:** poll ~5 minutes; do not merge on assumptions.
 
-**Failed check:** do not merge; open Netlify build log; compare with Layer B.
+**Failed check:** do not merge. Triage with
+[netlify-build-debug.md](./netlify-build-debug.md) or
+`debug-netlify-pr.sh <pr>`; compare with Layer B after install/build succeeds.
 
 ## Netlify CLI validate (Layer B)
 

--- a/.agents/skills/sq-site-dependabot/references/high-risk-packages.md
+++ b/.agents/skills/sq-site-dependabot/references/high-risk-packages.md
@@ -33,6 +33,16 @@ Dependabot PR title and `site/bun.lock` diff against this list.
 - Full external crawl remains **non-blocking** on PRs; do not block T0/T1 merges
   on nightly/external flake unless `make site-test` fails.
 
+## `netlify-cli` (T2; can fail Layer A while Site CI passes)
+
+- Bumping `netlify-cli` runs the **new** package `postinstall` during `bun install`
+  on Netlify deploy previews (it is a site devDependency).
+- If preview fails at **Install dependencies**, reproduce with
+  `cd site && bun install` on the PR branch; use
+  [netlify-build-debug.md](./netlify-build-debug.md).
+- Example (#621): v26.0.2 postinstall failed on Netlify (Node 22) — `execa` CJS
+  vs ESM in `@netlify/config`; hold until upstream fix or verified override.
+
 ## Netlify plugins (T2)
 
 - `@netlify/plugin-lighthouse` — failed plugin can fail deploy preview checks

--- a/.agents/skills/sq-site-dependabot/references/merge-failures.md
+++ b/.agents/skills/sq-site-dependabot/references/merge-failures.md
@@ -33,8 +33,10 @@ gh pr view <next> --json mergeable
   `@dependabot rebase` or close/reopen; do not skip to the next PR with conflicts.
 - **Site CI fails after rebase:** Hold that PR; `make ci` locally; T3 vs real
   breakage; no merge until green.
-- **Netlify preview failed or pending:** Do not merge; open build log; run
-  `make site-netlify-validate` to reproduce.
+- **Netlify preview failed or pending:** Do not merge. Run
+  [`debug-netlify-pr.sh`](../scripts/debug-netlify-pr.sh) or follow
+  [netlify-build-debug.md](./netlify-build-debug.md); then
+  `make site-netlify-validate` on a fixed branch if needed.
 - **`site-netlify-validate` failed:** Do not merge; compare Layer A log; fix;
   re-run from clean `make ci`.
 - **Missing `site/.env`:** Copy `site/.env.example`, fill tokens, run

--- a/.agents/skills/sq-site-dependabot/references/netlify-build-debug.md
+++ b/.agents/skills/sq-site-dependabot/references/netlify-build-debug.md
@@ -1,0 +1,145 @@
+# Netlify build debugging (Layer A failures)
+
+Use when `netlify/sq-web/deploy-preview` or Netlify sub-checks (Header rules,
+Pages changed, Redirect rules) fail on a Dependabot PR. Site CI (`lint` / `build`)
+can still be green — the remote Netlify install/build is a separate path.
+
+## Quick triage (PR number)
+
+From repo root (requires `site/.env` with `NETLIFY_*` and `gh` auth):
+
+```bash
+.agents/skills/sq-site-dependabot/scripts/debug-netlify-pr.sh <pr>
+```
+
+Manual equivalent is below.
+
+## 1. Collect deploy id from GitHub
+
+```bash
+export GH_PAGER=cat
+gh pr checks <pr>   # non-zero if any check failed
+gh pr view <pr> --json headRefOid,statusCheckRollup
+```
+
+- Open the Netlify check link (e.g. `app.netlify.com/.../deploys/<deploy_id>`).
+- Copy **`deploy_id`** (24-char hex) from the URL or checks output.
+- Confirm **`headRefOid`** matches the SHA Netlify built (stale-head guard).
+
+## 2. Netlify API — deploy summary (CLI)
+
+From `site/` with credentials loaded:
+
+```bash
+cd site
+set -a && . ./.env && set +a
+
+DEPLOY_ID="<from checks URL>"
+bun x netlify-cli api getDeploy --data "{\"deploy_id\":\"${DEPLOY_ID}\"}"
+```
+
+Read these fields first:
+
+| Field | Meaning |
+| ----- | ------- |
+| `state` | `ready` / `error` / `building` |
+| `error_message` | One-line failure (often enough) |
+| `commit_ref` | Should match PR `headRefOid` |
+| `context` | `deploy-preview` for PRs |
+| `review_id` | PR number when Git-integrated |
+
+Example (**PR #621**): `state: error`, `error_message`:
+`Failed during stage 'Install dependencies': dependency_installation script returned non-zero exit code: 1`
+
+## 3. Netlify API — build record
+
+`getDeploy` includes `build_id`. Fetch build metadata:
+
+```bash
+BUILD_ID="<from getDeploy.build_id>"
+bun x netlify-cli api getSiteBuild --data "{\"build_id\":\"${BUILD_ID}\"}"
+```
+
+Check `error` and `deploy_state`. Build logs in the Netlify UI:
+`admin_url` from `getDeploy` → deploys → **Deploy log** (API log endpoints
+vary; UI is reliable).
+
+## 4. Local reproduction (install vs Hugo build)
+
+Checkout the PR and mirror Netlify’s first step (`bun install` in `site/`):
+
+```bash
+gh pr checkout <pr>
+cd site
+bun install          # fails here if remote “Install dependencies” failed
+make ci              # only if install succeeds
+```
+
+Netlify preview config: [`site/netlify.toml`](../../../../site/netlify.toml)
+(`BUN_VERSION`, `NODE_VERSION`, `[context.deploy-preview]` command).
+
+**Important:** `netlify-cli` is a **devDependency** of `site/`. A PR that bumps
+`netlify-cli` runs the **new** package’s `postinstall` during `bun install` on
+Netlify and locally. A broken CLI release can fail before Hugo ever runs.
+
+## 5. Layer B comparison
+
+If Layer A failed but you need to test the tree anyway (after fixing install):
+
+```bash
+cd site
+make site-netlify-validate   # uses current checkout + remote build
+```
+
+Layer B can pass when Layer A failed on an older SHA — always compare `commit_ref`
+/ `headRefOid`.
+
+## 6. Verdict hints for the agent
+
+| `error_message` pattern | Likely cause | Action |
+| ----------------------- | ------------ | ------ |
+| `Install dependencies` / exit code 1 | `bun install` / postinstall | Open deploy log; reproduce `cd site && bun install` on PR branch |
+| `execa` / `Named export` in deploy log | `netlify-cli` postinstall + wrong `execa` in graph | See case study #621; prefer hold over blind `overrides` |
+| `Building site` / Hugo | `bun run build` | Reproduce `make ci`; open full deploy log |
+| Plugin / Lighthouse | `@netlify/plugin-lighthouse` | Open deploy log plugin section; compare `make ci` pass |
+| Unknown / empty | Stale check or transient | Re-run deploy; confirm `headRefOid` |
+
+## Case study: PR #621 (`netlify-cli` 25 → 26)
+
+- **Symptom:** Layer A failed; Site CI green.
+- **`getDeploy.error_message`:** Install dependencies stage failed.
+- **Netlify deploy log (authoritative):** Node **v22.13.1**, Bun **1.3.13**,
+  during `netlify-cli` postinstall:
+
+  ```text
+  @netlify/config/lib/env/git.js: import { execa } from 'execa';
+  SyntaxError: Named export 'execa' not found. The requested module 'execa' is a
+  CommonJS module …
+  error: postinstall script from "netlify-cli" exited with 1
+  ```
+
+  `@netlify/config` expects ESM named exports; the resolved `execa@5` is CJS.
+
+- **Local repro:** Run `cd site && bun install` on the PR branch. Outcome can
+  differ by Node version (e.g. pass on Node 26, fail on Netlify’s Node 22).
+  Always trust the **deploy log** over a single local run.
+
+- **Netlify AI “fix” (`overrides.execa: ^8.0.1`):** May unblock
+  `@netlify/config` on Node 22 but can break `netlify-cli`’s own
+  `import execaLib from 'execa'` postinstall on other Node versions. Treat as
+  experimental; verify with a fresh `bun.lock` on the PR branch and a new
+  deploy preview before merging.
+
+- **Conclusion:** Broken `netlify-cli@26` install graph, not a Hugo/site bug.
+  **Hold** or close PR; stay on **25.x** until Netlify ships a fixed CLI or you
+  have a verified override + green preview. Do not merge for green Site CI alone.
+
+## gh + curl helpers
+
+```bash
+# Deploy poll (same as site-netlify-validate)
+curl -fsS -H "Authorization: Bearer ${NETLIFY_AUTH_TOKEN}" \
+  "https://api.netlify.com/api/v1/sites/${NETLIFY_SITE_ID}/deploys/${DEPLOY_ID}"
+```
+
+Use `jq` for `state`, `error_message`, `commit_ref`.

--- a/.agents/skills/sq-site-dependabot/references/tool-bootstrap.md
+++ b/.agents/skills/sq-site-dependabot/references/tool-bootstrap.md
@@ -84,6 +84,7 @@ cd site && make check-netlify
   [site-ci.yml](../../../../.github/workflows/site-ci.yml)
 - **Netlify CLI:** `cd site && bun install` then `bun x netlify-cli --version`
   (not brew-only for Layer B)
+- **Failed preview debug:** `.agents/skills/sq-site-dependabot/scripts/debug-netlify-pr.sh <pr>`
 - **checkenv:** `site/scripts/checkenv.bash` (via `make check-env --merge`)
 
 ## Working directory

--- a/.agents/skills/sq-site-dependabot/scripts/debug-netlify-pr.sh
+++ b/.agents/skills/sq-site-dependabot/scripts/debug-netlify-pr.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# Debug a failed Netlify deploy-preview check for a site Dependabot PR.
+# Usage (repo root): debug-netlify-pr.sh <pr-number>
+# Requires: gh auth, site/.env (NETLIFY_AUTH_TOKEN, NETLIFY_SITE_ID), bun x netlify-cli
+set -euo pipefail
+
+export GH_PAGER=cat
+export PAGER=cat
+
+PR="${1:?Usage: debug-netlify-pr.sh <pr-number>}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+SITE_DIR="${REPO_ROOT}/site"
+
+echo "==> PR #${PR} — GitHub checks"
+if ! gh pr checks "${PR}" 2>&1; then
+	echo "(some checks failed — expected when debugging)" >&2
+fi
+
+HEAD_OID=$(gh pr view "${PR}" --json headRefOid --jq '.headRefOid')
+echo ""
+echo "headRefOid=${HEAD_OID}"
+
+echo ""
+echo "==> Netlify-related check lines"
+gh pr checks "${PR}" 2>&1 | /usr/bin/grep -iE 'netlify|sq-web|Header rules|Redirect|Pages changed' || true
+
+CHECKS_OUT=$(mktemp)
+trap 'rm -f "${DEPLOY_JSON}" "${CHECKS_OUT}"' EXIT
+gh pr checks "${PR}" >"${CHECKS_OUT}" 2>&1 || true
+DEPLOY_ID=$(/usr/bin/grep -oE 'deploys/[a-f0-9]{24}' "${CHECKS_OUT}" | head -1 | /usr/bin/cut -d/ -f2 || true)
+
+if [ -z "${DEPLOY_ID}" ]; then
+	echo "Could not parse deploy_id from gh pr checks URLs; open the Netlify check link manually." >&2
+	exit 1
+fi
+
+echo ""
+echo "deploy_id=${DEPLOY_ID}"
+
+if [ ! -f "${SITE_DIR}/.env" ]; then
+	echo "Missing ${SITE_DIR}/.env — copy from .env.example for API calls." >&2
+	exit 1
+fi
+
+# shellcheck disable=SC1091
+set -a && . "${SITE_DIR}/.env" && set +a
+
+if [ -z "${NETLIFY_AUTH_TOKEN:-}" ] || [ -z "${NETLIFY_SITE_ID:-}" ]; then
+	echo "NETLIFY_AUTH_TOKEN and NETLIFY_SITE_ID must be set in site/.env" >&2
+	exit 1
+fi
+
+echo ""
+echo "==> getDeploy (netlify-cli api)"
+DEPLOY_JSON=$(mktemp)
+(cd "${SITE_DIR}" && bun x netlify-cli api getDeploy --data "{\"deploy_id\":\"${DEPLOY_ID}\"}") >"${DEPLOY_JSON}"
+
+if command -v jq >/dev/null 2>&1; then
+	jq '{state, error_message, commit_ref, context, review_id, build_id, deploy_ssl_url}' "${DEPLOY_JSON}"
+	BUILD_ID=$(jq -r '.build_id // empty' "${DEPLOY_JSON}")
+	COMMIT_REF=$(jq -r '.commit_ref // empty' "${DEPLOY_JSON}")
+	if [ -n "${COMMIT_REF}" ] && [ "${COMMIT_REF}" != "${HEAD_OID}" ]; then
+		echo "warning: deploy commit_ref ${COMMIT_REF} != PR headRefOid ${HEAD_OID}" >&2
+	fi
+	if [ -n "${BUILD_ID}" ]; then
+		echo ""
+		echo "==> getSiteBuild"
+		(cd "${SITE_DIR}" && bun x netlify-cli api getSiteBuild --data "{\"build_id\":\"${BUILD_ID}\"}") \
+			| jq '{deploy_state, error, done, sha}' 2>/dev/null || true
+	fi
+else
+	cat "${DEPLOY_JSON}"
+fi
+
+echo ""
+echo "==> Deploy log (UI)"
+echo "  Open the Netlify check URL above → Deploy log (install errors are often"
+echo "  only visible here, e.g. netlify-cli postinstall / execa ESM vs CJS)."
+echo ""
+echo "==> Local reproduction (optional; Node version may differ from Netlify)"
+echo "  gh pr checkout ${PR}"
+echo "  cd site && bun install    # mirrors Netlify 'Install dependencies'"
+echo "  cd site && make ci        # if install succeeds"
+echo ""
+echo "See references/netlify-build-debug.md for interpretation."

--- a/.agents/skills/sq-site-dependabot/scripts/debug-netlify-pr.sh
+++ b/.agents/skills/sq-site-dependabot/scripts/debug-netlify-pr.sh
@@ -27,7 +27,14 @@ echo "==> Netlify-related check lines"
 gh pr checks "${PR}" 2>&1 | /usr/bin/grep -iE 'netlify|sq-web|Header rules|Redirect|Pages changed' || true
 
 CHECKS_OUT=$(mktemp)
-trap 'rm -f "${DEPLOY_JSON}" "${CHECKS_OUT}"' EXIT
+DEPLOY_JSON=""
+cleanup() {
+	rm -f "${CHECKS_OUT}"
+	if [ -n "${DEPLOY_JSON}" ]; then
+		rm -f "${DEPLOY_JSON}"
+	fi
+}
+trap cleanup EXIT
 gh pr checks "${PR}" >"${CHECKS_OUT}" 2>&1 || true
 DEPLOY_ID=$(/usr/bin/grep -oE 'deploys/[a-f0-9]{24}' "${CHECKS_OUT}" | head -1 | /usr/bin/cut -d/ -f2 || true)
 


### PR DESCRIPTION
This pull request enhances the documentation and tooling for debugging Netlify deploy-preview failures on Dependabot PRs. It introduces a new script and reference guide for efficient triage of Netlify build issues, updates existing docs to reference these new resources, and adds specific guidance for handling `netlify-cli` dependency bumps.

**Netlify build debugging improvements:**

* Added a comprehensive guide for debugging Netlify deploy-preview failures, covering API usage, local reproduction, and common error patterns in `.agents/skills/sq-site-dependabot/references/netlify-build-debug.md`.
* Introduced a new script, `debug-netlify-pr.sh`, to automate Netlify deploy triage for a given PR, including fetching deploy/build metadata and providing local reproduction steps in `.agents/skills/sq-site-dependabot/scripts/debug-netlify-pr.sh`.

**Documentation updates and cross-references:**

* Updated workflow and troubleshooting docs (`SKILL.md`, `ci-and-checks.md`, `merge-failures.md`, `tool-bootstrap.md`) to reference the new Netlify debug guide and script, clarifying recovery steps for failed/pending previews and failed checks. [[1]](diffhunk://#diff-a788d305734e4f74dc0c6f2452695ffa9c85093cc85f52f6e89e211c618d2c5dL108-R110) [[2]](diffhunk://#diff-c7da7d838bba1150d72ae92fa7b7707fac2f50ff045d0cb9e8eee99f652d4977L42-R44) [[3]](diffhunk://#diff-14248b09c58f2b5736e252dd43d2a64f9651a579058f7dd1c23586c9ec659139L36-R39) [[4]](diffhunk://#diff-019bbc123a5c7b0f6ac31d967e3c661622f000e93f1345ab0153baee7ab3ae91R87) [[5]](diffhunk://#diff-a788d305734e4f74dc0c6f2452695ffa9c85093cc85f52f6e89e211c618d2c5dR201)
* Added specific documentation for handling `netlify-cli` dependency bumps and their impact on Netlify Layer A failures in `.agents/skills/sq-site-dependabot/references/high-risk-packages.md`.