### PR TITLE
ci(codeql): exclude Hugo-templated JS from site scan

### DIFF
--- a/.github/codeql/codeql-site-config.yml
+++ b/.github/codeql/codeql-site-config.yml
@@ -10,3 +10,11 @@ paths-ignore:
   # (e.g. the Mermaid.js bundle in sakila.html). CodeQL flags issues inside
   # that minified library; they are not sq source and are not actionable here.
   - "site/static/examples"
+  # Hugo-templated JavaScript: these .js files embed Go template directives
+  # ({{ ... }}) that Hugo renders at build time, so as raw source they are not
+  # valid JavaScript. CodeQL's JS parser reports "Could not process some files
+  # due to syntax errors" (Unexpected token) on them. assets/js/index.js builds
+  # the FlexSearch client index; layouts/_default/index.js renders the search
+  # index output template.
+  - "site/assets/js/index.js"
+  - "site/layouts/_default/index.js"

--- a/.github/workflows/codeql-site.yml
+++ b/.github/workflows/codeql-site.yml
@@ -7,11 +7,13 @@ on:
     paths:
       - "site/**"
       - ".github/workflows/codeql-site.yml"
+      - ".github/codeql/codeql-site-config.yml"
   pull_request:
     branches: [master, develop]
     paths:
       - "site/**"
       - ".github/workflows/codeql-site.yml"
+      - ".github/codeql/codeql-site-config.yml"
   schedule:
     - cron: "0 11 * * 5"
 


### PR DESCRIPTION
## Problem

The repo's **Security and quality → Overview** shows "Code scanning: one or
more analysis tools are reporting problems — CodeQL is reporting warnings."
The `language:javascript` configuration (`.github/workflows/codeql-site.yml`)
reports:

> Could not process some files due to syntax errors. A parse error occurred:
> `Unexpected token`.

## Root cause

Two `.js` files under `site/` are actually **Hugo templates** — they embed Go
template directives (`{{ $list := slice }}`, `{{ range … }}`,
`{{ .Title | jsonify }}`) that Hugo renders at build time. As raw source they
are not valid JavaScript, so CodeQL's JS parser fails on them:

- `site/assets/js/index.js` — builds the FlexSearch client index (the file
  GitHub links to)
- `site/layouts/_default/index.js` — renders the search-index output template

`site/scripts/version-fetch.js` is **valid JavaScript** (its only `{{` is
inside a JSDoc `@returns` type annotation) and is deliberately **kept in
scope**.

## Fix

1. Add both templated files to `paths-ignore` in
   `.github/codeql/codeql-site-config.yml`, with a comment explaining why
   (matching the existing `static/examples` exclusion).
2. Add `.github/codeql/codeql-site-config.yml` to the workflow's
   `push`/`pull_request` path filters, so config-only changes re-trigger the
   analysis. Without this, a config-only commit would not re-run the scan
   until the next `site/` change or the Friday cron, and the warning would
   linger.

After this analysis runs, the CodeQL warning clears.
