### PR TITLE
ci: update actions, enable github-actions dependabot, add codecov

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,3 +15,10 @@ updates:
     directory: "/site"
     schedule:
       interval: "weekly"
+
+  # GitHub Actions used in .github/workflows/ (directory "/" is the repo root;
+  # Dependabot discovers all workflow files beneath it).
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -22,4 +22,4 @@ jobs:
       - name: 'Checkout Repository'
         uses: actions/checkout@v6
       - name: 'Dependency Review'
-        uses: actions/dependency-review-action@v4
+        uses: actions/dependency-review-action@v5

--- a/.github/workflows/docker-publish-ci.yml
+++ b/.github/workflows/docker-publish-ci.yml
@@ -31,24 +31,24 @@ jobs:
         # Add support for more platforms with QEMU (optional)
         # https://github.com/docker/setup-qemu-action
         name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
       # Install the cosign tool except on PR
       # https://github.com/sigstore/cosign-installer
       - name: Install cosign
         if: github.event_name != 'pull_request'
-        uses: sigstore/cosign-installer@v3
+        uses: sigstore/cosign-installer@v4
 
       # Set up BuildKit Docker container builder to be able to build
       # multi-platform images and export cache
       # https://github.com/docker/setup-buildx-action
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       # Login against a Docker registry except on PR
       # https://github.com/docker/login-action
       - name: Log into registry ${{ env.REGISTRY }}
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -58,7 +58,7 @@ jobs:
       # https://github.com/docker/metadata-action
       - name: Extract Docker metadata
         id: meta
-        uses: docker/metadata-action@v5 # v5.0.0
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
@@ -66,7 +66,7 @@ jobs:
       # https://github.com/docker/build-push-action
       - name: Build and push Docker image
         id: build-and-push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           file: packages/docker/alpine.Dockerfile
           context: packages/docker

--- a/.github/workflows/docker-publish-dispatch.yml
+++ b/.github/workflows/docker-publish-dispatch.yml
@@ -36,24 +36,24 @@ jobs:
         # Add support for more platforms with QEMU (optional)
         # https://github.com/docker/setup-qemu-action
         name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
       # Install the cosign tool except on PR
       # https://github.com/sigstore/cosign-installer
       - name: Install cosign
         if: github.event_name != 'pull_request'
-        uses: sigstore/cosign-installer@v3
+        uses: sigstore/cosign-installer@v4
 
       # Set up BuildKit Docker container builder to be able to build
       # multi-platform images and export cache
       # https://github.com/docker/setup-buildx-action
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       # Login against a Docker registry except on PR
       # https://github.com/docker/login-action
       - name: Log into registry ${{ env.REGISTRY }}
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -63,7 +63,7 @@ jobs:
       # https://github.com/docker/metadata-action
       - name: Extract Docker metadata
         id: meta
-        uses: docker/metadata-action@v5 # v5.0.0
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
@@ -71,7 +71,7 @@ jobs:
       # https://github.com/docker/build-push-action
       - name: Build and push Docker image
         id: build-and-push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           file: packages/docker/alpine.Dockerfile
           context: packages/docker

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,8 +45,9 @@ jobs:
           set -e
 
           # We tee the go test output to a file, so that "tparse" can
-          # render pretty output below.
-          go test -tags '${{ env.BUILD_TAGS }}' -timeout 20m -v -json -cover ./... | tee gotest.out.json
+          # render pretty output below. "-coverprofile" writes a coverage
+          # profile to coverage.out for upload to Codecov.
+          go test -tags '${{ env.BUILD_TAGS }}' -timeout 20m -v -json -cover -coverprofile=coverage.out ./... | tee gotest.out.json
 
       - name: 'Test output'
         if: always()
@@ -55,6 +56,15 @@ jobs:
           set -e
           go install github.com/mfridman/tparse@${{ env.TPARSE_VERSION }}
           tparse -all -sort=elapsed -file gotest.out.json
+
+      - name: Upload coverage to Codecov
+        if: always()
+        uses: codecov/codecov-action@v6
+        with:
+          files: ./coverage.out
+          flags: ${{ matrix.os }}
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false
 
 
   test-windows:
