### PR TITLE
ci: draft-aware CI gating + Windows smoke test to speed up the dev loop

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -22,6 +22,7 @@ on:
       - "go.sum"
       - ".github/workflows/codeql.yml"
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches: [master]
     paths:
       - "**/*.go"
@@ -31,9 +32,19 @@ on:
   schedule:
     - cron: '36 10 * * 0'
 
+concurrency:
+  group: codeql-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: >-
+    ${{ github.ref != 'refs/heads/master'
+        && !startsWith(github.ref, 'refs/tags/v') }}
+
 jobs:
   analyze:
     name: Analyze
+    # Skip on draft PRs; a draft can't be merged anyway, and marking it Ready
+    # (ready_for_review) triggers a scan. master pushes + the weekly schedule
+    # still scan.
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     permissions:
       actions: read

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -11,26 +11,15 @@
 #
 name: "CodeQL"
 
-# Go analysis only when Go/module inputs change (site JS is codeql-site.yml).
+# CodeQL is slow, so it's kept off the PR/dev loop (site JS is codeql-site.yml).
+# It runs nightly against master and on release tags (v*), where it's part of
+# release validation, plus on demand via workflow_dispatch.
 on:
   workflow_dispatch:
   push:
-    branches: [master]
-    paths:
-      - "**/*.go"
-      - "go.mod"
-      - "go.sum"
-      - ".github/workflows/codeql.yml"
-  pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
-    branches: [master]
-    paths:
-      - "**/*.go"
-      - "go.mod"
-      - "go.sum"
-      - ".github/workflows/codeql.yml"
+    tags: ['v*']
   schedule:
-    - cron: '36 10 * * 0'
+    - cron: '36 10 * * *' # Nightly (UTC).
 
 concurrency:
   group: codeql-${{ github.event_name }}-${{ github.ref }}
@@ -41,10 +30,6 @@ concurrency:
 jobs:
   analyze:
     name: Analyze
-    # Skip on draft PRs; a draft can't be merged anyway, and marking it Ready
-    # (ready_for_review) triggers a scan. master pushes + the weekly schedule
-    # still scan.
-    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     permissions:
       actions: read

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,14 +1,27 @@
 name: Main Pipeline
 on:
-  push:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     paths-ignore:
       - '**.md'
-      - 'sq.json' # This is updated by scoop; no need to run a new build
-      - '.github/workflows/*'
+      - 'sq.json' # Updated by scoop; no need to run a new build.
       - 'site/**'
+  push:
+    # No paths-ignore on push: master merges and release tags must always run
+    # (paths filtering on tag pushes is unreliable and could skip a release).
+    branches: [master]
+    tags: ['v*']
+  schedule:
+    - cron: '17 9 * * *' # Nightly full suite vs master (UTC; tunable).
 
-  # Allows this workflow to be manually triggered from the Actions tab
+  # Allows this workflow to be manually triggered from the Actions tab.
   workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: >-
+    ${{ github.ref != 'refs/heads/master'
+        && !startsWith(github.ref, 'refs/tags/v') }}
 
 env:
   GORELEASER_VERSION: 2.13.3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,7 +55,8 @@ jobs:
       - name: 'Go tests'
         shell: bash
         run: |
-          set -e
+          # pipefail so a `go test` failure isn't masked by the `| tee` below.
+          set -eo pipefail
 
           # Instrument coverage only on the ubuntu-24.04 runner (uploaded to
           # Codecov below); macOS runs a plain test to keep the matrix fast.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
         with:
-          fetch-depth: 0
+          fetch-depth: 1
 
       - name: Set up Go
         uses: actions/setup-go@v6
@@ -57,12 +57,19 @@ jobs:
         run: |
           set -e
 
-          # We tee the go test output to a file, so that "tparse" can
-          # render pretty output below. "-coverprofile" writes a coverage
-          # profile to coverage.out for upload to Codecov. "-coverpkg=./..."
+          # Instrument coverage only on the ubuntu-24.04 runner (uploaded to
+          # Codecov below); macOS runs a plain test to keep the matrix fast.
+          # If the matrix gains another ubuntu image, update the check below.
+          # "-coverpkg=./..."
           # attributes coverage across all packages (e.g. integration tests
           # exercising other packages), giving a more representative total.
