### PR TITLE
chore(deps): bump streamcache to v0.4.0, set go directive to 1.26.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/neilotoole/sq
 // NOTE: Some of these deps are marked with "BRITTLE". That means that extra
 // care needs to be taken when upgrading those versions, for various reasons.
 
-go 1.26.1
+go 1.26.3
 
 // godebug x509negativeserial=1 is set here because of an issue with older
 // SQL Server versions not doing the right thing with X509 certs (see RFC 5280).
@@ -49,7 +49,7 @@ require (
 	github.com/neilotoole/oncecache v0.1.0
 	github.com/neilotoole/shelleditor v0.4.1
 	github.com/neilotoole/slogt v1.1.0
-	github.com/neilotoole/streamcache v0.3.5
+	github.com/neilotoole/streamcache v0.4.0
 	github.com/neilotoole/tailbuf v0.1.1
 	github.com/nightlyone/lockfile v1.0.0
 	github.com/otiai10/copy v1.14.1
@@ -132,7 +132,7 @@ require (
 	github.com/muesli/mango v0.2.0 // indirect
 	github.com/muesli/mango-pflag v0.2.0 // indirect
 	github.com/nathan-fiscaletti/consolesize-go v0.0.0-20260406063853-3bac975de715 // indirect
-	github.com/neilotoole/fifomu v0.1.2 // indirect
+	github.com/neilotoole/fifomu v0.2.0 // indirect
 	github.com/otiai10/mint v1.6.3 // indirect
 	github.com/paulmach/orb v0.13.0 // indirect
 	github.com/pierrec/lz4/v4 v4.1.26 // indirect

--- a/go.sum
+++ b/go.sum
@@ -552,8 +552,8 @@ github.com/nathan-fiscaletti/consolesize-go v0.0.0-20260406063853-3bac975de715 h
 github.com/nathan-fiscaletti/consolesize-go v0.0.0-20260406063853-3bac975de715/go.mod h1:DQpEqvLUU3b35AJUVu5P6LFn/RY3qj4WtMjvrcE8gto=
 github.com/ncruces/go-strftime v1.0.0 h1:HMFp8mLCTPp341M/ZnA4qaf7ZlsbTc+miZjCLOFAw7w=
 github.com/ncruces/go-strftime v1.0.0/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
-github.com/neilotoole/fifomu v0.1.2 h1:sgJhcOTlEXGVj/nS5Bb8/qV+1wgmk+KPavcNuDw0rDM=
-github.com/neilotoole/fifomu v0.1.2/go.mod h1:9di2j+xBgr+nX6IPmpwQVxKt6yzgPLk9WXEj/aLwcao=
+github.com/neilotoole/fifomu v0.2.0 h1:6mBpHXsOIpyrOYZUab7Bz2R+HL6R1f6qo8v/m7CkJy0=
+github.com/neilotoole/fifomu v0.2.0/go.mod h1:tJqmHyCaQ/PH+nZdVLrVv+2ah5Zz/wpuKfPSYJit9ek=
 github.com/neilotoole/oncecache v0.1.0 h1:EHCNw1yg08rV1QBj9+E1B6fsVRU/ON7KTcjJ6ZX11nQ=
 github.com/neilotoole/oncecache v0.1.0/go.mod h1:59Vy10UFEIp/Zsd395DIJm4dIZrOb1zGAufZoF8oY8M=
 github.com/neilotoole/shelleditor v0.4.1 h1:74LEw2mVo3jtNw2BjII6RSss9DXgEqAbmCQDDiJvzO0=
@@ -562,8 +562,8 @@ github.com/neilotoole/slogt v1.1.0 h1:c7qE92sq+V0yvCuaxph+RQ2jOKL61c4hqS1Bv9W7FZ
 github.com/neilotoole/slogt v1.1.0/go.mod h1:RCrGXkPc/hYybNulqQrMHRtvlQ7F6NktNVLuLwk6V+w=
 github.com/neilotoole/slogt/v2 v2.0.0 h1:Kz8VWdkjXZnkVvN1hsGYI1ervWhlcDcIcVizUJbLbH8=
 github.com/neilotoole/slogt/v2 v2.0.0/go.mod h1:M/RN37tAuM3cpb/wD6lCpOSvphLMjuAzA/IV2hqJh3E=
-github.com/neilotoole/streamcache v0.3.5 h1:8YVgTcd3OpTC46zduXJE4WAhTjxQCEBHYVGDgQ6R3ss=
-github.com/neilotoole/streamcache v0.3.5/go.mod h1:yYJLcdAWI6jMeSSIfQ8vIydWxsrdAdGGNbYMXvWKV6M=
+github.com/neilotoole/streamcache v0.4.0 h1:QHyRD/K4ImWKX6scz6TiqNJnghle+APcAJWa9cajLo0=
+github.com/neilotoole/streamcache v0.4.0/go.mod h1:7o5Vy4LO24DGLCJEJwjeSPqNDZtKkg+C4mRov02eLjA=
 github.com/neilotoole/tailbuf v0.1.1 h1:Uzhh/+H/OcoY++mfU/AFZ+yq567v9R/Cshvps6fIklc=
 github.com/neilotoole/tailbuf v0.1.1/go.mod h1:drAfG791tTcCre7cR8m4LfHRVR7y0Ht1kpaLo0T7P8A=
 github.com/nightlyone/lockfile v1.0.0 h1:RHep2cFKK4PonZJDdEl4GmkabuhbsRMgk/k3uAmxBiA=
@@ -740,6 +740,8 @@ go.opentelemetry.io/otel/trace v1.43.0 h1:BkNrHpup+4k4w+ZZ86CZoHHEkohws8AY+WTX09
 go.opentelemetry.io/otel/trace v1.43.0/go.mod h1:/QJhyVBUUswCphDVxq+8mld+AvhXZLhe+8WVFxiFff0=
 go.uber.org/atomic v1.11.0 h1:ZvwS0R+56ePWxUNi+Atn9dWONBPp/AUETXlHW0DxSjE=
 go.uber.org/atomic v1.11.0/go.mod h1:LUxbIzbOniOlMKjJjyPfpl4v+PKK2cNJn91OQbhoJI0=
+go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
+go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=
 go.uber.org/multierr v1.11.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
 go.uber.org/zap v1.27.1 h1:08RqriUEv8+ArZRYSTXy1LeBScaMpVSTBhCeaZYfMYc=


### PR DESCRIPTION
## Summary

- Bump `github.com/neilotoole/streamcache` v0.3.5 → v0.4.0 (also pulls transitive `github.com/neilotoole/fifomu` v0.1.2 → v0.2.0).
- Set the `go.mod` `go` directive from `1.26.1` → `1.26.3` to match the toolchain in use.

## streamcache v0.4.0

The upgrade is backward compatible. The only API signature change is `New(src io.Reader)` → `New(src io.Reader, opts ...Option)`, a variadic addition, so the existing `streamcache.New(...)` call sites in `libsq/files` are unaffected. v0.4.0 adds an optional `MaxCacheSize` option and `ErrCacheLimit` (not wired up here).

## Verification

- `go mod tidy` clean
- `go build ./...` clean
- `go test -short ./libsq/files/...` passes (the only packages that use streamcache)