### PR TITLE
Update driver reference documentation for `sq` skill

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,8 @@ to this file for expanded contributor content.
 
 `sq` is a command-line data wrangler providing jq-style access to structured
 data sources (SQL databases like Postgres, MySQL, SQLite, SQL Server,
-ClickHouse; and document formats like CSV, JSON, Excel). User docs live at
+ClickHouse, Oracle, DuckDB; and document formats like CSV, JSON, Excel). User
+docs live at
 [sq.io](https://sq.io).
 
 ## Key documents
@@ -142,6 +143,13 @@ read the
 section of `CONTRIBUTING.md` — it covers package structure, type mapping,
 dialect configuration, test handles, and the SQL-vs-document driver split.
 
+**Adding a new driver type:** you must complete the
+[driver ship checklist](./CONTRIBUTING.md#driver-ship-checklist) in the same
+PR — including [`site/content/en/docs/drivers/`](site/content/en/docs/drivers/)
+and [`skills/sq/`](skills/sq/SKILL.md) (`SKILL.md` driver table plus
+`references/{driver}.md`). Do not mark driver work done until those files are
+updated; copy an existing `skills/sq/references/*.md` as a template.
+
 For a visual map of the driver interfaces (`driver.Driver`,
 `driver.SQLDriver`, `driver.Grip`, `driver.Registry`) and how they relate to
 the rest of the system, see [`ARCHITECTURE.md`](./ARCHITECTURE.md).
@@ -155,6 +163,10 @@ This repo ships [Agent Skills](https://agentskills.io/specification) for
 |----------|----------|
 | [`.agents/skills/`](.agents/skills/) | Contributors (Dependabot triage, etc.) |
 | [`skills/sq/`](skills/sq/SKILL.md) | End users of the `sq` CLI (distribution; not repo auto-discovery) |
+
+When you **add a new driver type**, update [`skills/sq/`](skills/sq/SKILL.md)
+per the [driver ship checklist](./CONTRIBUTING.md#driver-ship-checklist): add
+`references/{driver}.md` and a row in `SKILL.md`.
 
 Claude Code discovers the same tree via [`.claude/skills`](.claude/skills)
 (symlink to `.agents/skills`). Cursor and Codex load `.agents/skills/`

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1518,6 +1518,12 @@ func TestOracle_KindToDBType(t *testing.T) {
 }
 ```
 
+#### Step 7: Documentation and agent skill
+
+Complete the [driver ship checklist](CONTRIBUTING.md#driver-ship-checklist):
+sq.io page under `site/content/en/docs/drivers/`, plus
+`skills/sq/references/{driver}.md` and an entry in `skills/sq/SKILL.md`.
+
 ### Adding a New Data Type
 
 To add support for a new data type (e.g., `UUID`, `JSON`, `Geometry`):

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,8 @@ install, symlink layout, and expanded cross-agent notes, see
 
 `sq` is a command-line data wrangler providing jq-style access to structured
 data sources (SQL databases like Postgres, MySQL, SQLite, SQL Server,
-ClickHouse; and document formats like CSV, JSON, Excel). User docs live at
+ClickHouse, Oracle, DuckDB; and document formats like CSV, JSON, Excel). User
+docs live at
 [sq.io](https://sq.io).
 
 ## Key documents
@@ -142,6 +143,11 @@ read the
 ["New driver implementations"](./CONTRIBUTING.md#new-driver-implementations)
 section of `CONTRIBUTING.md` — it covers package structure, type mapping,
 dialect configuration, test handles, and the SQL-vs-document driver split.
+
+**Adding a new driver type:** complete the
+[driver ship checklist](./CONTRIBUTING.md#driver-ship-checklist) in the same
+PR (`site/content/en/docs/drivers/` plus `skills/sq/SKILL.md` and
+`skills/sq/references/{driver}.md`). See [AGENTS.md](./AGENTS.md#drivers).
 
 For a visual map of the driver interfaces (`driver.Driver`,
 `driver.SQLDriver`, `driver.Grip`, `driver.Registry`) and how they relate to

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,6 +83,8 @@ Use the usual GitHub process to open a PR. Before you do so, please:
 
 - Merge the latest `master` into your branch: `git merge origin/master`.
 - Run `make all`.
+- If the PR adds a **new driver type**, complete the
+  [driver ship checklist](#driver-ship-checklist) (sq.io and `skills/sq/`).
 
 ## CHANGELOG.md
 
@@ -263,6 +265,39 @@ For SQL drivers, [`drivers/postgres`](drivers/postgres) or
 
 For document drivers, see
 [`drivers/csv`](drivers/csv) or [`drivers/json`](drivers/json).
+
+### Driver ship checklist
+
+When you **add a new driver type** (a new value in `sq driver ls`), ship **code,
+site docs, and the end-user agent skill** in the same PR. Treat missing
+documentation as incomplete work — this is what keeps [sq.io](https://sq.io),
+`npx skills add`, and coding agents aligned with the binary.
+
+1. **Driver package** — `drivers/{driver}/` (and registration in
+   [`cli/run.go`](cli/run.go); see [ARCHITECTURE.md](ARCHITECTURE.md#extension-guide)).
+2. **Driver type** — constant in
+   [`libsq/source/drivertype/drivertype.go`](libsq/source/drivertype/drivertype.go).
+3. **Tests** — integration tests; for SQL drivers, a `sakiladb/{driver}` image
+   and handle in [`testh/sakila/sakila.go`](testh/sakila/sakila.go) when
+   applicable.
+4. **sq.io docs** — new page
+   `site/content/en/docs/drivers/{driver}.md` (follow an existing driver page;
+   link from [`site/content/en/docs/drivers/_index.md`](site/content/en/docs/drivers/_index.md)).
+5. **End-user agent skill** — required for every new driver:
+   - Add `skills/sq/references/{driver}.md` (short CLI-focused summary;
+     **canonical detail stays on sq.io**). Copy
+     [`skills/sq/references/postgres.md`](skills/sq/references/postgres.md)
+     (SQL) or [`skills/sq/references/csv.md`](skills/sq/references/csv.md)
+     (document).
+   - Update the driver table and `sq driver ls` examples in
+     [`skills/sq/SKILL.md`](skills/sq/SKILL.md).
+   - Run `markdownlint 'skills/sq/**/*.md' --ignore node_modules` (or
+     `markdownlint 'skills/sq/**/*.md' --ignore node_modules --fix`).
+6. **CHANGELOG** — add an `## Unreleased` / `Added` entry when the driver is
+   user-visible (maintainers may edit wording at release time).
+
+Optional: `drivers/{driver}/README.md` for maintainers (connection strings,
+local Docker, env vars for tests).
 
 ### All drivers
 

--- a/skills/sq/SKILL.md
+++ b/skills/sq/SKILL.md
@@ -26,7 +26,8 @@ sq help
 sq driver ls
 ```
 
-`sq driver ls` lists drivers available in this build (e.g. `postgres`, `sqlite3`, `csv`).
+`sq driver ls` lists drivers available in this build (e.g. `postgres`, `duckdb`,
+`oracle`, `sqlite3`, `csv`).
 
 ## Sources and handles
 
@@ -68,10 +69,12 @@ When the task involves a **specific driver** (connection strings, options, cavea
 | Driver (as in `sq driver ls`) | Reference                                            |
 | ----------------------------- | ---------------------------------------------------- |
 | `sqlite3`                     | [references/sqlite3.md](references/sqlite3.md)       |
+| `duckdb`                      | [references/duckdb.md](references/duckdb.md)         |
 | `postgres`                    | [references/postgres.md](references/postgres.md)     |
 | `sqlserver`                   | [references/sqlserver.md](references/sqlserver.md)   |
 | `mysql`                       | [references/mysql.md](references/mysql.md)           |
 | `clickhouse`                  | [references/clickhouse.md](references/clickhouse.md) |
+| `oracle`                      | [references/oracle.md](references/oracle.md)         |
 | `csv`                         | [references/csv.md](references/csv.md)               |
 | `tsv`                         | [references/tsv.md](references/tsv.md)               |
 | `json`                        | [references/json.md](references/json.md)             |

--- a/skills/sq/references/duckdb.md
+++ b/skills/sq/references/duckdb.md
@@ -1,0 +1,44 @@
+# DuckDB (`duckdb` driver)
+
+[DuckDB](https://duckdb.org/) analytics database (file-based or in-memory). Driver type in
+`sq driver ls`: **`duckdb`**. Implements all optional `sq` driver features.
+
+**Canonical docs:** [DuckDB driver](https://sq.io/docs/drivers/duckdb/)
+
+## Add a source
+
+Use [`sq add`](https://sq.io/docs/cmd/add) with the path to the `.duckdb` file (relative or
+absolute). Example:
+
+```shell
+sq add ./sakila.duckdb
+sq add --driver=duckdb ./sakila.duckdb
+```
+
+`sq` can usually [detect](https://sq.io/docs/detect/#driver-type) DuckDB files (`.duckdb`,
+`.ddb`, or the `DUCK` magic header); use `--driver=duckdb` if needed.
+
+**Connection string form** with prefix `duckdb://` and optional query parameters:
+
+```shell
+sq add 'duckdb:///abs/path/sakila.duckdb'
+sq add 'duckdb://:memory:'
+sq add 'duckdb:///path/sakila.duckdb?memory_limit=4GB&threads=4'
+```
+
+Common URI parameters: `access_mode` (`READ_ONLY` / `READ_WRITE`), `memory_limit`,
+`threads`, `enable_external_access`. See [sq.io](https://sq.io/docs/drivers/duckdb/) for the
+full list.
+
+## Bundled extensions
+
+Parquet, JSON, `httpfs` (HTTP/S3), ICU, Excel, and other in-tree extensions are statically
+linked — no `INSTALL` / `LOAD` step. You can query remote or local files directly, e.g.
+`read_parquet('file.parquet')` or `read_csv_auto('https://example.com/data.csv')`.
+
+## Notes
+
+- **Single writer:** only one process should open a `.duckdb` file for writes at a time;
+  use `access_mode=READ_ONLY` for concurrent readers.
+- Composite types (`LIST`, `STRUCT`, `MAP`) are stringified as text today; see driver docs
+  for type-mapping detail.

--- a/skills/sq/references/oracle.md
+++ b/skills/sq/references/oracle.md
@@ -1,0 +1,53 @@
+# Oracle (`oracle` driver)
+
+[Oracle Database](https://www.oracle.com/database/) over Oracle Net. Pure-Go
+[go-ora](https://github.com/sijms/go-ora) — no Oracle Instant Client, OCI, or CGo.
+
+**Canonical docs:** [Oracle driver](https://sq.io/docs/drivers/oracle/)
+
+## Experimental
+
+The Oracle driver is **experimental**; behavior may change. Tested primarily against Oracle
+Database 23ai Free ([sakiladb/oracle](https://github.com/sakiladb/oracle)). Prefer reporting
+issues via [sq issues](https://github.com/neilotoole/sq/issues/new/choose).
+
+## Add a source
+
+Location string should start with **`oracle://`**. Use [`sq add`](https://sq.io/docs/cmd/add)
+with **`-p`** so the password is prompted rather than embedded in the URL:
+
+```shell
+sq add -p 'oracle://user@host:1521/service_name'
+```
+
+Sakila test image:
+
+```shell
+sq add 'oracle://sakila:p_ssW0rd@localhost:1521/SAKILA' --handle @sakila_ora
+```
+
+Quote the URL when it contains `?`, `&`, spaces, or shell-special characters. Query
+parameters (SSL, wallet, timeouts) pass through to `go-ora`, e.g.
+`?SSL=true` or `?CONNECTION%20TIMEOUT=30`.
+
+`TNSNAMES.ora` aliases and Kerberos are not handled by `sq` directly — use an Oracle URL
+for `sq add`.
+
+## Schema and catalog
+
+- **Schema** in `sq` is the connected Oracle user (`CURRENT_SCHEMA`).
+- **Catalog** is the database/PDB name (`DB_NAME`); the URL **service name** routes the
+  connection but is not the catalog itself.
+- Unquoted identifiers are stored **uppercase** in Oracle; cross-source inserts to
+  case-sensitive destinations (Postgres, ClickHouse) map column names case-insensitively.
+
+## Behavior notes (summary)
+
+- Bind placeholders render as `:1`, `:2`, …
+- Empty strings are treated as `NULL` in Oracle.
+- Booleans are stored as `NUMBER(1,0)`.
+- `sq tbl` column-kind alteration is not implemented for Oracle yet.
+- Synonyms are not implemented yet.
+
+Local dev: `docker run -d -p 1521:1521 sakiladb/oracle:latest` (startup can take several
+minutes).


### PR DESCRIPTION

This pull request updates documentation and agent skill references to improve support for new driver types, specifically adding DuckDB and Oracle drivers. It introduces a clear "driver ship checklist" to ensure that code, documentation, and agent skills are all updated together when a new driver is added. The changes clarify contributor requirements and expand end-user documentation for these new drivers.

**Documentation process improvements:**

- Added a detailed "driver ship checklist" in `CONTRIBUTING.md` to ensure that every new driver type includes code, site documentation, and agent skill updates in the same pull request. This checklist is now referenced in all relevant contributor and agent documentation. [[1]](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055R269-R301) [[2]](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055R86-R87) [[3]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9R146-R152) [[4]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9R167-R170) [[5]](diffhunk://#diff-8f6366fd8e7a5fa30f7f05879999195b7cf5fa1e3d157822eb37f0e91d226cfdR1521-R1526) [[6]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7R147-R151)

**Expanded driver support and user documentation:**

- Updated references in user- and agent-facing documentation to include DuckDB and Oracle as supported drivers, including mentions in driver lists and example commands. [[1]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9L13-R14) [[2]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7L14-R15) [[3]](diffhunk://#diff-5999d2135bdd5a79d10975bdf9b77c68821ac21984c45d2d89c2d734e022ba5cL29-R30) [[4]](diffhunk://#diff-5999d2135bdd5a79d10975bdf9b77c68821ac21984c45d2d89c2d734e022ba5cR72-R77)
- Added new reference documentation for the DuckDB driver (`skills/sq/references/duckdb.md`) and the Oracle driver (`skills/sq/references/oracle.md`), providing connection examples, behavioral notes, and links to canonical docs. [[1]](diffhunk://#diff-b1f24e646642f5a1eae6577fa2928c5c3039801b1438f44abdd9ddc4103d8c28R1-R44) [[2]](diffhunk://#diff-6532bfd492db6f123f2b23f5d4b49ff45556ec4e468f1ac739c3200c1eade547R1-R53)