### PR TITLE
jsonw: report parse-error col as 1-based in --json output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,7 +53,10 @@ Breaking changes are annotated with ☢️, and alpha/beta features with 🐥.
 - [#637]: The structured `parse_error` field is included in `--json`
   error output, carrying `input` and `issues[].{line, col, token, msg,
   suggestion}`, plus rune-offset `start_char`/`stop_char` when a precise
-  span is available, for programmatic consumers.
+  span is available, for programmatic consumers. Both `line` and `col` are
+  1-based, matching the text error output and the position a person counts
+  to; the 0-based `start_char`/`stop_char` offsets remain available for
+  slicing the input directly.
 
 ### Fixed
 

--- a/cli/error_test.go
+++ b/cli/error_test.go
@@ -25,8 +25,9 @@ type e2eParseError struct {
 }
 
 type e2eParseIssue struct {
-	Col int    `json:"col"`
-	Msg string `json:"msg"`
+	Line int    `json:"line"`
+	Col  int    `json:"col"`
+	Msg  string `json:"msg"`
 }
 
 // TestPrintError_ParseError_EndToEnd runs a malformed SLQ query through the
@@ -57,7 +58,9 @@ func TestPrintError_ParseError_EndToEnd(t *testing.T) {
 		require.NoError(t, json.Unmarshal(tr.ErrOut.Bytes(), &got))
 		require.NotNil(t, got.ParseError, "parse_error must be present in --json error output")
 		require.NotEmpty(t, got.ParseError.Issues)
-		require.Equal(t, 9, got.ParseError.Issues[0].Col, "JSON col is 0-based")
+		require.Equal(t, 1, got.ParseError.Issues[0].Line, "JSON line is 1-based")
+		require.Equal(t, 10, got.ParseError.Issues[0].Col,
+			"JSON col is 1-based, matching the text output's 'col 10'")
 		require.Contains(t, got.ParseError.Issues[0].Msg, "unexpected 'this_is_invalid'")
 	})
 }

