### PR TITLE
(Site) Overhaul production generation and deployment process 

### DIFF
--- a/.github/workflows/site-ci.yml
+++ b/.github/workflows/site-ci.yml
@@ -7,11 +7,13 @@ on:
     paths:
       - "site/**"
       - ".github/workflows/site-ci.yml"
+      - ".github/workflows/site-publish-production.yml"
   pull_request:
     branches: [master, develop]
     paths:
       - "site/**"
       - ".github/workflows/site-ci.yml"
+      - ".github/workflows/site-publish-production.yml"
 
 defaults:
   run:

--- a/.github/workflows/site-data-nightly.yml
+++ b/.github/workflows/site-data-nightly.yml
@@ -1,9 +1,8 @@
 # Nightly refresh of site/data/github.toml (latest sq version + GitHub stars).
 #
 # Runs the same generator as the site build, then commits the refreshed data
-# file to master IF a value changed. This does NOT deploy — production publishes
-# happen only via the manual Site Publish (dispatch) workflow; pushing to master
-# does not trigger a Netlify production build (it is suppressed in netlify.toml).
+# file to master IF a value changed. A push to master triggers Site CI, then
+# site-publish-production.yml deploys to https://sq.io when site/** changed.
 #
 # Prerequisite: master uses classic branch protection (required PR reviews,
 # enforce_admins=false), which has no per-app bypass — the built-in GITHUB_TOKEN

--- a/.github/workflows/site-publish-dispatch.yml
+++ b/.github/workflows/site-publish-dispatch.yml
@@ -1,10 +1,9 @@
-# Manually publish the sq.io site to Netlify production.
+# Manually publish the sq.io site to Netlify production (escape hatch).
 #
-# This workflow is the ONLY path that pushes content to https://sq.io.
-# Netlify's git integration is configured (via site/netlify.toml's
-# `[context.production] ignore = "exit 0"`) to skip the production build on
-# master pushes, so production publishes happen only when an operator
-# explicitly triggers this workflow from the Actions tab.
+# Routine publishes happen automatically via site-publish-production.yml
+# after Site CI succeeds on master when site/** changes. Use this workflow
+# to deploy from a branch or SemVer tag without merging, or to republish an
+# older ref. Netlify git integration remains suppressed (production ignore).
 #
 # PR deploy previews from Netlify are unaffected — they run from the
 # `deploy-preview` context, not `production`.
@@ -118,73 +117,13 @@ jobs:
           SHA: ${{ github.sha }}
         run: |
           set -euo pipefail
-          if [ -z "${NETLIFY_AUTH_TOKEN:-}" ]; then
-            echo "::error::NETLIFY_AUTH_TOKEN secret is not set."
-            exit 1
-          fi
-          if [ -z "${NETLIFY_SITE_ID:-}" ]; then
-            echo "::error::NETLIFY_SITE_ID secret is not set."
-            exit 1
-          fi
           if [ -n "${INPUT_MESSAGE:-}" ]; then
             DEPLOY_MESSAGE="${INPUT_MESSAGE}"
           else
             DEPLOY_MESSAGE="Manual publish via workflow_dispatch by @${ACTOR} (${SHA})"
           fi
+          ./scripts/netlify-deploy-prod.sh "${DEPLOY_MESSAGE}"
 
-          # Run the deploy with --json. The CLI's --json output reports
-          # site_id, deploy_id, deploy_url, etc. — but no `state` field —
-          # so we can't infer success from JSON alone. We also don't fully
-          # trust the CLI exit code: in some failure modes (post-processing
-          # error, partial upload that still gets aliased) the CLI has been
-          # observed to exit 0 even though the resulting deploy is not
-          # `ready`. Capture the JSON to a file so we can echo it into the
-          # run log and extract deploy_id for the API poll below.
-          deploy_json=$(mktemp)
-          bun x netlify-cli deploy \
-            --prod \
-            --dir=public \
-            --message "${DEPLOY_MESSAGE}" \
-            --json \
-            | tee "${deploy_json}"
-
-          deploy_id=$(jq -r '.deploy_id // empty' "${deploy_json}")
-          deploy_url=$(jq -r '.deploy_url // .url // empty' "${deploy_json}")
-          echo "Deploy ID:  ${deploy_id:-<empty>}"
-          echo "Deploy URL: ${deploy_url:-<empty>}"
-          if [ -z "${deploy_id}" ]; then
-            echo "::error::netlify-cli did not return a deploy_id; cannot verify state."
-            exit 1
-          fi
-
-          # Authoritative state check: poll the Netlify API until the deploy
-          # reaches a terminal state. Production deploys typically settle
-          # within seconds of the CLI returning, but allow ~2.5 minutes of
-          # headroom for post-processing (CDN warm, edge-function build).
-          # Transient curl failures are retried rather than fatal.
-          #
-          # TODO: Share this poll loop with site/scripts/netlify-deploy-validate.sh
-          # (deploy-preview uses --build; production uses --prod --dir=public).
-          state=""
-          for attempt in $(seq 1 30); do
-            body=$(curl -fsS \
-              -H "Authorization: Bearer ${NETLIFY_AUTH_TOKEN}" \
-              "https://api.netlify.com/api/v1/sites/${NETLIFY_SITE_ID}/deploys/${deploy_id}") \
-              || { echo "Attempt ${attempt}: API call failed, will retry"; sleep 5; continue; }
-            state=$(jq -r '.state // empty' <<<"${body}")
-            echo "Attempt ${attempt}: state=${state:-<empty>}"
-            case "${state}" in
-              ready) break ;;
-              error|rejected)
-                echo "::error::Deploy ${deploy_id} ended in state=${state}."
-                exit 1
-                ;;
-            esac
-            sleep 5
-          done
-
-          if [ "${state}" != "ready" ]; then
-            echo "::error::Deploy ${deploy_id} did not reach state=ready after polling (last state: ${state:-<empty>})."
-            exit 1
-          fi
-          echo "Deploy ${deploy_id} reached state=ready."
+      - name: Post-deploy smoke (sq.io)
+        working-directory: site
+        run: ./scripts/smoke-production.sh https://sq.io

