### PR TITLE
fix(sqlserver): scope source-level inspect to current schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,15 @@ Breaking changes are annotated with ☢️, and alpha/beta features with 🐥.
 
 ### Fixed
 
+- [#613]: [`sq inspect`](https://sq.io/docs/inspect) of a SQL Server source no
+  longer returns tables from schemas other than the source's current schema.
+  - `getAllTables` queried `INFORMATION_SCHEMA.TABLES` without a `TABLE_SCHEMA`
+    filter, so source-level inspect returned every table the connected user
+    could see (e.g. `dbo` plus any other schema). Cross-schema tables surfaced
+    with empty foreign-key / unique-constraint / index metadata, and a
+    same-named table in another schema collided with the real one on its bare
+    name. The query is now scoped to the current schema, as the Postgres,
+    Oracle, and DuckDB drivers already scope theirs.
 - [#471]: The SQLite driver no longer fails with `unsupported Scan, storing
   driver.Value type string into type *time.Time` when a `DATETIME`/`DATE`
   column stores text that `mattn/go-sqlite3` doesn't natively convert — most
@@ -1538,6 +1547,7 @@ make working with lots of sources much easier.
 [#572]: https://github.com/neilotoole/sq/pull/572
 [#601]: https://github.com/neilotoole/sq/issues/601
 [#602]: https://github.com/neilotoole/sq/pull/602
+[#613]: https://github.com/neilotoole/sq/issues/613
 [#615]: https://github.com/neilotoole/sq/issues/615
 [#628]: https://github.com/neilotoole/sq/issues/628
 [#629]: https://github.com/neilotoole/sq/issues/629

--- a/drivers/sqlserver/metadata.go
+++ b/drivers/sqlserver/metadata.go
@@ -737,7 +737,7 @@ ORDER BY TABLE_NAME ASC, TABLE_TYPE ASC`
 
 	rows, err := db.QueryContext(ctx, query, tblSchema)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, errw(err)
 	}
 	defer sqlz.CloseRows(log, rows)
 

--- a/drivers/sqlserver/metadata.go
+++ b/drivers/sqlserver/metadata.go
@@ -149,7 +149,7 @@ GROUP BY database_id) AS total_size_bytes`
 		return md, nil
 	}
 
-	tblNames, tblTypes, err := getAllTables(ctx, db)
+	tblNames, tblTypes, err := getAllTables(ctx, db, schema)
 	if err != nil {
 		return nil, err
 	}
@@ -723,15 +723,19 @@ ORDER BY parent_t.name, fk.name, fkc.constraint_column_id`
 }
 
 // getAllTables returns all of the table names, and the table types
-// (i.e. "BASE TABLE" or "VIEW").
-func getAllTables(ctx context.Context, db sqlz.DB) (tblNames, tblTypes []string, err error) {
+// (i.e. "BASE TABLE" or "VIEW") in the given schema. The query is scoped to
+// tblSchema because the connected user typically sees tables across multiple
+// schemas (at minimum dbo + INFORMATION_SCHEMA); without the filter, tables
+// outside the source's current schema leak into source-level inspect, and
+// same-named tables across schemas collide on the bare table name. See #613.
+func getAllTables(ctx context.Context, db sqlz.DB, tblSchema string) (tblNames, tblTypes []string, err error) {
 	log := lg.FromContext(ctx)
 
 	const query = `SELECT TABLE_NAME, TABLE_TYPE FROM INFORMATION_SCHEMA.TABLES
-WHERE TABLE_TYPE='BASE TABLE' OR TABLE_TYPE='VIEW'
+WHERE TABLE_SCHEMA = @p1 AND (TABLE_TYPE = 'BASE TABLE' OR TABLE_TYPE = 'VIEW')
 ORDER BY TABLE_NAME ASC, TABLE_TYPE ASC`
 
-	rows, err := db.QueryContext(ctx, query)
+	rows, err := db.QueryContext(ctx, query, tblSchema)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/drivers/sqlserver/sqlserver_test.go
+++ b/drivers/sqlserver/sqlserver_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/neilotoole/sq/testh"
 	"github.com/neilotoole/sq/testh/fixt"
 	"github.com/neilotoole/sq/testh/sakila"
+	"github.com/neilotoole/sq/testh/tu"
 )
 
 func TestSmoke(t *testing.T) {
@@ -109,6 +110,52 @@ func TestDriver_CreateTable_NotNullDefault(t *testing.T) {
 			require.Equal(t, 0, len(b), "b should be non-nil but zero length")
 		})
 	}
