### PR TITLE
ci: run nix tests with -short on the dev loop; full suite nightly/release

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,6 +36,12 @@ jobs:
 
     runs-on: ${{ matrix.os }}
 
+    env:
+      # Full run (no -short, with coverage) nightly, on release tags, and on
+      # manual dispatch. The PR/master dev loop runs -short without coverage,
+      # skipping long-running tests (e.g. large-fixture JSON/XLSX ingest).
+      FULL_RUN: ${{ github.event_name == 'schedule' || startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch' }}
+
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -57,19 +63,24 @@ jobs:
           # pipefail so a `go test` failure isn't masked by the `| tee` below.
           set -eo pipefail
 
-          # Instrument coverage only on the ubuntu-24.04 runner (uploaded to
-          # Codecov below); macOS runs a plain test to keep the matrix fast.
-          # If the matrix gains another ubuntu image, update the check below.
-          # "-coverpkg=./..."
-          # attributes coverage across all packages (e.g. integration tests
-          # exercising other packages), giving a more representative total.
+          test_args=()
           cover_args=()
-          if [ "${{ matrix.os }}" = "ubuntu-24.04" ]; then
-            cover_args=(-cover -coverpkg=./... -coverprofile=coverage.out)
+          if [ "${FULL_RUN}" = "true" ]; then
+            # Full run: instrument coverage on the ubuntu-24.04 runner only
+            # (uploaded to Codecov below); macOS runs without coverage.
+            # "-coverpkg=./..." attributes coverage across all packages (e.g.
+            # integration tests exercising other packages).
+            if [ "${{ matrix.os }}" = "ubuntu-24.04" ]; then
+              cover_args=(-cover -coverpkg=./... -coverprofile=coverage.out)
+            fi
+          else
+            # Dev loop (PRs, master merges): skip long-running tests. The full
+            # suite runs nightly and on release tags.
+            test_args=(-short)
           fi
 
           go test -tags '${{ env.BUILD_TAGS }}' -timeout 20m -v -json \
-            "${cover_args[@]}" ./... | tee gotest.out.json
+            "${test_args[@]}" "${cover_args[@]}" ./... | tee gotest.out.json
 
       - name: 'Test output'
         if: always()
@@ -80,7 +91,7 @@ jobs:
           tparse -all -sort=elapsed -file gotest.out.json
 
       - name: Upload coverage to Codecov
-        if: always() && matrix.os == 'ubuntu-24.04'
+        if: always() && matrix.os == 'ubuntu-24.04' && env.FULL_RUN == 'true'
         uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6
         with:
           files: ./coverage.out

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,15 +89,18 @@ Use the usual GitHub process to open a PR. Before you do so, please:
 ### CI: the fast loop and the slow jobs
 
 CI is PR-centric: a branch gets CI once a pull request exists. Every push to a
-PR runs lint, the Linux/macOS tests, and a fast **Windows smoke** test
-(`test/smoke/`); the in-progress run for a superseded commit is cancelled when
-you push again. The same fast set runs on merges to master.
+PR runs lint, a fast `-short` pass of the Linux/macOS tests, and a **Windows
+smoke** test (`test/smoke/`); the in-progress run for a superseded commit is
+cancelled when you push again. The same fast set runs on merges to master.
 
-The slow jobs — the **full Windows suite** and **CodeQL** — are kept off the
-dev loop. They run **nightly** against master and on **release tags** (`v*`),
-where the full Windows suite gates `publish` and CodeQL runs as part of release
-validation. You can also run either on demand from the Actions tab via **Run
-workflow** (`workflow_dispatch`).
+The slow jobs are kept off the dev loop and run **nightly** against master and
+on **release tags** (`v*`): the **full Linux/macOS suite** (no `-short`, with
+coverage), the **full Windows suite** (gates `publish`), and **CodeQL**
+(release validation). You can also run any of them on demand from the Actions
+tab via **Run workflow** (`workflow_dispatch`).
+
+Mark long-running tests with `tu.SkipShort` so they stay out of the dev loop
+but still run in the nightly/release suites.
 
 ## CHANGELOG.md
 


### PR DESCRIPTION
## Summary

Follow-up to the CI dev-loop work (#678). The Linux/macOS `test-nix` job still
ran the **full** test suite on every PR, and that run was dominated by
long-running document-driver tests that are *already* marked `tu.SkipShort`:

- `TestJSONData_Cities/cities.large.json` — ingests a 20 MB JSON fixture, ~146s
  (≈60% of the ~247s test run)
- the `drivers/xlsx` sakila suite — ~15 tests at 8–9s each

This runs the nix tests `-short` on the PR/master dev loop (skipping those) and
the full suite (no `-short`, with coverage) nightly and on release tags. A
`FULL_RUN` env gates the behavior; coverage instrumentation + Codecov upload
now happen only on the full runs.

## Effect

- Ubuntu `test-nix` job: ~5.4 min → ~2 min (test run ~247s → ~60–90s)
- PR loop overall: ~6 min → ~3 min (long pole becomes Windows smoke / lint)
- Full coverage + the heavy tests still run nightly against master and gate
  releases.

## Test plan

- [ ] PR run: nix jobs run `-short` (heavy JSON/XLSX tests skipped), no Codecov upload
- [ ] Confirmed locally: `TestJSONData_Cities` skips under `-short`; xlsx sakila suite skips
- [ ] Nightly/tag (manual `workflow_dispatch` to verify): full suite runs, coverage uploads