### PR TITLE
Allow GA4 google.com endpoint in site CSP

### DIFF
--- a/site/README.md
+++ b/site/README.md
@@ -145,7 +145,7 @@ The project uses GitHub Actions and Netlify for continuous integration:
 | Push to `master` or `develop` (and PRs) | `.github/workflows/site-ci.yml` runs `make ci` when `site/**` changes, plus an informational full link crawl                   |
 | Pull request                            | Netlify deploy preview (when configured)                                                                                       |
 | Stable GitHub release (`vX.Y.Z`)        | `.github/workflows/site-publish-release.yml` builds, deploys to [sq.io](https://sq.io), and runs post-deploy smoke checks      |
-| Manual `workflow_dispatch`              | `.github/workflows/site-publish-dispatch.yml` — publish doc or dependency changes before the next release                        |
+| Manual `workflow_dispatch`              | `.github/workflows/site-publish-dispatch.yml` — publish doc or dependency changes before the next release                      |
 | Daily schedule / manual                 | `.github/workflows/site-links-nightly.yml` runs a full external link crawl                                                     |
 | Daily schedule / manual                 | `.github/workflows/site-data-nightly.yml` refreshes `data/github.toml`; push triggers Site CI only (no production deploy)      |
 

--- a/site/netlify.toml
+++ b/site/netlify.toml
@@ -88,7 +88,7 @@ output_path = "reports/lighthouse.html"
       default-src 'self' 'unsafe-inline' sq.io;
       script-src 'self' 'unsafe-inline' 'unsafe-eval' 'wasm-unsafe-eval' sq.io asciinema.org www.googletagmanager.com cdn.vemetric.com;
       frame-src 'self' 'unsafe-inline' sq.io asciinema.org;
-      connect-src 'self' sq.io asciinema.org www.google-analytics.com hub.vemetric.com;
+      connect-src 'self' sq.io asciinema.org www.google-analytics.com www.google.com hub.vemetric.com;
       img-src 'self' 'unsafe-inline' data: https: sq.io www.netlify.com;
       style-src 'self' 'unsafe-inline' sq.io www.netlify.com;
       font-src 'self' 'unsafe-inline' sq.io cdnjs.cloudflare.com github.com maxcdn.bootstrapcdn.com themes.googleusercontent.com use.fontawesome.com

--- a/site/scripts/smoke-production.sh
+++ b/site/scripts/smoke-production.sh
@@ -55,7 +55,10 @@ fi
 if ! echo "${CSP}" | grep -qi 'hub\.vemetric\.com'; then
 	fail "CSP missing hub.vemetric.com in connect-src"
 fi
-pass "CSP includes Vemetric domains"
+if ! echo "${CSP}" | grep -qi 'www\.google\.com'; then
+	fail "CSP missing www.google.com in connect-src (GA4 /g/collect)"
+fi
+pass "CSP includes Vemetric and GA4 domains"
 
 CACHE=$(curl -fsSI "${BASE_URL}/" | tr -d '\r' | grep -i '^cache-control:' || true)
 if [[ -z "${CACHE}" ]]; then


### PR DESCRIPTION
## Summary
- Add `www.google.com` to `connect-src` in `site/netlify.toml` so GA4 `/g/collect` beacons are not blocked by CSP.
- Extend `smoke-production.sh` to assert the GA4 endpoint is present after deploy.

Fixes console CSP errors when navigating back to sq.io from external links (e.g. clicking the version badge to GitHub releases, then using the browser Back button). GA4 flushes queued hits on bfcache restore to `www.google.com/g/collect`, which was not in the previous allowlist.

## Test plan
- [ ] Merge and run **Site Publish** (manual dispatch) to deploy to production
- [ ] Load https://sq.io → click version badge → GitHub releases → browser Back
- [ ] Confirm no CSP errors for `google.com/g/collect` in the console (without refresh)
- [ ] Run `site/scripts/smoke-production.sh` against production after deploy