### PR TITLE
mysql,postgres: scope TableExists to current schema (#484)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,17 @@ Breaking changes are annotated with ☢️, and alpha/beta features with 🐥.
 
 ### Fixed
 
+- [#484]: Inserting into an existing MySQL or PostgreSQL table via
+  [`--insert`](https://sq.io/docs/output#insert) no longer fails when a
+  table of the same name also exists in another schema. `TableExists` ran
+  an unscoped `COUNT(*)` over `INFORMATION_SCHEMA`, so a name present in two
+  schemas returned 2 and the `count == 1` check wrongly reported the table
+  as absent; sq then tried to `CREATE` the existing table and the insert
+  failed with a "table already exists" error. The check is now scoped to
+  the current schema (`DATABASE()` on MySQL, `current_schema()` on
+  PostgreSQL) and treats any match as existing. The other SQL drivers (SQL
+  Server, ClickHouse, Oracle, DuckDB, SQLite) already scoped correctly.
+
 - [#633]: A [query](https://sq.io/docs/query) using the single-segment
   `@handle.table:alias` form on the left of a pipeline (e.g.
   `@sakila.actor:a | .a.first_name`) no longer silently collapses to
@@ -1502,6 +1513,7 @@ make working with lots of sources much easier.
 [#437]: https://github.com/neilotoole/sq/issues/437
 [#445]: https://github.com/neilotoole/sq/issues/445
 [#446]: https://github.com/neilotoole/sq/issues/446
+[#484]: https://github.com/neilotoole/sq/issues/484
 [#498]: https://github.com/neilotoole/sq/issues/498
 [#469]: https://github.com/neilotoole/sq/issues/469
 [#470]: https://github.com/neilotoole/sq/issues/470

--- a/drivers/mysql/mysql.go
+++ b/drivers/mysql/mysql.go
@@ -450,7 +450,12 @@ func (d *driveri) CopyTable(ctx context.Context, db sqlz.DB,
 
 // TableExists implements driver.SQLDriver.
 func (d *driveri) TableExists(ctx context.Context, db sqlz.DB, tbl string) (bool, error) {
-	const query = `SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = ?`
+	// Scope to the current schema (database). Without TABLE_SCHEMA = DATABASE()
+	// the COUNT spans every schema, so a table name that exists in two schemas
+	// would return 2 and the old "count == 1" check wrongly reported the table
+	// as absent (#484). Match on the current schema and treat any hit as exists.
+	const query = `SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLES
+WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ?`
 
 	var count int64
 	err := db.QueryRowContext(ctx, query, tbl).Scan(&count)
@@ -458,7 +463,7 @@ func (d *driveri) TableExists(ctx context.Context, db sqlz.DB, tbl string) (bool
 		return false, errw(err)
 	}
 
-	return count == 1, nil
+	return count > 0, nil
 }
 
 // DropTable implements driver.SQLDriver.

--- a/drivers/mysql/mysql_test.go
+++ b/drivers/mysql/mysql_test.go
@@ -156,3 +156,47 @@ func TestNumericSchema(t *testing.T) {
 		})
 	}
 }
+
+// TestTableExists_CurrentSchema is a regression test for #484: TableExists
+// must be scoped to the connection's current schema. When the same table
+// name exists in two schemas, the previous unscoped COUNT(*) returned 2, so
+// TableExists wrongly reported the table as absent and sq tried to CREATE the
+// already-existing table, failing the insert. In MySQL a schema is a database.
+func TestTableExists_CurrentSchema(t *testing.T) {
+	t.Parallel()
+
+	for _, handle := range sakila.MyAll() {
+		t.Run(handle, func(t *testing.T) {
+			t.Parallel()
+
+			th, _, drvr, _, db := testh.NewWith(t, handle)
+			ctx := th.Context
+
+			tblName := stringz.UniqTableName(t.Name())
+			otherSchema := stringz.UniqTableName("gh484_other")
+
+			// Create the table in the current (sakila) schema.
+			_, err := db.ExecContext(ctx, "CREATE TABLE `"+tblName+"` (id INT)")
+			require.NoError(t, err)
+			t.Cleanup(func() {
+				_, _ = db.ExecContext(ctx, "DROP TABLE IF EXISTS `"+tblName+"`")
+			})
+
+			// Create a second schema holding a table of the SAME name, so the
+			// name now exists in two schemas (the #484 scenario).
+			_, err = db.ExecContext(ctx, "CREATE DATABASE `"+otherSchema+"`")
+			require.NoError(t, err)
+			t.Cleanup(func() {
+				_, _ = db.ExecContext(ctx, "DROP DATABASE IF EXISTS `"+otherSchema+"`")
+			})
+			_, err = db.ExecContext(ctx, "CREATE TABLE `"+otherSchema+"`.`"+tblName+"` (id INT)")
+			require.NoError(t, err)
+
+			exists, err := drvr.TableExists(ctx, db, tblName)
+			require.NoError(t, err)
+			require.True(t, exists,
+				"TableExists must find the table in the current schema even when "+
+					"the name also exists in another schema (#484)")
+		})
+	}
+}

--- a/drivers/mysql/mysql_test.go
+++ b/drivers/mysql/mysql_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/neilotoole/sq/testh"
 	"github.com/neilotoole/sq/testh/fixt"
 	"github.com/neilotoole/sq/testh/sakila"
+	"github.com/neilotoole/sq/testh/tu"
 )
 
 func TestSmoke(t *testing.T) {
@@ -163,6 +164,7 @@ func TestNumericSchema(t *testing.T) {
 // TableExists wrongly reported the table as absent and sq tried to CREATE the
 // already-existing table, failing the insert. In MySQL a schema is a database.
 func TestTableExists_CurrentSchema(t *testing.T) {
+	tu.SkipShort(t, true)
 	t.Parallel()
 
 	for _, handle := range sakila.MyAll() {

--- a/drivers/postgres/postgres.go
+++ b/drivers/postgres/postgres.go
@@ -552,8 +552,12 @@ func (d *driveri) CopyTable(ctx context.Context, db sqlz.DB,
 
 // TableExists implements driver.SQLDriver.
 func (d *driveri) TableExists(ctx context.Context, db sqlz.DB, tbl string) (bool, error) {
+	// Scope to the current schema. Without table_schema = current_schema() the
+	// COUNT spans every schema, so a table name that exists in two schemas
+	// would return 2 and the old "count == 1" check wrongly reported the table
+	// as absent (#484). Match on the current schema and treat any hit as exists.
 	const query = `SELECT COUNT(*) FROM information_schema.tables
-WHERE table_name = $1`
+WHERE table_schema = current_schema() AND table_name = $1`
 
 	var count int64
 	err := db.QueryRowContext(ctx, query, tbl).Scan(&count)
@@ -561,7 +565,7 @@ WHERE table_name = $1`
 		return false, errw(err)
 	}
 
-	return count == 1, nil
+	return count > 0, nil
 }
 
 // ListTableNames implements driver.SQLDriver.

--- a/drivers/postgres/postgres_test.go
+++ b/drivers/postgres/postgres_test.go
@@ -420,3 +420,47 @@ func TestIsErrRelationDoesNotExist(t *testing.T) {
 	require.Error(t, err)
 	require.True(t, postgres.IsErrRelationNotExist(err))
 }
+
+// TestTableExists_CurrentSchema is a regression test for #484: TableExists
+// must be scoped to the connection's current schema. When the same table name
+// exists in two schemas, the previous unscoped COUNT(*) returned 2, so
+// TableExists wrongly reported the table as absent and sq tried to CREATE the
+// already-existing table, failing the insert.
+func TestTableExists_CurrentSchema(t *testing.T) {
+	t.Parallel()
+
+	for _, handle := range sakila.PgAll() {
+		t.Run(handle, func(t *testing.T) {
+			t.Parallel()
+
+			th, _, drvr, _, db := testh.NewWith(t, handle)
+			ctx := th.Context
+
+			tblName := stringz.UniqTableName(t.Name())
+			otherSchema := stringz.UniqTableName("gh484_other")
+
+			// Create the table in the current schema (public).
+			_, err := db.ExecContext(ctx, `CREATE TABLE "`+tblName+`" (id int)`)
+			require.NoError(t, err)
+			t.Cleanup(func() {
+				_, _ = db.ExecContext(ctx, `DROP TABLE IF EXISTS "`+tblName+`"`)
+			})
+
+			// Create a second schema holding a table of the SAME name, so the
+			// name now exists in two schemas (the #484 scenario).
+			_, err = db.ExecContext(ctx, `CREATE SCHEMA "`+otherSchema+`"`)
+			require.NoError(t, err)
+			t.Cleanup(func() {
+				_, _ = db.ExecContext(ctx, `DROP SCHEMA IF EXISTS "`+otherSchema+`" CASCADE`)
+			})
+			_, err = db.ExecContext(ctx, `CREATE TABLE "`+otherSchema+`"."`+tblName+`" (id int)`)
+			require.NoError(t, err)
+
+			exists, err := drvr.TableExists(ctx, db, tblName)
+			require.NoError(t, err)
+			require.True(t, exists,
+				"TableExists must find the table in the current schema even when "+
+					"the name also exists in another schema (#484)")
+		})
+	}
+}

--- a/drivers/postgres/postgres_test.go
+++ b/drivers/postgres/postgres_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/neilotoole/sq/testh"
 	"github.com/neilotoole/sq/testh/fixt"
 	"github.com/neilotoole/sq/testh/sakila"
+	"github.com/neilotoole/sq/testh/tu"
 )
 
 func TestSmoke(t *testing.T) {
@@ -427,6 +428,7 @@ func TestIsErrRelationDoesNotExist(t *testing.T) {
 // TableExists wrongly reported the table as absent and sq tried to CREATE the
 // already-existing table, failing the insert.
 func TestTableExists_CurrentSchema(t *testing.T) {
+	tu.SkipShort(t, true)
 	t.Parallel()
 
 	for _, handle := range sakila.PgAll() {
@@ -439,7 +441,8 @@ func TestTableExists_CurrentSchema(t *testing.T) {
 			tblName := stringz.UniqTableName(t.Name())
 			otherSchema := stringz.UniqTableName("gh484_other")
 
-			// Create the table in the current schema (public).
+			// Create the table in the current schema (current_schema(),
+			// whatever search_path resolves it to — typically public).
 			_, err := db.ExecContext(ctx, `CREATE TABLE "`+tblName+`" (id int)`)
 			require.NoError(t, err)
 			t.Cleanup(func() {


### PR DESCRIPTION
Fixes #484.

## Problem

`TableExists` on the MySQL and PostgreSQL drivers ran an **unscoped**
`COUNT(*)` over `INFORMATION_SCHEMA.TABLES`:

```sql
-- mysql
SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = ?
-- postgres
SELECT COUNT(*) FROM information_schema.tables WHERE table_name = $1
```

The count therefore spanned **every** schema. When a table of the same name
existed in two schemas (e.g. `users` in both the working schema and another),
the count was `2`, and the `count == 1` check reported the table as **absent**.
sq then issued `CREATE TABLE` for the already-existing table, and the insert
failed with a "table already exists" error — the symptom reported in #484.

## Fix

Scope the lookup to the connection's current schema and treat any match as
existing:

| Driver | Scope predicate | Count check |
|---|---|---|
| MySQL | `TABLE_SCHEMA = DATABASE()` | `count > 0` |
| PostgreSQL | `table_schema = current_schema()` | `count > 0` |

A schema-scoped lookup can only return 0 or 1 (table names are unique within a
schema), so switching `count == 1` → `count > 0` is behavior-preserving for the
ordinary single-schema case while fixing the multi-schema case.

## Driver audit

The other SQL drivers were checked and already scope correctly — no changes:

- **SQL Server** — `table_schema = schema_name()`
- **ClickHouse** — `database = currentDatabase()`
- **Oracle** — `user_objects` (current schema)
- **DuckDB** — `schema_name = current_schema()`
- **SQLite** — single `sqlite_master` namespace; no cross-schema duplicates

## Tests

Added `TestTableExists_CurrentSchema` to both `drivers/mysql` and
`drivers/postgres`. Each test creates the same table name in two schemas (a
second `DATABASE`/`SCHEMA`) and asserts `TableExists` still finds it. Written
test-first: both failed against the old code ("Should be true") and pass after
the fix. They run against the configured handles and auto-skip unconfigured
ones.