### PR TITLE
Colorize mermaid-erd output on a TTY

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ Breaking changes are annotated with ☢️, and alpha/beta features with 🐥.
 
 ### Changed
 
+- [#692]: [`sq inspect -f mermaid-erd`](https://sq.io/docs/inspect#mermaid-erd)
+  now syntax-colors its `erDiagram` source when writing to a terminal. Output to
+  a file or pipe (and under `--no-color`, `NO_COLOR`, or `--monochrome`) is
+  unchanged, so redirected `.mmd` files stay byte-identical to the plain source.
 - The `sqlserver` driver description shown by
   [`sq driver ls`](https://sq.io/docs/cmd/driver-ls) is now simply "Microsoft SQL
   Server", dropping the trailing "/ Azure SQL Edge" (Azure SQL Edge was retired by
@@ -1591,6 +1595,7 @@ make working with lots of sources much easier.
 [#648]: https://github.com/neilotoole/sq/pull/648
 [#652]: https://github.com/neilotoole/sq/issues/652
 [#658]: https://github.com/neilotoole/sq/pull/658
+[#692]: https://github.com/neilotoole/sq/issues/692
 
 [v0.15.2]: https://github.com/neilotoole/sq/releases/tag/v0.15.2
 [v0.15.3]: https://github.com/neilotoole/sq/compare/v0.15.2...v0.15.3

--- a/cli/output/mermaidw/colorize.go
+++ b/cli/output/mermaidw/colorize.go
@@ -28,20 +28,23 @@ func colorize(src string, pr *output.Printing) string {
 	return strings.Join(lines, "\n")
 }
 
-// reCardinality detects a relationship line by an ER cardinality glyph
-// (| o } {) adjacent to the --/.. connector, rather than a bare --/.. (which
-// can appear inside a quoted label).
-var reCardinality = regexp.MustCompile(`[|}o{](?:--|\.\.)|(?:--|\.\.)[|}o{]`)
-
 // Per-line token regexes, each capturing every character (including
 // whitespace) so reassembly is lossless: stripping the emitted ANSI escapes
 // reproduces the input exactly. Entity operands may be quoted (sq quotes any
 // name that isn't a bare identifier), so they match "..." or a bare token.
+//
+// The relationship operator is an ER cardinality token — glyphs (| o } {)
+// around a --/.. connector — rather than any non-space run. Requiring a real
+// cardinality token here is what distinguishes a relationship from a 3-token
+// attribute line ("int id PK"), and stops a quoted entity name that merely
+// contains a "--" substring from being misread as a relationship.
+const cardOp = `[|}o{]+(?:--|\.\.)[|}o{]+`
+
 var (
 	reComment     = regexp.MustCompile(`^(\s*)(%%.*)$`)
 	reKeyword     = regexp.MustCompile(`^(\s*)(erDiagram)(\s*)$`)
-	reRelLabel    = regexp.MustCompile(`^(\s*)("[^"]*"|\S+)(\s+)(\S+)(\s+)("[^"]*"|\S+)(\s+:\s+)(".*")(\s*)$`)
-	reRel         = regexp.MustCompile(`^(\s*)("[^"]*"|\S+)(\s+)(\S+)(\s+)("[^"]*"|\S+)(\s*)$`)
+	reRelLabel    = regexp.MustCompile(`^(\s*)("[^"]*"|\S+)(\s+)(` + cardOp + `)(\s+)("[^"]*"|\S+)(\s+:\s+)(".*")(\s*)$`)
+	reRel         = regexp.MustCompile(`^(\s*)("[^"]*"|\S+)(\s+)(` + cardOp + `)(\s+)("[^"]*"|\S+)(\s*)$`)
 	reEntityOpen  = regexp.MustCompile(`^(\s*)("[^"]*"|\S+)(\s*)(\{)(\s*)$`)
 	reEntityClose = regexp.MustCompile(`^(\s*)(\})(\s*)$`)
 	// reAttr matches "type name [keys]" where keys is PK/FK/UK, comma- or
@@ -65,9 +68,18 @@ func colorizeLine(line string, pr *output.Printing) string {
 		return assemble(reComment, line, nil, pr.Faint)
 	case trimmed == "erDiagram":
 		return assemble(reKeyword, line, nil, pr.Key, nil)
-	case reCardinality.MatchString(trimmed):
-		// LEFT op RIGHT [: "label"]: entities -> Header, operator -> Punc,
-		// label -> String; the " : " separator stays default.
+	case trimmed == "}":
+		return assemble(reEntityClose, line, nil, pr.Punc, nil)
+	case strings.HasSuffix(trimmed, "{"):
+		// NAME {: name -> Header, brace -> Punc. Checked before the
+		// relationship branch so a quoted name containing a cardinality-like
+		// substring (e.g. "weird o--table") is still colorized as an entity.
+		return assemble(reEntityOpen, line, nil, pr.Header, nil, pr.Punc, nil)
+	default:
+		// Relationship: LEFT op RIGHT [: "label"]; entities -> Header,
+		// operator -> Punc, label -> String, the " : " separator stays default.
+		// The strict cardinality operator (see the regex block) keeps an
+		// attribute line ("int id PK") from matching here.
 		if s, ok := assembleOK(reRelLabel, line,
 			nil, pr.Header, nil, pr.Punc, nil, pr.Header, nil, pr.String, nil); ok {
 			return s
@@ -76,13 +88,6 @@ func colorizeLine(line string, pr *output.Printing) string {
 			nil, pr.Header, nil, pr.Punc, nil, pr.Header, nil); ok {
 			return s
 		}
-		return line
-	case strings.HasSuffix(trimmed, "{"):
-		// NAME {: name -> Header, brace -> Punc.
-		return assemble(reEntityOpen, line, nil, pr.Header, nil, pr.Punc, nil)
-	case trimmed == "}":
-		return assemble(reEntityClose, line, nil, pr.Punc, nil)
-	default:
 		// Attribute: type -> Number, name -> default, keys -> Key.
 		return assemble(reAttr, line, nil, pr.Number, nil, nil, pr.Key, nil)
 	}

--- a/cli/output/mermaidw/colorize.go
+++ b/cli/output/mermaidw/colorize.go
@@ -46,7 +46,10 @@ var (
 	reEntityClose = regexp.MustCompile(`^(\s*)(\})(\s*)$`)
 	// reAttr matches "type name [keys]" where keys is PK/FK/UK, comma- or
 	// space-joined (sq joins with a comma, e.g. "PK,FK"). The optional keys
-	// group includes its own leading whitespace.
+	// group includes its own leading whitespace. Unlike #691's attribute rule,
+	// there is no trailing-comment group: sq's renderer sanitizes attribute
+	// names/types to bare words and never emits an attribute-level comment, so
+	// the simpler shape suffices and an unexpected line falls through to plain.
 	reAttr = regexp.MustCompile(`^(\s*)("[^"]*"|\S+)(\s+)("[^"]*"|\S+)(\s+(?:PK|FK|UK)(?:[ ,](?:PK|FK|UK))*)?(\s*)$`)
 )
 

--- a/cli/output/mermaidw/colorize.go
+++ b/cli/output/mermaidw/colorize.go
@@ -1,0 +1,122 @@
+package mermaidw
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/fatih/color"
+
+	"github.com/neilotoole/sq/cli/output"
+)
+
+// colorize applies ANSI color to a rendered Mermaid erDiagram source, wrapping
+// each token with its mapped output.Printing color. It returns src unchanged
+// when pr is nil or in monochrome mode, so non-TTY sinks (files, pipes,
+// --no-color, NO_COLOR, --monochrome) stay byte-identical to the plain diagram
+// — ANSI escapes would corrupt a redirected .mmd. The per-line grammar mirrors
+// the docs-site tokenizer added in #691
+// (site/layouts/_default/_markup/render-codeblock-mermaid.html).
+func colorize(src string, pr *output.Printing) string {
+	if pr == nil || pr.IsMonochrome() {
+		return src
+	}
+
+	lines := strings.Split(src, "\n")
+	for i, line := range lines {
+		lines[i] = colorizeLine(line, pr)
+	}
+	return strings.Join(lines, "\n")
+}
+
+// reCardinality detects a relationship line by an ER cardinality glyph
+// (| o } {) adjacent to the --/.. connector, rather than a bare --/.. (which
+// can appear inside a quoted label).
+var reCardinality = regexp.MustCompile(`[|}o{](?:--|\.\.)|(?:--|\.\.)[|}o{]`)
+
+// Per-line token regexes, each capturing every character (including
+// whitespace) so reassembly is lossless: stripping the emitted ANSI escapes
+// reproduces the input exactly. Entity operands may be quoted (sq quotes any
+// name that isn't a bare identifier), so they match "..." or a bare token.
+var (
+	reComment     = regexp.MustCompile(`^(\s*)(%%.*)$`)
+	reKeyword     = regexp.MustCompile(`^(\s*)(erDiagram)(\s*)$`)
+	reRelLabel    = regexp.MustCompile(`^(\s*)("[^"]*"|\S+)(\s+)(\S+)(\s+)("[^"]*"|\S+)(\s+:\s+)(".*")(\s*)$`)
+	reRel         = regexp.MustCompile(`^(\s*)("[^"]*"|\S+)(\s+)(\S+)(\s+)("[^"]*"|\S+)(\s*)$`)
+	reEntityOpen  = regexp.MustCompile(`^(\s*)("[^"]*"|\S+)(\s*)(\{)(\s*)$`)
+	reEntityClose = regexp.MustCompile(`^(\s*)(\})(\s*)$`)
+	// reAttr matches "type name [keys]" where keys is PK/FK/UK, comma- or
+	// space-joined (sq joins with a comma, e.g. "PK,FK"). The optional keys
+	// group includes its own leading whitespace.
+	reAttr = regexp.MustCompile(`^(\s*)("[^"]*"|\S+)(\s+)("[^"]*"|\S+)(\s+(?:PK|FK|UK)(?:[ ,](?:PK|FK|UK))*)?(\s*)$`)
+)
+
+// colorizeLine colorizes a single erDiagram line. Lines that match no known
+// token shape are returned unchanged, so an unexpected line is emitted plain
+// rather than corrupted.
+func colorizeLine(line string, pr *output.Printing) string {
+	trimmed := strings.TrimSpace(line)
+	switch {
+	case trimmed == "":
+		return line
+	case strings.HasPrefix(trimmed, "%%"):
+		return assemble(reComment, line, nil, pr.Faint)
+	case trimmed == "erDiagram":
+		return assemble(reKeyword, line, nil, pr.Key, nil)
+	case reCardinality.MatchString(trimmed):
+		// LEFT op RIGHT [: "label"]: entities -> Header, operator -> Punc,
+		// label -> String; the " : " separator stays default.
+		if s, ok := assembleOK(reRelLabel, line,
+			nil, pr.Header, nil, pr.Punc, nil, pr.Header, nil, pr.String, nil); ok {
+			return s
+		}
+		if s, ok := assembleOK(reRel, line,
+			nil, pr.Header, nil, pr.Punc, nil, pr.Header, nil); ok {
+			return s
+		}
+		return line
+	case strings.HasSuffix(trimmed, "{"):
+		// NAME {: name -> Header, brace -> Punc.
+		return assemble(reEntityOpen, line, nil, pr.Header, nil, pr.Punc, nil)
+	case trimmed == "}":
+		return assemble(reEntityClose, line, nil, pr.Punc, nil)
+	default:
+		// Attribute: type -> Number, name -> default, keys -> Key.
+		return assemble(reAttr, line, nil, pr.Number, nil, nil, pr.Key, nil)
+	}
+}
+
+// assemble matches re against line and rebuilds it, wrapping each capture
+// group with the color at the same position in clrs (a nil entry leaves that
+// group uncolored). It returns line unchanged when re doesn't match.
+func assemble(re *regexp.Regexp, line string, clrs ...*color.Color) string {
+	s, _ := assembleOK(re, line, clrs...)
+	return s
+}
+
+// assembleOK is assemble, additionally reporting whether re matched.
+func assembleOK(re *regexp.Regexp, line string, clrs ...*color.Color) (string, bool) {
+	m := re.FindStringSubmatch(line)
+	if m == nil {
+		return line, false
+	}
+
+	var b strings.Builder
+	// m[0] is the whole match; capture groups start at m[1], aligned with clrs.
+	for i, group := range m[1:] {
+		if i < len(clrs) && clrs[i] != nil {
+			b.WriteString(span(clrs[i], group))
+			continue
+		}
+		b.WriteString(group)
+	}
+	return b.String(), true
+}
+
+// span wraps s with clr, leaving an empty string untouched so an absent
+// optional capture group contributes no stray escape sequence.
+func span(clr *color.Color, s string) string {
+	if s == "" {
+		return s
+	}
+	return clr.Sprint(s)
+}

--- a/cli/output/mermaidw/colorize_internal_test.go
+++ b/cli/output/mermaidw/colorize_internal_test.go
@@ -9,7 +9,9 @@ import (
 )
 
 // colorPrinting returns a color-enabled *output.Printing for the colorizer
-// unit tests.
+// unit tests. EnableColor(true) sets each color's per-instance flag, which
+// overrides the package global color.NoColor, so the wrapped output contains
+// ANSI escapes even under NO_COLOR, TERM=dumb, or a non-TTY test sink.
 func colorPrinting() *output.Printing {
 	pr := output.NewPrinting()
 	pr.EnableColor(true)

--- a/cli/output/mermaidw/colorize_internal_test.go
+++ b/cli/output/mermaidw/colorize_internal_test.go
@@ -62,6 +62,13 @@ func TestColorizeLine(t *testing.T) {
 			in:   `    "weird table" {`,
 			want: "    " + pr.Header.Sprint(`"weird table"`) + " " + pr.Punc.Sprint("{"),
 		},
+		// A quoted entity name can contain an ER-cardinality substring (e.g.
+		// "o--"); relationship detection must not mistake this entity-open line
+		// for a relationship and leave it uncolored.
+		"entity_open_quoted_cardinality_substring": {
+			in:   `    "weird o--table" {`,
+			want: "    " + pr.Header.Sprint(`"weird o--table"`) + " " + pr.Punc.Sprint("{"),
+		},
 		"entity_close": {
 			in:   "    }",
 			want: "    " + pr.Punc.Sprint("}"),

--- a/cli/output/mermaidw/colorize_internal_test.go
+++ b/cli/output/mermaidw/colorize_internal_test.go
@@ -1,0 +1,105 @@
+package mermaidw
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/neilotoole/sq/cli/output"
+)
+
+// colorPrinting returns a color-enabled *output.Printing for the colorizer
+// unit tests.
+func colorPrinting() *output.Printing {
+	pr := output.NewPrinting()
+	pr.EnableColor(true)
+	return pr
+}
+
+// TestColorize_passthrough confirms colorize returns its input unchanged when
+// there's no color config (nil) or in monochrome mode — the two states in
+// which non-TTY output must stay byte-identical to the plain diagram.
+func TestColorize_passthrough(t *testing.T) {
+	const src = "erDiagram\n    actor {\n        int id PK\n    }\n"
+
+	require.Equal(t, src, colorize(src, nil), "nil Printing")
+
+	mono := output.NewPrinting()
+	mono.EnableColor(false)
+	require.Equal(t, src, colorize(src, mono), "monochrome Printing")
+}
+
+// TestColorizeLine covers each line-grammar branch directly, including the
+// parity branches mirrored from #691 that sq's own renderer never emits
+// (comments, label-less relationships) and the safe passthrough for an
+// unrecognized line.
+func TestColorizeLine(t *testing.T) {
+	pr := colorPrinting()
+
+	testCases := map[string]struct {
+		in   string
+		want string
+	}{
+		"blank": {
+			in:   "",
+			want: "",
+		},
+		"indent_only": {
+			in:   "    ",
+			want: "    ",
+		},
+		"keyword": {
+			in:   "erDiagram",
+			want: pr.Key.Sprint("erDiagram"),
+		},
+		"entity_open": {
+			in:   "    actor {",
+			want: "    " + pr.Header.Sprint("actor") + " " + pr.Punc.Sprint("{"),
+		},
+		"entity_open_quoted": {
+			in:   `    "weird table" {`,
+			want: "    " + pr.Header.Sprint(`"weird table"`) + " " + pr.Punc.Sprint("{"),
+		},
+		"entity_close": {
+			in:   "    }",
+			want: "    " + pr.Punc.Sprint("}"),
+		},
+		"attr_no_keys": {
+			in:   "        text first_name",
+			want: "        " + pr.Number.Sprint("text") + " first_name",
+		},
+		"attr_keys": {
+			in:   "        int actor_id PK,FK",
+			want: "        " + pr.Number.Sprint("int") + " actor_id" + pr.Key.Sprint(" PK,FK"),
+		},
+		"relationship_label": {
+			in: `    actor ||--o{ film_actor : "fk"`,
+			want: "    " + pr.Header.Sprint("actor") + " " + pr.Punc.Sprint("||--o{") +
+				" " + pr.Header.Sprint("film_actor") + " : " + pr.String.Sprint(`"fk"`),
+		},
+		// sq always emits a label, but #691's grammar (and this colorizer)
+		// handles the label-less form too.
+		"relationship_no_label": {
+			in: "    actor ||--o{ film_actor",
+			want: "    " + pr.Header.Sprint("actor") + " " + pr.Punc.Sprint("||--o{") +
+				" " + pr.Header.Sprint("film_actor"),
+		},
+		// sq never emits comments, but the grammar colors them faint.
+		"comment": {
+			in:   "    %% a note",
+			want: "    " + pr.Faint.Sprint("%% a note"),
+		},
+		// A line matching no token shape is emitted unchanged rather than
+		// corrupted.
+		"unrecognized_passthrough": {
+			in:   "    one two three four five",
+			want: "    one two three four five",
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			require.Equal(t, tc.want, colorizeLine(tc.in, pr))
+		})
+	}
+}

--- a/cli/output/mermaidw/metadatawriter.go
+++ b/cli/output/mermaidw/metadatawriter.go
@@ -37,14 +37,15 @@ var errNothingToRender = errz.New(
 // format, emitting bare Mermaid.js erDiagram source.
 type metadataWriter struct {
 	out io.Writer
+	pr  *output.Printing
 }
 
 // NewMetadataWriter returns a new output.MetadataWriter that outputs bare
-// Mermaid.js erDiagram source. The *output.Printing arg is accepted for
-// call-site consistency with the other metadata writers but is unused: the
-// diagram source is plain text with no color, redaction, or provenance.
-func NewMetadataWriter(out io.Writer, _ *output.Printing) output.MetadataWriter {
-	return &metadataWriter{out: out}
+// Mermaid.js erDiagram source. When pr enables color (a TTY sink), the diagram
+// is syntax-colored; in monochrome mode (files, pipes, --no-color, NO_COLOR,
+// --monochrome) the output is plain, byte-identical to the bare source.
+func NewMetadataWriter(out io.Writer, pr *output.Printing) output.MetadataWriter {
+	return &metadataWriter{out: out, pr: pr}
 }
 
 // SourceMetadata implements output.MetadataWriter. It writes the whole-source
@@ -71,12 +72,13 @@ func (w *metadataWriter) TableMetadata(md *metadata.Table) error {
 
 // writeDiagram writes the rendered diagram source to w.out, returning
 // errNothingToRender when src is empty (the mermaid package returns "" when
-// there's nothing to draw).
+// there's nothing to draw). On a TTY sink the source is syntax-colored;
+// otherwise it's written plain.
 func (w *metadataWriter) writeDiagram(src string) error {
 	if src == "" {
 		return errNothingToRender
 	}
-	_, err := io.WriteString(w.out, src)
+	_, err := io.WriteString(w.out, colorize(src, w.pr))
 	return err
 }
 

--- a/cli/output/mermaidw/metadatawriter_test.go
+++ b/cli/output/mermaidw/metadatawriter_test.go
@@ -143,6 +143,10 @@ func TestMetadataWriter_TableMetadata(t *testing.T) {
 // category is wrapped in its mapped output.Printing color, and stripping the
 // ANSI escapes reproduces the plain diagram byte-for-byte.
 func TestMetadataWriter_SourceMetadata_colorized(t *testing.T) {
+	// NewPrinting calls EnableColor(true), which sets each color's per-instance
+	// flag (fatih/color Color.EnableColor); that flag overrides the package
+	// global color.NoColor, so these assertions emit ANSI regardless of
+	// NO_COLOR, TERM=dumb, or a non-TTY test sink.
 	pr := output.NewPrinting()
 	require.False(t, pr.IsMonochrome(), "NewPrinting should be color-enabled")
 
@@ -205,6 +209,34 @@ func TestMetadataWriter_colorized_quotedEntity(t *testing.T) {
 		"quoted entity name colorized as a single Header token")
 	require.Contains(t, stripANSI(got), `"weird table" ||--o{ child`,
 		"round-trip preserves the quoted relationship line")
+}
+
+// TestMetadataWriter_TableMetadata_colorized verifies the focused single-table
+// ERD is colorized via the same writeDiagram path as the whole-source ERD, and
+// that stripping ANSI reproduces the plain focused diagram exactly.
+func TestMetadataWriter_TableMetadata_colorized(t *testing.T) {
+	const plainTableERD = `erDiagram
+    film_actor {
+        int actor_id PK,FK
+        int film_id PK
+    }
+    actor ||--o{ film_actor : "fk_film_actor_actor"
+`
+
+	src := newTestSource()
+	filmActor := src.Table("film_actor")
+	require.NotNil(t, filmActor)
+
+	pr := output.NewPrinting()
+	buf := &bytes.Buffer{}
+	w := mermaidw.NewMetadataWriter(buf, pr)
+	require.NoError(t, w.TableMetadata(filmActor))
+	got := buf.String()
+
+	require.NotEqual(t, plainTableERD, got, "expected colorized output")
+	require.Contains(t, got, pr.Key.Sprint("erDiagram"))
+	require.Contains(t, got, pr.Header.Sprint("film_actor"))
+	require.Equal(t, plainTableERD, stripANSI(got))
 }
 
 // TestMetadataWriter_monochrome_byteIdentical is the non-TTY regression guard:

--- a/cli/output/mermaidw/metadatawriter_test.go
+++ b/cli/output/mermaidw/metadatawriter_test.go
@@ -2,6 +2,7 @@ package mermaidw_test
 
 import (
 	"bytes"
+	"regexp"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -12,6 +13,37 @@ import (
 	"github.com/neilotoole/sq/libsq/source/drivertype"
 	"github.com/neilotoole/sq/libsq/source/metadata"
 )
+
+// plainSourceERD is the uncolored whole-source ERD for newTestSource(); the
+// colorized tests assert that stripping ANSI escapes reproduces it exactly.
+const plainSourceERD = `erDiagram
+    actor {
+        int actor_id PK
+        text first_name
+    }
+    film_actor {
+        int actor_id PK,FK
+        int film_id PK
+    }
+    actor ||--o{ film_actor : "fk_film_actor_actor"
+`
+
+// ansiRe matches an SGR ANSI escape sequence (e.g. "\x1b[34;1m").
+var ansiRe = regexp.MustCompile(`\x1b\[[0-9;]*m`)
+
+// stripANSI removes all SGR ANSI escape sequences from s.
+func stripANSI(s string) string {
+	return ansiRe.ReplaceAllString(s, "")
+}
+
+// monoPrinting returns a monochrome (color-disabled) *output.Printing, so the
+// plain-structure goldens below assert the bare diagram source rather than
+// colorized TTY output.
+func monoPrinting() *output.Printing {
+	pr := output.NewPrinting()
+	pr.EnableColor(false)
+	return pr
+}
 
 // newTestSource builds a small deterministic two-table source
 // (actor + film_actor, with film_actor.actor_id → actor.actor_id) and
@@ -81,7 +113,7 @@ func TestMetadataWriter_SourceMetadata(t *testing.T) {
 `
 
 	buf := &bytes.Buffer{}
-	w := mermaidw.NewMetadataWriter(buf, output.NewPrinting())
+	w := mermaidw.NewMetadataWriter(buf, monoPrinting())
 	require.NoError(t, w.SourceMetadata(newTestSource(), true))
 	require.Equal(t, want, buf.String())
 }
@@ -101,9 +133,92 @@ func TestMetadataWriter_TableMetadata(t *testing.T) {
 	require.NotNil(t, filmActor)
 
 	buf := &bytes.Buffer{}
-	w := mermaidw.NewMetadataWriter(buf, output.NewPrinting())
+	w := mermaidw.NewMetadataWriter(buf, monoPrinting())
 	require.NoError(t, w.TableMetadata(filmActor))
 	require.Equal(t, want, buf.String())
+}
+
+// TestMetadataWriter_SourceMetadata_colorized verifies that, given a
+// color-enabled (TTY) Printing, the whole-source ERD is colorized: each token
+// category is wrapped in its mapped output.Printing color, and stripping the
+// ANSI escapes reproduces the plain diagram byte-for-byte.
+func TestMetadataWriter_SourceMetadata_colorized(t *testing.T) {
+	pr := output.NewPrinting()
+	require.False(t, pr.IsMonochrome(), "NewPrinting should be color-enabled")
+
+	buf := &bytes.Buffer{}
+	w := mermaidw.NewMetadataWriter(buf, pr)
+	require.NoError(t, w.SourceMetadata(newTestSource(), true))
+	got := buf.String()
+
+	// Output must actually contain color (otherwise the assertions below would
+	// pass trivially against plain text).
+	require.NotEqual(t, plainSourceERD, got, "expected colorized output")
+
+	// Each token category is wrapped in its mapped color.
+	require.Contains(t, got, pr.Key.Sprint("erDiagram"), "diagram keyword")
+	require.Contains(t, got, pr.Header.Sprint("actor"), "entity name")
+	require.Contains(t, got, pr.Number.Sprint("int"), "column type")
+	require.Contains(t, got, pr.Key.Sprint(" PK,FK"), "key markers")
+	require.Contains(t, got, pr.Punc.Sprint("||--o{"), "cardinality operator")
+	require.Contains(t, got, pr.String.Sprint(`"fk_film_actor_actor"`), "relationship label")
+
+	// Stripping ANSI reproduces the plain diagram exactly: colorization only
+	// adds escapes, never changes the underlying characters.
+	require.Equal(t, plainSourceERD, stripANSI(got))
+}
+
+// TestMetadataWriter_colorized_quotedEntity verifies that a non-bare-identifier
+// table name (which the renderer double-quotes) is colorized as a single Header
+// token in both its entity block and the relationship line — the quote glyphs
+// and embedded space stay inside one span.
+func TestMetadataWriter_colorized_quotedEntity(t *testing.T) {
+	parent := &metadata.Table{
+		Name: "weird table", TableType: "table",
+		Columns: []*metadata.Column{
+			{Name: "id", Position: 1, PrimaryKey: true, ColumnType: "INTEGER", Kind: kind.Int},
+		},
+	}
+	child := &metadata.Table{
+		Name: "child", TableType: "table",
+		Columns: []*metadata.Column{
+			{Name: "pid", Position: 1, ColumnType: "INTEGER", Kind: kind.Int},
+		},
+		FK: &metadata.FKGroup{Outgoing: []*metadata.ForeignKey{{
+			Name: "fk_child_weird", Table: "child", Columns: []string{"pid"},
+			RefTable: "weird table", RefColumns: []string{"id"},
+		}}},
+	}
+	src := &metadata.Source{
+		Handle: "@q", Name: "q", Driver: drivertype.Type("sqlite3"),
+		Tables: []*metadata.Table{parent, child},
+	}
+	metadata.LinkForeignKeys(nil, src)
+
+	pr := output.NewPrinting()
+	buf := &bytes.Buffer{}
+	w := mermaidw.NewMetadataWriter(buf, pr)
+	require.NoError(t, w.SourceMetadata(src, true))
+	got := buf.String()
+
+	require.Contains(t, got, pr.Header.Sprint(`"weird table"`),
+		"quoted entity name colorized as a single Header token")
+	require.Contains(t, stripANSI(got), `"weird table" ||--o{ child`,
+		"round-trip preserves the quoted relationship line")
+}
+
+// TestMetadataWriter_monochrome_byteIdentical is the non-TTY regression guard:
+// a monochrome Printing (the state for files, pipes, --no-color, NO_COLOR,
+// --monochrome) must yield output byte-identical to the plain diagram, with no
+// ANSI escapes that would corrupt a redirected .mmd file.
+func TestMetadataWriter_monochrome_byteIdentical(t *testing.T) {
+	buf := &bytes.Buffer{}
+	w := mermaidw.NewMetadataWriter(buf, monoPrinting())
+	require.NoError(t, w.SourceMetadata(newTestSource(), true))
+
+	got := buf.String()
+	require.Equal(t, plainSourceERD, got)
+	require.Equal(t, got, stripANSI(got), "monochrome output must contain no ANSI escapes")
 }
 
 // TestMetadataWriter_unsupported verifies that operations with no ERD
@@ -171,7 +286,7 @@ func TestMetadataWriter_mermaidQuoting(t *testing.T) {
 	}
 
 	buf := &bytes.Buffer{}
-	w := mermaidw.NewMetadataWriter(buf, output.NewPrinting())
+	w := mermaidw.NewMetadataWriter(buf, monoPrinting())
 	require.NoError(t, w.SourceMetadata(src, true))
 
 	got := buf.String()


### PR DESCRIPTION
## Summary

`sq inspect -f mermaid-erd` emitted plain, monochrome `erDiagram` source even on a
terminal, unlike every other `sq` output format. This colorizes the diagram on a TTY,
reusing the central `output.Printing` palette.

The `mermaidw` writer already received a `*output.Printing` but discarded it; it now
retains it and runs the rendered diagram through a line classifier that mirrors the
docs-site tokenizer added in #691.

## Token → color mapping

| Token | Example | `Printing` color |
|---|---|---|
| Diagram keyword / key markers | `erDiagram`, `PK`, `PK,FK` | `Key` (blue bold) |
| Entity name | `actor`, `"weird table"` | `Header` (blue) |
| Column type | `int`, `text`, `datetime` | `Number` (cyan) |
| Column name | `first_name` | default |
| Cardinality / braces | `\|\|--o{`, `{` `}` | `Punc` (bold) |
| Quoted label | `"film_actor_actor_id_fkey"` | `String` (green) |
| `%%` comment | `%% note` | `Faint` |

## Non-TTY output is unchanged

Colorization is gated on `Printing.IsMonochrome()`, so files, pipes, and
`--no-color` / `NO_COLOR` / `--monochrome` stay **byte-identical** to the plain source —
ANSI escapes would corrupt a redirected `.mmd`. The classifier reassembles each line
from regex submatches (wrapping only non-empty groups), so stripping the ANSI escapes
reproduces the original text exactly; a round-trip test enforces this.

## Implementation notes

- The colorizer lives in `mermaidw` as a post-processing pass; `internal/mermaid`'s
  plain renderer (and its goldens) are untouched, avoiding an import cycle.
- No new `Printing` fields, no new CLI flags.

## Tests

- Existing source/table goldens now run monochrome — they double as the non-TTY
  regression guard.
- New: colorized round-trip + per-token spot-checks, quoted-entity colorization,
  monochrome byte-identical, and direct per-branch classifier coverage.

Verified end-to-end against `sakila.db`: TTY → colorized; pipe and `--monochrome` →
0 ANSI bytes.

Closes #692