@@ -161,7 +171,7 @@ jobs:
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
 
       - name: Upload assets (darwin)
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: dist-darwin
           path: dist-darwin
@@ -192,7 +202,7 @@ jobs:
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
 
       - name: Upload assets (linux-amd64)
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: dist-linux-amd64
           path: dist-linux
@@ -228,7 +238,7 @@ jobs:
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
 
       - name: Upload assets (linux-arm64)
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: dist-linux-arm64
           path: dist-linux
@@ -261,7 +271,7 @@ jobs:
 
 
       - name: Upload assets (windows)
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: dist-windows
           path: dist-windows
@@ -289,25 +299,25 @@ jobs:
           go-version-file: go.mod
 
       - name: Download darwin artifacts
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           name: dist-darwin
           path: dist-darwin
 
       - name: Download linux-amd64 artifacts
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           name: dist-linux-amd64
           path: dist-linux
 
       - name: Download linux-arm64 artifacts
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           name: dist-linux-arm64
           path: dist-linux
 
       - name: Download windows artifacts
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           name: dist-windows
           path: dist-windows

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 [![Go Report Card](https://goreportcard.com/badge/neilotoole/sq)](https://goreportcard.com/report/neilotoole/sq)
 [![License](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/neilotoole/sq/blob/master/LICENSE)
 ![Main pipeline](https://github.com/neilotoole/sq/actions/workflows/main.yml/badge.svg)
+[![codecov](https://codecov.io/gh/neilotoole/sq/graph/badge.svg)](https://codecov.io/gh/neilotoole/sq)
 
 # sq data wrangler
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,23 @@
+# Codecov configuration.
+# See https://docs.codecov.com/docs/codecov-yaml for all options.
+#
+# Coverage is uploaded from the test-nix matrix (ubuntu + macos) in
+# .github/workflows/main.yml, tagged per-OS via flags. Checks are
+# informational so they report status without blocking PR merges.
+
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true
+
+comment:
+  layout: "reach, diff, flags, files"
+  require_changes: false
+
+flag_management:
+  default_rules:
+    carryforward: true


### PR DESCRIPTION
## Summary

CI maintenance: bring workflow actions up to date, have Dependabot keep
them current, and start uploading test coverage to Codecov.

## Changes

### Bump stale workflow actions
Nine actions were a major version behind. Updated to latest:

| Action | From → To |
|---|---|
| actions/upload-artifact | v6 → v7 |
| actions/download-artifact | v7 → v8 |
| actions/dependency-review-action | v4 → v5 |
| docker/build-push-action | v6 → v7 |
| docker/login-action | v3 → v4 |
| docker/metadata-action | v5 → v6 |
| docker/setup-buildx-action | v3 → v4 |
| docker/setup-qemu-action | v3 → v4 |
| sigstore/cosign-installer | v3 → v4 |

The artifact bumps are safe for our usage: `upload-artifact@v7`'s direct
(unzipped) upload is opt-in, and `download-artifact@v8` auto-detects
zipped artifacts (it also now errors on hash mismatch by default, a
security improvement).

### Dependabot watches GitHub Actions
Added the `github-actions` ecosystem (`directory: "/"`, weekly) to
`.github/dependabot.yml`. The absence of this entry is why the actions
above drifted behind; Dependabot will now open PRs for action bumps.

### Codecov upload
- `test-nix` now runs `go test … -coverprofile=coverage.out` and uploads
  via `codecov/codecov-action@v6` using the existing `CODECOV_TOKEN`,
  tagged per-OS via `flags`, with `fail_ci_if_error: false` so a Codecov
  outage never breaks CI.
- New root `codecov.yml` with **informational** project/patch checks
  (reports coverage without blocking merges).
- Codecov badge added to the README.

Scoped coverage to the `test-nix` matrix (ubuntu + macos); the Windows
test job was left out as its test step is more fragile.

## Verification
- `actionlint` clean across all workflows.
- `dependabot.yml` and `codecov.yml` parse OK.
- README badge introduces no new markdownlint findings.