--- a/cli/output/jsonw/errorwriter.go
+++ b/cli/output/jsonw/errorwriter.go
@@ -40,7 +40,8 @@ type parseIssueJSON struct { //nolint:govet // declaration order is the JSON out
 	Col  int `json:"col"`
 	// StartChar and StopChar are 0-based rune offsets into Input (from the
 	// issue's Span), suitable for slicing []rune(Input) directly. Omitted when
-	// the issue has no span (e.g. the synthetic <EOF> token).
+	// the issue has no usable span: either a nil span (some lexer errors) or
+	// an empty span (Stop < Start, e.g. the synthetic <EOF> token).
 	StartChar  *int   `json:"start_char,omitempty"`
 	StopChar   *int   `json:"stop_char,omitempty"`
 	Token      string `json:"token,omitempty"`

--- a/cli/output/jsonw/errorwriter.go
+++ b/cli/output/jsonw/errorwriter.go
@@ -33,8 +33,14 @@ type errorDetail struct { //nolint:govet // declaration order is the JSON output
 }
 
 type parseIssueJSON struct { //nolint:govet // declaration order is the JSON output order
-	Line       int    `json:"line"`
-	Col        int    `json:"col"`
+	// Line and Col are 1-based human coordinates: the position a person would
+	// count to in the input. They match the line/col shown in the text error
+	// output. For 0-based machine offsets into the input, use StartChar/StopChar.
+	Line int `json:"line"`
+	Col  int `json:"col"`
+	// StartChar and StopChar are 0-based rune offsets into Input (from the
+	// issue's Span), suitable for slicing []rune(Input) directly. Omitted when
+	// the issue has no span (e.g. the synthetic <EOF> token).
 	StartChar  *int   `json:"start_char,omitempty"`
 	StopChar   *int   `json:"stop_char,omitempty"`
 	Token      string `json:"token,omitempty"`
@@ -113,8 +119,12 @@ func toParseErrorJSON(pe *ast.ParseError) *parseErrorJSON {
 	}
 	for i, iss := range pe.Issues {
 		ij := parseIssueJSON{
-			Line:       iss.Line,
-			Col:        iss.Col,
+			Line: iss.Line,
+			// DisplayCol yields the 1-based column. iss.Col is stored 0-based
+			// (to index runes and align with Span); the wire form emits the
+			// 1-based value so JSON consumers see the same column as the text
+			// output, with no per-axis 0-vs-1 mismatch.
+			Col:        iss.DisplayCol(),
 			Token:      iss.Token,
 			Msg:        iss.Msg,
 			Suggestion: iss.Suggestion,

--- a/cli/output/jsonw/errorwriter_test.go
+++ b/cli/output/jsonw/errorwriter_test.go
@@ -96,6 +96,13 @@ func TestJSONErrorWriter_ParseError_NoSpan(t *testing.T) {
 	require.NotContains(t, raw, "start_char", "nil Span must omit start_char")
 	require.NotContains(t, raw, "stop_char", "nil Span must omit stop_char")
 	require.Contains(t, raw, `"col"`, "col is always present")
+
+	// Even with no span, the 1-based human col must still be reported.
+	var got testErrorDetailJSON
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &got))
+	require.Equal(t, 1, got.ParseError.Issues[0].Line)
+	require.Equal(t, 8, got.ParseError.Issues[0].Col,
+		"Col 7 (0-based) must surface as col 8 even when no span is emitted")
 }
 
 func TestJSONErrorWriter_ParseError_Suggestion(t *testing.T) {
@@ -141,6 +148,12 @@ func TestJSONErrorWriter_ParseError_EmptySpanOmitted(t *testing.T) {
 	require.NotContains(t, raw, "start_char", "empty (EOF) span must omit start_char")
 	require.NotContains(t, raw, "stop_char", "empty (EOF) span must omit stop_char")
 	require.Contains(t, raw, `"col"`, "col is always present")
+
+	// The empty-span <EOF> case still reports a 1-based human col.
+	var got testErrorDetailJSON
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &got))
+	require.Equal(t, 9, got.ParseError.Issues[0].Col,
+		"Col 8 (0-based) must surface as col 9 for the <EOF> empty-span case")
 }
 
 func TestJSONErrorWriter_ParseError_MixedSpans(t *testing.T) {

--- a/cli/output/jsonw/errorwriter_test.go
+++ b/cli/output/jsonw/errorwriter_test.go
@@ -65,6 +65,12 @@ func TestJSONErrorWriter_ParseError(t *testing.T) {
 	require.Equal(t, pe.Input, got.ParseError.Input)
 	require.Len(t, got.ParseError.Issues, 1)
 	require.Equal(t, "this_is_invalid", got.ParseError.Issues[0].Token)
+	// line/col are 1-based human coordinates: a 0-based Col of 9 surfaces as
+	// col 10, matching the text error output.
+	require.Equal(t, 1, got.ParseError.Issues[0].Line)
+	require.Equal(t, 10, got.ParseError.Issues[0].Col)
+	// start_char/stop_char stay 0-based rune offsets, so start_char (9) is
+	// deliberately one less than col (10) for the same position.
 	require.Equal(t, 9, got.ParseError.Issues[0].StartChar)
 	require.Equal(t, 23, got.ParseError.Issues[0].StopChar)
 }

--- a/libsq/ast/parseerror.go
+++ b/libsq/ast/parseerror.go
@@ -72,13 +72,26 @@ type ParseIssue struct {
 
 	// Col is the 0-based column on Line where the issue was detected. It is
 	// kept 0-based to match Span's rune offsets and ANTLR's reported column;
-	// human-facing renderings use DisplayCol for the 1-based value.
+	// all output renderings (text and --json alike) use DisplayCol for the
+	// 1-based value users and consumers see.
 	Col int
 }
 
-// DisplayCol returns the 1-based column for human-facing output (Col is
-// stored 0-based). Use this for messages shown to users; the raw 0-based
-// Col is what the JSON wire form emits for programmatic consumers.
+// DisplayCol returns the 1-based column for output (Col is stored 0-based).
+//
+// Every output channel reports 1-based line/col: the text error message and
+// the --json wire form both route the column through DisplayCol. We emit
+// 1-based, not the raw 0-based Col, because that's the universal human
+// convention — every compiler (gcc, go, rustc), linter, and editor status bar
+// counts line/col from 1. A reader who sees "col 0" for the first column, or
+// "col 4" for the 5th character, assumes a bug, and "line 4" that means
+// "editor line 5" is a cross-referencing papercut. Even LSP, which is 0-based
+// on the wire, is translated to 1-based by editors before display: 0-based
+// human output has essentially no successful precedent.
+//
+// Col stays 0-based in storage to index []rune(Input) directly and align with
+// Span's rune offsets; the 0-based machine offsets are exposed separately as
+// start_char/stop_char for programmatic consumers that need to slice the input.
 func (iss ParseIssue) DisplayCol() int {
 	return iss.Col + 1
 }


### PR DESCRIPTION
Follow-up to #637, which introduced the structured `parse_error` field in
`--json` error output.

## Problem

The `parse_error` JSON wire form emitted `col` as **0-based**, while the text
error output (and the `line` field everywhere) used **1-based**. The same
position therefore read inconsistently:

- text: `syntax error at line 1, col 10: ...`
- json: `"line": 1, "col": 9`

Per-axis 0-vs-1 disagreement within one object is surprising and error-prone,
and 0-based columns violate the universal human convention (every compiler,
linter, and editor status bar counts line/col from 1).

## Fix

Route the JSON column through `ParseIssue.DisplayCol`, so both channels report
1-based `line` and `col`. The `parse_error` field is unreleased (added under
Unreleased for #637), so there is no frozen wire contract to preserve.

`ParseIssue.Col` stays **0-based in storage** to index `[]rune(Input)` directly
and align with `Span`; the 0-based machine offsets remain available on the wire
as `start_char`/`stop_char` for consumers that slice the input. So a position
surfaces as `col: 10` (1-based, human) alongside `start_char: 9` (0-based, rune
offset) — deliberately distinct.

## Changes

- `cli/output/jsonw/errorwriter.go`: emit `DisplayCol()` for `col`; document
  the 1-based human coords vs 0-based `start_char`/`stop_char` offsets.
- `libsq/ast/parseerror.go`: record the 1-based rationale on `DisplayCol`; fix
  the now-stale godoc that said the JSON form emits the raw 0-based value.
- Tests: assert JSON `col` is 1-based and matches the text output (e.g. `col 10`
  vs `start_char 9`); update the end-to-end test.
- `CHANGELOG.md`: note both `line` and `col` are 1-based under the #637 entry.