### PR TITLE
clickhouse: create CopyTable destination in target schema (#652)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,14 +57,14 @@ Breaking changes are annotated with ☢️, and alpha/beta features with 🐥.
 
 ### Fixed
 
-- [#652]: [`sq tbl copy`](https://sq.io/docs/cmd/tbl-copy) into a different
-  schema on a ClickHouse source now creates the destination table in the
-  target schema. The ClickHouse driver built the `CREATE TABLE` from the bare
-  table name (dropping the schema), so the table was created in the current
-  database while the data-copy `INSERT` targeted the schema-qualified name —
-  the copy then failed with "table doesn't exist" when copying data, or
-  silently landed in the wrong database otherwise. The `CREATE` is now
-  schema-qualified, matching the `INSERT` and the other SQL drivers.
+- [#652]: The ClickHouse driver now creates a copied table in its target
+  schema (ClickHouse database) when the copy specifies one, rather than always
+  in the connection's current database. `CopyTable` built the `CREATE TABLE`
+  from the bare table name while the data-copy `INSERT` used the
+  schema-qualified name, so a cross-schema copy created the table in the wrong
+  database (and failed outright when also copying data). ClickHouse now matches
+  the other SQL drivers' `CopyTable`. No CLI command targets a cross-schema
+  copy today, so this is a latent driver-level fix surfaced while testing #484.
 
 - [#484]:
   [`--insert`](https://sq.io/docs/tutorial#insert--modify) into a MySQL or

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,15 @@ Breaking changes are annotated with ☢️, and alpha/beta features with 🐥.
 
 ### Fixed
 
+- [#652]: [`sq tbl copy`](https://sq.io/docs/cmd/tbl-copy) into a different
+  schema on a ClickHouse source now creates the destination table in the
+  target schema. The ClickHouse driver built the `CREATE TABLE` from the bare
+  table name (dropping the schema), so the table was created in the current
+  database while the data-copy `INSERT` targeted the schema-qualified name —
+  the copy then failed with "table doesn't exist" when copying data, or
+  silently landed in the wrong database otherwise. The `CREATE` is now
+  schema-qualified, matching the `INSERT` and the other SQL drivers.
+
 - [#484]:
   [`--insert`](https://sq.io/docs/tutorial#insert--modify) into a MySQL or
   Postgres table no longer fails when a same-named table exists in another
@@ -1549,6 +1558,7 @@ make working with lots of sources much easier.
 [#633]: https://github.com/neilotoole/sq/issues/633
 [#637]: https://github.com/neilotoole/sq/pull/637
 [#640]: https://github.com/neilotoole/sq/issues/640
+[#652]: https://github.com/neilotoole/sq/issues/652
 
 
 [v0.15.2]: https://github.com/neilotoole/sq/releases/tag/v0.15.2

--- a/drivers/clickhouse/clickhouse.go
+++ b/drivers/clickhouse/clickhouse.go
@@ -756,9 +756,9 @@ func (d *driveri) CopyTable(
 		}
 	}
 
-	// Build the CREATE with the schema-qualified destination name so the table
-	// lands in toTable's schema rather than the current database; the INSERT
-	// below targets the same qualified name. See issue #652.
+	// Build the CREATE from tblfmt(toTable) so that, when toTable.Schema is set,
+	// the table lands in that schema rather than the current database; the
+	// INSERT below targets the same name. See issue #652.
 	createStmt := buildCreateTableStmtName(tblfmt(toTable), destTblDef)
 	if _, err = db.ExecContext(ctx, createStmt); err != nil {
 		return 0, errw(err)

--- a/drivers/clickhouse/clickhouse.go
+++ b/drivers/clickhouse/clickhouse.go
@@ -714,9 +714,9 @@ func (d *driveri) SchemaExists(ctx context.Context, db sqlz.DB, schma string) (b
 // The process:
 //  1. Retrieves the source table's schema (column names and types)
 //     via [getTableMetadata], which queries ClickHouse system.columns.
-//  2. Creates the destination table with the same column schema using
-//     [driveri.CreateTable] (MergeTree engine, ORDER BY first NOT NULL
-//     column or tuple()).
+//  2. Creates the destination table with the same column schema by executing
+//     a schema-qualified CREATE (MergeTree engine, ORDER BY first NOT NULL
+//     column or tuple()) so the table lands in toTable's schema; see #652.
 //  3. If copyData is true, copies all rows using INSERT INTO ... SELECT.
 //
 // Both fromTable and toTable are rendered via [tblfmt], which preserves

--- a/drivers/clickhouse/clickhouse.go
+++ b/drivers/clickhouse/clickhouse.go
@@ -756,8 +756,12 @@ func (d *driveri) CopyTable(
 		}
 	}
 
-	if err = d.CreateTable(ctx, db, destTblDef); err != nil {
-		return 0, err
+	// Build the CREATE with the schema-qualified destination name so the table
+	// lands in toTable's schema rather than the current database; the INSERT
+	// below targets the same qualified name. See issue #652.
+	createStmt := buildCreateTableStmtName(tblfmt(toTable), destTblDef)
+	if _, err = db.ExecContext(ctx, createStmt); err != nil {
+		return 0, errw(err)
 	}
 
 	if !copyData {

--- a/drivers/clickhouse/clickhouse_test.go
+++ b/drivers/clickhouse/clickhouse_test.go
@@ -437,6 +437,12 @@ func TestDriver_CopyTable_TargetSchema(t *testing.T) {
 	t.Cleanup(func() { assert.NoError(t, drvr.DropSchema(ctx, db, otherSchema)) })
 
 	tblName := stringz.UniqTableName("actor_652")
+	// Defensively drop tblName from the current database too. If the #652 fix
+	// regresses (or the test fails before its assertions), CopyTable could
+	// create the table in the current database, where DropSchema(otherSchema)
+	// would not reap it; this avoids leaking an orphan table into sakila.
+	t.Cleanup(func() { assert.NoError(t, drvr.DropTable(ctx, db, tablefq.From(tblName), true)) })
+
 	_, err := drvr.CopyTable(ctx, db, tablefq.From(sakila.TblActor),
 		tablefq.T{Schema: otherSchema, Table: tblName}, true)
 	require.NoError(t, err)

--- a/drivers/clickhouse/clickhouse_test.go
+++ b/drivers/clickhouse/clickhouse_test.go
@@ -13,6 +13,7 @@ package clickhouse_test
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/neilotoole/sq/drivers/clickhouse"
@@ -415,4 +416,47 @@ func TestDriver_CopyTable(t *testing.T) {
 	sink, err := th.QuerySQL(src, nil, "SELECT * FROM "+stringz.BacktickQuote(destTblName))
 	require.NoError(t, err)
 	require.Equal(t, 1, len(sink.Recs))
+}
+
+// TestDriver_CopyTable_TargetSchema is a regression test for
+// https://github.com/neilotoole/sq/issues/652. CopyTable must create the
+// destination table in toTable.Schema, not in the connection's current
+// database. Previously CopyTable built the CREATE statement from the bare
+// table name (dropping the schema), so the table was created in the current
+// database even though the data-copy INSERT targeted <schema>.<table>: with
+// copyData=true the INSERT then failed ("table doesn't exist"), and with
+// copyData=false the table was silently created in the wrong database.
+func TestDriver_CopyTable_TargetSchema(t *testing.T) {
+	tu.SkipShort(t, true)
+
+	th, src, drvr, _, db := testh.NewWith(t, sakila.CH)
+	ctx := th.Context
+
+	otherSchema := "test_schema_" + stringz.Uniq8()
+	require.NoError(t, drvr.CreateSchema(ctx, db, otherSchema))
+	t.Cleanup(func() { assert.NoError(t, drvr.DropSchema(ctx, db, otherSchema)) })
+
+	tblName := stringz.UniqTableName("actor_652")
+	_, err := drvr.CopyTable(ctx, db, tablefq.From(sakila.TblActor),
+		tablefq.T{Schema: otherSchema, Table: tblName}, true)
+	require.NoError(t, err)
+
+	// The table must be created in otherSchema, not the current database.
+	var inOther, inCurrent int
+	require.NoError(t, db.QueryRowContext(ctx,
+		"SELECT count(*) FROM system.tables WHERE database = ? AND name = ?",
+		otherSchema, tblName).Scan(&inOther))
+	require.Equal(t, 1, inOther,
+		"table should be created in target schema %q, not the current database", otherSchema)
+
+	require.NoError(t, db.QueryRowContext(ctx,
+		"SELECT count(*) FROM system.tables WHERE database = currentDatabase() AND name = ?",
+		tblName).Scan(&inCurrent))
+	require.Equal(t, 0, inCurrent, "table must not be created in the current database")
+
+	// The copied data must be queryable in the target schema.
+	sink, err := th.QuerySQL(src, nil,
+		"SELECT * FROM "+stringz.BacktickQuote(otherSchema)+"."+stringz.BacktickQuote(tblName))
+	require.NoError(t, err)
+	require.Equal(t, sakila.TblActorCount, len(sink.Recs))
 }

--- a/drivers/clickhouse/internal_test.go
+++ b/drivers/clickhouse/internal_test.go
@@ -34,9 +34,10 @@ import (
 
 // render.go exports.
 var (
-	DbTypeNameFromKind   = dbTypeNameFromKind
-	BuildCreateTableStmt = buildCreateTableStmt
-	BuildUpdateStmt      = buildUpdateStmt
+	DbTypeNameFromKind       = dbTypeNameFromKind
+	BuildCreateTableStmt     = buildCreateTableStmt
+	BuildCreateTableStmtName = buildCreateTableStmtName
+	BuildUpdateStmt          = buildUpdateStmt
 )
 
 // metadata.go exports.

--- a/drivers/clickhouse/render.go
+++ b/drivers/clickhouse/render.go
@@ -109,9 +109,18 @@ func dbTypeNameFromKind(knd kind.Kind) string {
 //	) ENGINE = MergeTree()
 //	ORDER BY `col1`  -- or ORDER BY tuple() if all columns are nullable
 func buildCreateTableStmt(tblDef *schema.Table) string {
+	return buildCreateTableStmtName(stringz.BacktickQuote(tblDef.Name), tblDef)
+}
+
+// buildCreateTableStmtName builds a CREATE TABLE statement using qtblName as the
+// table name. qtblName must already be quoted and may be schema-qualified (e.g.
+// `db`.`tbl`); CopyTable passes a schema-qualified name (tblfmt(toTable)) so the
+// destination table is created in toTable's schema rather than the connection's
+// current database. See https://github.com/neilotoole/sq/issues/652.
+func buildCreateTableStmtName(qtblName string, tblDef *schema.Table) string {
 	sb := strings.Builder{}
 	sb.WriteString("CREATE TABLE ")
-	sb.WriteString(stringz.BacktickQuote(tblDef.Name))
+	sb.WriteString(qtblName)
 	sb.WriteString(" (\n")
 
 	for i, colDef := range tblDef.Cols {

--- a/drivers/clickhouse/render.go
+++ b/drivers/clickhouse/render.go
@@ -114,9 +114,10 @@ func buildCreateTableStmt(tblDef *schema.Table) string {
 
 // buildCreateTableStmtName builds a CREATE TABLE statement using qtblName as the
 // table name. qtblName must already be quoted and may be schema-qualified (e.g.
-// `db`.`tbl`); CopyTable passes a schema-qualified name (tblfmt(toTable)) so the
-// destination table is created in toTable's schema rather than the connection's
-// current database. See https://github.com/neilotoole/sq/issues/652.
+// `db`.`tbl`); CopyTable passes tblfmt(toTable), which is schema-qualified when
+// toTable.Schema is set, so the destination table is then created in that schema
+// rather than the connection's current database. See
+// https://github.com/neilotoole/sq/issues/652.
 func buildCreateTableStmtName(qtblName string, tblDef *schema.Table) string {
 	sb := strings.Builder{}
 	sb.WriteString("CREATE TABLE ")

--- a/drivers/clickhouse/render_test.go
+++ b/drivers/clickhouse/render_test.go
@@ -128,6 +128,24 @@ func TestBuildCreateTableStmt(t *testing.T) {
 	require.Contains(t, stmt3, "ORDER BY `not_null_col`")
 }
 
+// TestBuildCreateTableStmtName_SchemaQualified is a short-mode (no live
+// ClickHouse) regression guard for https://github.com/neilotoole/sq/issues/652:
+// a schema-qualified, already-quoted table name must be rendered verbatim in
+// the CREATE TABLE statement — the schema qualifier must not be dropped.
+// CopyTable passes such a name via tblfmt(toTable).
+func TestBuildCreateTableStmtName_SchemaQualified(t *testing.T) {
+	tblDef := schema.NewTable("actor", []string{"id"}, []kind.Kind{kind.Int})
+
+	stmt := clickhouse.BuildCreateTableStmtName("`mydb`.`actor`", tblDef)
+	require.Contains(t, stmt, "CREATE TABLE `mydb`.`actor` (")
+	require.NotContains(t, stmt, "CREATE TABLE `actor` (",
+		"#652: the schema qualifier must not be dropped")
+	require.Contains(t, stmt, "ENGINE = MergeTree()")
+
+	// The bare-name delegation via buildCreateTableStmt is unchanged.
+	require.Contains(t, clickhouse.BuildCreateTableStmt(tblDef), "CREATE TABLE `actor` (")
+}
+
 // TestBuildUpdateStmt tests UPDATE statement generation using ClickHouse's
 // ALTER TABLE UPDATE syntax.
 //

--- a/libsq/driver/driver_test.go
+++ b/libsq/driver/driver_test.go
@@ -95,11 +95,9 @@ func TestDriver_TableExists_MultipleSchemas(t *testing.T) {
 	// Only MySQL and Postgres were affected by #484. The other drivers were
 	// already schema-scoped (or single-schema, for SQLite, whose unqualified
 	// sqlite_master never sees attached schemas) and serve here as contract
-	// guards against future regressions. Oracle is omitted because its
-	// CreateSchema is unsupported, and ClickHouse because its CopyTable doesn't
-	// honor the target schema (#652); both already scope TableExists to the
-	// current schema (Oracle via user_objects, ClickHouse via currentDatabase()),
-	// so neither was affected by #484.
+	// guards against future regressions; ClickHouse, included since its
+	// CopyTable was fixed to honor the target schema (#652), also guards that.
+	// Oracle is omitted because its CreateSchema is unsupported.
 	testCases := []struct {
 		handle        string
 		defaultSchema string
@@ -109,6 +107,7 @@ func TestDriver_TableExists_MultipleSchemas(t *testing.T) {
 		{sakila.Pg, "public"},
 		{sakila.My, "sakila"},
 		{sakila.MS, "dbo"},
+		{sakila.CH, "sakila"},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
Fixes #652.

ClickHouse's `CopyTable` built the `CREATE TABLE` statement from the bare
table name (`tblDef.Name`), dropping `toTable.Schema`, so the destination
table was created in the connection's current database. The data-copy
`INSERT` step, by contrast, used the schema-qualified `tblfmt(toTable)`:

- `copyData=true`: `INSERT INTO <schema>.<table>` failed because the table was
  created in the current database, not `<schema>` ("table doesn't exist").
- `copyData=false`: the table was silently created in the wrong database.

This was discovered while adding the multi-schema regression test for #484,
which is why ClickHouse was excluded from that test.

## Fix

Render the `CREATE` with the schema-qualified destination name, mirroring the
`INSERT` step and the other SQL drivers' `CopyTable` (e.g. Postgres). A new
`buildCreateTableStmtName(qtblName, tblDef)` helper takes the already-rendered
name; `buildCreateTableStmt` delegates to it, so its signature and the
existing render tests are unchanged. Same-schema copies render identically, so
ordinary `sq tbl copy` is unaffected.

## Testing

- `TestDriver_CopyTable_TargetSchema` (drivers/clickhouse) asserts the copied
  table is created in the target schema and not the current database. Verified
  fault-detecting: it fails on the pre-fix code with `NotExistError` and passes
  with the fix.
- Re-enabled ClickHouse in `TestDriver_TableExists_MultipleSchemas`
  (libsq/driver), which had excluded it specifically because of #652; it now
  passes as an integration-level guard, and the stale exclusion is removed.
- Existing `TestDriver_CopyTable`, `TestDriver_CreateTable`, and
  `TestBuildCreateTableStmt` still pass.
