### PR TITLE
site(inspect): build-time syntax coloring for mermaid-erd source

### DIFF
--- a/site/content/en/docs/inspect/index.md
+++ b/site/content/en/docs/inspect/index.md
@@ -191,7 +191,7 @@ $ sq inspect @sakila_pg -f mermaid-erd -o sakila.mmd
 ```
 
 ```mermaid
-%% sq inspect @sakila/pg.actor -f mermaid-erd
+%% sq inspect @sakila_pg.actor -f mermaid-erd
 erDiagram
     actor {
         int actor_id PK

--- a/site/content/en/docs/inspect/index.md
+++ b/site/content/en/docs/inspect/index.md
@@ -46,7 +46,7 @@ metadata, and the schema structure (tables, columns, etc.).
 
 <a id="--text-default"></a>
 
-### `text` (default)
+### `text`
 
 ```shell
 $ sq inspect @sakila_pg
@@ -142,13 +142,13 @@ $ sq inspect @sakila_pg --html -o sakila.html
 $ sq inspect @sakila_pg --html > sakila.html && open sakila.html
 ```
 
-![sq_inspect_html](sq_inspect_html.png)
-
 {{< alert icon="👉" >}}
 See the [**live example**](/examples/sakila.html): the `html` schema document
-for the Postgres [sakila](https://github.com/jOOQ/sakila) sample database,
-rendered right in your browser.
+for the Postgres [sakila](https://github.com/jOOQ/sakila) sample database.
+Note that you can click on the diagram in your browser to zoom/pan etc.
 {{< /alert >}}
+
+![sq_inspect_html](sq_inspect_html.png)
 
 By default, the page loads Mermaid.js from a CDN, producing a small file that
 requires internet access to render the diagram. To produce a fully
@@ -188,6 +188,18 @@ $ sq inspect @sakila_pg.film_actor -f mermaid-erd
 
 # Write the diagram to a file.
 $ sq inspect @sakila_pg -f mermaid-erd -o sakila.mmd
+```
+
+```mermaid
+%% sq inspect @sakila/pg.actor -f mermaid-erd
+erDiagram
+    actor {
+        int actor_id PK
+        text first_name
+        text last_name
+        datetime last_update
+    }
+    actor ||--o{ film_actor : "film_actor_actor_id_fkey"
 ```
 
 The format covers only source and single-table schema inspection. Operations

--- a/site/layouts/_default/_markup/render-codeblock-mermaid.html
+++ b/site/layouts/_default/_markup/render-codeblock-mermaid.html
@@ -1,0 +1,59 @@
+{{- /*
+  render-codeblock-mermaid.html — build-time syntax coloring for fenced
+  ```mermaid blocks.
+
+  `sq inspect -f mermaid-erd` emits Mermaid erDiagram source, and Chroma (the
+  site's server-side highlighter) has no Mermaid lexer, so these blocks would
+  otherwise render as flat, uncolored text. Rather than pull in a client-side
+  highlighter, we tokenize the small, stable erDiagram grammar here and wrap
+  each token in a span that reuses Chroma's Nord palette classes (.k, .kt,
+  .nc, .s, .o, .p, .c1). Coloring therefore tracks the existing light/dark
+  syntax themes (_syntax.scss / _syntax-dark.scss) with no extra CSS or JS.
+
+  Note: this deliberately emits `language-mermaid-erd`, NOT `language-mermaid`,
+  so mermaid.js never treats it as a diagram to render — this is the *source*
+  view. A future rendered-diagram tab should emit `.language-mermaid` directly
+  (e.g. via a shortcode) rather than a fenced block, so it bypasses this hook.
+*/ -}}
+{{- $src := .Inner | chomp -}}
+{{- $lines := split $src "\n" -}}
+{{- $out := slice -}}
+{{- range $line := $lines -}}
+  {{- /* Minimal HTML escaping; keep quotes intact so string matching works.
+        Note: `replace` takes input FIRST, unlike `replaceRE` below. */ -}}
+  {{- $e := replace $line "&" "&amp;" -}}
+  {{- $e = replace $e "<" "&lt;" -}}
+  {{- $e = replace $e ">" "&gt;" -}}
+  {{- $trim := trim $line " \t" -}}
+  {{- $h := $e -}}
+  {{- if not $trim -}}
+    {{- /* Blank line: pass through. */ -}}
+  {{- else if hasPrefix $trim "%%" -}}
+    {{- /* Comment to end of line. */ -}}
+    {{- $h = $e | replaceRE `^(\s*)(%%.*)$` `${1}<span class="c1">${2}</span>` -}}
+  {{- else if eq $trim "erDiagram" -}}
+    {{- /* Diagram-type keyword. */ -}}
+    {{- $h = $e | replaceRE `^(\s*)(erDiagram)\s*$` `${1}<span class="k">${2}</span>` -}}
+  {{- else if findRE `(--|\.\.)` $trim -}}
+    {{- /* Relationship: LEFT  op  RIGHT [: "label"] */ -}}
+    {{- if findRE `:\s+".*"\s*$` $e -}}
+      {{- $h = $e | replaceRE `^(\s*)(\S+)(\s+)(\S+)(\s+)(\S+)(\s+:\s+)(".*")\s*$` `${1}<span class="nc">${2}</span>${3}<span class="o">${4}</span>${5}<span class="nc">${6}</span><span class="p">${7}</span><span class="s">${8}</span>` -}}
+    {{- else -}}
+      {{- $h = $e | replaceRE `^(\s*)(\S+)(\s+)(\S+)(\s+)(\S+)\s*$` `${1}<span class="nc">${2}</span>${3}<span class="o">${4}</span>${5}<span class="nc">${6}</span>` -}}
+    {{- end -}}
+  {{- else if hasSuffix $trim "{" -}}
+    {{- /* Entity block open: NAME { */ -}}
+    {{- $h = $e | replaceRE `^(\s*)(\S+)(\s*)(\{)\s*$` `${1}<span class="nc">${2}</span>${3}<span class="p">${4}</span>` -}}
+  {{- else if eq $trim "}" -}}
+    {{- /* Entity block close. */ -}}
+    {{- $h = $e | replaceRE `^(\s*)(\})\s*$` `${1}<span class="p">${2}</span>` -}}
+  {{- else -}}
+    {{- /* Attribute: type name [PK|FK|UK ...] ["comment"] */ -}}
+    {{- $h = $e | replaceRE `^(\s*)(\S+)(\s+)(\S+)((?:\s+(?:PK|FK|UK))*)(\s+".*")?\s*$` `${1}<span class="kt">${2}</span>${3}<span class="n">${4}</span><span class="k">${5}</span><span class="s">${6}</span>` -}}
+  {{- end -}}
+  {{- $out = $out | append $h -}}
+{{- end -}}
+{{- /* Drop empty spans left by absent optional groups (keys / comments). */ -}}
+{{- $html := delimit $out "\n" -}}
+{{- $html = replaceRE `<span class="[^"]*"></span>` "" $html -}}
+<div class="highlight"><pre tabindex="0" class="chroma"><code class="language-mermaid-erd" data-lang="mermaid">{{ $html | safeHTML }}</code></pre></div>

--- a/site/layouts/_default/_markup/render-codeblock-mermaid.html
+++ b/site/layouts/_default/_markup/render-codeblock-mermaid.html
@@ -7,7 +7,7 @@
   otherwise render as flat, uncolored text. Rather than pull in a client-side
   highlighter, we tokenize the small, stable erDiagram grammar here and wrap
   each token in a span that reuses Chroma's Nord palette classes (.k, .kt,
-  .nc, .s, .o, .p, .c1). Coloring therefore tracks the existing light/dark
+  .nc, .n, .s, .o, .p, .c1). Coloring therefore tracks the existing light/dark
   syntax themes (_syntax.scss / _syntax-dark.scss) with no extra CSS or JS.
 
   Note: this deliberately emits `language-mermaid-erd`, NOT `language-mermaid`,
