### PR TITLE
drivers: scope TableExists to current schema (#484)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,17 @@ Breaking changes are annotated with ☢️, and alpha/beta features with 🐥.
 
 ### Fixed
 
+- [#484]:
+  [`--insert`](https://sq.io/docs/tutorial#insert--modify) into a MySQL or
+  Postgres table no longer fails when a same-named table exists in another
+  schema. The drivers' `TableExists` check queried `information_schema.tables`
+  filtered only by table name, so a name present in two schemas returned
+  `COUNT(*) = 2`; the `== 1` test then reported the table as missing and `sq`
+  tried to `CREATE` it, which the database rejected with "table already
+  exists". The lookup is now scoped to the connection's current schema
+  (`DATABASE()` for MySQL, `CURRENT_SCHEMA()` for Postgres) and treats any
+  match as existing, matching the other SQL drivers.
+
 - [#633]: A [query](https://sq.io/docs/query) using the single-segment
   `@handle.table:alias` form on the left of a pipeline (e.g.
   `@sakila.actor:a | .a.first_name`) no longer silently collapses to
@@ -1502,6 +1513,7 @@ make working with lots of sources much easier.
 [#437]: https://github.com/neilotoole/sq/issues/437
 [#445]: https://github.com/neilotoole/sq/issues/445
 [#446]: https://github.com/neilotoole/sq/issues/446
+[#484]: https://github.com/neilotoole/sq/issues/484
 [#498]: https://github.com/neilotoole/sq/issues/498
 [#469]: https://github.com/neilotoole/sq/issues/469
 [#470]: https://github.com/neilotoole/sq/issues/470

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,8 +65,8 @@ Breaking changes are annotated with ☢️, and alpha/beta features with 🐥.
   `COUNT(*) = 2`; the `== 1` test then reported the table as missing and `sq`
   tried to `CREATE` it, which the database rejected with "table already
   exists". The lookup is now scoped to the connection's current schema
-  (`DATABASE()` for MySQL, `CURRENT_SCHEMA()` for Postgres) and treats any
-  match as existing, matching the other SQL drivers.
+  (`DATABASE()` for MySQL, `CURRENT_SCHEMA()` for Postgres), as the other SQL
+  drivers already scope theirs.
 
 - [#633]: A [query](https://sq.io/docs/query) using the single-segment
   `@handle.table:alias` form on the left of a pipeline (e.g.

--- a/cli/cmd_slq_test.go
+++ b/cli/cmd_slq_test.go
@@ -55,6 +55,60 @@ func TestCmdSLQ_Insert_Create(t *testing.T) {
 	require.Equal(t, sakila.TblActorCount, len(sink.Recs))
 }
 
+// TestCmdSLQ_Insert_MultipleSchemas is an end-to-end regression test for
+// https://github.com/neilotoole/sq/issues/484. Inserting into a table that
+// also exists in another schema of the destination must succeed. Before the
+// fix, the MySQL/Postgres TableExists check counted the table name across all
+// schemas, so the create-if-not-exists hook (libsq.DBWriterCreateTableIfNotExistsHook)
+// misjudged existence: with the name present in two schemas it reported the
+// table as missing and tried to CREATE the already-existing table, failing
+// with "table already exists" — exactly the symptom reported in #484.
+//
+// This drives the full --insert path (the hook -> TableExists -> CreateTable),
+// which the unit test TestDriver_TableExists_MultipleSchemas does not exercise.
+// Only MySQL and Postgres were affected, so only those are tested here.
+func TestCmdSLQ_Insert_MultipleSchemas(t *testing.T) {
+	for _, dest := range []string{sakila.Pg, sakila.My} {
+		t.Run(dest, func(t *testing.T) {
+			th, destSrc, drvr, _, db := testh.NewWith(t, dest)
+			ctx := th.Context
+
+			conn, err := db.Conn(ctx)
+			require.NoError(t, err)
+			t.Cleanup(func() { assert.NoError(t, conn.Close()) })
+
+			// destTbl is an empty actor copy in the current schema; it stands in
+			// for the user's pre-existing destination table. th.CopyTable
+			// registers its own cleanup.
+			destTbl := th.CopyTable(true, destSrc, tablefq.From(sakila.TblActor), tablefq.T{}, false)
+
+			// Create a same-named table in another schema to trigger #484: the
+			// name now exists in two schemas at once.
+			otherSchema := "test_schema_" + stringz.Uniq8()
+			require.NoError(t, drvr.CreateSchema(ctx, conn, otherSchema))
+			t.Cleanup(func() { assert.NoError(t, drvr.DropSchema(ctx, conn, otherSchema)) })
+			_, err = drvr.CopyTable(ctx, conn, tablefq.From(sakila.TblActor),
+				tablefq.T{Schema: otherSchema, Table: destTbl}, false)
+			require.NoError(t, err)
+
+			// Insert actor rows into the current-schema table. Before the fix
+			// this failed with "table already exists" because TableExists saw
+			// the name in both schemas and the hook tried to re-CREATE it.
+			tr := testrun.New(ctx, t, nil).Add(*destSrc)
+			insertTo := fmt.Sprintf("%s.%s", destSrc.Handle, destTbl)
+			cols := stringz.PrefixSlice(sakila.TblActorCols(), ".")
+			query := fmt.Sprintf("%s.%s | %s", destSrc.Handle, sakila.TblActor, strings.Join(cols, ", "))
+
+			err = tr.Exec("slq", "--insert="+insertTo, query)
+			require.NoError(t, err)
+
+			sink, err := th.QuerySQL(destSrc, nil, "select * from "+destTbl)
+			require.NoError(t, err)
+			require.Equal(t, sakila.TblActorCount, len(sink.Recs))
+		})
+	}
+}
+
 // TestCmdSLQ_Insert tests the "sq slq QUERY --insert=@dest.tbl" functionality,
 // which executes an SLQ query against one source and inserts the results into
 // a table in another (or the same) source. This is similar to TestCmdSQL_Insert

--- a/drivers/mysql/mysql.go
+++ b/drivers/mysql/mysql.go
@@ -450,7 +450,8 @@ func (d *driveri) CopyTable(ctx context.Context, db sqlz.DB,
 
 // TableExists implements driver.SQLDriver.
 func (d *driveri) TableExists(ctx context.Context, db sqlz.DB, tbl string) (bool, error) {
-	const query = `SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = ?`
+	const query = `SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLES
+WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ?`
 
 	var count int64
 	err := db.QueryRowContext(ctx, query, tbl).Scan(&count)
@@ -458,7 +459,7 @@ func (d *driveri) TableExists(ctx context.Context, db sqlz.DB, tbl string) (bool
 		return false, errw(err)
 	}
 
-	return count == 1, nil
+	return count > 0, nil
 }
 
 // DropTable implements driver.SQLDriver.

--- a/drivers/mysql/mysql.go
+++ b/drivers/mysql/mysql.go
@@ -450,6 +450,10 @@ func (d *driveri) CopyTable(ctx context.Context, db sqlz.DB,
 
 // TableExists implements driver.SQLDriver.
 func (d *driveri) TableExists(ctx context.Context, db sqlz.DB, tbl string) (bool, error) {
+	// Scope to the current database via DATABASE() so a same-named table in
+	// another schema isn't counted (see issue #484). With the TABLE_SCHEMA
+	// predicate, the count is 0 or 1, so > 0 means the table exists in the
+	// current schema; don't drop the predicate or the count can exceed 1.
 	const query = `SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLES
 WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ?`
 

--- a/drivers/postgres/postgres.go
+++ b/drivers/postgres/postgres.go
@@ -552,6 +552,10 @@ func (d *driveri) CopyTable(ctx context.Context, db sqlz.DB,
 
 // TableExists implements driver.SQLDriver.
 func (d *driveri) TableExists(ctx context.Context, db sqlz.DB, tbl string) (bool, error) {
+	// Scope to the current schema via CURRENT_SCHEMA() so a same-named table in
+	// another schema isn't counted (see issue #484). With the table_schema
+	// predicate, the count is 0 or 1, so > 0 means the table exists in the
+	// current schema; don't drop the predicate or the count can exceed 1.
 	const query = `SELECT COUNT(*) FROM information_schema.tables
 WHERE table_schema = CURRENT_SCHEMA() AND table_name = $1`
 

--- a/drivers/postgres/postgres.go
+++ b/drivers/postgres/postgres.go
@@ -553,7 +553,7 @@ func (d *driveri) CopyTable(ctx context.Context, db sqlz.DB,
 // TableExists implements driver.SQLDriver.
 func (d *driveri) TableExists(ctx context.Context, db sqlz.DB, tbl string) (bool, error) {
 	const query = `SELECT COUNT(*) FROM information_schema.tables
-WHERE table_name = $1`
+WHERE table_schema = CURRENT_SCHEMA() AND table_name = $1`
 
 	var count int64
 	err := db.QueryRowContext(ctx, query, tbl).Scan(&count)
@@ -561,7 +561,7 @@ WHERE table_name = $1`
 		return false, errw(err)
 	}
 
-	return count == 1, nil
+	return count > 0, nil
 }
 
 // ListTableNames implements driver.SQLDriver.

--- a/libsq/driver/driver_test.go
+++ b/libsq/driver/driver_test.go
@@ -96,8 +96,10 @@ func TestDriver_TableExists_MultipleSchemas(t *testing.T) {
 	// already schema-scoped (or single-schema, for SQLite, whose unqualified
 	// sqlite_master never sees attached schemas) and serve here as contract
 	// guards against future regressions. Oracle is omitted because its
-	// CreateSchema is unsupported, and ClickHouse because CopyTable can't report
-	// rows affected (it's covered separately under drivers/clickhouse).
+	// CreateSchema is unsupported, and ClickHouse because this CopyTable-based
+	// cross-schema flow doesn't behave consistently for it; both already scope
+	// TableExists to the current schema (Oracle via user_objects, ClickHouse
+	// via currentDatabase()), so neither was affected by #484.
 	testCases := []struct {
 		handle        string
 		defaultSchema string

--- a/libsq/driver/driver_test.go
+++ b/libsq/driver/driver_test.go
@@ -92,11 +92,18 @@ func TestDriver_TableExists(t *testing.T) {
 //     as present, so --insert skipped CREATE and the subsequent INSERT failed
 //     because the table was absent from the current schema.
 func TestDriver_TableExists_MultipleSchemas(t *testing.T) {
+	// Only MySQL and Postgres were affected by #484. The other drivers were
+	// already schema-scoped (or single-schema, for SQLite, whose unqualified
+	// sqlite_master never sees attached schemas) and serve here as contract
+	// guards against future regressions. Oracle is omitted because its
+	// CreateSchema is unsupported, and ClickHouse because CopyTable can't report
+	// rows affected (it's covered separately under drivers/clickhouse).
 	testCases := []struct {
 		handle        string
 		defaultSchema string
 	}{
 		{sakila.SL3, "main"},
+		{sakila.Duck, "main"},
 		{sakila.Pg, "public"},
 		{sakila.My, "sakila"},
 		{sakila.MS, "dbo"},
@@ -104,7 +111,7 @@ func TestDriver_TableExists_MultipleSchemas(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.handle, func(t *testing.T) {
-			th, src, drvr, _, db := testh.NewWith(t, tc.handle)
+			th, _, drvr, _, db := testh.NewWith(t, tc.handle)
 			ctx := th.Context
 
 			conn, err := db.Conn(ctx)
@@ -140,7 +147,7 @@ func TestDriver_TableExists_MultipleSchemas(t *testing.T) {
 			// Now create the table in the current schema too, so the name
 			// exists in two schemas at once.
 			currentTblFQ := tablefq.From(tblName)
-			t.Cleanup(func() { th.DropTable(src, currentTblFQ) })
+			t.Cleanup(func() { assert.NoError(t, drvr.DropTable(ctx, conn, currentTblFQ, true)) })
 			_, err = drvr.CopyTable(ctx, conn, srcTblFQ, currentTblFQ, false)
 			require.NoError(t, err)
 

--- a/libsq/driver/driver_test.go
+++ b/libsq/driver/driver_test.go
@@ -96,10 +96,10 @@ func TestDriver_TableExists_MultipleSchemas(t *testing.T) {
 	// already schema-scoped (or single-schema, for SQLite, whose unqualified
 	// sqlite_master never sees attached schemas) and serve here as contract
 	// guards against future regressions. Oracle is omitted because its
-	// CreateSchema is unsupported, and ClickHouse because this CopyTable-based
-	// cross-schema flow doesn't behave consistently for it; both already scope
-	// TableExists to the current schema (Oracle via user_objects, ClickHouse
-	// via currentDatabase()), so neither was affected by #484.
+	// CreateSchema is unsupported, and ClickHouse because its CopyTable doesn't
+	// honor the target schema (#652); both already scope TableExists to the
+	// current schema (Oracle via user_objects, ClickHouse via currentDatabase()),
+	// so neither was affected by #484.
 	testCases := []struct {
 		handle        string
 		defaultSchema string

--- a/libsq/driver/driver_test.go
+++ b/libsq/driver/driver_test.go
@@ -78,6 +78,84 @@ func TestDriver_TableExists(t *testing.T) {
 	}
 }
 
+// TestDriver_TableExists_MultipleSchemas is a regression test for
+// https://github.com/neilotoole/sq/issues/484. TableExists must scope its
+// lookup to the connection's current schema. Previously the MySQL and Postgres
+// drivers queried information_schema.tables filtered only by table name (no
+// schema predicate) and compared COUNT(*) == 1, so a table whose name also
+// existed in another schema produced the wrong result:
+//
+//   - Same-named table in two schemas: COUNT(*) == 2, so the "== 1" check
+//     reported the table as missing, and --insert tried (and failed) to CREATE
+//     an already-existing table ("Table 'x' already exists").
+//   - Same-named table only in another schema: COUNT(*) == 1 reported the table
+//     as present, so --insert skipped CREATE and the subsequent INSERT failed
+//     because the table was absent from the current schema.
+func TestDriver_TableExists_MultipleSchemas(t *testing.T) {
+	testCases := []struct {
+		handle        string
+		defaultSchema string
+	}{
+		{sakila.SL3, "main"},
+		{sakila.Pg, "public"},
+		{sakila.My, "sakila"},
+		{sakila.MS, "dbo"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.handle, func(t *testing.T) {
+			th, src, drvr, _, db := testh.NewWith(t, tc.handle)
+			ctx := th.Context
+
+			conn, err := db.Conn(ctx)
+			require.NoError(t, err)
+			t.Cleanup(func() { assert.NoError(t, conn.Close()) })
+
+			gotSchema, err := drvr.CurrentSchema(ctx, conn)
+			require.NoError(t, err)
+			require.Equal(t, tc.defaultSchema, gotSchema)
+
+			// otherSchema holds a same-named table that must NOT be mistaken
+			// for one in the current schema.
+			otherSchema := "test_schema_" + stringz.Uniq8()
+			require.NoError(t, drvr.CreateSchema(ctx, conn, otherSchema))
+			t.Cleanup(func() { assert.NoError(t, drvr.DropSchema(ctx, conn, otherSchema)) })
+
+			tblName := stringz.UniqTableName("actor_484")
+			srcTblFQ := tablefq.From(sakila.TblActor)
+
+			// Create the table in otherSchema only.
+			_, err = drvr.CopyTable(ctx, conn, srcTblFQ, tablefq.T{Schema: otherSchema, Table: tblName}, false)
+			require.NoError(t, err)
+
+			// TableExists checks the current schema, where the table does not
+			// yet exist, so it must report false even though the name exists in
+			// otherSchema.
+			exists, err := drvr.TableExists(ctx, conn, tblName)
+			require.NoError(t, err)
+			require.False(t, exists,
+				"table %q exists only in schema %q, not in current schema %q",
+				tblName, otherSchema, tc.defaultSchema)
+
+			// Now create the table in the current schema too, so the name
+			// exists in two schemas at once.
+			currentTblFQ := tablefq.From(tblName)
+			t.Cleanup(func() { th.DropTable(src, currentTblFQ) })
+			_, err = drvr.CopyTable(ctx, conn, srcTblFQ, currentTblFQ, false)
+			require.NoError(t, err)
+
+			// TableExists must now report true: the table is present in the
+			// current schema, even though the same name also exists in
+			// otherSchema.
+			exists, err = drvr.TableExists(ctx, conn, tblName)
+			require.NoError(t, err)
+			require.True(t, exists,
+				"table %q exists in current schema %q (and also in %q)",
+				tblName, tc.defaultSchema, otherSchema)
+		})
+	}
+}
+
 func TestDriver_CopyTable(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Fixes #484.

`--insert` into a MySQL or Postgres table failed when a table of the same
name also existed in another schema. Both drivers' `TableExists` queried
`information_schema.tables` filtered only by table name and compared
`COUNT(*) == 1`:

- Same-named table in **two** schemas → `COUNT(*) == 2` → reported as missing
  → `sq` tried to `CREATE` it → `Table 'x' already exists`.
- Same-named table in **another schema only** → `COUNT(*) == 1` → reported as
  existing → `CREATE` skipped → the subsequent `INSERT` failed.

## Fix

Scope the lookup to the connection's current schema and treat any match as
existing, matching the SQL Server, ClickHouse, Oracle, and DuckDB drivers
(which were already correct):

- MySQL: `WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ?`, `COUNT(*) > 0`
- Postgres: `WHERE table_schema = CURRENT_SCHEMA() AND table_name = $1`, `COUNT(*) > 0`

SQLite uses unqualified `sqlite_master` (single-schema), so it was unaffected.

## Testing

`TestDriver_TableExists_MultipleSchemas` reproduces both failure modes across
SQLite, Postgres, MySQL, and SQL Server. It fails on the unfixed
MySQL/Postgres drivers (for the right reason) and passes after the fix; the
existing `TestDriver_TableExists` and the `--insert` command tests
(`TestCmdSLQ_Insert*`, `TestCmdSQL_Insert`) remain green.