+}
+
+// TestSourceMetadata_ScopedToCurrentSchema verifies that source-level
+// inspect returns only tables in the source's current schema, not tables
+// from other schemas that the connected user happens to be able to see.
+// This is a regression test for issue #613.
+// See: https://github.com/neilotoole/sq/issues/613
+func TestSourceMetadata_ScopedToCurrentSchema(t *testing.T) {
+	// Deliberately not parallel: this runs a full source-level inspect
+	// (many concurrent per-table metadata queries) and creates/drops a
+	// schema. Running it in the sequential phase keeps it from deadlocking
+	// against the DDL performed by the parallel tests in this package.
+	tu.SkipShort(t, true)
+
+	th, _, drvr, grip, db := testh.NewWith(t, sakila.MS)
+	ctx := th.Context
+
+	// Create a second schema and copy dbo.actor into it under the SAME
+	// name. getAllTables must be scoped to the source's current schema
+	// (dbo); otherwise it returns "actor" twice (once per schema), and the
+	// per-table metadata for both rows collides on the bare table name,
+	// yielding a duplicate "actor" entry in the source metadata.
+	otherSchema := "gh613_" + stringz.Uniq8()
+	require.NoError(t, drvr.CreateSchema(ctx, db, otherSchema))
+	t.Cleanup(func() {
+		assert.NoError(t, drvr.DropSchema(ctx, db, otherSchema))
+	})
+
+	destTblFQ := tablefq.T{Schema: otherSchema, Table: sakila.TblActor}
+	srcTblFQ := tablefq.From(sakila.TblActor)
+	_, err := drvr.CopyTable(ctx, db, srcTblFQ, destTblFQ, true)
+	require.NoError(t, err, "CopyTable into other schema should succeed")
+
+	md, err := grip.SourceMetadata(ctx, false)
+	require.NoError(t, err)
+	require.Equal(t, "dbo", md.Schema)
+
+	var actorCount int
+	for _, name := range md.TableNames() {
+		if name == sakila.TblActor {
+			actorCount++
+		}
+	}
+	require.Equal(t, 1, actorCount,
+		"source-level inspect must return tables only from the current schema, "+
+			"so %q must appear exactly once", sakila.TblActor)
 }
 
 // TestNumericSchema tests that numeric and numeric-prefixed schema names

--- a/drivers/sqlserver/sqlserver_test.go
+++ b/drivers/sqlserver/sqlserver_test.go
@@ -127,11 +127,17 @@ func TestSourceMetadata_ScopedToCurrentSchema(t *testing.T) {
 	th, _, drvr, grip, db := testh.NewWith(t, sakila.MS)
 	ctx := th.Context
 
-	// Create a second schema and copy dbo.actor into it under the SAME
-	// name. getAllTables must be scoped to the source's current schema
-	// (dbo); otherwise it returns "actor" twice (once per schema), and the
-	// per-table metadata for both rows collides on the bare table name,
-	// yielding a duplicate "actor" entry in the source metadata.
+	// Copy dbo.actor into a second schema under the SAME name. The same
+	// name is deliberate, and is what makes this a deterministic regression
+	// signal: an unscoped getAllTables returns "actor" twice (once per
+	// schema), and the per-table metadata for both rows resolves to dbo.actor
+	// and collides on the bare table name, yielding a duplicate "actor" entry.
+	//
+	// A *uniquely*-named table in the other schema would NOT distinguish the
+	// bug from the fix: the per-table loader (sp_spaceused, which resolves the
+	// bare name against dbo) silently skips a cross-schema table that has no
+	// dbo counterpart, so it never reaches md.Tables whether getAllTables is
+	// scoped or not. The collision is therefore the symptom to assert on.
 	otherSchema := "gh613_" + stringz.Uniq8()
 	require.NoError(t, drvr.CreateSchema(ctx, db, otherSchema))
 	t.Cleanup(func() {
@@ -154,8 +160,9 @@ func TestSourceMetadata_ScopedToCurrentSchema(t *testing.T) {
 		}
 	}
 	require.Equal(t, 1, actorCount,
-		"source-level inspect must return tables only from the current schema, "+
-			"so %q must appear exactly once", sakila.TblActor)
+		"source-level inspect must be scoped to the current schema: the "+
+			"same-named %q in another schema must not produce a duplicate entry",
+		sakila.TblActor)
 }
 
 // TestNumericSchema tests that numeric and numeric-prefixed schema names


### PR DESCRIPTION
## Summary

In the SQL Server driver, `getAllTables` (`drivers/sqlserver/metadata.go`)
queried `INFORMATION_SCHEMA.TABLES` without a `TABLE_SCHEMA` filter, so
source-level [`sq inspect`](https://sq.io/docs/inspect) returned every table
the connected user could see — at minimum `dbo` plus any other schema — not
just the source's current schema.

This was pre-existing (introduced in 2020) but became more visible after #600:
the FK / unique-constraint / index bulk loaders are correctly scoped to the
current schema, so cross-schema tables now appeared with **empty** FK / UC /
index metadata. Worse, a same-named table in another schema collided with the
real one on its bare table name inside the `Assign*` helpers, and the
per-table loader assembled `FQName` using the source-level schema for every
table.

Closes #613.

## Fix

- `getAllTables` now takes the resolved schema and filters the query with
  `TABLE_SCHEMA = @p1 AND (TABLE_TYPE = 'BASE TABLE' OR TABLE_TYPE = 'VIEW')`.
- The lone caller passes the `schema` already resolved from `getSourceMetadata`'s
  preamble query.

This matches how the Postgres (`current_schema()`), Oracle (`USER_*` views),
and DuckDB (`schema_name = current_schema()`) drivers already scope their
table enumeration.

## Test

Added `TestSourceMetadata_ScopedToCurrentSchema`, written test-first:

- Copies `dbo.actor` into a freshly created second schema under the **same**
  name, runs source-level inspect, and asserts `actor` appears exactly once.
- Confirmed it fails without the fix (`actor` count 2) and passes with it.

The test is deliberately non-parallel: a full source-level inspect issues many
concurrent per-table metadata queries whose read locks deadlock against the
DDL performed by the parallel tests in this package. Running it in the
sequential phase (siblings paused) makes it deterministic — verified stable
across 10 consecutive full-package runs.

## Verification

- `go build ./...`, full `drivers/sqlserver` suite, and `cli` inspect tests all
  pass; the standard single-schema (`dbo`) sakila fixture output is unchanged.
- `gofumpt` / `golangci-lint` clean on the changed files.