@@ -34,22 +34,30 @@
   {{- else if eq $trim "erDiagram" -}}
     {{- /* Diagram-type keyword. */ -}}
     {{- $h = $e | replaceRE `^(\s*)(erDiagram)\s*$` `${1}<span class="k">${2}</span>` -}}
-  {{- else if findRE `(--|\.\.)` $trim -}}
-    {{- /* Relationship: LEFT  op  RIGHT [: "label"] */ -}}
+  {{- else if findRE `[|}o{](?:--|\.\.)|(?:--|\.\.)[|}o{]` $trim -}}
+    {{- /* Relationship: LEFT  op  RIGHT [: "label"]. We detect it by an ER
+          cardinality operator — a `--`/`..` line with a cardinality glyph
+          (| o } {) adjacent — rather than a bare `--`/`..`, so dashes inside a
+          quoted column comment don't masquerade as a relationship. Entity
+          names may be quoted (sq quotes any name that isn't a bare
+          identifier), so each operand matches "..." (which can contain
+          spaces) or a bare token. */ -}}
     {{- if findRE `:\s+".*"\s*$` $e -}}
-      {{- $h = $e | replaceRE `^(\s*)(\S+)(\s+)(\S+)(\s+)(\S+)(\s+:\s+)(".*")\s*$` `${1}<span class="nc">${2}</span>${3}<span class="o">${4}</span>${5}<span class="nc">${6}</span><span class="p">${7}</span><span class="s">${8}</span>` -}}
+      {{- $h = $e | replaceRE `^(\s*)("[^"]*"|\S+)(\s+)(\S+)(\s+)("[^"]*"|\S+)(\s+:\s+)(".*")\s*$` `${1}<span class="nc">${2}</span>${3}<span class="o">${4}</span>${5}<span class="nc">${6}</span><span class="p">${7}</span><span class="s">${8}</span>` -}}
     {{- else -}}
