### PR TITLE
ci: add -coverpkg=./... to attribute cross-package coverage

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,8 +46,10 @@ jobs:
 
           # We tee the go test output to a file, so that "tparse" can
           # render pretty output below. "-coverprofile" writes a coverage
-          # profile to coverage.out for upload to Codecov.
-          go test -tags '${{ env.BUILD_TAGS }}' -timeout 20m -v -json -cover -coverprofile=coverage.out ./... | tee gotest.out.json
+          # profile to coverage.out for upload to Codecov. "-coverpkg=./..."
+          # attributes coverage across all packages (e.g. integration tests
+          # exercising other packages), giving a more representative total.
+          go test -tags '${{ env.BUILD_TAGS }}' -timeout 20m -v -json -cover -coverpkg=./... -coverprofile=coverage.out ./... | tee gotest.out.json
 
       - name: 'Test output'
         if: always()


### PR DESCRIPTION
## Summary

Follow-up to #672. The `test-nix` coverage profile was built with
per-package coverage only, so a statement was credited as covered only
when exercised by tests *in its own package*. Integration-style tests
that drive other packages weren't attributed back, understating the
Codecov total (the badge landed at ~29%).

This adds `-coverpkg=./...` to the `go test` invocation so coverage is
attributed across all packages, producing a more representative figure.

## Trade-off

`-coverpkg=./...` instruments every matched package, so the test run
takes somewhat longer. The existing `-timeout 20m` has ample headroom
(the prior ubuntu run was ~7m), so no timeout change is needed.

## Verification

- `actionlint` clean.
- Coverage upload itself was already confirmed working in #672; this
  only changes how the profile is computed. The badge will refresh to
  the higher figure once this merges and Codecov reprocesses `master`.