-          go test -tags '${{ env.BUILD_TAGS }}' -timeout 20m -v -json -cover -coverpkg=./... -coverprofile=coverage.out ./... | tee gotest.out.json
+          cover_args=()
+          if [ "${{ matrix.os }}" = "ubuntu-24.04" ]; then
+            cover_args=(-cover -coverpkg=./... -coverprofile=coverage.out)
+          fi
+
+          go test -tags '${{ env.BUILD_TAGS }}' -timeout 20m -v -json \
+            "${cover_args[@]}" ./... | tee gotest.out.json
 
       - name: 'Test output'
         if: always()
@@ -73,7 +80,7 @@ jobs:
           tparse -all -sort=elapsed -file gotest.out.json
 
       - name: Upload coverage to Codecov
-        if: always()
+        if: always() && matrix.os == 'ubuntu-24.04'
         uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6
         with:
           files: ./coverage.out
@@ -163,7 +170,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
         with:
-          fetch-depth: 0
+          fetch-depth: 1
 
       - name: Lint GH workflow files
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,7 +1,6 @@
 name: Main Pipeline
 on:
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
     paths-ignore:
       - '**.md'
       - 'sq.json' # Updated by scoop; no need to run a new build.
@@ -91,9 +90,12 @@ jobs:
 
 
   test-windows-smoke:
-    # Fast Windows check for the draft-PR dev loop: compile everything (catches
-    # CGO/SQLite breakage) and run only the focused smoke suite.
-    if: github.event_name == 'pull_request' && github.event.pull_request.draft == true
+    # Fast Windows check for the dev loop: compile everything (catches
+    # CGO/SQLite breakage) and run only the focused smoke suite. Runs on every
+    # PR and on master merges; the full suite runs nightly and on release tags.
+    if: >-
+      github.event_name == 'pull_request'
+      || (github.event_name == 'push' && github.ref == 'refs/heads/master')
     runs-on: windows-2022
     steps:
       - name: Checkout
@@ -111,12 +113,11 @@ jobs:
         run: go test -tags '${{ env.BUILD_TAGS }}' -timeout 10m -v ./test/smoke/...
 
   test-windows-full:
-    # Full Windows suite. Runs on Ready (non-draft) PRs, master merges,
-    # release tags, and the nightly schedule.
+    # Full Windows suite. Runs nightly against master, on release tags (it
+    # gates publish), and on manual dispatch — not on PRs or master merges,
+    # which get the fast smoke check above.
     if: >-
-      (github.event_name == 'pull_request' && github.event.pull_request.draft == false)
-      || (github.event_name == 'push' && github.ref == 'refs/heads/master')
-      || startsWith(github.ref, 'refs/tags/v')
+      startsWith(github.ref, 'refs/tags/v')
       || github.event_name == 'schedule'
       || github.event_name == 'workflow_dispatch'
     runs-on: windows-2022

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -82,7 +82,35 @@ jobs:
           fail_ci_if_error: false
 
 
-  test-windows:
+  test-windows-smoke:
+    # Fast Windows check for the draft-PR dev loop: compile everything (catches
+    # CGO/SQLite breakage) and run only the focused smoke suite.
+    if: github.event_name == 'pull_request' && github.event.pull_request.draft == true
+    runs-on: windows-2022
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+
+      - name: Build
+        run: go build -tags '${{ env.BUILD_TAGS }}' -v ./...
+
+      - name: Smoke tests
+        run: go test -tags '${{ env.BUILD_TAGS }}' -timeout 10m -v ./test/smoke/...
+
+  test-windows-full:
+    # Full Windows suite. Runs on Ready (non-draft) PRs, master merges,
+    # release tags, and the nightly schedule.
+    if: >-
+      (github.event_name == 'pull_request' && github.event.pull_request.draft == false)
+      || (github.event_name == 'push' && github.ref == 'refs/heads/master')
+      || startsWith(github.ref, 'refs/tags/v')
+      || github.event_name == 'schedule'
+      || github.event_name == 'workflow_dispatch'
     runs-on: windows-2022
     steps:
     # Copied from https://github.com/mattn/go-sqlite3/blob/master/.github/workflows/go.yaml#L73