-      {{- $h = $e | replaceRE `^(\s*)(\S+)(\s+)(\S+)(\s+)(\S+)\s*$` `${1}<span class="nc">${2}</span>${3}<span class="o">${4}</span>${5}<span class="nc">${6}</span>` -}}
+      {{- $h = $e | replaceRE `^(\s*)("[^"]*"|\S+)(\s+)(\S+)(\s+)("[^"]*"|\S+)\s*$` `${1}<span class="nc">${2}</span>${3}<span class="o">${4}</span>${5}<span class="nc">${6}</span>` -}}
     {{- end -}}
   {{- else if hasSuffix $trim "{" -}}
-    {{- /* Entity block open: NAME { */ -}}
-    {{- $h = $e | replaceRE `^(\s*)(\S+)(\s*)(\{)\s*$` `${1}<span class="nc">${2}</span>${3}<span class="p">${4}</span>` -}}
+    {{- /* Entity block open: NAME { (NAME may be quoted). */ -}}
+    {{- $h = $e | replaceRE `^(\s*)("[^"]*"|\S+)(\s*)(\{)\s*$` `${1}<span class="nc">${2}</span>${3}<span class="p">${4}</span>` -}}
   {{- else if eq $trim "}" -}}
     {{- /* Entity block close. */ -}}
     {{- $h = $e | replaceRE `^(\s*)(\})\s*$` `${1}<span class="p">${2}</span>` -}}
   {{- else -}}
-    {{- /* Attribute: type name [PK|FK|UK ...] ["comment"] */ -}}
-    {{- $h = $e | replaceRE `^(\s*)(\S+)(\s+)(\S+)((?:\s+(?:PK|FK|UK))*)(\s+".*")?\s*$` `${1}<span class="kt">${2}</span>${3}<span class="n">${4}</span><span class="k">${5}</span><span class="s">${6}</span>` -}}
+    {{- /* Attribute: type name [keys] ["comment"]. The name may be quoted;
+          keys are PK/FK/UK, comma- or space-joined (sq joins with a comma,
+          e.g. "PK,FK"). */ -}}
+    {{- $h = $e | replaceRE `^(\s*)(\S+)(\s+)("[^"]*"|\S+)(\s+(?:PK|FK|UK)(?:[ ,](?:PK|FK|UK))*)?(\s+".*")?\s*$` `${1}<span class="kt">${2}</span>${3}<span class="n">${4}</span><span class="k">${5}</span><span class="s">${6}</span>` -}}
   {{- end -}}
   {{- $out = $out | append $h -}}
 {{- end -}}


### PR DESCRIPTION
## What

Adds a Hugo codeblock render hook (`site/layouts/_default/_markup/render-codeblock-mermaid.html`) that syntax-colors fenced ` ```mermaid ` blocks at build time.

Chroma (the site's server-side highlighter) has no Mermaid lexer, so these blocks previously rendered as flat, uncolored text. The hook tokenizes the erDiagram grammar that `sq inspect -f mermaid-erd` emits and wraps tokens in spans reusing Chroma's existing **Nord palette classes** (`.k`, `.kt`, `.nc`, `.s`, `.o`, `.p`, `.c1`) — so coloring tracks the site's light/dark syntax themes with **no extra CSS or JavaScript**.

## Notes

- The hook emits `language-mermaid-erd` (not `language-mermaid`), so `mermaid.js` never tries to render it as a diagram — this is the *source* view, and the dark code-block background is preserved.
- Scoped to the erDiagram grammar, which is exactly what `-f mermaid-erd` produces. Only the inspect page uses ` ```mermaid ` fences today, so blast radius is zero.

## Also in this PR (inspect page)

- Add the mermaid-erd example block (the block the hook colorizes).
- Simplify the `text` format heading (`text (default)` → `text`).
- Reorder the html-section screenshot and callout.

Site-only change — no CHANGELOG entry per `CLAUDE.md`.