### PR TITLE
sqlserver: simplify driver description to "Microsoft SQL Server"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,15 @@ Breaking changes are annotated with ☢️, and alpha/beta features with 🐥.
 > `v0.18.2`. This typically means that there was some CI/tooling mishap. Ignore
 > those gaps.
 
+## Unreleased
+
+### Changed
+
+- The `sqlserver` driver description shown by
+  [`sq driver ls`](https://sq.io/docs/cmd/driver-ls) is now simply "Microsoft SQL
+  Server", dropping the trailing "/ Azure SQL Edge" (Azure SQL Edge was retired by
+  Microsoft on 2025-09-30).
+
 ## [v0.53.0] - 2026-05-25
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ $ sq driver ls
 DRIVER      DESCRIPTION
 sqlite3     SQLite
 postgres    PostgreSQL
-sqlserver   Microsoft SQL Server / Azure SQL Edge
+sqlserver   Microsoft SQL Server
 mysql       MySQL
 clickhouse  ClickHouse
 oracle      Oracle

--- a/cli/cmd_add.go
+++ b/cli/cmd_add.go
@@ -103,7 +103,7 @@ minimum, the following drivers are bundled:
 
   sqlite3    SQLite
   postgres   PostgreSQL
-  sqlserver  Microsoft SQL Server / Azure SQL Edge
+  sqlserver  Microsoft SQL Server
   mysql      MySQL
   clickhouse ClickHouse
   oracle     Oracle Database (experimental)

--- a/drivers/sqlserver/sqlserver.go
+++ b/drivers/sqlserver/sqlserver.go
@@ -96,7 +96,7 @@ func (d *driveri) ErrWrapFunc() func(error) error {
 func (d *driveri) DriverMetadata() driver.Metadata {
 	return driver.Metadata{
 		Type:        drivertype.MSSQL,
-		Description: "Microsoft SQL Server / Azure SQL Edge",
+		Description: "Microsoft SQL Server",
 		Doc:         "https://github.com/microsoft/go-mssqldb",
 		IsSQL:       true,
 		DefaultPort: 1433,

--- a/site/content/en/docs/cmd/add.help.txt
+++ b/site/content/en/docs/cmd/add.help.txt
@@ -74,7 +74,7 @@ minimum, the following drivers are bundled:
 
   sqlite3    SQLite
   postgres   PostgreSQL
-  sqlserver  Microsoft SQL Server / Azure SQL Edge
+  sqlserver  Microsoft SQL Server
   mysql      MySQL
   clickhouse ClickHouse
   oracle     Oracle Database (experimental)

--- a/site/content/en/docs/cmd/driver-ls.output.txt
+++ b/site/content/en/docs/cmd/driver-ls.output.txt
@@ -2,7 +2,7 @@ DRIVER      DESCRIPTION                            USER-DEFINED  DOC
 sqlite3     SQLite                                 false         https://github.com/mattn/go-sqlite3
 duckdb      DuckDB                                 false         https://duckdb.org
 postgres    PostgreSQL                             false         https://github.com/jackc/pgx
-sqlserver   Microsoft SQL Server / Azure SQL Edge  false         https://github.com/microsoft/go-mssqldb
+sqlserver   Microsoft SQL Server                   false         https://github.com/microsoft/go-mssqldb
 mysql       MySQL                                  false         https://github.com/go-sql-driver/mysql
 clickhouse  ClickHouse                             false         https://github.com/ClickHouse/clickhouse-go
 oracle      Oracle                                 false         https://github.com/sijms/go-ora

--- a/site/content/en/docs/drivers/sqlserver.md
+++ b/site/content/en/docs/drivers/sqlserver.md
@@ -11,8 +11,7 @@ aliases:
 - /docs/drivers/sql-server
 ---
 The `sq` SQL Server driver implements connectivity for
-the Microsoft [SQL Server](https://www.microsoft.com/en-us/sql-server) and
-[Azure SQL Edge](https://azure.microsoft.com/en-us/products/azure-sql/edge/) databases.
+Microsoft [SQL Server](https://www.microsoft.com/en-us/sql-server).
 The driver implements all optional driver features.
 
 ## Add source

--- a/site/layouts/index.html
+++ b/site/layouts/index.html
@@ -61,8 +61,8 @@
           <li><a href="/docs/output#csv">CSV</a></li>
           <li><a href="/docs/output#tsv">TSV</a></li>
           <li><a href="/docs/output#json">JSON</a></li>
-          <li><a href="/docs/output#jsonl">JSONL</a> <span class="mute">(JSON Lines)</span></li>
           <li><a href="/docs/output#jsona">JSONA</a> <span class="mute">(JSON Array)</span></li>
+          <li><a href="/docs/output#jsonl">JSONL</a> <span class="mute">(JSON Lines)</span></li>
           <li><a href="/docs/output#xml">XML</a></li>
           <li><a href="/docs/output#html">HTML</a></li>
           <li><a href="/docs/output#markdown">Markdown</a></li>

--- a/skills/sq/references/sqlserver.md
+++ b/skills/sq/references/sqlserver.md
@@ -1,6 +1,6 @@
 # Microsoft SQL Server (`sqlserver` driver)
 
-[SQL Server](https://www.microsoft.com/sql-server) and [Azure SQL Edge](https://azure.microsoft.com/products/azure-sql-edge/). Driver implements all optional `sq` features.
+[SQL Server](https://www.microsoft.com/sql-server). Driver implements all optional `sq` features.
 
 **Canonical docs:** [SQL Server driver](https://sq.io/docs/drivers/sqlserver/)
 


### PR DESCRIPTION
## Summary

A couple of small, mostly-cosmetic updates.

### 1. Simplify the `sqlserver` driver description

Change the `sqlserver` driver description to **"Microsoft SQL Server"**, dropping the trailing `/ Azure SQL Edge`.

Microsoft [retired Azure SQL Edge on 2025-09-30](https://learn.microsoft.com/en-us/lifecycle/products/azure-sql-edge), and there is no umbrella "SQL Server family" brand (the `Azure SQL` family is cloud-only), so the plain name is the cleanest fit.

The description lives in `drivers/sqlserver` `DriverMetadata` and surfaces in `sq driver ls` and `sq add --help`. This updates:

- `drivers/sqlserver/sqlserver.go` — the metadata description (source of truth)
- `README.md` — driver list table
- `cli/cmd_add.go` — `sq add --help` bundled-drivers list
- `site/content/en/docs/cmd/{add.help.txt,driver-ls.output.txt}` — checked-in cmd-help snapshots
- `site/content/en/docs/drivers/sqlserver.md` — driver doc intro
- `skills/sq/references/sqlserver.md` — skill reference headline
- `CHANGELOG.md` — `Unreleased` → `Changed` entry

**Left as-is:** test-only references to the Azure SQL Edge Docker image — the `AZ1` sakila test handle (`testh/sakila/sakila.go`) and the contributor docs (`site/content/en/docs/develop/sakila.md`) — are intentionally kept, since they document how the SQL Server test suite actually runs (including the arm64 path).

### 2. Reorder homepage output formats

`site/layouts/index.html`: list **JSONA before JSONL** in the homepage output-formats list, matching the canonical `json → jsona → jsonl` ordering used in the driver list and output docs.

## Verification

- `make lint` — 0 issues
- `make lint-markdown` — 0 errors
- `site/` markdown lint — 0 errors
- `go build ./drivers/sqlserver/... ./cli/...` — OK