@@ -96,7 +124,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v6
       with:
-        fetch-depth: 0
+        fetch-depth: 1
 
     - name: Set up Go
       uses: actions/setup-go@v6
@@ -119,7 +147,7 @@ jobs:
 
         # We send the Go test output to a file, so that "tparse" can
         # render pretty output below.
-        go test -tags '${{ env.BUILD_TAGS }}' -timeout 20m -v -json -cover ./... > gotest.out.json
+        go test -tags '${{ env.BUILD_TAGS }}' -timeout 20m -v -json ./... > gotest.out.json
 
     - name: 'Test output'
       if: always()
@@ -297,7 +325,7 @@ jobs:
     needs:
       - lint
       - test-nix
-      - test-windows
+      - test-windows-full
       - binaries-darwin
       - binaries-linux-amd64
       - binaries-linux-arm64

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,18 +86,18 @@ Use the usual GitHub process to open a PR. Before you do so, please:
 - If the PR adds a **new driver type**, complete the
   [driver ship checklist](#driver-ship-checklist) (sq.io and `skills/sq/`).
 
-### CI and draft PRs
+### CI: the fast loop and the slow jobs
 
-CI is PR-centric: a branch gets CI once a pull request exists. Open your PR as
-a **draft** to start the fast dev loop — every push runs lint, the Linux/macOS
-tests, and a fast **Windows smoke** test (`test/smoke/`). The in-progress run
-for a superseded commit is cancelled when you push again.
+CI is PR-centric: a branch gets CI once a pull request exists. Every push to a
+PR runs lint, the Linux/macOS tests, and a fast **Windows smoke** test
+(`test/smoke/`); the in-progress run for a superseded commit is cancelled when
+you push again. The same fast set runs on merges to master.
 
-When you click **Ready for review**, the **full Windows suite** and **CodeQL**
-run on the PR. The full Windows suite also runs on master merges, nightly, and
-on release tags. Because a draft PR can't be merged, marking it Ready
-guarantees the full suite runs on the PR before merge. (To make these checks
-*block* merge, add them as required status checks in branch protection.)
+The slow jobs — the **full Windows suite** and **CodeQL** — are kept off the
+dev loop. They run **nightly** against master and on **release tags** (`v*`),
+where the full Windows suite gates `publish` and CodeQL runs as part of release
+validation. You can also run either on demand from the Actions tab via **Run
+workflow** (`workflow_dispatch`).
 
 ## CHANGELOG.md
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,6 +86,19 @@ Use the usual GitHub process to open a PR. Before you do so, please:
 - If the PR adds a **new driver type**, complete the
   [driver ship checklist](#driver-ship-checklist) (sq.io and `skills/sq/`).
 
+### CI and draft PRs
+
+CI is PR-centric: a branch gets CI once a pull request exists. Open your PR as
+a **draft** to start the fast dev loop — every push runs lint, the Linux/macOS
+tests, and a fast **Windows smoke** test (`test/smoke/`). The in-progress run
+for a superseded commit is cancelled when you push again.
+
+When you click **Ready for review**, the **full Windows suite** and **CodeQL**
+run on the PR. The full Windows suite also runs on master merges, nightly, and
+on release tags. Because a draft PR can't be merged, marking it Ready
+guarantees the full suite runs on the PR before merge. (To make these checks
+*block* merge, add them as required status checks in branch protection.)
+
 ## CHANGELOG.md
 
 The [CHANGELOG.md](./CHANGELOG.md) file is sacrosanct, in that it *must* be updated every

--- a/test/smoke/smoke_test.go
+++ b/test/smoke/smoke_test.go
@@ -1,0 +1,124 @@
+// Package smoke contains a small, fast cross-platform smoke suite that
+// exercises the parts of sq historically fragile on Windows: path/DSN
+// parsing, config/cache/temp dir resolution, file-based queries, and output
+// rendering. It runs on every platform as part of the normal test suite, and
+// is the only Windows job that runs on draft PRs (see
+// .github/workflows/main.yml).
+package smoke
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/neilotoole/sq/cli/config/yamlstore"
+	"github.com/neilotoole/sq/cli/testrun"
+	"github.com/neilotoole/sq/libsq/core/ioz"
+	"github.com/neilotoole/sq/libsq/files"
+	"github.com/neilotoole/sq/libsq/source/drivertype"
+	"github.com/neilotoole/sq/libsq/source/location"
+	"github.com/neilotoole/sq/testh/proj"
+	"github.com/neilotoole/sq/testh/sakila"
+)
+
+// TestWindowsSmoke is a fast smoke suite for Windows-fragile behavior.
+// Despite the name it runs on all platforms; on Windows it is the only test
+// job that runs on draft PRs.
+func TestWindowsSmoke(t *testing.T) {
+	t.Run("location", func(t *testing.T) {
+		// These cases intentionally duplicate libsq/source/location's unit
+		// tests: on draft PRs the Windows job runs ONLY this smoke package,
+		// so this is the only place the C:\ drive-path parse is checked on
+		// Windows. Do not "dedupe" it away.
+		// Cross-platform cases.
+		got, err := location.Parse("/path/to/sakila.xlsx")
+		require.NoError(t, err)
+		require.Equal(t, "sakila", got.Name)
+		require.Equal(t, ".xlsx", got.Ext)
+
+		got, err = location.Parse("https://server:8080/path/to/sakila.xlsx")
+		require.NoError(t, err)
+		require.Equal(t, "https", got.Scheme)
+		require.Equal(t, "server", got.Hostname)
+		require.Equal(t, 8080, got.Port)
+		require.Equal(t, "sakila", got.Name)
+
+		// Windows drive-path cases only parse as intended on Windows.
+		if runtime.GOOS != "windows" {
+			return
+		}
+
+		got, err = location.Parse(`sqlite3://C:\path\to\sakila.sqlite`)
+		require.NoError(t, err)
+		require.Equal(t, drivertype.SQLite, got.DriverType)
+		require.Equal(t, "sqlite3", got.Scheme)
+		require.Equal(t, "sakila", got.Name)
+		require.Equal(t, ".sqlite", got.Ext)
+		require.Equal(t, `C:\path\to\sakila.sqlite`, got.DSN)
+	})
+
+	t.Run("dirs", func(t *testing.T) {
+		cfgDir, _, err := yamlstore.ConfigDir(nil)
+		require.NoError(t, err)
+		require.NotEmpty(t, cfgDir)
+		require.True(t, filepath.IsAbs(cfgDir), "config dir must be absolute: %s", cfgDir)
+
+		cacheDir := files.DefaultCacheDir()
+		require.NotEmpty(t, cacheDir)
+		require.True(t, filepath.IsAbs(cacheDir), "cache dir must be absolute: %s", cacheDir)
+
+		// Exercise the rename-dir trick, which is fragile on Windows.
+		base := t.TempDir()
+		oldDir := filepath.Join(base, "old")
+		newDir := filepath.Join(base, "new")
+		require.NoError(t, os.MkdirAll(filepath.Join(oldDir, "sub"), 0o700))
+		require.NoError(t, os.MkdirAll(newDir, 0o700))
+		require.NoError(t, ioz.RenameDir(oldDir, newDir))
+		require.DirExists(t, filepath.Join(newDir, "sub"))
+	})
+
+	t.Run("end_to_end", func(t *testing.T) {
+		ctx := context.Background()
+
+		// @sqlite is added first, so it becomes the active source.
+		tr := testrun.New(ctx, t, nil)
+		require.NoError(t, tr.Exec("add", proj.Abs(sakila.PathSL3), "--handle", "@sqlite"))
+
+		tr = testrun.New(ctx, t, tr)
+		require.NoError(t, tr.Exec("add", proj.Abs(sakila.PathCSVActor), "--handle", "@csv"))
+
+		// .actor exists only in @sqlite and .data only in @csv, so a
+		// mis-routed query fails loudly rather than silently returning the
+		// same row count.
+		// Query the active SQLite source.
+		tr = testrun.New(ctx, t, tr)
+		require.NoError(t, tr.Exec("--csv", "--no-header", ".actor"))
+		require.Len(t, tr.BindCSV(), sakila.TblActorCount)
+
+		// Query the CSV source explicitly.
+		tr = testrun.New(ctx, t, tr)
+		require.NoError(t, tr.Exec("--csv", "--no-header", "--src", "@csv", ".data"))
+		require.Len(t, tr.BindCSV(), sakila.TblActorCount)
+	})
+
+	t.Run("output", func(t *testing.T) {
+		ctx := context.Background()
+
+		tr := testrun.New(ctx, t, nil)
+		require.NoError(t, tr.Exec("add", proj.Abs(sakila.PathCSVActor), "--handle", "@csv"))
+
+		tr = testrun.New(ctx, t, tr)
+		require.NoError(t, tr.Exec("--json", "--src", "@csv", ".data"))
+
+		out := tr.Out.String()
+		require.NotContains(t, out, "\r", "JSON output must not contain carriage returns")
+		require.NotContains(t, out, "\x1b[", "output must not contain ANSI escapes when not a TTY")
+		rows := tr.BindSliceMap()
+		require.Len(t, rows, sakila.TblActorCount)
+		require.Contains(t, rows[0], "actor_id", "output should be actor records")
+	})
+}

--- a/test/smoke/smoke_test.go
+++ b/test/smoke/smoke_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/neilotoole/sq/cli/config"
 	"github.com/neilotoole/sq/cli/config/yamlstore"
 	"github.com/neilotoole/sq/cli/testrun"
 	"github.com/neilotoole/sq/libsq/core/ioz"
@@ -62,6 +63,13 @@ func TestWindowsSmoke(t *testing.T) {
 	})
 
 	t.Run("dirs", func(t *testing.T) {
+		// Keep this hermetic: pin the env vars that config/cache resolution
+		// consults to known absolute temp paths, so an ambient (possibly
+		// relative) SQ_CONFIG or XDG_CACHE_HOME can't skew the result.
+		tmp := t.TempDir()
+		t.Setenv(config.EnvarConfig, filepath.Join(tmp, "config"))
+		t.Setenv("XDG_CACHE_HOME", filepath.Join(tmp, "cache"))
+
 		cfgDir, _, err := yamlstore.ConfigDir(nil)
 		require.NoError(t, err)
 		require.NotEmpty(t, cfgDir)


### PR DESCRIPTION
## Summary

Cuts the draft-PR CI loop from ~13 min (gated by the full Windows test job) to
~5–6 min, while preserving full Windows + CodeQL coverage at high-value moments.

- Add a small cross-platform `test/smoke` package (`TestWindowsSmoke`) covering
  the Windows-fragile areas: location/DSN parsing (`C:\` drive paths), config /
  cache / temp-dir resolution, a file-based CSV+SQLite query end-to-end, and
  output/CRLF/terminal rendering. It runs on all platforms in the normal suite.
- Make the Main Pipeline **PR-centric** (`pull_request` incl. `ready_for_review`,
  `push` to master/tags, nightly `schedule`, `workflow_dispatch`) with
  **concurrency cancellation** (cancel-in-progress for PR branches).
- Split the Windows job: `test-windows-smoke` (draft PRs, builds everything +
  runs only `./test/smoke/`) vs `test-windows-full` (Ready PRs / master merges /
  nightly / tags / manual). `publish` now depends on `test-windows-full`.
- Apply the same draft-gating + concurrency to **CodeQL** (weekly schedule kept).
- P2: shallow `fetch-depth: 1` on test/lint jobs (full history kept for the
  GoReleaser jobs); coverage instrumentation + Codecov upload restricted to the
  ubuntu-24.04 leg.
- Document the draft-PR workflow in `CONTRIBUTING.md`.

## Validation (draft-gating behavior to confirm on this PR)

- [ ] While **draft**: only `lint`, `test-nix (ubuntu-24.04)`, `test-nix (macos-15)`,
      and `test-windows-smoke` run; `test-windows-full` and CodeQL `Analyze` are skipped.
- [ ] Push again quickly → the superseded in-progress run is cancelled.
- [ ] Mark **Ready for review** → `test-windows-full` and CodeQL `Analyze` run.
- [ ] Decide whether to add these as required status checks in branch protection
      (currently none are required, so CI does not yet *block* merge).