### PR TITLE
test(ci): exercise nightly PAT push via temporary stars perturbation

### DIFF
--- a/site/data/github.toml
+++ b/site/data/github.toml
@@ -3,4 +3,4 @@
 # nightly by .github/workflows/site-data-nightly.yml; the committed values
 # are the offline / fetch-failure fallback.
 latest_version = "0.53.0"
-stars = 2480
+stars = 1


### PR DESCRIPTION
Temporary, self-correcting test of the `site-data-nightly.yml` PAT push. Sets `data/github.toml` stars to a deliberately-stale `1`; the next nightly dispatch fetches the real count and pushes the correction via `SITE_DATA_PUSH_TOKEN`, proving it can write to protected `master`. The build regenerates the real value in-artifact, so the deploy preview is unaffected.