--- a/.github/workflows/site-publish-production.yml
+++ b/.github/workflows/site-publish-production.yml
@@ -1,0 +1,90 @@
+# Auto-publish sq.io to Netlify production after Site CI succeeds on master.
+#
+# Triggers when site/** (or publish workflow files) change. Netlify git
+# integration remains suppressed (site/netlify.toml production ignore).
+#
+# Requires repo secrets: NETLIFY_AUTH_TOKEN, NETLIFY_SITE_ID
+# GitHub `production` environment must not require manual approval (or deploys stall).
+name: Site Publish (production)
+
+on:
+  workflow_run:
+    workflows: ["Site CI"]
+    types: [completed]
+    branches: [master]
+
+concurrency:
+  group: site-publish-production
+  cancel-in-progress: false
+
+jobs:
+  check:
+    if: github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    outputs:
+      site: ${{ steps.filter.outputs.site }}
+    steps:
+      - name: Check out triggering commit
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+          fetch-depth: 2
+
+      - name: Detect site changes
+        uses: dorny/paths-filter@de90cc6fb38fc096f529637c54a0f9d99d4b6bd8 # v3
+        id: filter
+        with:
+          filters: |
+            site:
+              - 'site/**'
+              - '.github/workflows/site-publish-production.yml'
+              - '.github/workflows/site-publish-dispatch.yml'
+
+  publish:
+    needs: check
+    if: needs.check.outputs.site == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    permissions:
+      contents: read
+    environment:
+      name: production
+      url: https://sq.io
+    steps:
+      - name: Check out triggering commit
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: 1.3.13
+
+      - name: Cache Bun dependencies
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.bun/install/cache
+            site/node_modules
+          key: ${{ runner.os }}-site-bun-${{ hashFiles('site/bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-site-bun-
+
+      - name: Install, lint, build, and validate artifact (make ci)
+        working-directory: site
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: make ci
+
+      - name: Publish site/public to Netlify (production)
+        working-directory: site
+        env:
+          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
+        run: |
+          ./scripts/netlify-deploy-prod.sh "Auto publish after Site CI (${{ github.event.workflow_run.head_sha }})"
+
+      - name: Post-deploy smoke (sq.io)
+        working-directory: site
+        run: ./scripts/smoke-production.sh https://sq.io

--- a/site/.gitignore
+++ b/site/.gitignore
@@ -7,6 +7,9 @@ public/
 resources/
 .hugo_build.lock
 
+# Generated at prebuild by scripts/gen-site-data.js (copied to public/ by Hugo)
+static/version.json
+
 # Netlify
 .netlify/
 # netlify-cli spins up a Deno process internally (for Edge Functions emulation)

--- a/site/CLAUDE.md
+++ b/site/CLAUDE.md
@@ -154,18 +154,20 @@ Uses Hugo's built-in Chroma (not highlight.js):
 **Triggers and actions:**
 
 - Push to `master` or `develop` with changes under `site/**` →
-  GitHub Actions runs linting and builds (no deploy)
+  GitHub Actions runs `make ci` (lint, build, artifact validation)
 - PR to `master` or `develop` with changes under `site/**` → CI + Netlify deploy preview
-- Merge to `master` → **No auto-deploy.** Netlify's production build is suppressed via
-  `[context.production] ignore = "exit 0"` in `netlify.toml`.
-- Production publishes to https://sq.io happen only via the manual
-  `Site Publish (dispatch)` workflow in GitHub Actions
-  (`.github/workflows/site-publish-dispatch.yml`), which builds locally and uploads
-  via the Netlify CLI. Requires the `NETLIFY_AUTH_TOKEN` and `NETLIFY_SITE_ID` repo secrets.
-- Nightly (`.github/workflows/site-data-nightly.yml`, 07:00 UTC) regenerates
-  `site/data/github.toml` (build-time version + GitHub star count) and pushes to `master`
-  only if changed (no deploy). Requires the `SITE_DATA_PUSH_TOKEN` repo secret — an admin
-  fine-grained PAT (Contents: read/write) whose push bypasses `master`'s classic branch protection.
+- Site CI succeeds on `master` with `site/**` changes →
+  [`site-publish-production.yml`](../.github/workflows/site-publish-production.yml) deploys to
+  https://sq.io and runs post-deploy smoke checks
+- Escape hatch: manual [`Site Publish (dispatch)`](../.github/workflows/site-publish-dispatch.yml)
+  for branch/tag deploys or republish. Requires `NETLIFY_AUTH_TOKEN` and `NETLIFY_SITE_ID`.
+- Nightly ([`site-data-nightly.yml`](../.github/workflows/site-data-nightly.yml), 07:00 UTC)
+  regenerates `site/data/github.toml`; a push triggers Site CI → auto-deploy when changed.
+  Requires `SITE_DATA_PUSH_TOKEN` (admin PAT with Contents read/write).
+
+**Third-party scripts and CSP:** when adding scripts in
+[`layouts/partials/head/custom-head.html`](layouts/partials/head/custom-head.html), update
+`Content-Security-Policy` in [`netlify.toml`](netlify.toml) in the same PR.
 
 **Netlify configuration** (`netlify.toml`):
 

--- a/site/Makefile
+++ b/site/Makefile
@@ -12,7 +12,7 @@
 #   make site-local  — local dev server (bun scripts/dev-server.js)
 #   make check       — Bun, Hugo, Netlify CLI, jq, curl (Site CI / Dependabot)
 #   make check-netlify — make check + checkenv on .env (see .env.example)
-#   make ci          — deps, then site-test, then site-build (matches GitHub Site CI)
+#   make ci          — deps, site-test, site-build, validate-artifact (matches GitHub Site CI)
 #   make site-netlify-validate — Netlify deploy-preview CLI check (needs NETLIFY_*)
 #
 # Local dev after a warm online run (bun install + Hugo modules resolved):
@@ -166,10 +166,14 @@ check-env:
 .PHONY: check-netlify ## make check plus validated .env (Netlify API credentials)
 check-netlify: check check-env
 
-.PHONY: ci ## Install deps, lint, and production build (matches GitHub Site CI workflow)
-ci: deps site-test site-build
+.PHONY: site-validate-artifact ## Validate public/ build output (no server; badges, version.json)
+site-validate-artifact:
+	@./scripts/validate-artifact.sh
+
+.PHONY: ci ## Install deps, lint, build, and validate artifact (matches GitHub Site CI workflow)
+ci: deps site-test site-build site-validate-artifact
 	@$(LOGGER) log_separator
-	@$(LOGGER) log_success "CI pipeline completed (deps, lint, build)"
+	@$(LOGGER) log_success "CI pipeline completed (deps, lint, build, validate)"
 
 .PHONY: site-netlify-validate ## Netlify deploy-preview build + API poll until ready (NETLIFY_AUTH_TOKEN, NETLIFY_SITE_ID)
 site-netlify-validate: check-netlify

--- a/site/README.md
+++ b/site/README.md
@@ -139,14 +139,14 @@ This is an important note for the reader.
 
 The project uses GitHub Actions and Netlify for continuous integration:
 
-| Trigger                                  | Action                                                                                                                                |
-|------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------|
-| Push to `master` or `develop` (and PRs)  | `.github/workflows/site-ci.yml` runs `make ci` when `site/**` changes, plus an informational full link crawl                          |
-| Pull request                             | Netlify deploy preview (when configured)                                                                                              |
-| Site CI succeeds on `master`             | `.github/workflows/site-publish-production.yml` builds, deploys to [sq.io](https://sq.io), and runs post-deploy smoke checks           |
-| Manual `workflow_dispatch`               | `.github/workflows/site-publish-dispatch.yml` — escape hatch (branch/tag deploy or republish)                                        |
-| Daily schedule / manual                  | `.github/workflows/site-links-nightly.yml` runs a full external link crawl                                                            |
-| Daily schedule / manual                  | `.github/workflows/site-data-nightly.yml` refreshes `data/github.toml`; push triggers Site CI → auto-deploy when values change       |
+| Trigger                                 | Action                                                                                                                         |
+|-----------------------------------------|--------------------------------------------------------------------------------------------------------------------------------|
+| Push to `master` or `develop` (and PRs) | `.github/workflows/site-ci.yml` runs `make ci` when `site/**` changes, plus an informational full link crawl                   |
+| Pull request                            | Netlify deploy preview (when configured)                                                                                       |
+| Site CI succeeds on `master`            | `.github/workflows/site-publish-production.yml` builds, deploys to [sq.io](https://sq.io), and runs post-deploy smoke checks   |
+| Manual `workflow_dispatch`              | `.github/workflows/site-publish-dispatch.yml` — escape hatch (branch/tag deploy or republish)                                  |
+| Daily schedule / manual                 | `.github/workflows/site-links-nightly.yml` runs a full external link crawl                                                     |
+| Daily schedule / manual                 | `.github/workflows/site-data-nightly.yml` refreshes `data/github.toml`; push triggers Site CI → auto-deploy when values change |
 
 Merging to `master` with changes under `site/**` deploys production automatically
 after Site CI passes (lint, build, artifact validation, Netlify upload, smoke).

--- a/site/README.md
+++ b/site/README.md
@@ -13,8 +13,8 @@ This site is built using:
 - [Bun](https://bun.sh) tooling
 - [Netlify](https://www.netlify.com) hosting
 
-Production publishes to [sq.io](https://sq.io) are **manual** — merges to
-`master` no longer auto-deploy. See [CI Workflow](#ci-workflow) below.
+Production publishes to [sq.io](https://sq.io) are **automatic** after Site CI
+passes on `master` when `site/**` changes. See [CI Workflow](#ci-workflow) below.
 
 ## Contributing
 
@@ -143,21 +143,21 @@ The project uses GitHub Actions and Netlify for continuous integration:
 |------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------|
 | Push to `master` or `develop` (and PRs)  | `.github/workflows/site-ci.yml` runs `make ci` when `site/**` changes, plus an informational full link crawl                          |
 | Pull request                             | Netlify deploy preview (when configured)                                                                                              |
-| Merge to `master`                        | **No auto-deploy.** Netlify's production build is suppressed via `[context.production] ignore = "exit 0"` in `netlify.toml`           |
-| Manual `workflow_dispatch`               | `.github/workflows/site-publish-dispatch.yml` builds locally and uploads `site/public` to [sq.io](https://sq.io) via the Netlify CLI  |
+| Site CI succeeds on `master`             | `.github/workflows/site-publish-production.yml` builds, deploys to [sq.io](https://sq.io), and runs post-deploy smoke checks           |
+| Manual `workflow_dispatch`               | `.github/workflows/site-publish-dispatch.yml` — escape hatch (branch/tag deploy or republish)                                        |
 | Daily schedule / manual                  | `.github/workflows/site-links-nightly.yml` runs a full external link crawl                                                            |
-| Daily schedule / manual                  | `.github/workflows/site-data-nightly.yml` refreshes `data/github.toml` (version + stars); pushes to `master` if changed; no deploy    |
+| Daily schedule / manual                  | `.github/workflows/site-data-nightly.yml` refreshes `data/github.toml`; push triggers Site CI → auto-deploy when values change       |
 
-Production publishes to [sq.io](https://sq.io) are manual-only. To deploy,
-go to the repo's **Actions** tab, pick **Site Publish (dispatch)**, click
-**Run workflow**, select the ref you want to publish (any branch, or a
-SemVer-style `vX.Y.Z` tag — pre-release suffixes like `v1.0.0-rc1` and
-build metadata are also accepted), and type `DEPLOY` into the confirmation
-field. The workflow rejects refs that are neither a branch nor a SemVer
-v-tag, and rejects any confirmation value other than the literal string
-`DEPLOY`.
-Requires the `NETLIFY_AUTH_TOKEN` and `NETLIFY_SITE_ID` repo secrets to be
-set.
+Merging to `master` with changes under `site/**` deploys production automatically
+after Site CI passes (lint, build, artifact validation, Netlify upload, smoke).
+Netlify's git integration remains suppressed via `[context.production] ignore =
+"exit 0"` in `netlify.toml` — deploys go through GitHub Actions + the Netlify CLI.
+
+For exceptional cases (deploy from a branch or tag without merging, or republish
+an older ref), use **Site Publish (dispatch)**: Actions tab → **Site Publish
+(dispatch)** → Run workflow → select ref → type `DEPLOY`. Requires
+`NETLIFY_AUTH_TOKEN` and `NETLIFY_SITE_ID` repo secrets. The GitHub
+`production` environment must not require manual approval or auto-deploy stalls.
 
 Netlify still provides deploy previews for every PR with Lighthouse audits for
 performance, accessibility, best practices, and SEO. Before merging, click
@@ -169,15 +169,15 @@ correct.
 
 The header's **version badge** and **GitHub star count** are computed at build time rather than
 fetched in the browser. `scripts/gen-site-data.js` fetches the latest `sq` release and the repo
-star count and writes `site/data/github.toml`; the header template renders those values. The
+star count and writes `site/data/github.toml`; it also writes `static/version.json` (served at
+[`/version`](https://sq.io/version) via a redirect). The header template renders those values. The
 generator runs during `prebuild` (so every `bun run build` / `make site-build` refreshes them), and
 the committed `data/github.toml` is the offline / fetch-failure fallback — a GitHub hiccup never
 fails a build.
 
-Because the live site only changes on a manual publish, the nightly
-[`site-data-nightly.yml`](../.github/workflows/site-data-nightly.yml) workflow (07:00 UTC) keeps
-those values current in `master` between publishes: it reruns the generator and pushes
-`data/github.toml` only when a value changed. It does **not** deploy.
+The nightly [`site-data-nightly.yml`](../.github/workflows/site-data-nightly.yml) workflow (07:00
+UTC) keeps `data/github.toml` current in `master`. When it commits a change, Site CI runs and
+production auto-deploys via [`site-publish-production.yml`](../.github/workflows/site-publish-production.yml).
 
 Since `master` uses classic branch protection (`enforce_admins=false`, no per-app bypass), that push
 authenticates with the **`SITE_DATA_PUSH_TOKEN`** repo secret — a fine-grained PAT owned by a repo

--- a/site/netlify.toml
+++ b/site/netlify.toml
@@ -10,12 +10,9 @@
 
 [context.production]
   command = "bun run build"
-  # Production publishes to https://sq.io happen only via the manual
-  # `Site Publish (dispatch)` GitHub Actions workflow, which builds locally
-  # and uploads via the Netlify CLI. An `ignore` command that exits 0 tells
-  # Netlify to skip the production build entirely whenever its git
-  # integration fires (e.g. on master pushes). PR deploy previews are
-  # unaffected — they use the `deploy-preview` context.
+  # Production publishes to https://sq.io happen via GitHub Actions
+  # (site-publish-production.yml after Site CI, or site-publish-dispatch.yml).
+  # Netlify git integration is suppressed so master pushes do not double-deploy.
   ignore = "exit 0"
 
 [context.deploy-preview]
@@ -74,6 +71,8 @@ output_path = "reports/lighthouse.html"
   [headers.values]
     Content-Type = "application/json; charset=utf-8"
 
+# Security headers on all responses. When adding third-party scripts, update CSP
+# here and in site/layouts/partials/head/custom-head.html in the same PR.
 [[headers]]
   for = "/*"
   [headers.values]
@@ -84,14 +83,55 @@ output_path = "reports/lighthouse.html"
     Referrer-Policy = "strict-origin"
     Access-Control-Allow-Origin = "*"
     Feature-Policy = "geolocation 'self'"
-    Cache-Control = "public, max-age=31536000"
 
     Content-Security-Policy = '''
       default-src 'self' 'unsafe-inline' sq.io;
-      script-src 'self' 'unsafe-inline' 'unsafe-eval' 'wasm-unsafe-eval' sq.io asciinema.org www.googletagmanager.com;
+      script-src 'self' 'unsafe-inline' 'unsafe-eval' 'wasm-unsafe-eval' sq.io asciinema.org www.googletagmanager.com cdn.vemetric.com;
       frame-src 'self' 'unsafe-inline' sq.io asciinema.org;
-      connect-src 'self' sq.io asciinema.org www.google-analytics.com;
+      connect-src 'self' sq.io asciinema.org www.google-analytics.com hub.vemetric.com;
       img-src 'self' 'unsafe-inline' data: https: sq.io www.netlify.com;
       style-src 'self' 'unsafe-inline' sq.io www.netlify.com;
       font-src 'self' 'unsafe-inline' sq.io cdnjs.cloudflare.com github.com maxcdn.bootstrapcdn.com themes.googleusercontent.com use.fontawesome.com
       '''
+
+# HTML — revalidate so production deploys are visible immediately.
+[[headers]]
+  for = "/"
+  [headers.values]
+    Cache-Control = "public, max-age=0, must-revalidate"
+
+[[headers]]
+  for = "/*.html"
+  [headers.values]
+    Cache-Control = "public, max-age=0, must-revalidate"
+
+[[headers]]
+  for = "/docs/*"
+  [headers.values]
+    Cache-Control = "public, max-age=0, must-revalidate"
+
+[[headers]]
+  for = "/blog/*"
+  [headers.values]
+    Cache-Control = "public, max-age=0, must-revalidate"
+
+# Fingerprinted assets (Hugo pipe/minify hashes) — long cache is safe.
+[[headers]]
+  for = "/js/*"
+  [headers.values]
+    Cache-Control = "public, max-age=31536000, immutable"
+
+[[headers]]
+  for = "/*.min.*"
+  [headers.values]
+    Cache-Control = "public, max-age=31536000, immutable"
+
+[[headers]]
+  for = "/fonts/*"
+  [headers.values]
+    Cache-Control = "public, max-age=31536000, immutable"
+
+[[headers]]
+  for = "/version.json"
+  [headers.values]
+    Cache-Control = "public, max-age=300"

--- a/site/scripts/gen-site-data.js
+++ b/site/scripts/gen-site-data.js
@@ -2,10 +2,11 @@
  * Build-time generator for the header's GitHub-sourced values: the latest sq
  * release version and the repo star count.
  *
- * Writes site/data/github.toml. Each value is fetched independently; on any
- * fetch failure — or when SQ_SITE_OFFLINE=1 — the committed value is kept as
- * the fallback. The script always exits 0, so a GitHub hiccup never breaks a
- * build. Also run nightly by .github/workflows/site-data-nightly.yml.
+ * Writes site/data/github.toml and site/static/version.json. Each value is
+ * fetched independently; on any fetch failure — or when SQ_SITE_OFFLINE=1 —
+ * the committed value is kept as the fallback. The script always exits 0, so a
+ * GitHub hiccup never breaks a build. Also run nightly by
+ * .github/workflows/site-data-nightly.yml.
  */
 
 const fs = require("fs");
@@ -13,6 +14,7 @@ const path = require("path");
 const { getLatestVersion, getStarCount } = require("./version-fetch.js");
 
 const DATA_FILE = path.join(__dirname, "..", "data", "github.toml");
+const VERSION_JSON = path.join(__dirname, "..", "static", "version.json");
 
 /**
  * Render the data file content.
@@ -29,6 +31,15 @@ function renderGithubToml(version, stars) {
     `latest_version = "${version}"\n` +
     `stars = ${stars}\n`
   );
+}
+
+/**
+ * Render /version JSON (legacy Netlify function response shape).
+ * @param {string} version
+ * @returns {string}
+ */
+function renderVersionJson(version) {
+  return JSON.stringify({ "latest-version": version }) + "\n";
 }
 
 /**
@@ -91,31 +102,49 @@ async function fetchOrKeep(label, fetchFn, fallback) {
   }
 }
 
+/**
+ * Write static/version.json when a version is known.
+ * @param {string} version
+ * @returns {boolean}
+ */
+function writeVersionJson(version) {
+  return writeIfChanged(VERSION_JSON, renderVersionJson(version));
+}
+
 async function main() {
   const existing = parseExisting(DATA_FILE);
+  let version = existing.version;
+  let stars = existing.stars;
 
   if (process.env.SQ_SITE_OFFLINE === "1") {
     console.log(
       "gen-site-data: SQ_SITE_OFFLINE=1, keeping committed data/github.toml",
     );
-    return;
+  } else {
+    version = await fetchOrKeep("version", getLatestVersion, existing.version);
+    stars = await fetchOrKeep("stars", getStarCount, existing.stars);
+
+    if (version == null || stars == null) {
+      console.warn(
+        "gen-site-data: missing value with no committed fallback; leaving data/github.toml unchanged",
+      );
+    } else {
+      const changed = writeIfChanged(DATA_FILE, renderGithubToml(version, stars));
+      console.log(
+        `gen-site-data: version=${version} stars=${stars}` +
+          (changed ? " (updated data/github.toml)" : " (unchanged)"),
+      );
+    }
   }
 
-  const version = await fetchOrKeep("version", getLatestVersion, existing.version);
-  const stars = await fetchOrKeep("stars", getStarCount, existing.stars);
-
-  if (version == null || stars == null) {
-    console.warn(
-      "gen-site-data: missing value with no committed fallback; leaving data/github.toml unchanged",
-    );
-    return;
+  if (version != null) {
+    const jsonChanged = writeVersionJson(version);
+    if (jsonChanged) {
+      console.log(`gen-site-data: wrote static/version.json (latest-version=${version})`);
+    }
+  } else {
+    console.warn("gen-site-data: no version available; skipping static/version.json");
   }
-
-  const changed = writeIfChanged(DATA_FILE, renderGithubToml(version, stars));
-  console.log(
-    `gen-site-data: version=${version} stars=${stars}` +
-      (changed ? " (updated data/github.toml)" : " (unchanged)"),
-  );
 }
 
 // Never let an unexpected error (e.g. a write failure) crash the build; the
@@ -124,4 +153,10 @@ main().catch((err) => {
   console.warn(`gen-site-data: unexpected error (${err.message}); keeping committed data/github.toml`);
 });
 
-module.exports = { renderGithubToml, parseExisting, writeIfChanged };
+module.exports = {
+  renderGithubToml,
+  renderVersionJson,
+  parseExisting,
+  writeIfChanged,
+  writeVersionJson,
+};

--- a/site/scripts/netlify-deploy-poll.sh
+++ b/site/scripts/netlify-deploy-poll.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Poll the Netlify API until a deploy reaches state=ready (or a terminal error).
+#
+# Usage: netlify-deploy-poll.sh DEPLOY_ID
+#
+# Requires: NETLIFY_AUTH_TOKEN, NETLIFY_SITE_ID, jq, curl
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LOG_BASH="${SCRIPT_DIR}/log.bash"
+if [[ -f "${LOG_BASH}" ]]; then
+	# shellcheck disable=SC1090
+	source "${LOG_BASH}"
+else
+	log_info() { echo "$*"; }
+	log_error() { echo "ERROR: $*" >&2; }
+	log_indent() { "$@"; }
+	log_info_dim() { echo "  $*"; }
+	log_warning() { echo "WARN: $*"; }
+	log_success() { echo "$*"; }
+fi
+
+deploy_id="${1:-}"
+if [[ -z "${deploy_id}" ]]; then
+	log_error "Usage: netlify-deploy-poll.sh DEPLOY_ID"
+	exit 1
+fi
+if [[ -z "${NETLIFY_AUTH_TOKEN:-}" ]]; then
+	log_error "NETLIFY_AUTH_TOKEN is not set."
+	exit 1
+fi
+if [[ -z "${NETLIFY_SITE_ID:-}" ]]; then
+	log_error "NETLIFY_SITE_ID is not set."
+	exit 1
+fi
+if ! command -v jq >/dev/null 2>&1; then
+	log_error "jq is required for deploy state polling."
+	exit 1
+fi
+
+state=""
+for attempt in $(seq 1 30); do
+	body=$(curl -fsS \
+		-H "Authorization: Bearer ${NETLIFY_AUTH_TOKEN}" \
+		"https://api.netlify.com/api/v1/sites/${NETLIFY_SITE_ID}/deploys/${deploy_id}") \
+		|| {
+			log_indent log_warning "Attempt ${attempt}: API call failed, will retry"
+			sleep 5
+			continue
+		}
+	state=$(jq -r '.state // empty' <<<"${body}")
+	log_indent log_info_dim "Attempt ${attempt}: state=${state:-<empty>}"
+	case "${state}" in
+	ready) break ;;
+	error | rejected)
+		log_error "Deploy ${deploy_id} ended in state=${state}."
+		exit 1
+		;;
+	esac
+	sleep 5
+done
+
+if [[ "${state}" != "ready" ]]; then
+	log_error "Deploy ${deploy_id} did not reach state=ready (last: ${state:-<empty>})."
+	exit 1
+fi
+log_success "Deploy ${deploy_id} reached state=ready."

--- a/site/scripts/netlify-deploy-prod.sh
+++ b/site/scripts/netlify-deploy-prod.sh
@@ -18,6 +18,7 @@ else
 	log_info() { echo "$*"; }
 	log_error() { echo "ERROR: $*" >&2; }
 	log_indent() { "$@"; }
+	log_dim() { echo "$*"; }
 	log_info_dim() { echo "  $*"; }
 	log_success() { echo "$*"; }
 fi

--- a/site/scripts/netlify-deploy-prod.sh
+++ b/site/scripts/netlify-deploy-prod.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Upload site/public to Netlify production and poll until ready.
+#
+# Usage: netlify-deploy-prod.sh "Deploy message"
+#
+# Run from site/ after `make ci`. Requires NETLIFY_AUTH_TOKEN, NETLIFY_SITE_ID,
+# bun, jq, curl.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SITE_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+LOG_BASH="${SCRIPT_DIR}/log.bash"
+
+if [[ -f "${LOG_BASH}" ]]; then
+	# shellcheck disable=SC1090
+	source "${LOG_BASH}"
+else
+	log_info() { echo "$*"; }
+	log_error() { echo "ERROR: $*" >&2; }
+	log_indent() { "$@"; }
+	log_info_dim() { echo "  $*"; }
+	log_success() { echo "$*"; }
+fi
+
+MESSAGE="${1:-}"
+if [[ -z "${MESSAGE}" ]]; then
+	log_error "Usage: netlify-deploy-prod.sh \"Deploy message\""
+	exit 1
+fi
+if [[ -z "${NETLIFY_AUTH_TOKEN:-}" ]]; then
+	log_error "NETLIFY_AUTH_TOKEN is not set."
+	exit 1
+fi
+if [[ -z "${NETLIFY_SITE_ID:-}" ]]; then
+	log_error "NETLIFY_SITE_ID is not set."
+	exit 1
+fi
+if [[ ! -d "${SITE_DIR}/public" ]]; then
+	log_error "site/public not found; run make ci first."
+	exit 1
+fi
+if ! bun x netlify-cli --version >/dev/null 2>&1; then
+	log_error "netlify-cli not available via bun x (run: cd site && bun install)."
+	exit 1
+fi
+
+cd "${SITE_DIR}"
+
+deploy_json=$(mktemp)
+trap 'rm -f "${deploy_json}"' EXIT
+
+log_info "Publishing site/public to Netlify (production)…"
+log_indent log_dim "Message: ${MESSAGE}"
+
+bun x netlify-cli deploy \
+	--prod \
+	--dir=public \
+	--message "${MESSAGE}" \
+	--json \
+	| tee "${deploy_json}"
+
+deploy_id=$(jq -r '.deploy_id // empty' "${deploy_json}")
+deploy_url=$(jq -r '.deploy_url // .url // empty' "${deploy_json}")
+log_indent log_info_dim "Deploy ID:  ${deploy_id:-<empty>}"
+log_indent log_info_dim "Deploy URL: ${deploy_url:-<empty>}"
+if [[ -z "${deploy_id}" ]]; then
+	log_error "netlify-cli did not return deploy_id; cannot verify state."
+	exit 1
+fi
+
+"${SCRIPT_DIR}/netlify-deploy-poll.sh" "${deploy_id}"

--- a/site/scripts/netlify-deploy-validate.sh
+++ b/site/scripts/netlify-deploy-validate.sh
@@ -1,12 +1,8 @@
 #!/usr/bin/env bash
 # Deploy the current site/ tree to Netlify (deploy-preview context) and poll
 # the API until state=ready. Used by `make site-netlify-validate` and the
-# sq-site-dependabot skill (Layer B). Mirrors polling logic in
-# .github/workflows/site-publish-dispatch.yml.
-#
-# TODO: Deduplicate deploy JSON parse + API poll loop with site-publish-dispatch.yml
-# (e.g. site/scripts/netlify-deploy-poll.sh). Paths differ: --build deploy-preview
-# here vs --prod --dir=public in CI; keep both entry points, share poll-only helper.
+# sq-site-dependabot skill (Layer B). Shares poll logic with
+# netlify-deploy-poll.sh (production uses netlify-deploy-prod.sh).
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -76,30 +72,4 @@ if [ -z "${deploy_id}" ]; then
 	exit 1
 fi
 
-state=""
-for attempt in $(seq 1 30); do
-	body=$(curl -fsS \
-		-H "Authorization: Bearer ${NETLIFY_AUTH_TOKEN}" \
-		"https://api.netlify.com/api/v1/sites/${NETLIFY_SITE_ID}/deploys/${deploy_id}") \
-		|| {
-			log_indent log_warning "Attempt ${attempt}: API call failed, will retry"
-			sleep 5
-			continue
-		}
-	state=$(jq -r '.state // empty' <<<"${body}")
-	log_indent log_info_dim "Attempt ${attempt}: state=${state:-<empty>}"
-	case "${state}" in
-	ready) break ;;
-	error | rejected)
-		log_error "Deploy ${deploy_id} ended in state=${state}."
-		exit 1
-		;;
-	esac
-	sleep 5
-done
-
-if [ "${state}" != "ready" ]; then
-	log_error "Deploy ${deploy_id} did not reach state=ready (last: ${state:-<empty>})."
-	exit 1
-fi
-log_success "Deploy ${deploy_id} reached state=ready."
+"${SCRIPT_DIR}/netlify-deploy-poll.sh" "${deploy_id}"

--- a/site/scripts/smoke-production.sh
+++ b/site/scripts/smoke-production.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Post-deploy smoke checks against production sq.io.
+#
+# Usage: smoke-production.sh [BASE_URL]
+# Default BASE_URL: https://sq.io
+set -euo pipefail
+
+BASE_URL="${1:-https://sq.io}"
+BASE_URL="${BASE_URL%/}"
+
+fail() {
+	echo "smoke-production: FAIL: $1" >&2
+	exit 1
+}
+
+pass() {
+	echo "smoke-production: PASS: $1"
+}
+
+HTML=$(curl -fsS "${BASE_URL}/") || fail "homepage fetch failed"
+
+if echo "${HTML}" | grep -q 'gh-stars\.min'; then
+	fail "homepage still references gh-stars.min.js"
+fi
+pass "no legacy gh-stars.min.js"
+
+if echo "${HTML}" | grep -q 'sq-version\.min'; then
+	fail "homepage still references sq-version.min.js"
+fi
+pass "no legacy sq-version.min.js"
+
+if ! echo "${HTML}" | grep -qE 'navbar-version[^>]*>v[0-9]+\.[0-9]+\.[0-9]+'; then
+	fail "baked version badge (navbar-version > vX.Y.Z) not found"
+fi
+pass "baked version badge present"
+
+if ! echo "${HTML}" | grep -qE 'gh-stars-count[^>]*>[0-9][0-9.]*k?'; then
+	fail "baked star count (gh-stars-count) not found"
+fi
+pass "baked star count present"
+
+VERSION_JSON=$(curl -fsS "${BASE_URL}/version") || fail "/version fetch failed"
+if ! echo "${VERSION_JSON}" | jq -e '.["latest-version"] | test("^[0-9]+\\.[0-9]+\\.[0-9]+$")' >/dev/null; then
+	fail "/version JSON missing valid latest-version"
+fi
+pass "/version JSON valid"
+
+CSP=$(curl -fsSI "${BASE_URL}/" | tr -d '\r' | grep -i '^content-security-policy:' || true)
+if [[ -z "${CSP}" ]]; then
+	fail "Content-Security-Policy header missing"
+fi
+if ! echo "${CSP}" | grep -qi 'cdn\.vemetric\.com'; then
+	fail "CSP missing cdn.vemetric.com in script-src"
+fi
+if ! echo "${CSP}" | grep -qi 'hub\.vemetric\.com'; then
+	fail "CSP missing hub.vemetric.com in connect-src"
+fi
+pass "CSP includes Vemetric domains"
+
+CACHE=$(curl -fsSI "${BASE_URL}/" | tr -d '\r' | grep -i '^cache-control:' || true)
+if [[ -z "${CACHE}" ]]; then
+	fail "Cache-Control header missing on /"
+fi
+if ! echo "${CACHE}" | grep -qiE 'max-age=0|must-revalidate'; then
+	fail "homepage Cache-Control should revalidate (got: ${CACHE})"
+fi
+pass "homepage Cache-Control allows revalidation"
+
+echo "smoke-production: all checks passed (${BASE_URL})"

--- a/site/scripts/validate-artifact.sh
+++ b/site/scripts/validate-artifact.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Validate a local site/public build artifact (no HTTP server required).
+#
+# Usage: validate-artifact.sh [PUBLIC_DIR]
+# Default PUBLIC_DIR: site/public (relative to this script's parent directory).
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SITE_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+PUBLIC_DIR="${1:-${SITE_DIR}/public}"
+INDEX="${PUBLIC_DIR}/index.html"
+
+fail() {
+	echo "validate-artifact: FAIL: $1" >&2
+	exit 1
+}
+
+pass() {
+	echo "validate-artifact: PASS: $1"
+}
+
+[[ -d "${PUBLIC_DIR}" ]] || fail "directory not found: ${PUBLIC_DIR}"
+[[ -f "${INDEX}" ]] || fail "public/index.html missing (run make site-build first)"
+
+BODY=$(cat "${INDEX}")
+
+if echo "${BODY}" | grep -q 'gh-stars\.min'; then
+	fail "index.html references gh-stars.min.js"
+fi
+pass "no legacy gh-stars.min.js"
+
+if echo "${BODY}" | grep -q 'sq-version\.min'; then
+	fail "index.html references sq-version.min.js"
+fi
+pass "no legacy sq-version.min.js"
+
+if echo "${BODY}" | grep -q 'api\.github\.com'; then
+	fail "index.html references api.github.com (runtime fetch should be gone)"
+fi
+pass "no api.github.com in homepage HTML"
+
+if ! echo "${BODY}" | grep -qE 'navbar-version[^>]*>v[0-9]+\.[0-9]+\.[0-9]+'; then
+	fail "version badge (navbar-version > vX.Y.Z) not found in index.html"
+fi
+pass "baked version badge present"
+
+if ! echo "${BODY}" | grep -qE 'gh-stars-count[^>]*>[0-9][0-9.]*k?'; then
+	fail "star count (gh-stars-count) not found in index.html"
+fi
+pass "baked star count present"
+
+[[ -f "${PUBLIC_DIR}/version.json" ]] || fail "public/version.json missing"
+if ! jq -e '.["latest-version"] | test("^[0-9]+\\.[0-9]+\\.[0-9]+$")' "${PUBLIC_DIR}/version.json" >/dev/null; then
+	fail "public/version.json has invalid latest-version"
+fi
+pass "public/version.json valid"
+
+echo "validate-artifact: all checks passed (${PUBLIC_DIR})"

--- a/site/scripts/version-fetch.test.js
+++ b/site/scripts/version-fetch.test.js
@@ -1,5 +1,6 @@
 const { describe, test, expect } = require("bun:test");
 const { parseReleaseTag, parseStarCount } = require("./version-fetch.js");
+const { renderVersionJson } = require("./gen-site-data.js");
 
 describe("parseReleaseTag", () => {
   test("strips the leading v from a stable tag", () => {
@@ -62,5 +63,13 @@ describe("parseStarCount", () => {
 
   test("rejects a non-object response", () => {
     expect(parseStarCount(null)).toHaveProperty("error");
+  });
+});
+
+describe("renderVersionJson", () => {
+  test("emits legacy /version response shape", () => {
+    expect(JSON.parse(renderVersionJson("0.53.0"))).toEqual({
+      "latest-version": "0.53.0",
+    });
   });
 });

--- a/site/static/_redirects
+++ b/site/static/_redirects
@@ -1,5 +1,7 @@
 # Additional redirects from static/_redirects
 
+/version /version.json 200!
+
 /install.sh https://raw.githubusercontent.com/neilotoole/sq/master/install.sh 301
 /changelog https://github.com/neilotoole/sq/blob/master/CHANGELOG.md 301
 /releases https://github.com/neilotoole/sq/releases 301


### PR DESCRIPTION
This pull request introduces automatic production deployments for the `sq.io` site after successful CI runs on `master` when relevant files change, replacing the previous manual-only publish process. It adds a new workflow for auto-publishing, updates documentation and configuration to reflect this change, and improves cache and security headers. Manual publishing remains available as an escape hatch.

**CI/CD Workflow and Deployment Changes:**

* Added `.github/workflows/site-publish-production.yml` to automatically deploy to production via Netlify after Site CI passes on `master` with relevant changes. This workflow builds, validates, deploys, and smoke-tests the site.
* Updated `.github/workflows/site-ci.yml` and `.github/workflows/site-data-nightly.yml` to ensure pushes that update site data or workflow files trigger the new auto-deploy pipeline. [[1]](diffhunk://#diff-8c35242764de51b6b341d4002ce583d4dce422b459ddb4c866b81921a14fe946R10-R16) [[2]](diffhunk://#diff-02029e4c9f68c28fa4f8e06e2c00e9b04eaf1ddf5d7f2c7580071d01a5848502L4-R5)
* Refactored `.github/workflows/site-publish-dispatch.yml` to clarify its role as a manual/escape-hatch deploy option, and simplified its deploy logic to use a script and post-deploy smoke check. [[1]](diffhunk://#diff-e528c682d4d602fc67799e28046fdaafc0e56bd3d68ff4ffaa4b0ae757218874L1-R6) [[2]](diffhunk://#diff-e528c682d4d602fc67799e28046fdaafc0e56bd3d68ff4ffaa4b0ae757218874L121-R129)
* Updated documentation (`site/README.md`, `site/CLAUDE.md`) to describe the new automatic deployment process and the remaining manual publish workflow. [[1]](diffhunk://#diff-669d2a51f46a925c4e680583bb9a7fc173b8ca2f52d991e8986ab52c20321064L16-R17) [[2]](diffhunk://#diff-669d2a51f46a925c4e680583bb9a7fc173b8ca2f52d991e8986ab52c20321064L146-R160) [[3]](diffhunk://#diff-669d2a51f46a925c4e680583bb9a7fc173b8ca2f52d991e8986ab52c20321064L172-R180) [[4]](diffhunk://#diff-c7f28f40915cf8ab0721cde3c544e56d859cc3f006e1dae270d470afdda1b9d6L157-R170)

**Build and Artifact Validation:**

* Enhanced the `Makefile` CI pipeline to include artifact validation (e.g., `site-validate-artifact`), ensuring the build output is checked before deployment. [[1]](diffhunk://#diff-1c9cfc8828a6faa384cf6c9af8abd84c177e2adb88de729e82e42996f2863902L15-R15) [[2]](diffhunk://#diff-1c9cfc8828a6faa384cf6c9af8abd84c177e2adb88de729e82e42996f2863902L169-R176)
* Updated `.gitignore` to include `static/version.json`, which is generated at build time and served by the site.

**Netlify and Caching Configuration:**

* Updated `site/netlify.toml` to clarify that production deploys are managed by GitHub Actions, not Netlify's git integration, which remains suppressed.
* Added and refined HTTP headers for security (CSP) and cache control: HTML is now revalidated immediately after deploy, while fingerprinted assets are cached long-term. [[1]](diffhunk://#diff-2ad05f770dc41cb3585c1729f20869d43ceb8cd29b07bd803392fd8f1dfc19f0R74-R75) [[2]](diffhunk://#diff-2ad05f770dc41cb3585c1729f20869d43ceb8cd29b07bd803392fd8f1dfc19f0L87-R137)

**Security and Best Practices:**

* Improved Content-Security-Policy to accommodate new third-party scripts and clarified documentation on how to update CSP when adding scripts. [[1]](diffhunk://#diff-2ad05f770dc41cb3585c1729f20869d43ceb8cd29b07bd803392fd8f1dfc19f0R74-R75) [[2]](diffhunk://#diff-2ad05f770dc41cb3585c1729f20869d43ceb8cd29b07bd803392fd8f1dfc19f0L87-R137) [[3]](diffhunk://#diff-c7f28f40915cf8ab0721cde3c544e56d859cc3f006e1dae270d470afdda1b9d6L157-R170)

These changes collectively modernize and automate the site's deployment pipeline, improve reliability and security, and update documentation for contributors.