### PR TITLE
fix(slq): apply reserved-word aliases, reject $arg aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,16 @@ Breaking changes are annotated with ☢️, and alpha/beta features with 🐥.
     `handleTable` rule, so the parser's error recovery silently discarded the
     alias and every downstream segment (projections, joins, etc.). The
     multi-segment form `@sakila | .actor:a | ...` was unaffected.
+- [#646]: A [query](https://sq.io/docs/query) whose alias is a reserved word
+  (e.g. `.actor | .first_name:count`, `@sakila.actor:count`, or
+  `join(.film_actor:count, ...)`) now applies that alias instead of silently
+  dropping it. An alias that is an argument reference (e.g. `:$x`) is now
+  rejected with a clear error rather than silently discarded.
+  - Alias extraction only read the `ID` and quoted `STRING` tokens, so the
+    `ALIAS_RESERVED` (`:count`) and `ARG` (`:$x`) tokens that the grammar
+    already permits resolved to an empty alias on column, table, and
+    expression nodes; only the no-arg `func` form had a workaround. Extraction
+    is now shared across every alias position.
 - [#445]: Cross-source [`join`](https://sq.io/docs/query#join) no longer
   fails when the participating sources contain tables with the same
   name (e.g. `@src1.actor | join(@src2.actor, .actor_id)`).
@@ -1555,6 +1565,7 @@ make working with lots of sources much easier.
 [#633]: https://github.com/neilotoole/sq/issues/633
 [#637]: https://github.com/neilotoole/sq/pull/637
 [#640]: https://github.com/neilotoole/sq/issues/640
+[#646]: https://github.com/neilotoole/sq/issues/646
 [#652]: https://github.com/neilotoole/sq/issues/652
 
 

--- a/grammar/README.md
+++ b/grammar/README.md
@@ -423,6 +423,10 @@ A non-exhaustive list of things that have bitten contributors:
 - **Aliasing a keyword.** Always works via the `:keyword` form thanks to
   `ALIAS_RESERVED`, but only for the keywords listed there. New
   keywords need to be added.
+- **Arg references aren't aliases.** `:$x` is grammatically accepted (the
+  `alias` rule's `ARG` branch) but rejected at AST-build time — an argument
+  reference is a value placeholder, not a name. Use a plain or quoted alias
+  instead.
 - **`narrowing` passes can reject grammatically-valid input.** Some
   errors only surface at AST-build time (e.g. `having` without
   `group_by`, multiple row ranges). Grep `libsq/ast` for `verify*` /

--- a/libsq/ast/alias.go
+++ b/libsq/ast/alias.go
@@ -15,7 +15,7 @@ import (
 // The shapes are:
 //
 //   - ID: e.g. ":given_name" yields "given_name".
-//   - STRING: e.g. a double-quoted ":<...>" yields the unquoted text.
+//   - STRING: e.g. the quoted form :"given name" yields "given name".
 //   - ALIAS_RESERVED: e.g. ":count" yields "count". ALIAS_RESERVED is a
 //     pre-baked ":keyword" token (e.g. ":count") that the grammar uses to
 //     work around the lexer otherwise tokenizing the keyword; the leading

--- a/libsq/ast/alias.go
+++ b/libsq/ast/alias.go
@@ -7,17 +7,53 @@ import (
 	"github.com/neilotoole/sq/libsq/core/stringz"
 )
 
+// extractAliasValue returns the alias value from ctx, handling every token
+// shape permitted by the grammar's alias rule:
+//
+//	alias: ALIAS_RESERVED | ':' (ARG | ID | STRING)
+//
+// The shapes are:
+//
+//   - ID: e.g. ":given_name" yields "given_name".
+//   - STRING: e.g. a double-quoted ":<...>" yields the unquoted text.
+//   - ALIAS_RESERVED: e.g. ":count" yields "count". ALIAS_RESERVED is a
+//     pre-baked ":keyword" token (e.g. ":count") that the grammar uses to
+//     work around the lexer otherwise tokenizing the keyword; the leading
+//     colon is trimmed to recover the name.
+//   - ARG: e.g. ":$x" is rejected. An ARG (e.g. "$x") is a parameter
+//     reference, not a name, and sq does not substitute it in the alias
+//     position. Rather than silently produce a literal "$x" column, it is
+//     reported as an error.
+//
+// It returns ("", nil) when ctx is nil or carries no alias token.
+func extractAliasValue(ctx slq.IAliasContext) (string, error) {
+	if ctx == nil {
+		return "", nil
+	}
+
+	switch {
+	case ctx.ID() != nil:
+		return ctx.ID().GetText(), nil
+	case ctx.STRING() != nil:
+		return stringz.StripDoubleQuote(ctx.STRING().GetText()), nil
+	case ctx.ALIAS_RESERVED() != nil:
+		return strings.TrimPrefix(ctx.ALIAS_RESERVED().GetText(), ":"), nil
+	case ctx.ARG() != nil:
+		return "", errorf("alias may not be an argument reference: %s", ctx.ARG().GetText())
+	default:
+		return "", nil
+	}
+}
+
 // VisitAlias implements slq.SLQVisitor.
 func (v *parseTreeVisitor) VisitAlias(ctx *slq.AliasContext) any {
-	if ctx == nil || ctx.ID() == nil && ctx.GetText() == "" {
+	if ctx == nil {
 		return nil
 	}
 
-	var alias string
-	if ctx.ID() != nil {
-		alias = ctx.ID().GetText()
-	} else if ctx.STRING() != nil {
-		alias = stringz.StripDoubleQuote(ctx.STRING().GetText())
+	alias, err := extractAliasValue(ctx)
+	if err != nil {
+		return err
 	}
 
 	switch node := v.cur.(type) {
@@ -28,32 +64,7 @@ func (v *parseTreeVisitor) VisitAlias(ctx *slq.AliasContext) any {
 	case *ExprElementNode:
 		node.alias = alias
 	case *FuncNode:
-		if alias != "" {
-			node.alias = alias
-			return nil
-		}
-
-		// NOTE: The grammar has a dodgy hack to deal with no-arg funcs
-		// with an alias that is a reserved word.
-		//
-		// For example, let's start with this snippet. Note that "count" is
-		// a function, equivalent to count().
-		//
-		//   .actor | count
-		//
-		// Then add an alias that is a reserved word, such as a function name.
-		// In this example, we will use an alias of "count" as well.
-		//
-		//   .actor | count:count
-		//
-		// Well, the grammar doesn't know how to handle this. Most likely the
-		// grammar could be refactored to deal with this more gracefully. The
-		// hack is to look at the full text of the context (e.g. ":count"),
-		// instead of just ID, and look for the alias after the colon.
-
-		text := ctx.GetText()
-		node.alias = strings.TrimPrefix(text, ":")
-
+		node.alias = alias
 	default:
 		return errorf("alias not allowed for type %T: %v", node, ctx.GetText())
 	}

--- a/libsq/ast/alias_test.go
+++ b/libsq/ast/alias_test.go
@@ -1,0 +1,104 @@
+package ast
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/neilotoole/sq/libsq/core/lg/lgt"
+	"github.com/neilotoole/sq/testh/tu"
+)
+
+// collectAliases returns every non-empty alias attached to a result-column,
+// table, expression, or function node in ast.
+func collectAliases(ast *AST) []string {
+	var aliases []string
+	add := func(s string) {
+		if s != "" {
+			aliases = append(aliases, s)
+		}
+	}
+	for _, n := range FindNodes[*ColSelectorNode](ast) {
+		add(n.Alias())
+	}
+	for _, n := range FindNodes[*TblColSelectorNode](ast) {
+		add(n.Alias())
+	}
+	for _, n := range FindNodes[*TblSelectorNode](ast) {
+		add(n.Alias())
+	}
+	// Join target tables hang off JoinNode.Table() rather than being tree
+	// children, so they aren't reached by the TblSelectorNode walk above.
+	for _, n := range FindNodes[*JoinNode](ast) {
+		if tbl := n.Table(); tbl != nil {
+			add(tbl.Alias())
+		}
+	}
+	for _, n := range FindNodes[*ExprElementNode](ast) {
+		add(n.Alias())
+	}
+	for _, n := range FindNodes[*FuncNode](ast) {
+		add(n.Alias())
+	}
+	return aliases
+}
+
+// TestAlias_ReservedWordApplied verifies that an alias which is a reserved
+// word (the ALIAS_RESERVED token, e.g. ":count") is applied as the alias,
+// not silently dropped, in every alias position. See issue #646.
+func TestAlias_ReservedWordApplied(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name string
+		in   string
+	}{
+		{"col-selector", `@sakila | .actor | .first_name:count`},
+		{"tbl-selector-multiseg", `@sakila | .actor:count | .first_name`},
+		{"handle-table", `@sakila.actor:count | .first_name`},
+		{"join-table", `@sakila | .actor | join(.film_actor:count, .actor.actor_id == .film_actor.actor_id)`},
+		{"expr-element", `@sakila | .actor | (1+2):count`},
+		{"func", `@sakila | .actor | sum(.actor_id):count`},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tu.Name(tc.name), func(t *testing.T) {
+			t.Parallel()
+
+			log := lgt.New(t)
+			ast, err := Parse(log, tc.in)
+			require.NoError(t, err)
+			require.Contains(t, collectAliases(ast), "count",
+				"alias %q should be applied for %q", "count", tc.in)
+		})
+	}
+}
+
+// TestAlias_ArgRejected verifies that an argument reference used as an alias
+// (the ARG token, e.g. ":$x") is rejected with an error rather than silently
+// dropped or applied as a literal "$x" column. See issue #646.
+func TestAlias_ArgRejected(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name string
+		in   string
+	}{
+		{"col-selector", `@sakila | .actor | .first_name:$x`},
+		{"tbl-selector-multiseg", `@sakila | .actor:$x | .first_name`},
+		{"handle-table", `@sakila.actor:$x | .first_name`},
+		{"join-table", `@sakila | .actor | join(.film_actor:$x, .actor.actor_id == .film_actor.actor_id)`},
+		{"expr-element", `@sakila | .actor | (1+2):$x`},
+		{"func", `@sakila | .actor | sum(.actor_id):$x`},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tu.Name(tc.name), func(t *testing.T) {
+			t.Parallel()
+
+			log := lgt.New(t)
+			_, err := Parse(log, tc.in)
+			require.Error(t, err, "arg alias should be rejected for %q", tc.in)
+		})
+	}
+}

--- a/libsq/ast/alias_test.go
+++ b/libsq/ast/alias_test.go
@@ -59,6 +59,11 @@ func TestAlias_ReservedWordApplied(t *testing.T) {
 		{"join-table", `@sakila | .actor | join(.film_actor:count, .actor.actor_id == .film_actor.actor_id)`},
 		{"expr-element", `@sakila | .actor | (1+2):count`},
 		{"func", `@sakila | .actor | sum(.actor_id):count`},
+		// count is special-cased in the grammar (VisitCountFunc) and was the
+		// original motivation for the removed reserved-word hack, so cover
+		// both the bare and parenthesized forms explicitly.
+		{"func-count-bare", `@sakila | .actor | count:count`},
+		{"func-count-paren", `@sakila | .actor | count(.first_name):count`},
 	}
 
 	for _, tc := range testCases {
@@ -68,8 +73,14 @@ func TestAlias_ReservedWordApplied(t *testing.T) {
 			log := lgt.New(t)
 			ast, err := Parse(log, tc.in)
 			require.NoError(t, err)
-			require.Contains(t, collectAliases(ast), "count",
-				"alias %q should be applied for %q", "count", tc.in)
+			// Exact match, not Contains: every test query carries exactly one
+			// alias (the one under test), so asserting the whole slice equals
+			// ["count"] catches a dropped alias (empty slice), the previously
+			// observed expr mangling (e.g. "(1+2):count"), and the count()
+			// default-alias tautology (a bare count defaults its alias to
+			// "count", which a presence check would not distinguish).
+			require.Equal(t, []string{"count"}, collectAliases(ast),
+				"%q should be the only alias, exactly %q", tc.in, "count")
 		})
 	}
 }

--- a/libsq/ast/handle.go
+++ b/libsq/ast/handle.go
@@ -58,9 +58,8 @@ func (v *parseTreeVisitor) VisitHandleTable(ctx *slq.HandleTableContext) any {
 
 	// Optional trailing alias, e.g. @sakila.actor:a. Mirror VisitJoinTable:
 	// make the new node current and visit the alias, which sets node.alias.
-	// VisitAlias reads ID and quoted (STRING) aliases; reserved-word aliases
-	// (the ALIAS_RESERVED token, e.g. :count) are not attached here, matching
-	// the existing joinTable and ".tbl:alias" selector paths.
+	// VisitAlias handles every alias shape (ID, quoted STRING, and reserved
+	// words such as :count); an argument reference (e.g. :$x) is rejected.
 	if ctx.Alias() != nil {
 		aliasCtx, ok := ctx.Alias().(*slq.AliasContext)
 		if !ok {

--- a/libsq/ast/selector.go
+++ b/libsq/ast/selector.go
@@ -7,7 +7,6 @@ import (
 	antlr "github.com/antlr4-go/antlr/v4"
 
 	"github.com/neilotoole/sq/libsq/ast/internal/slq"
-	"github.com/neilotoole/sq/libsq/core/stringz"
 	"github.com/neilotoole/sq/libsq/core/tablefq"
 )
 
@@ -19,11 +18,8 @@ func (v *parseTreeVisitor) VisitSelectorElement(ctx *slq.SelectorElementContext)
 	}
 
 	if aliasCtx := ctx.Alias(); aliasCtx != nil {
-		if aliasCtx.ID() != nil {
-			node.alias = aliasCtx.ID().GetText()
-		}
-		if aliasCtx.STRING() != nil {
-			node.alias = stringz.StripDoubleQuote(aliasCtx.STRING().GetText())
+		if node.alias, err = extractAliasValue(aliasCtx); err != nil {
+			return err
 		}
 	}
 

--- a/libsq/query_cols_test.go
+++ b/libsq/query_cols_test.go
@@ -75,6 +75,26 @@ func TestQuery_cols(t *testing.T) {
 			wantRecCount: sakila.TblActorCount,
 		},
 		{
+			// A reserved word (the ALIAS_RESERVED token, e.g. :count) used as
+			// a column alias is applied, not silently dropped. See issue #646.
+			name:    "cols-alias-reserved-word",
+			in:      `@sakila | .actor | .first_name:count`,
+			wantSQL: `SELECT "first_name" AS "count" FROM "actor"`,
+			override: driverMap{
+				drivertype.MySQL:      "SELECT `first_name` AS `count` FROM `actor`",
+				drivertype.ClickHouse: "SELECT `first_name` AS `count` FROM `actor`",
+			},
+			wantRecCount: sakila.TblActorCount,
+		},
+		{
+			// An argument reference (the ARG token, e.g. :$x) is not a valid
+			// alias and is rejected rather than silently dropped. See #646.
+			name:            "cols-alias-arg-rejected",
+			in:              `@sakila | .actor | .first_name:$x`,
+			wantErr:         true,
+			wantErrContains: "alias may not be an argument reference",
+		},
+		{
 			name:    "handle-table/cols",
 			in:      `@sakila.actor | .first_name, .last_name`,
 			wantSQL: `SELECT "first_name", "last_name" FROM "actor"`,

--- a/libsq/query_expr_test.go
+++ b/libsq/query_expr_test.go
@@ -199,6 +199,22 @@ func TestQuery_expr_literal(t *testing.T) {
 			},
 			wantRecCount: sakila.TblActorCount,
 		},
+		{
+			// A reserved word as an expression alias is applied, and the
+			// expression is no longer mangled into the alias. See issue #646.
+			name:    "table/addition_alias_reserved_word",
+			in:      `@sakila | .actor | (1+2):count`,
+			wantSQL: `SELECT (1+2) AS "count" FROM "actor"`,
+			override: driverMap{
+				drivertype.MySQL:      "SELECT (1+2) AS `count` FROM `actor`",
+				drivertype.ClickHouse: "SELECT (1+2) AS `count` FROM `actor`",
+			},
+			sinkFns: []SinkTestFunc{
+				assertSinkColValue(0, int64(3)),
+				assertSinkColName(0, "count"),
+			},
+			wantRecCount: sakila.TblActorCount,
+		},
 	}
 
 	for i, tc := range testCases {

--- a/site/content/en/docs/query/index.md
+++ b/site/content/en/docs/query/index.md
@@ -415,6 +415,11 @@ PENELOPE
 NICK
 ```
 
+The alias may even be a reserved word such as `count`; `sq` quotes it in the
+generated SQL, so `.first_name:count` renders as `"first_name" AS "count"`.
+An [argument](#predefined-variables) reference such as `$x` can't be used as
+an alias, however.
+
 ## Whitespace names
 
 If a table or column name has whitespace, surround the name in quotes.


### PR DESCRIPTION
## Summary

Fixes #646. SLQ aliases that are reserved words (e.g. `:count`) or argument
references (e.g. `:$x`) were silently dropped on selector, table, and
expression AST nodes; only the no-arg `func` case had a `GetText()`
workaround. (Surfaced during review of #645 / #633.)

Per the agreed policy:

- **Reserved-word aliases are applied.** `.first_name:count`,
  `@sakila.actor:count`, `join(.film_actor:count, ...)`, `(1+2):count`,
  `count:count`, etc. now carry the alias, matching existing `func` behavior.
  The alias renders enquoted, e.g. `SELECT "first_name" AS "count"`.
- **`$arg` aliases are rejected.** A `$x` argument reference is a value
  placeholder, not a name, and is not substituted in the alias position, so
  it now returns a clear error (`alias may not be an argument reference: $x`)
  rather than being silently dropped.

## Implementation

The grammar (`alias: ALIAS_RESERVED | ':' (ARG | ID | STRING)`) already
permits all four token shapes, so this is purely a visitor-layer fix: **no
grammar change** and no parser regeneration.

The issue suggested extending `VisitAlias`, but its first listed case
(multi-segment `@sakila | .actor:count`) and the column case
(`.first_name:count`) actually flow through the inline `VisitSelectorElement`
path, not `VisitAlias`. Both sites now share a single `extractAliasValue`
helper in `libsq/ast/alias.go`, which also removes the duplicated extraction
and the func-only `GetText` hack. As a side effect the expr-element case is no
longer mangled (`(1+2):count` previously became a column literally named
`(1+2):count`).

## Docs

- `CHANGELOG.md` — entry under Fixed.
- `grammar/README.md` — pitfalls note that `:$x` is grammatically accepted but
  rejected at AST-build time.
- `site/content/en/docs/query/index.md` — query-guide note that an alias may
  be a reserved word (rendered enquoted), and that a `$arg` reference cannot.

## Test plan

- `libsq/ast/alias_test.go` — reserved-word applied / `$arg` rejected across
  every alias position: column, multi-segment table, handleTable, joinTable,
  expr, and func (including `count:count` and `count(.col):count`). Asserts
  the exact resulting alias, so a dropped alias, the expr mangling, and the
  `count()` default-alias tautology are all caught.
- `libsq/query_cols_test.go` / `libsq/query_expr_test.go` — end-to-end
  SLQ-to-SQL cases verifying `AS "count"` (and the `$arg` error) across all
  six dialects.
- `golangci-lint`: 0 issues; full `libsq/ast` and `libsq` query suites pass.