### PR TITLE
Fix SQLite scan failure on Rails-style datetime(6) columns (#471)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,12 @@ Breaking changes are annotated with ☢️, and alpha/beta features with 🐥.
 
 ### Fixed
 
+- [#471]: The SQLite driver no longer fails with `unsupported Scan, storing
+  driver.Value type string into type *time.Time` when a `DATETIME`/`DATE`
+  column stores text that `mattn/go-sqlite3` doesn't natively convert — most
+  commonly Rails' microsecond-precision `datetime(6)` columns. `sq` now
+  re-runs the same timestamp parse and falls back to the raw text only when
+  the value is genuinely unparseable.
 - `sq <command> --format=FORMAT` (e.g. `sq inspect --format=xlsx`) no longer
   fails with a spurious "diff does not support output format" error. The
   format check for [`sq diff`](https://sq.io/docs/diff) was being applied to
@@ -1505,6 +1511,7 @@ make working with lots of sources much easier.
 [#498]: https://github.com/neilotoole/sq/issues/498
 [#469]: https://github.com/neilotoole/sq/issues/469
 [#470]: https://github.com/neilotoole/sq/issues/470
+[#471]: https://github.com/neilotoole/sq/issues/471
 [#499]: https://github.com/neilotoole/sq/issues/499
 [#501]: https://github.com/neilotoole/sq/pull/501
 [#502]: https://github.com/neilotoole/sq/pull/502

--- a/drivers/sqlite3/datetime_robustness_test.go
+++ b/drivers/sqlite3/datetime_robustness_test.go
@@ -1,0 +1,56 @@
+package sqlite3_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/neilotoole/sq/cli/output"
+	"github.com/neilotoole/sq/libsq"
+	"github.com/neilotoole/sq/libsq/core/stringz"
+	"github.com/neilotoole/sq/libsq/core/tablefq"
+	"github.com/neilotoole/sq/testh"
+	"github.com/neilotoole/sq/testh/sakila"
+)
+
+// TestQueryRailsDatetime is a regression test for #471: a DATETIME column
+// declared with a parameterized type ("datetime(6)", as written by Rails)
+// stores microsecond text that mattn/go-sqlite3 does not natively convert.
+// The query must succeed, parsing valid values to time.Time and preserving
+// genuinely unparseable text as a string.
+func TestQueryRailsDatetime(t *testing.T) {
+	th := testh.New(t)
+	src := th.Source(sakila.SL3)
+	db := th.OpenDB(src)
+
+	// Unique table name so the test is robust against a stale table left
+	// by a crashed prior run sharing this source (cf. createTypeTestTbls).
+	tbl := stringz.UniqTableName("rails_dt_gh471")
+	_, err := db.ExecContext(th.Context,
+		"CREATE TABLE "+tbl+" (id INTEGER PRIMARY KEY, created_at datetime(6))")
+	require.NoError(t, err)
+	th.Cleanup.Add(func() { th.DropTable(src, tablefq.From(tbl)) })
+
+	_, err = db.ExecContext(th.Context,
+		"INSERT INTO "+tbl+" (id, created_at) VALUES (1, '2024-01-15 12:34:56.123456'), (2, 'not-a-date')")
+	require.NoError(t, err)
+
+	sink := &testh.RecordSink{}
+	recw := output.NewRecordWriterAdapter(th.Context, sink)
+	err = libsq.QuerySQL(th.Context, th.Open(src), nil, recw,
+		"SELECT id, created_at FROM "+tbl+" ORDER BY id")
+	require.NoError(t, err)
+	_, err = recw.Wait()
+	require.NoError(t, err)
+
+	require.Len(t, sink.Recs, 2)
+
+	gotTime, ok := sink.Recs[0][1].(time.Time)
+	require.Truef(t, ok, "row 0 created_at: want time.Time, got %T", sink.Recs[0][1])
+	require.True(t, time.Date(2024, 1, 15, 12, 34, 56, 123456000, time.UTC).Equal(gotTime))
+
+	gotStr, ok := sink.Recs[1][1].(string)
+	require.Truef(t, ok, "row 1 created_at: want string, got %T", sink.Recs[1][1])
+	require.Equal(t, "not-a-date", gotStr)
+}

--- a/drivers/sqlite3/internal_test.go
+++ b/drivers/sqlite3/internal_test.go
@@ -9,6 +9,7 @@ import (
 var (
 	KindFromDBTypeName = kindFromDBTypeName
 	GetTblRowCounts    = getTblRowCounts
+	RTypeNullTime      = rtypeNullTime
 )
 
 func TestPlaceholders(t *testing.T) {

--- a/drivers/sqlite3/metadata.go
+++ b/drivers/sqlite3/metadata.go
@@ -115,10 +115,10 @@ func setScanType(ctx context.Context, colType *record.ColumnTypeData) {
 		scanType = sqlz.RTypeBytes
 
 	case kind.Datetime:
-		scanType = sqlz.RTypeNullTime
+		scanType = rtypeNullTime
 
 	case kind.Date:
-		scanType = sqlz.RTypeNullTime
+		scanType = rtypeNullTime
 
 	case kind.Time:
 		scanType = sqlz.RTypeNullString

--- a/drivers/sqlite3/metadata_test.go
+++ b/drivers/sqlite3/metadata_test.go
@@ -153,7 +153,7 @@ func TestRecordMetadata(t *testing.T) {
 			colKinds: []kind.Kind{kind.Int, kind.Text, kind.Text, kind.Datetime},
 			scanTypes: []reflect.Type{
 				sqlz.RTypeNullInt64, sqlz.RTypeNullString, sqlz.RTypeNullString,
-				sqlz.RTypeNullTime,
+				sqlite3.RTypeNullTime,
 			},
 			colsMeta: []*metadata.Column{
 				{Name: "actor_id", Position: 0, PrimaryKey: true, BaseType: "INTEGER", ColumnType: "INTEGER", Kind: kind.Int, Nullable: false},
@@ -167,7 +167,7 @@ func TestRecordMetadata(t *testing.T) {
 			rowCount:  sakila.TblFilmActorCount,
 			colNames:  sakila.TblFilmActorCols(),
 			colKinds:  []kind.Kind{kind.Int, kind.Int, kind.Datetime},
-			scanTypes: []reflect.Type{sqlz.RTypeNullInt64, sqlz.RTypeNullInt64, sqlz.RTypeNullTime},
+			scanTypes: []reflect.Type{sqlz.RTypeNullInt64, sqlz.RTypeNullInt64, sqlite3.RTypeNullTime},
 			colsMeta: []*metadata.Column{
 				{Name: "actor_id", Position: 0, PrimaryKey: true, BaseType: "INT", ColumnType: "INT", Kind: kind.Int, Nullable: false},
 				{Name: "film_id", Position: 1, PrimaryKey: true, BaseType: "INT", ColumnType: "INT", Kind: kind.Int, Nullable: false},
@@ -181,7 +181,7 @@ func TestRecordMetadata(t *testing.T) {
 			colKinds: []kind.Kind{kind.Int, kind.Int, kind.Int, kind.Int, kind.Decimal, kind.Datetime, kind.Datetime},
 			scanTypes: []reflect.Type{
 				sqlz.RTypeNullInt64, sqlz.RTypeNullInt64, sqlz.RTypeNullInt64,
-				sqlz.RTypeNullInt64, sqlz.RTypeNullDecimal, sqlz.RTypeNullTime, sqlz.RTypeNullTime,
+				sqlz.RTypeNullInt64, sqlz.RTypeNullDecimal, sqlite3.RTypeNullTime, sqlite3.RTypeNullTime,
 			},
 			colsMeta: []*metadata.Column{
 				{Name: "payment_id", Position: 0, PrimaryKey: true, BaseType: "INT", ColumnType: "INT", Kind: kind.Int, Nullable: false},

--- a/drivers/sqlite3/nulltime.go
+++ b/drivers/sqlite3/nulltime.go
@@ -13,7 +13,7 @@ import (
 
 // rtypeNullTime is the reflect.Type of nullTime. setScanType uses it as the
 // scan destination for SQLite columns mapped to kind.Datetime or kind.Date.
-var rtypeNullTime = reflect.TypeFor[nullTime]() //nolint:unused // wired in a later task
+var rtypeNullTime = reflect.TypeFor[nullTime]()
 
 // nullTime is the scan destination for SQLite columns mapped to a time kind
 // (kind.Datetime, kind.Date). It exists because mattn/go-sqlite3 only converts

--- a/drivers/sqlite3/nulltime.go
+++ b/drivers/sqlite3/nulltime.go
@@ -2,6 +2,7 @@ package sqlite3
 
 import (
 	"reflect"
+	"strconv"
 	"strings"
 	"time"
 
@@ -51,6 +52,13 @@ func (n *nullTime) Scan(src any) error {
 		return nil
 	case int64:
 		*n = nullTime{Time: epochToTime(v), Valid: true, IsTime: true}
+		return nil
+	case float64:
+		// SQLite REAL storage (e.g. a Julian day) for a time column. mattn
+		// returns these as float64 with no conversion; we don't try to
+		// interpret them as instants, but preserve the value as text so the
+		// query doesn't hard-fail (the goal of #471).
+		*n = nullTime{String: strconv.FormatFloat(v, 'f', -1, 64), Valid: true}
 		return nil
 	default:
 		return errz.Errorf("sqlite3: cannot scan %T into nullTime", src)

--- a/drivers/sqlite3/nulltime.go
+++ b/drivers/sqlite3/nulltime.go
@@ -1,0 +1,82 @@
+package sqlite3
+
+import (
+	"reflect"
+	"strings"
+	"time"
+
+	mattn "github.com/mattn/go-sqlite3"
+
+	"github.com/neilotoole/sq/libsq/core/errz"
+)
+
+// rtypeNullTime is the reflect.Type of nullTime. setScanType uses it as the
+// scan destination for SQLite columns mapped to kind.Datetime or kind.Date.
+var rtypeNullTime = reflect.TypeFor[nullTime]() //nolint:unused // wired in a later task
+
+// nullTime is the scan destination for SQLite columns mapped to a time kind
+// (kind.Datetime, kind.Date). It exists because mattn/go-sqlite3 only converts
+// a cell to time.Time when the column's declared type is exactly "date",
+// "datetime", or "timestamp" — it does not strip a parameterized suffix such
+// as "datetime(6)" (as written by Rails). For such columns mattn returns the
+// raw string or int instead, which cannot scan into *sql.NullTime, producing:
+//
+//	unsupported Scan, storing driver.Value type string into type *time.Time
+//
+// nullTime accepts whatever mattn returns and, for string/[]byte values,
+// re-runs mattn's own SQLiteTimestampFormats — i.e. the parse mattn would have
+// performed had it stripped the parens — recovering a proper time.Time.
+// Genuinely unparseable text is preserved verbatim in String.
+type nullTime struct {
+	Time   time.Time
+	String string
+	Valid  bool // a non-NULL value was scanned
+	IsTime bool // value resolved to a time.Time (else use String)
+}
+
+// Scan implements sql.Scanner.
+func (n *nullTime) Scan(src any) error {
+	switch v := src.(type) {
+	case nil:
+		*n = nullTime{}
+		return nil
+	case time.Time:
+		*n = nullTime{Time: v, Valid: true, IsTime: true}
+		return nil
+	case string:
+		n.scanText(v)
+		return nil
+	case []byte:
+		n.scanText(string(v))
+		return nil
+	case int64:
+		*n = nullTime{Time: epochToTime(v), Valid: true, IsTime: true}
+		return nil
+	default:
+		return errz.Errorf("sqlite3: cannot scan %T into nullTime", src)
+	}
+}
+
+// scanText parses s using mattn's SQLiteTimestampFormats, the same set mattn
+// applies to exact-match date/datetime/timestamp columns. On success the value
+// resolves to a time.Time; otherwise the raw text is preserved in String.
+func (n *nullTime) scanText(s string) {
+	trimmed := strings.TrimSuffix(s, "Z")
+	for _, format := range mattn.SQLiteTimestampFormats {
+		if t, err := time.ParseInLocation(format, trimmed, time.UTC); err == nil {
+			*n = nullTime{Time: t, Valid: true, IsTime: true}
+			return
+		}
+	}
+	*n = nullTime{String: s, Valid: true}
+}
+
+// epochToTime converts an integer epoch to a time.Time, mirroring
+// mattn/go-sqlite3's heuristic: magnitudes above 1e12 are treated as
+// milliseconds, otherwise as seconds.
+func epochToTime(v int64) time.Time {
+	if v > 1e12 || v < -1e12 {
+		return time.Unix(0, v*int64(time.Millisecond)).UTC()
+	}
+	return time.Unix(v, 0).UTC()
+}

--- a/drivers/sqlite3/nulltime.go
+++ b/drivers/sqlite3/nulltime.go
@@ -55,9 +55,13 @@ func (n *nullTime) Scan(src any) error {
 		return nil
 	case float64:
 		// SQLite REAL storage (e.g. a Julian day) for a time column. mattn
-		// returns these as float64 with no conversion; we don't try to
-		// interpret them as instants, but preserve the value as text so the
-		// query doesn't hard-fail (the goal of #471).
+		// returns these as float64 with no conversion. We don't interpret them
+		// as instants; we preserve the value rather than hard-failing the query
+		// (the goal of #471). It is deliberately rendered as text, not kept as a
+		// float64: the column's kind stays Datetime/Date, and the datetime
+		// encoders in the JSON and YAML writers accept only time.Time or string
+		// — handing them a float64 would reintroduce the very scan failure this
+		// change removes. Text is the one form every output writer renders.
 		*n = nullTime{String: strconv.FormatFloat(v, 'f', -1, 64), Valid: true}
 		return nil
 	default:

--- a/drivers/sqlite3/nulltime_test.go
+++ b/drivers/sqlite3/nulltime_test.go
@@ -20,22 +20,31 @@ func TestNullTimeScan(t *testing.T) {
 		isTime  bool
 		want    time.Time
 		wantStr string
+		wantErr bool
 	}{
 		{name: "nil", src: nil, valid: false},
 		{name: "time", src: tm, valid: true, isTime: true, want: tm},
 		{name: "rails_micro", src: "2024-01-15 12:34:56.123456", valid: true, isTime: true, want: railsInstant},
 		{name: "rfc3339_z", src: "2024-01-15T12:34:56Z", valid: true, isTime: true, want: tm},
+		{name: "rfc3339_micro_z", src: "2024-01-15T12:34:56.123456Z", valid: true, isTime: true, want: railsInstant},
 		{name: "date_only", src: "2024-01-15", valid: true, isTime: true, want: time.Date(2024, 1, 15, 0, 0, 0, 0, time.UTC)},
 		{name: "junk", src: "not-a-date", valid: true, isTime: false, wantStr: "not-a-date"},
 		{name: "epoch_seconds", src: int64(1700000000), valid: true, isTime: true, want: epochInstant},
 		{name: "epoch_millis", src: int64(1700000000000), valid: true, isTime: true, want: epochInstant},
 		{name: "bytes_micro", src: []byte("2024-01-15 12:34:56.123456"), valid: true, isTime: true, want: railsInstant},
+		{name: "float_real", src: float64(2460000.5), valid: true, isTime: false, wantStr: "2460000.5"},
+		{name: "unsupported_type", src: true, wantErr: true},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			var nt nullTime
-			require.NoError(t, nt.Scan(tc.src))
+			err := nt.Scan(tc.src)
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
 			require.Equal(t, tc.valid, nt.Valid)
 			require.Equal(t, tc.isTime, nt.IsTime)
 			if tc.isTime {

--- a/drivers/sqlite3/nulltime_test.go
+++ b/drivers/sqlite3/nulltime_test.go
@@ -1,0 +1,47 @@
+package sqlite3
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNullTimeScan(t *testing.T) {
+	// 1700000000s == 1700000000000ms == 2023-11-14 22:13:20 UTC.
+	epochInstant := time.Date(2023, 11, 14, 22, 13, 20, 0, time.UTC)
+	railsInstant := time.Date(2024, 1, 15, 12, 34, 56, 123456000, time.UTC)
+	tm := time.Date(2024, 1, 15, 12, 34, 56, 0, time.UTC)
+
+	testCases := []struct {
+		name    string
+		src     any
+		valid   bool
+		isTime  bool
+		want    time.Time
+		wantStr string
+	}{
+		{name: "nil", src: nil, valid: false},
+		{name: "time", src: tm, valid: true, isTime: true, want: tm},
+		{name: "rails_micro", src: "2024-01-15 12:34:56.123456", valid: true, isTime: true, want: railsInstant},
+		{name: "rfc3339_z", src: "2024-01-15T12:34:56Z", valid: true, isTime: true, want: tm},
+		{name: "date_only", src: "2024-01-15", valid: true, isTime: true, want: time.Date(2024, 1, 15, 0, 0, 0, 0, time.UTC)},
+		{name: "junk", src: "not-a-date", valid: true, isTime: false, wantStr: "not-a-date"},
+		{name: "epoch_seconds", src: int64(1700000000), valid: true, isTime: true, want: epochInstant},
+		{name: "epoch_millis", src: int64(1700000000000), valid: true, isTime: true, want: epochInstant},
+		{name: "bytes_micro", src: []byte("2024-01-15 12:34:56.123456"), valid: true, isTime: true, want: railsInstant},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var nt nullTime
+			require.NoError(t, nt.Scan(tc.src))
+			require.Equal(t, tc.valid, nt.Valid)
+			require.Equal(t, tc.isTime, nt.IsTime)
+			if tc.isTime {
+				require.Truef(t, tc.want.Equal(nt.Time), "want %s, got %s", tc.want, nt.Time)
+			}
+			require.Equal(t, tc.wantStr, nt.String)
+		})
+	}
+}

--- a/drivers/sqlite3/sqlite3.go
+++ b/drivers/sqlite3/sqlite3.go
@@ -527,6 +527,11 @@ func newRecordFromScanRow(meta record.Meta, row []any) (rec record.Record) {
 			}
 			record.SetKindIfUnknown(meta, i, kind.Datetime)
 		case *nullTime:
+			// No SetKindIfUnknown call (unlike the sibling cases): a *nullTime
+			// dest is only allocated for columns already classified as
+			// kind.Datetime/kind.Date, so the kind is never unknown here. The
+			// value is the parsed time, or the raw string when the stored text
+			// didn't match a known datetime layout.
 			switch {
 			case !col.Valid:
 				rec[i] = nil

--- a/drivers/sqlite3/sqlite3.go
+++ b/drivers/sqlite3/sqlite3.go
@@ -526,6 +526,15 @@ func newRecordFromScanRow(meta record.Meta, row []any) (rec record.Record) {
 				rec[i] = nil
 			}
 			record.SetKindIfUnknown(meta, i, kind.Datetime)
+		case *nullTime:
+			switch {
+			case !col.Valid:
+				rec[i] = nil
+			case col.IsTime:
+				rec[i] = col.Time
+			default:
+				rec[i] = col.String
+			}
 		case *time.Time:
 			rec[i] = *col
 			record.SetKindIfUnknown(meta, i, kind.Datetime)

--- a/libsq/core/kind/kind_test.go
+++ b/libsq/core/kind/kind_test.go
@@ -82,7 +82,13 @@ const (
 	fixtDatetimeAnsic   = "Mon Jan 2 15:04:05 2006"
 	fixtDatetimeUnix    = "Mon Jan 2 15:04:05 MST 2006"
 	fixtDatetimeRFC3339 = "2002-10-02T10:00:00-05:00"
-	fixtDatetimeMicro   = "2024-01-15 12:34:56.123456"
+	// fixtDatetimeMicro is space-separated with fractional seconds. The detector
+	// matches it via the existing DateHourMinuteSecond layout
+	// ("2006-01-02 15:04:05"): Go's time.Parse accepts a trailing fractional
+	// second even when the layout omits one, so no dedicated fractional layout
+	// is needed. Adding an optional-fractional layout to datetimeFormats would
+	// also break TestDetectKindDatetime's per-layout round-trip.
+	fixtDatetimeMicro = "2024-01-15 12:34:56.123456"
 )
 
 func TestDetector(t *testing.T) {

--- a/libsq/core/kind/kind_test.go
+++ b/libsq/core/kind/kind_test.go
@@ -82,6 +82,7 @@ const (
 	fixtDatetimeAnsic   = "Mon Jan 2 15:04:05 2006"
 	fixtDatetimeUnix    = "Mon Jan 2 15:04:05 MST 2006"
 	fixtDatetimeRFC3339 = "2002-10-02T10:00:00-05:00"
+	fixtDatetimeMicro   = "2024-01-15 12:34:56.123456"
 )
 
 func TestDetector(t *testing.T) {
@@ -141,6 +142,7 @@ func TestDetector(t *testing.T) {
 		{in: []any{time.RFC1123}, want: kind.Datetime, wantMunge: true},
 		{in: []any{time.RFC1123Z}, want: kind.Datetime, wantMunge: true},
 		{in: []any{fixtDatetimeRFC3339}, want: kind.Datetime, wantMunge: true},
+		{in: []any{fixtDatetimeMicro}, want: kind.Datetime, wantMunge: true},
 	}
 
 	for i, tc := range testCases {


### PR DESCRIPTION
## Summary

Fixes #471. Querying a SQLite table whose `DATETIME`/`DATE` columns were
declared with a parameterized type — most commonly Rails' `datetime(6)`,
which stores microsecond text like `2024-01-15 12:34:56.123456` — failed with:

```
unsupported Scan, storing driver.Value type string into type *time.Time
```

`mattn/go-sqlite3` only converts a cell to `time.Time` when the column's
declared type is *exactly* `date`/`datetime`/`timestamp`; it does not strip the
`(6)`, so it returns the raw string. `sq` *does* strip the parens, classifies
the column `kind.Datetime`, and forced a `*sql.NullTime` scan destination — which
can't accept a string. The irony: `sq` correctly identifies the column as a
datetime; mattn only balked because of the parens.

- Add a driver-local `nullTime` `sql.Scanner` that accepts whatever mattn
  returns and, for text values, re-runs mattn's own `SQLiteTimestampFormats`
  (the parse mattn would have performed had it stripped the parens), recovering
  a proper `time.Time`. Genuinely unparseable text is preserved as a string
  rather than failing the query. It also handles `int64` epochs (mattn's
  heuristic) and preserves `float64` (REAL) values instead of hard-failing.
- Use it as the scan destination for `kind.Datetime`/`kind.Date` (`kind.Time`
  already scanned as a string).
- Unwrap `*nullTime` in `newRecordFromScanRow`. The column's kind stays
  Datetime/Date; the rare unparseable value arrives as a string, which every
  output writer already renders (they switch on value type).
- Add a regression test confirming the document-source kind detector also
  classifies microsecond datetimes. It already did — Go's `time.Parse` accepts a
  trailing fractional second even when the layout omits it — so no detector code
  change was needed.

Well-behaved datetime columns are unchanged (still arrive as `time.Time`).

Out of scope, as separate follow-ups: the user-facing per-column type-override
"escape hatch" originally requested in the issue, and the case where a column
declared *exactly* `datetime` holds unparseable text (mattn silently returns
zero-time and has already discarded the original bytes, so it can't be recovered
at the scan destination).

## Test Plan

- [x] `TestNullTimeScan` — scanner unit coverage (time / string / `[]byte` /
  int64 epoch s+ms / float REAL / junk / nil / unsupported type).
- [x] `TestQueryRailsDatetime` — end-to-end query of a `datetime(6)` table with
  one microsecond value (→ `time.Time`) and one unparseable value (→ string);
  asserts no error.
- [x] `TestRecordMetadata` — updated scan-type expectations.
- [x] `TestDetector` — regression case for `2024-01-15 12:34:56.123456`.
- [x] `make lint` → 0 issues; `make test-short` → full pass.