### PR TITLE
test(inspect): add per-driver FK/UC/Index integration tests (#616)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,14 +20,15 @@ Breaking changes are annotated with ☢️, and alpha/beta features with 🐥.
 
 ### Added
 
-- [#616]: [`sq inspect`](https://sq.io/docs/inspect) foreign-key, unique-constraint, and
-  index introspection gained per-driver integration tests for the Postgres, MySQL,
-  SQL Server, and Oracle loaders — composite-FK column pairing, `ON DELETE` / `ON
-  UPDATE` referential actions, Postgres reserved-word FK identifiers, SQL Server
-  same-catalog FK shape, plus self-referential FK pointer identity and a
-  `Source.Clone` deep-copy round-trip in the shared metadata layer. The
-  `tablew` verbose renderer also gained a golden-layout test pinning header
-  order and the parens-wrapped styling of UC-backing indexes.
+- [#616]: [`sq inspect`](https://sq.io/docs/inspect) foreign-key, unique-constraint,
+  and index introspection gained per-driver integration tests for the Postgres,
+  MySQL, SQL Server, Oracle, and DuckDB loaders — composite-FK column pairing,
+  `ON DELETE` / `ON UPDATE` referential actions, Postgres / DuckDB reserved-word
+  FK identifiers, SQL Server same-catalog FK shape, plus self-referential FK
+  pointer identity and a `Source.Clone` deep-copy round-trip in the shared
+  metadata layer. The text-table verbose renderer also gained a golden-layout
+  test pinning header order and the parens-wrapped styling of unique-constraint-backing
+  indexes.
 - [#660]: [`sq inspect`](https://sq.io/docs/inspect) gained
   [`svg-erd`](https://sq.io/docs/inspect#svg-erd) and
   [`png-erd`](https://sq.io/docs/inspect#png-erd) output formats that render the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,14 @@ Breaking changes are annotated with ☢️, and alpha/beta features with 🐥.
 
 ### Added
 
+- [#616]: [`sq inspect`](https://sq.io/docs/inspect) foreign-key, unique-constraint, and
+  index introspection gained per-driver integration tests for the Postgres, MySQL,
+  SQL Server, and Oracle loaders — composite-FK column pairing, `ON DELETE` / `ON
+  UPDATE` referential actions, Postgres reserved-word FK identifiers, SQL Server
+  same-catalog FK shape, plus self-referential FK pointer identity and a
+  `Source.Clone` deep-copy round-trip in the shared metadata layer. The
+  `tablew` verbose renderer also gained a golden-layout test pinning header
+  order and the parens-wrapped styling of UC-backing indexes.
 - [#660]: [`sq inspect`](https://sq.io/docs/inspect) gained
   [`svg-erd`](https://sq.io/docs/inspect#svg-erd) and
   [`png-erd`](https://sq.io/docs/inspect#png-erd) output formats that render the
@@ -1594,6 +1602,7 @@ make working with lots of sources much easier.
 [#612]: https://github.com/neilotoole/sq/issues/612
 [#613]: https://github.com/neilotoole/sq/issues/613
 [#615]: https://github.com/neilotoole/sq/issues/615
+[#616]: https://github.com/neilotoole/sq/issues/616
 [#617]: https://github.com/neilotoole/sq/issues/617
 [#618]: https://github.com/neilotoole/sq/issues/618
 [#628]: https://github.com/neilotoole/sq/issues/628

--- a/cli/output/tablew/metadatawriter_test.go
+++ b/cli/output/tablew/metadatawriter_test.go
@@ -344,7 +344,8 @@ func TestPrintTablesVerbose_COLSPlainNumeric(t *testing.T) {
 }
 
 // TestPrintTablesVerbose_GoldenLayout is the end-to-end golden test
-// for [mdWriter.printTablesVerbose]. It pins:
+// for [mdWriter.printTablesVerbose]; helper-function coverage lives
+// alongside [indexEntriesByColumn] / [formatIdxCell]. It pins:
 //
 //   - the header row order (NAME / TYPE / ROWS / COLS / NAME / TYPE /
 //     PK / FK / INDEXES / UNIQUE CONSTRAINTS) so a header reorder or
@@ -356,11 +357,6 @@ func TestPrintTablesVerbose_COLSPlainNumeric(t *testing.T) {
 //     indistinguishable from a standalone unique index — is caught.
 //   - the standalone-unique-index path (no parens) so the two cases
 //     stay visibly distinct.
-//
-// Helper-function tests already cover [indexEntriesByColumn] +
-// [formatIdxCell] in isolation; this test wires them through the full
-// row-render pipeline so a regression in writeRow / column transformers
-// can't break the user-visible layout without a test failure.
 func TestPrintTablesVerbose_GoldenLayout(t *testing.T) {
 	tbls := []*metadata.Table{
 		{
@@ -399,7 +395,7 @@ func TestPrintTablesVerbose_GoldenLayout(t *testing.T) {
 	lines := strings.Split(strings.TrimRight(out, "\n"), "\n")
 	require.GreaterOrEqual(t, len(lines), 4, "expected header + 3 column rows: got %q", out)
 
-	// Header row is line 0 with this writer. The columns are
+	// lines[0] is the header row with this writer. The columns are
 	// whitespace-padded in declaration order, so an in-order substring
 	// search is enough to pin the layout.
 	header := lines[0]
@@ -435,13 +431,17 @@ func TestPrintTablesVerbose_GoldenLayout(t *testing.T) {
 	//   - demo_email_key (UC-backing → parenthesized)
 	//   - idx_email_solo (standalone unique → bare)
 	// Both must appear; the UC-backing one must be parens-wrapped, the
-	// solo one must NOT be wrapped.
-	require.Contains(t, emailRow, "(demo_email_key)",
-		"UC-backing index name must render parens-wrapped to mark it as secondary to UNIQUE CONSTRAINTS")
+	// solo one must NOT be wrapped. Count-based assertions catch a
+	// regression that double-wraps the name (e.g. "((demo_email_key))")
+	// — a substring-only Contains check would silently pass on that.
+	require.Equal(t, 1, strings.Count(emailRow, "(demo_email_key)"),
+		"UC-backing index name must render exactly once parens-wrapped to mark it as secondary to UNIQUE CONSTRAINTS")
 	require.Contains(t, emailRow, "idx_email_solo",
 		"standalone unique index must appear in INDEXES")
 	require.NotContains(t, emailRow, "(idx_email_solo)",
 		"standalone unique index must NOT be parens-wrapped — only UC-backing entries get that styling")
-	require.Contains(t, emailRow, "demo_email_key",
-		"the UC name itself must still appear in the UNIQUE CONSTRAINTS cell")
+	// The UC name must appear at least twice: once parens-wrapped in
+	// the INDEXES cell, and once bare in the UNIQUE CONSTRAINTS cell.
+	require.GreaterOrEqual(t, strings.Count(emailRow, "demo_email_key"), 2,
+		"the UC name must appear in both the INDEXES (wrapped) and UNIQUE CONSTRAINTS (bare) cells")
 }

--- a/cli/output/tablew/metadatawriter_test.go
+++ b/cli/output/tablew/metadatawriter_test.go
@@ -342,3 +342,106 @@ func TestPrintTablesVerbose_COLSPlainNumeric(t *testing.T) {
 		"with color disabled the row must contain no ANSI escape sequences")
 	require.NotContains(t, emptyRow, "\x1b[")
 }
+
+// TestPrintTablesVerbose_GoldenLayout is the end-to-end golden test
+// for [mdWriter.printTablesVerbose]. It pins:
+//
+//   - the header row order (NAME / TYPE / ROWS / COLS / NAME / TYPE /
+//     PK / FK / INDEXES / UNIQUE CONSTRAINTS) so a header reorder or
+//     rename in the writer surfaces as a test failure rather than as
+//     a silent CLI UX regression.
+//   - the UC-backing index rendering (parens-wrap, surviving even
+//     after the Subdued style is stripped by EnableColor(false)) so a
+//     regression that drops the parens — leaving the index name
+//     indistinguishable from a standalone unique index — is caught.
+//   - the standalone-unique-index path (no parens) so the two cases
+//     stay visibly distinct.
+//
+// Helper-function tests already cover [indexEntriesByColumn] +
+// [formatIdxCell] in isolation; this test wires them through the full
+// row-render pipeline so a regression in writeRow / column transformers
+// can't break the user-visible layout without a test failure.
+func TestPrintTablesVerbose_GoldenLayout(t *testing.T) {
+	tbls := []*metadata.Table{
+		{
+			Name:      "demo",
+			TableType: "table",
+			RowCount:  42,
+			Columns: []*metadata.Column{
+				{Name: "id", BaseType: "INTEGER", PrimaryKey: true},
+				{Name: "email", BaseType: "TEXT"},
+				{Name: "nickname", BaseType: "TEXT"},
+			},
+			UniqueConstraints: []*metadata.UniqueConstraint{
+				{Name: "demo_email_key", Table: "demo", Columns: []string{"email"}},
+			},
+			Indexes: []*metadata.Index{
+				// PK-backing — filtered upstream by indexEntriesByColumn.
+				{Name: "demo_pkey", Table: "demo", Columns: []string{"id"}, Unique: true, Primary: true},
+				// UC-backing — must render parenthesized.
+				{Name: "demo_email_key", Table: "demo", Columns: []string{"email"}, Unique: true},
+				// Standalone unique — must render WITHOUT parens.
+				{Name: "idx_email_solo", Table: "demo", Columns: []string{"email"}, Unique: true},
+				// Plain secondary — bare name.
+				{Name: "idx_demo_nick", Table: "demo", Columns: []string{"nickname"}},
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	pr := output.NewPrinting()
+	pr.EnableColor(false)
+	w := NewMetadataWriter(&buf, pr).(*mdWriter)
+	require.NoError(t, w.printTablesVerbose(tbls))
+
+	out := buf.String()
+	require.NotEmpty(t, out)
+	lines := strings.Split(strings.TrimRight(out, "\n"), "\n")
+	require.GreaterOrEqual(t, len(lines), 4, "expected header + 3 column rows: got %q", out)
+
+	// Header row is line 0 with this writer. The columns are
+	// whitespace-padded in declaration order, so an in-order substring
+	// search is enough to pin the layout.
+	header := lines[0]
+	wantHeaders := []string{
+		"NAME", "TYPE", "ROWS", "COLS",
+		"NAME", "TYPE", "PK", "FK",
+		"INDEXES", "UNIQUE CONSTRAINTS",
+	}
+	pos := 0
+	for _, h := range wantHeaders {
+		idx := strings.Index(header[pos:], h)
+		require.NotEqual(t, -1, idx,
+			"header %q not found in expected position in row %q", h, header)
+		pos += idx + len(h)
+	}
+
+	// Locate the per-column rows. The "id" row is the table's leading
+	// row (starts with "demo"); the "email" and "nickname" rows are
+	// continuation rows (whitespace-padded NAME/TYPE/ROWS/COLS cells).
+	var emailRow string
+	for _, line := range lines {
+		// A continuation row mentioning "email" must NOT also start
+		// with the table name (that's the leading "demo " row whose
+		// per-column NAME cell holds "id").
+		if !strings.HasPrefix(line, "demo") && strings.Contains(line, "email") {
+			emailRow = line
+			break
+		}
+	}
+	require.NotEmpty(t, emailRow, "email column row not found in:\n%s", out)
+
+	// The email column participates in:
+	//   - demo_email_key (UC-backing → parenthesized)
+	//   - idx_email_solo (standalone unique → bare)
+	// Both must appear; the UC-backing one must be parens-wrapped, the
+	// solo one must NOT be wrapped.
+	require.Contains(t, emailRow, "(demo_email_key)",
+		"UC-backing index name must render parens-wrapped to mark it as secondary to UNIQUE CONSTRAINTS")
+	require.Contains(t, emailRow, "idx_email_solo",
+		"standalone unique index must appear in INDEXES")
+	require.NotContains(t, emailRow, "(idx_email_solo)",
+		"standalone unique index must NOT be parens-wrapped — only UC-backing entries get that styling")
+	require.Contains(t, emailRow, "demo_email_key",
+		"the UC name itself must still appear in the UNIQUE CONSTRAINTS cell")
+}

--- a/drivers/duckdb/metadata_test.go
+++ b/drivers/duckdb/metadata_test.go
@@ -346,6 +346,41 @@ func TestTableMetadata_CompositeForeignKey(t *testing.T) {
 	require.Equal(t, []string{"a", "b"}, fk.RefColumns)
 }
 
+// TestTableMetadata_ReservedWordForeignKeyColumn verifies that a
+// DuckDB FK declared on a quoted reserved-word column ("from")
+// round-trips through the loader with the identifier unwrapped in
+// FK.Columns. A loader that stripped or double-quoted the identifier
+// would surface the wrong name.
+func TestTableMetadata_ReservedWordForeignKeyColumn(t *testing.T) {
+	th := testh.New(t)
+	src := &source.Source{
+		Handle:   "@reserved_fk_duck",
+		Type:     drivertype.DuckDB,
+		Location: "duckdb://:memory:",
+	}
+	th.Add(src)
+	grip := th.Open(src)
+	ctx := context.Background()
+	db, err := grip.DB(ctx)
+	require.NoError(t, err)
+
+	_, err = db.ExecContext(ctx, `CREATE TABLE parent (id INT PRIMARY KEY)`)
+	require.NoError(t, err)
+	_, err = db.ExecContext(ctx,
+		`CREATE TABLE child ("from" INT, FOREIGN KEY ("from") REFERENCES parent (id))`)
+	require.NoError(t, err)
+
+	md, err := grip.TableMetadata(ctx, "child")
+	require.NoError(t, err)
+	require.NotNil(t, md.FK)
+	require.Len(t, md.FK.Outgoing, 1)
+	fk := md.FK.Outgoing[0]
+	require.Equal(t, "parent", fk.RefTable)
+	require.Equal(t, []string{"from"}, fk.Columns,
+		`quoted reserved-word column "from" must round-trip unquoted in Columns`)
+	require.Equal(t, []string{"id"}, fk.RefColumns)
+}
+
 // TestTableMetadata_UniqueConstraints verifies UNIQUE-constraint
 // introspection on inline and composite forms.
 func TestTableMetadata_UniqueConstraints(t *testing.T) {

--- a/drivers/mysql/metadata_test.go
+++ b/drivers/mysql/metadata_test.go
@@ -160,9 +160,13 @@ func TestIndexes_ExpressionArity_MySQL(t *testing.T) {
 
 // TestForeignKey_CompositeOrdering_MySQL verifies that a composite FK
 // preserves the declared column pairing across (Columns, RefColumns).
-// Loops every supported MySQL version so a driver-version regression
-// in the INFORMATION_SCHEMA KEY_COLUMN_USAGE / REFERENTIAL_CONSTRAINTS
-// join surfaces here.
+// The parent PK uses (b, a) descending while the child FK uses
+// (x, y) ascending so any loader bug that sorts either side
+// independently — or pairs by name rather than by position — is
+// caught (an alphabetic-on-both-sides fixture would let such a bug
+// slip past). Looped across MyAll() because INFORMATION_SCHEMA
+// column casing has historically differed between MySQL 5.6/5.7 and
+// 8.0 — a real regression vector for this loader.
 func TestForeignKey_CompositeOrdering_MySQL(t *testing.T) {
 	tu.SkipShort(t, true)
 	t.Parallel()
@@ -178,11 +182,12 @@ func TestForeignKey_CompositeOrdering_MySQL(t *testing.T) {
 			parent := stringz.UniqTableName("fk_comp_parent")
 			child := stringz.UniqTableName("fk_comp_child")
 			_, err := db.ExecContext(th.Context,
-				"CREATE TABLE "+parent+" (a INT, b INT, PRIMARY KEY (a, b))")
+				"CREATE TABLE "+parent+" (a INT, b INT, PRIMARY KEY (b, a)) ENGINE=InnoDB")
 			require.NoError(t, err)
 			t.Cleanup(func() { th.DropTable(src, tablefq.From(parent)) })
 			_, err = db.ExecContext(th.Context,
-				"CREATE TABLE "+child+" (x INT, y INT, FOREIGN KEY (x, y) REFERENCES "+parent+" (a, b))")
+				"CREATE TABLE "+child+" (x INT, y INT, FOREIGN KEY (x, y) REFERENCES "+parent+
+					" (b, a)) ENGINE=InnoDB")
 			require.NoError(t, err)
 			t.Cleanup(func() { th.DropTable(src, tablefq.From(child)) })
 
@@ -193,7 +198,7 @@ func TestForeignKey_CompositeOrdering_MySQL(t *testing.T) {
 			fk := md.FK.Outgoing[0]
 			require.Equal(t, parent, fk.RefTable)
 			require.Equal(t, []string{"x", "y"}, fk.Columns)
-			require.Equal(t, []string{"a", "b"}, fk.RefColumns)
+			require.Equal(t, []string{"b", "a"}, fk.RefColumns)
 		})
 	}
 }
@@ -201,8 +206,11 @@ func TestForeignKey_CompositeOrdering_MySQL(t *testing.T) {
 // TestForeignKey_OnDeleteOnUpdate_MySQL pins that the loader populates
 // OnDelete / OnUpdate from INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS
 // with the explicit non-default actions ("CASCADE" / "SET NULL").
-// Looped across MyAll because the column casing and storage-engine
-// differences between MySQL versions are a plausible regression vector.
+// Looped across MyAll() — MySQL only enforces FKs under InnoDB (the
+// DDL pins ENGINE=InnoDB explicitly) and the REFERENTIAL_CONSTRAINTS
+// view's column casing has shifted between 5.6/5.7 and 8.0, so a
+// per-version regression in the loader's column-name unmarshaling
+// would surface here.
 func TestForeignKey_OnDeleteOnUpdate_MySQL(t *testing.T) {
 	tu.SkipShort(t, true)
 	t.Parallel()

--- a/drivers/mysql/metadata_test.go
+++ b/drivers/mysql/metadata_test.go
@@ -157,3 +157,82 @@ func TestIndexes_ExpressionArity_MySQL(t *testing.T) {
 	require.Equal(t, []string{"a", "", "c"}, mixed.Columns,
 		"the (LOWER(b)) key position must be the empty-string sentinel")
 }
+
+// TestForeignKey_CompositeOrdering_MySQL verifies that a composite FK
+// preserves the declared column pairing across (Columns, RefColumns).
+// Loops every supported MySQL version so a driver-version regression
+// in the INFORMATION_SCHEMA KEY_COLUMN_USAGE / REFERENTIAL_CONSTRAINTS
+// join surfaces here.
+func TestForeignKey_CompositeOrdering_MySQL(t *testing.T) {
+	tu.SkipShort(t, true)
+	t.Parallel()
+
+	for _, handle := range sakila.MyAll() {
+		t.Run(handle, func(t *testing.T) {
+			t.Parallel()
+
+			th := testh.New(t)
+			src := th.Source(handle)
+			db := th.OpenDB(src)
+
+			parent := stringz.UniqTableName("fk_comp_parent")
+			child := stringz.UniqTableName("fk_comp_child")
+			_, err := db.ExecContext(th.Context,
+				"CREATE TABLE "+parent+" (a INT, b INT, PRIMARY KEY (a, b))")
+			require.NoError(t, err)
+			t.Cleanup(func() { th.DropTable(src, tablefq.From(parent)) })
+			_, err = db.ExecContext(th.Context,
+				"CREATE TABLE "+child+" (x INT, y INT, FOREIGN KEY (x, y) REFERENCES "+parent+" (a, b))")
+			require.NoError(t, err)
+			t.Cleanup(func() { th.DropTable(src, tablefq.From(child)) })
+
+			md, err := th.Open(src).TableMetadata(th.Context, child)
+			require.NoError(t, err)
+			require.NotNil(t, md.FK)
+			require.Len(t, md.FK.Outgoing, 1)
+			fk := md.FK.Outgoing[0]
+			require.Equal(t, parent, fk.RefTable)
+			require.Equal(t, []string{"x", "y"}, fk.Columns)
+			require.Equal(t, []string{"a", "b"}, fk.RefColumns)
+		})
+	}
+}
+
+// TestForeignKey_OnDeleteOnUpdate_MySQL pins that the loader populates
+// OnDelete / OnUpdate from INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS
+// with the explicit non-default actions ("CASCADE" / "SET NULL").
+// Looped across MyAll because the column casing and storage-engine
+// differences between MySQL versions are a plausible regression vector.
+func TestForeignKey_OnDeleteOnUpdate_MySQL(t *testing.T) {
+	tu.SkipShort(t, true)
+	t.Parallel()
+
+	for _, handle := range sakila.MyAll() {
+		t.Run(handle, func(t *testing.T) {
+			t.Parallel()
+
+			th := testh.New(t)
+			src := th.Source(handle)
+			db := th.OpenDB(src)
+
+			parent := stringz.UniqTableName("fk_act_parent")
+			child := stringz.UniqTableName("fk_act_child")
+			_, err := db.ExecContext(th.Context,
+				"CREATE TABLE "+parent+" (id INT PRIMARY KEY) ENGINE=InnoDB")
+			require.NoError(t, err)
+			t.Cleanup(func() { th.DropTable(src, tablefq.From(parent)) })
+			_, err = db.ExecContext(th.Context,
+				"CREATE TABLE "+child+" (parent_id INT, FOREIGN KEY (parent_id) REFERENCES "+parent+
+					" (id) ON DELETE CASCADE ON UPDATE SET NULL) ENGINE=InnoDB")
+			require.NoError(t, err)
+			t.Cleanup(func() { th.DropTable(src, tablefq.From(child)) })
+
+			md, err := th.Open(src).TableMetadata(th.Context, child)
+			require.NoError(t, err)
+			require.Len(t, md.FK.Outgoing, 1)
+			fk := md.FK.Outgoing[0]
+			require.Equal(t, "CASCADE", fk.OnDelete)
+			require.Equal(t, "SET NULL", fk.OnUpdate)
+		})
+	}
+}

--- a/drivers/oracle/metadata_test.go
+++ b/drivers/oracle/metadata_test.go
@@ -29,7 +29,10 @@ func upperAll(ss []string) []string {
 // preserves the declared column pairing across (Columns, RefColumns).
 // Oracle's FK loader (all_cons_columns joined via constraint_name +
 // position) is the only common-driver loader where a missing ORDER BY
-// would non-deterministically scramble composite FKs.
+// would non-deterministically scramble composite FKs. The parent PK
+// uses (b, a) descending while the child FK uses (x, y) ascending so
+// any loader bug that sorts either side independently — or pairs by
+// name rather than by position — is caught.
 func TestForeignKey_CompositeOrdering_Oracle(t *testing.T) {
 	tu.SkipShort(t, true)
 	t.Parallel()
@@ -44,12 +47,12 @@ func TestForeignKey_CompositeOrdering_Oracle(t *testing.T) {
 	parent := stringz.UniqTableName("fk_comp_parent")
 	child := stringz.UniqTableName("fk_comp_child")
 	_, err := db.ExecContext(th.Context,
-		"CREATE TABLE "+parent+" (a NUMBER NOT NULL, b NUMBER NOT NULL, PRIMARY KEY (a, b))")
+		"CREATE TABLE "+parent+" (a NUMBER NOT NULL, b NUMBER NOT NULL, PRIMARY KEY (b, a))")
 	require.NoError(t, err)
 	t.Cleanup(func() { th.DropTable(src, tablefq.From(parent)) })
 	_, err = db.ExecContext(th.Context,
 		"CREATE TABLE "+child+" (x NUMBER NOT NULL, y NUMBER NOT NULL, "+
-			"FOREIGN KEY (x, y) REFERENCES "+parent+" (a, b))")
+			"FOREIGN KEY (x, y) REFERENCES "+parent+" (b, a))")
 	require.NoError(t, err)
 	t.Cleanup(func() { th.DropTable(src, tablefq.From(child)) })
 
@@ -62,7 +65,7 @@ func TestForeignKey_CompositeOrdering_Oracle(t *testing.T) {
 	fk := md.FK.Outgoing[0]
 	require.Equal(t, strings.ToUpper(parent), fk.RefTable)
 	require.Equal(t, upperAll([]string{"x", "y"}), fk.Columns)
-	require.Equal(t, upperAll([]string{"a", "b"}), fk.RefColumns)
+	require.Equal(t, upperAll([]string{"b", "a"}), fk.RefColumns)
 }
 
 // TestForeignKey_OnDelete_Oracle pins that the loader populates

--- a/drivers/oracle/metadata_test.go
+++ b/drivers/oracle/metadata_test.go
@@ -1,0 +1,102 @@
+package oracle_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/neilotoole/sq/libsq/core/stringz"
+	"github.com/neilotoole/sq/libsq/core/tablefq"
+	"github.com/neilotoole/sq/testh"
+	"github.com/neilotoole/sq/testh/sakila"
+	"github.com/neilotoole/sq/testh/tu"
+)
+
+// upperAll returns a copy of ss with each element uppercased. Oracle
+// stores unquoted identifiers as upper case, so FK metadata round-trips
+// in upper. Asserting against upper(want) keeps the literals in the
+// test readable in their declared form.
+func upperAll(ss []string) []string {
+	out := make([]string, len(ss))
+	for i, s := range ss {
+		out[i] = strings.ToUpper(s)
+	}
+	return out
+}
+
+// TestForeignKey_CompositeOrdering_Oracle verifies that a composite FK
+// preserves the declared column pairing across (Columns, RefColumns).
+// Oracle's FK loader (all_cons_columns joined via constraint_name +
+// position) is the only common-driver loader where a missing ORDER BY
+// would non-deterministically scramble composite FKs.
+func TestForeignKey_CompositeOrdering_Oracle(t *testing.T) {
+	tu.SkipShort(t, true)
+	t.Parallel()
+
+	th := testh.New(t)
+	if !th.SourceConfigured(sakila.Ora) {
+		t.Skip("Oracle Sakila source not configured")
+	}
+	src := th.Source(sakila.Ora)
+	db := th.OpenDB(src)
+
+	parent := stringz.UniqTableName("fk_comp_parent")
+	child := stringz.UniqTableName("fk_comp_child")
+	_, err := db.ExecContext(th.Context,
+		"CREATE TABLE "+parent+" (a NUMBER NOT NULL, b NUMBER NOT NULL, PRIMARY KEY (a, b))")
+	require.NoError(t, err)
+	t.Cleanup(func() { th.DropTable(src, tablefq.From(parent)) })
+	_, err = db.ExecContext(th.Context,
+		"CREATE TABLE "+child+" (x NUMBER NOT NULL, y NUMBER NOT NULL, "+
+			"FOREIGN KEY (x, y) REFERENCES "+parent+" (a, b))")
+	require.NoError(t, err)
+	t.Cleanup(func() { th.DropTable(src, tablefq.From(child)) })
+
+	// Oracle stores unquoted identifiers upper-case; TableMetadata
+	// looks them up by the stored form.
+	md, err := th.Open(src).TableMetadata(th.Context, strings.ToUpper(child))
+	require.NoError(t, err)
+	require.NotNil(t, md.FK)
+	require.Len(t, md.FK.Outgoing, 1)
+	fk := md.FK.Outgoing[0]
+	require.Equal(t, strings.ToUpper(parent), fk.RefTable)
+	require.Equal(t, upperAll([]string{"x", "y"}), fk.Columns)
+	require.Equal(t, upperAll([]string{"a", "b"}), fk.RefColumns)
+}
+
+// TestForeignKey_OnDelete_Oracle pins that the loader populates
+// OnDelete from all_constraints.delete_rule. Oracle exposes no
+// equivalent for ON UPDATE referential actions, so OnUpdate must
+// remain empty even when ON DELETE is set.
+func TestForeignKey_OnDelete_Oracle(t *testing.T) {
+	tu.SkipShort(t, true)
+	t.Parallel()
+
+	th := testh.New(t)
+	if !th.SourceConfigured(sakila.Ora) {
+		t.Skip("Oracle Sakila source not configured")
+	}
+	src := th.Source(sakila.Ora)
+	db := th.OpenDB(src)
+
+	parent := stringz.UniqTableName("fk_act_parent")
+	child := stringz.UniqTableName("fk_act_child")
+	_, err := db.ExecContext(th.Context,
+		"CREATE TABLE "+parent+" (id NUMBER NOT NULL PRIMARY KEY)")
+	require.NoError(t, err)
+	t.Cleanup(func() { th.DropTable(src, tablefq.From(parent)) })
+	_, err = db.ExecContext(th.Context,
+		"CREATE TABLE "+child+" (parent_id NUMBER, "+
+			"FOREIGN KEY (parent_id) REFERENCES "+parent+" (id) ON DELETE CASCADE)")
+	require.NoError(t, err)
+	t.Cleanup(func() { th.DropTable(src, tablefq.From(child)) })
+
+	md, err := th.Open(src).TableMetadata(th.Context, strings.ToUpper(child))
+	require.NoError(t, err)
+	require.Len(t, md.FK.Outgoing, 1)
+	fk := md.FK.Outgoing[0]
+	require.Equal(t, "CASCADE", fk.OnDelete)
+	require.Empty(t, fk.OnUpdate,
+		"Oracle exposes no ON UPDATE referential action; OnUpdate must stay empty")
+}

--- a/drivers/postgres/metadata_test.go
+++ b/drivers/postgres/metadata_test.go
@@ -85,3 +85,100 @@ func TestIndexes_IncludeFilter_Postgres(t *testing.T) {
 	require.Equal(t, []string{"k"}, inc.Columns,
 		"INCLUDE column 'extra' must not appear in Index.Columns")
 }
+
+// TestForeignKey_CompositeOrdering_Postgres verifies that a composite FK
+// preserves the declared column pairing across (Columns, RefColumns) —
+// a driver miscounting ordinal positions in the row scan would scramble
+// the pairing and ship a structurally invalid FK.
+func TestForeignKey_CompositeOrdering_Postgres(t *testing.T) {
+	tu.SkipShort(t, true)
+	t.Parallel()
+
+	th := testh.New(t)
+	src := th.Source(sakila.Pg)
+	db := th.OpenDB(src)
+
+	parent := stringz.UniqTableName("fk_comp_parent")
+	child := stringz.UniqTableName("fk_comp_child")
+	_, err := db.ExecContext(th.Context,
+		"CREATE TABLE "+parent+" (a INT, b INT, PRIMARY KEY (a, b))")
+	require.NoError(t, err)
+	t.Cleanup(func() { th.DropTable(src, tablefq.From(parent)) })
+	_, err = db.ExecContext(th.Context,
+		"CREATE TABLE "+child+" (x INT, y INT, FOREIGN KEY (x, y) REFERENCES "+parent+" (a, b))")
+	require.NoError(t, err)
+	t.Cleanup(func() { th.DropTable(src, tablefq.From(child)) })
+
+	md, err := th.Open(src).TableMetadata(th.Context, child)
+	require.NoError(t, err)
+	require.NotNil(t, md.FK)
+	require.Len(t, md.FK.Outgoing, 1)
+	fk := md.FK.Outgoing[0]
+	require.Equal(t, parent, fk.RefTable)
+	require.Equal(t, []string{"x", "y"}, fk.Columns)
+	require.Equal(t, []string{"a", "b"}, fk.RefColumns)
+}
+
+// TestForeignKey_OnDeleteOnUpdate_Postgres pins that the loader
+// populates OnDelete / OnUpdate from
+// information_schema.referential_constraints — sakila itself uses
+// default actions, so this exercises explicit non-default values.
+func TestForeignKey_OnDeleteOnUpdate_Postgres(t *testing.T) {
+	tu.SkipShort(t, true)
+	t.Parallel()
+
+	th := testh.New(t)
+	src := th.Source(sakila.Pg)
+	db := th.OpenDB(src)
+
+	parent := stringz.UniqTableName("fk_act_parent")
+	child := stringz.UniqTableName("fk_act_child")
+	_, err := db.ExecContext(th.Context,
+		"CREATE TABLE "+parent+" (id INT PRIMARY KEY)")
+	require.NoError(t, err)
+	t.Cleanup(func() { th.DropTable(src, tablefq.From(parent)) })
+	_, err = db.ExecContext(th.Context,
+		"CREATE TABLE "+child+" (parent_id INT REFERENCES "+parent+
+			" (id) ON DELETE CASCADE ON UPDATE SET NULL)")
+	require.NoError(t, err)
+	t.Cleanup(func() { th.DropTable(src, tablefq.From(child)) })
+
+	md, err := th.Open(src).TableMetadata(th.Context, child)
+	require.NoError(t, err)
+	require.Len(t, md.FK.Outgoing, 1)
+	fk := md.FK.Outgoing[0]
+	require.Equal(t, "CASCADE", fk.OnDelete)
+	require.Equal(t, "SET NULL", fk.OnUpdate)
+}
+
+// TestForeignKey_ReservedWordColumn_Postgres verifies that a quoted
+// reserved-word column name ("from") round-trips through the FK loader
+// unquoted in Columns / RefColumns. A loader that strips or
+// double-quotes the identifier would surface the wrong name.
+func TestForeignKey_ReservedWordColumn_Postgres(t *testing.T) {
+	tu.SkipShort(t, true)
+	t.Parallel()
+
+	th := testh.New(t)
+	src := th.Source(sakila.Pg)
+	db := th.OpenDB(src)
+
+	parent := stringz.UniqTableName("fk_rw_parent")
+	child := stringz.UniqTableName("fk_rw_child")
+	_, err := db.ExecContext(th.Context,
+		"CREATE TABLE "+parent+" (id INT PRIMARY KEY)")
+	require.NoError(t, err)
+	t.Cleanup(func() { th.DropTable(src, tablefq.From(parent)) })
+	_, err = db.ExecContext(th.Context,
+		`CREATE TABLE `+child+` ("from" INT, FOREIGN KEY ("from") REFERENCES `+parent+` (id))`)
+	require.NoError(t, err)
+	t.Cleanup(func() { th.DropTable(src, tablefq.From(child)) })
+
+	md, err := th.Open(src).TableMetadata(th.Context, child)
+	require.NoError(t, err)
+	require.Len(t, md.FK.Outgoing, 1)
+	fk := md.FK.Outgoing[0]
+	require.Equal(t, []string{"from"}, fk.Columns,
+		`quoted reserved-word column "from" must round-trip unquoted in Columns`)
+	require.Equal(t, []string{"id"}, fk.RefColumns)
+}

--- a/drivers/postgres/metadata_test.go
+++ b/drivers/postgres/metadata_test.go
@@ -90,6 +90,14 @@ func TestIndexes_IncludeFilter_Postgres(t *testing.T) {
 // preserves the declared column pairing across (Columns, RefColumns) —
 // a driver miscounting ordinal positions in the row scan would scramble
 // the pairing and ship a structurally invalid FK.
+//
+// The parent PK is declared (b, a) — alphabetically descending — while
+// the child FK is declared (x, y) — alphabetically ascending. This
+// asymmetry means a loader that pairs by position correctly produces
+// Columns=[x,y] / RefColumns=[b,a], but any loader bug that sorts
+// either side independently (or that pairs by name rather than by
+// position) yields a deterministically wrong result that this test
+// catches.
 func TestForeignKey_CompositeOrdering_Postgres(t *testing.T) {
 	tu.SkipShort(t, true)
 	t.Parallel()
@@ -101,11 +109,11 @@ func TestForeignKey_CompositeOrdering_Postgres(t *testing.T) {
 	parent := stringz.UniqTableName("fk_comp_parent")
 	child := stringz.UniqTableName("fk_comp_child")
 	_, err := db.ExecContext(th.Context,
-		"CREATE TABLE "+parent+" (a INT, b INT, PRIMARY KEY (a, b))")
+		"CREATE TABLE "+parent+" (a INT, b INT, PRIMARY KEY (b, a))")
 	require.NoError(t, err)
 	t.Cleanup(func() { th.DropTable(src, tablefq.From(parent)) })
 	_, err = db.ExecContext(th.Context,
-		"CREATE TABLE "+child+" (x INT, y INT, FOREIGN KEY (x, y) REFERENCES "+parent+" (a, b))")
+		"CREATE TABLE "+child+" (x INT, y INT, FOREIGN KEY (x, y) REFERENCES "+parent+" (b, a))")
 	require.NoError(t, err)
 	t.Cleanup(func() { th.DropTable(src, tablefq.From(child)) })
 
@@ -116,7 +124,7 @@ func TestForeignKey_CompositeOrdering_Postgres(t *testing.T) {
 	fk := md.FK.Outgoing[0]
 	require.Equal(t, parent, fk.RefTable)
 	require.Equal(t, []string{"x", "y"}, fk.Columns)
-	require.Equal(t, []string{"a", "b"}, fk.RefColumns)
+	require.Equal(t, []string{"b", "a"}, fk.RefColumns)
 }
 
 // TestForeignKey_OnDeleteOnUpdate_Postgres pins that the loader

--- a/drivers/sqlserver/metadata_test.go
+++ b/drivers/sqlserver/metadata_test.go
@@ -1,0 +1,142 @@
+package sqlserver_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/neilotoole/sq/libsq/core/stringz"
+	"github.com/neilotoole/sq/libsq/core/tablefq"
+	"github.com/neilotoole/sq/testh"
+	"github.com/neilotoole/sq/testh/sakila"
+	"github.com/neilotoole/sq/testh/tu"
+)
+
+// TestForeignKey_CompositeOrdering_SQLServer verifies that a composite
+// FK preserves the declared column pairing across (Columns, RefColumns).
+// SQL Server's FK loader uses sys.foreign_key_columns ordered by
+// constraint_column_id; a regression in that ORDER BY would scramble
+// composite pairings.
+func TestForeignKey_CompositeOrdering_SQLServer(t *testing.T) {
+	tu.SkipShort(t, true)
+	t.Parallel()
+
+	for _, handle := range sakila.MSAll() {
+		t.Run(handle, func(t *testing.T) {
+			t.Parallel()
+
+			th := testh.New(t)
+			src := th.Source(handle)
+			db := th.OpenDB(src)
+
+			parent := stringz.UniqTableName("fk_comp_parent")
+			child := stringz.UniqTableName("fk_comp_child")
+			_, err := db.ExecContext(th.Context,
+				"CREATE TABLE "+parent+" (a INT NOT NULL, b INT NOT NULL, PRIMARY KEY (a, b))")
+			require.NoError(t, err)
+			t.Cleanup(func() { th.DropTable(src, tablefq.From(parent)) })
+			_, err = db.ExecContext(th.Context,
+				"CREATE TABLE "+child+" (x INT NOT NULL, y INT NOT NULL, "+
+					"FOREIGN KEY (x, y) REFERENCES "+parent+" (a, b))")
+			require.NoError(t, err)
+			t.Cleanup(func() { th.DropTable(src, tablefq.From(child)) })
+
+			md, err := th.Open(src).TableMetadata(th.Context, child)
+			require.NoError(t, err)
+			require.NotNil(t, md.FK)
+			require.Len(t, md.FK.Outgoing, 1)
+			fk := md.FK.Outgoing[0]
+			require.Equal(t, parent, fk.RefTable)
+			require.Equal(t, []string{"x", "y"}, fk.Columns)
+			require.Equal(t, []string{"a", "b"}, fk.RefColumns)
+		})
+	}
+}
+
+// TestForeignKey_OnDeleteOnUpdate_SQLServer pins that the loader
+// populates OnDelete / OnUpdate from sys.foreign_keys with the
+// REPLACE-normalized form (no underscores). SQL Server reports
+// "NO_ACTION", "SET_NULL" etc. via *_referential_action_desc; the
+// REPLACE in getMSSQLForeignKeys rewrites them to the space-separated
+// form used by the other drivers.
+func TestForeignKey_OnDeleteOnUpdate_SQLServer(t *testing.T) {
+	tu.SkipShort(t, true)
+	t.Parallel()
+
+	for _, handle := range sakila.MSAll() {
+		t.Run(handle, func(t *testing.T) {
+			t.Parallel()
+
+			th := testh.New(t)
+			src := th.Source(handle)
+			db := th.OpenDB(src)
+
+			parent := stringz.UniqTableName("fk_act_parent")
+			child := stringz.UniqTableName("fk_act_child")
+			_, err := db.ExecContext(th.Context,
+				"CREATE TABLE "+parent+" (id INT NOT NULL PRIMARY KEY)")
+			require.NoError(t, err)
+			t.Cleanup(func() { th.DropTable(src, tablefq.From(parent)) })
+			_, err = db.ExecContext(th.Context,
+				"CREATE TABLE "+child+" (parent_id INT, "+
+					"FOREIGN KEY (parent_id) REFERENCES "+parent+
+					" (id) ON DELETE CASCADE ON UPDATE SET NULL)")
+			require.NoError(t, err)
+			t.Cleanup(func() { th.DropTable(src, tablefq.From(child)) })
+
+			md, err := th.Open(src).TableMetadata(th.Context, child)
+			require.NoError(t, err)
+			require.Len(t, md.FK.Outgoing, 1)
+			fk := md.FK.Outgoing[0]
+			require.Equal(t, "CASCADE", fk.OnDelete)
+			require.Equal(t, "SET NULL", fk.OnUpdate,
+				"REPLACE(update_referential_action_desc, '_', ' ') must rewrite SET_NULL to SET NULL")
+		})
+	}
+}
+
+// TestForeignKey_SameCatalog_SQLServer pins the loader's current
+// behavior for ordinary same-DB FKs: RefCatalog is left empty (the
+// constraint is implicitly in the current catalog) and RefSchema is
+// cleared by the loader's NULLIF when it matches the parent schema.
+// SQL Server itself does not support declared cross-database FK
+// constraints (only triggers/synonyms can fake them), so the issue
+// #616 P3 row reframes here as "pin the same-catalog shape and
+// document the cross-catalog gap". A future loader change that
+// surfaces cross-DB synonym refs should add a sibling test populating
+// RefCatalog explicitly.
+func TestForeignKey_SameCatalog_SQLServer(t *testing.T) {
+	tu.SkipShort(t, true)
+	t.Parallel()
+
+	for _, handle := range sakila.MSAll() {
+		t.Run(handle, func(t *testing.T) {
+			t.Parallel()
+
+			th := testh.New(t)
+			src := th.Source(handle)
+			db := th.OpenDB(src)
+
+			parent := stringz.UniqTableName("fk_cat_parent")
+			child := stringz.UniqTableName("fk_cat_child")
+			_, err := db.ExecContext(th.Context,
+				"CREATE TABLE "+parent+" (id INT NOT NULL PRIMARY KEY)")
+			require.NoError(t, err)
+			t.Cleanup(func() { th.DropTable(src, tablefq.From(parent)) })
+			_, err = db.ExecContext(th.Context,
+				"CREATE TABLE "+child+" (parent_id INT, "+
+					"FOREIGN KEY (parent_id) REFERENCES "+parent+" (id))")
+			require.NoError(t, err)
+			t.Cleanup(func() { th.DropTable(src, tablefq.From(child)) })
+
+			md, err := th.Open(src).TableMetadata(th.Context, child)
+			require.NoError(t, err)
+			require.Len(t, md.FK.Outgoing, 1)
+			fk := md.FK.Outgoing[0]
+			require.Empty(t, fk.RefCatalog,
+				"same-DB FK must leave RefCatalog empty; populated only by a cross-catalog loader extension")
+			require.Empty(t, fk.RefSchema,
+				"same-schema FK must have RefSchema cleared by the loader's NULLIF")
+		})
+	}
+}

--- a/drivers/sqlserver/metadata_test.go
+++ b/drivers/sqlserver/metadata_test.go
@@ -16,7 +16,10 @@ import (
 // FK preserves the declared column pairing across (Columns, RefColumns).
 // SQL Server's FK loader uses sys.foreign_key_columns ordered by
 // constraint_column_id; a regression in that ORDER BY would scramble
-// composite pairings.
+// composite pairings. The parent PK uses (b, a) descending while the
+// child FK uses (x, y) ascending so any loader bug that sorts either
+// side independently — or pairs by name rather than by position — is
+// caught.
 func TestForeignKey_CompositeOrdering_SQLServer(t *testing.T) {
 	tu.SkipShort(t, true)
 	t.Parallel()
@@ -32,12 +35,12 @@ func TestForeignKey_CompositeOrdering_SQLServer(t *testing.T) {
 			parent := stringz.UniqTableName("fk_comp_parent")
 			child := stringz.UniqTableName("fk_comp_child")
 			_, err := db.ExecContext(th.Context,
-				"CREATE TABLE "+parent+" (a INT NOT NULL, b INT NOT NULL, PRIMARY KEY (a, b))")
+				"CREATE TABLE "+parent+" (a INT NOT NULL, b INT NOT NULL, PRIMARY KEY (b, a))")
 			require.NoError(t, err)
 			t.Cleanup(func() { th.DropTable(src, tablefq.From(parent)) })
 			_, err = db.ExecContext(th.Context,
 				"CREATE TABLE "+child+" (x INT NOT NULL, y INT NOT NULL, "+
-					"FOREIGN KEY (x, y) REFERENCES "+parent+" (a, b))")
+					"FOREIGN KEY (x, y) REFERENCES "+parent+" (b, a))")
 			require.NoError(t, err)
 			t.Cleanup(func() { th.DropTable(src, tablefq.From(child)) })
 
@@ -48,7 +51,7 @@ func TestForeignKey_CompositeOrdering_SQLServer(t *testing.T) {
 			fk := md.FK.Outgoing[0]
 			require.Equal(t, parent, fk.RefTable)
 			require.Equal(t, []string{"x", "y"}, fk.Columns)
-			require.Equal(t, []string{"a", "b"}, fk.RefColumns)
+			require.Equal(t, []string{"b", "a"}, fk.RefColumns)
 		})
 	}
 }
@@ -90,7 +93,7 @@ func TestForeignKey_OnDeleteOnUpdate_SQLServer(t *testing.T) {
 			fk := md.FK.Outgoing[0]
 			require.Equal(t, "CASCADE", fk.OnDelete)
 			require.Equal(t, "SET NULL", fk.OnUpdate,
-				"REPLACE(update_referential_action_desc, '_', ' ') must rewrite SET_NULL to SET NULL")
+				"loader must normalize SET_NULL → SET NULL to match the other drivers")
 		})
 	}
 }
@@ -100,11 +103,10 @@ func TestForeignKey_OnDeleteOnUpdate_SQLServer(t *testing.T) {
 // constraint is implicitly in the current catalog) and RefSchema is
 // cleared by the loader's NULLIF when it matches the parent schema.
 // SQL Server itself does not support declared cross-database FK
-// constraints (only triggers/synonyms can fake them), so the issue
-// #616 P3 row reframes here as "pin the same-catalog shape and
-// document the cross-catalog gap". A future loader change that
-// surfaces cross-DB synonym refs should add a sibling test populating
-// RefCatalog explicitly.
+// constraints (only triggers/synonyms can fake them), so issue #616's
+// original cross-catalog assertion reframes here as a same-catalog
+// shape pin. A future loader change that surfaces cross-DB synonym
+// refs should add a sibling test populating RefCatalog explicitly.
 func TestForeignKey_SameCatalog_SQLServer(t *testing.T) {
 	tu.SkipShort(t, true)
 	t.Parallel()

--- a/libsq/source/metadata/metadata_test.go
+++ b/libsq/source/metadata/metadata_test.go
@@ -988,17 +988,20 @@ func TestSource_Clone_FKMutationIsolated(t *testing.T) {
 	gotFK := got.Table("film").FK.Outgoing[0]
 
 	// Mutate every reference-typed field on the cloned FK and verify
-	// the original is untouched. The mutations must use the same
-	// addressing the renderer / round-trip code would (index assignment
-	// on Columns / RefColumns, plain field overwrite for the scalars).
-	gotFK.Columns[0] = "mutated"
-	gotFK.RefColumns = append(gotFK.RefColumns, "extra")
+	// the original is untouched. Use index-assignment (in-place
+	// mutation) on both Columns and RefColumns — a shallow-copy bug
+	// where the cloned slice shares the original's backing array would
+	// surface here. Append on its own typically reallocates because
+	// slice literals have cap == len, so it doesn't reliably exercise
+	// the shared-backing-array hazard; the index-assign does.
+	gotFK.Columns[0] = "mutated_col"
+	gotFK.RefColumns[0] = "mutated_ref"
 	gotFK.OnDelete = "CASCADE"
 
 	require.Equal(t, []string{"language_id"}, fk.Columns,
-		"original FK.Columns must be unaffected by clone mutation")
+		"original FK.Columns must be unaffected by in-place mutation on the clone")
 	require.Equal(t, []string{"language_id"}, fk.RefColumns,
-		"original FK.RefColumns must be unaffected by clone mutation (append on clone reallocated)")
+		"original FK.RefColumns must be unaffected by in-place mutation on the clone")
 	require.Empty(t, fk.OnDelete,
 		"original FK.OnDelete must be unaffected by clone mutation")
 

--- a/libsq/source/metadata/metadata_test.go
+++ b/libsq/source/metadata/metadata_test.go
@@ -856,11 +856,12 @@ func TestLinkForeignKeys(t *testing.T) {
 		// The existing "idempotent" subcase calls LinkForeignKeys twice
 		// and verifies the legitimate Incoming entry isn't duplicated.
 		// This subcase goes further: it injects a bogus FK pointer
-		// directly into an Incoming slice between calls and verifies
-		// the next LinkForeignKeys pass purges it. That pins the
-		// pre-clear step at metadata.go:LinkForeignKeys (Incoming = nil
-		// for every table before re-deriving) — a regression that only
-		// appends would leave the bogus pointer in place forever.
+		// directly into an Incoming slice between the two calls and
+		// verifies the second LinkForeignKeys pass purges it. That
+		// pins the pre-clear step in [metadata.LinkForeignKeys]
+		// (FK.Incoming is set to nil on every FK-bearing table before
+		// re-deriving) — a regression that only appended would leave
+		// the bogus pointer in place forever.
 		fk := &metadata.ForeignKey{
 			Table:      "child",
 			Columns:    []string{"parent_id"},
@@ -898,7 +899,7 @@ func TestLinkForeignKeys(t *testing.T) {
 
 		metadata.LinkForeignKeys(nil, src)
 		require.Len(t, parent.FK.Incoming, 1,
-			"a third LinkForeignKeys must drop the injected bogus pointer")
+			"the second LinkForeignKeys must drop the injected bogus pointer")
 		require.Same(t, fk, parent.FK.Incoming[0],
 			"the legitimate Incoming entry must survive the clear-and-rederive cycle")
 	})

--- a/libsq/source/metadata/metadata_test.go
+++ b/libsq/source/metadata/metadata_test.go
@@ -809,6 +809,99 @@ func TestLinkForeignKeys(t *testing.T) {
 		require.Nil(t, src.Table("category").FK,
 			"category got no incoming link because the typo'd FK didn't reach it")
 	})
+
+	t.Run("self_referential_fk_pointer_identity", func(t *testing.T) {
+		// A table whose outgoing FK references itself must appear in both
+		// FK.Outgoing and FK.Incoming with identical pointer identity —
+		// LinkForeignKeys treats the referenced table as just another
+		// table in the source, and "the same table" is not a special
+		// case. Asserting Same (not just Equal) catches a future
+		// regression where LinkForeignKeys clones the FK before
+		// inserting into Incoming, breaking back-ref-to-outgoing
+		// pointer equality.
+		fk := &metadata.ForeignKey{
+			Name:       "fk_employee_manager",
+			Table:      "employee",
+			Columns:    []string{"manager_id"},
+			RefTable:   "employee",
+			RefColumns: []string{"id"},
+		}
+
+		src := &metadata.Source{
+			Tables: []*metadata.Table{
+				{
+					Name: "employee",
+					Columns: []*metadata.Column{
+						{Name: "id", PrimaryKey: true},
+						{Name: "manager_id"},
+					},
+					FK: metadata.NewFKGroup([]*metadata.ForeignKey{fk}, nil),
+				},
+			},
+		}
+
+		metadata.LinkForeignKeys(nil, src)
+
+		employee := src.Table("employee")
+		require.NotNil(t, employee.FK)
+		require.Len(t, employee.FK.Outgoing, 1)
+		require.Len(t, employee.FK.Incoming, 1,
+			"self-referential FK must surface on FK.Incoming on the same table")
+		require.Same(t, fk, employee.FK.Outgoing[0])
+		require.Same(t, employee.FK.Outgoing[0], employee.FK.Incoming[0],
+			"self-ref Outgoing and Incoming must share pointer identity")
+	})
+
+	t.Run("idempotence_clears_bogus_pointer", func(t *testing.T) {
+		// The existing "idempotent" subcase calls LinkForeignKeys twice
+		// and verifies the legitimate Incoming entry isn't duplicated.
+		// This subcase goes further: it injects a bogus FK pointer
+		// directly into an Incoming slice between calls and verifies
+		// the next LinkForeignKeys pass purges it. That pins the
+		// pre-clear step at metadata.go:LinkForeignKeys (Incoming = nil
+		// for every table before re-deriving) — a regression that only
+		// appends would leave the bogus pointer in place forever.
+		fk := &metadata.ForeignKey{
+			Table:      "child",
+			Columns:    []string{"parent_id"},
+			RefTable:   "parent",
+			RefColumns: []string{"id"},
+		}
+		bogus := &metadata.ForeignKey{
+			Name:     "fk_bogus_injected",
+			Table:    "ghost",
+			RefTable: "parent",
+		}
+
+		src := &metadata.Source{
+			Tables: []*metadata.Table{
+				{
+					Name:    "child",
+					Columns: []*metadata.Column{{Name: "parent_id"}},
+					FK:      metadata.NewFKGroup([]*metadata.ForeignKey{fk}, nil),
+				},
+				{
+					Name:    "parent",
+					Columns: []*metadata.Column{{Name: "id"}},
+				},
+			},
+		}
+
+		metadata.LinkForeignKeys(nil, src)
+		parent := src.Table("parent")
+		require.Len(t, parent.FK.Incoming, 1)
+
+		// Inject a bogus pointer into the Incoming slice as a regression
+		// would: e.g. a re-entrant caller appending without clearing.
+		parent.FK.Incoming = append(parent.FK.Incoming, bogus)
+		require.Len(t, parent.FK.Incoming, 2)
+
+		metadata.LinkForeignKeys(nil, src)
+		require.Len(t, parent.FK.Incoming, 1,
+			"a third LinkForeignKeys must drop the injected bogus pointer")
+		require.Same(t, fk, parent.FK.Incoming[0],
+			"the legitimate Incoming entry must survive the clear-and-rederive cycle")
+	})
 }
 
 func TestSource_Clone_RelinksForeignKeys(t *testing.T) {
@@ -859,6 +952,63 @@ func TestSource_Clone_RelinksForeignKeys(t *testing.T) {
 		"original Source.FK.Incoming must be unaffected by Clone()")
 	require.NotSame(t, gotFilm.FK.Outgoing[0], origLanguage.FK.Incoming[0],
 		"clone and original FK.Incoming must not share pointer identity")
+}
+
+// TestSource_Clone_FKMutationIsolated pins the end-to-end deep-copy
+// guarantee: mutating an FK's Columns slice on the clone must not
+// affect the original Source, and the original's FK.Incoming back-ref
+// must still point at the original's Outgoing entry (no aliasing
+// across the Clone boundary).
+func TestSource_Clone_FKMutationIsolated(t *testing.T) {
+	fk := &metadata.ForeignKey{
+		Name:       "fk_film_language",
+		Table:      "film",
+		Columns:    []string{"language_id"},
+		RefTable:   "language",
+		RefColumns: []string{"language_id"},
+	}
+
+	src := &metadata.Source{
+		Tables: []*metadata.Table{
+			{
+				Name:    "film",
+				Columns: []*metadata.Column{{Name: "language_id"}},
+				FK:      metadata.NewFKGroup([]*metadata.ForeignKey{fk}, nil),
+			},
+			{
+				Name:    "language",
+				Columns: []*metadata.Column{{Name: "language_id"}},
+			},
+		},
+	}
+	metadata.LinkForeignKeys(nil, src)
+
+	got := src.Clone()
+	gotFK := got.Table("film").FK.Outgoing[0]
+
+	// Mutate every reference-typed field on the cloned FK and verify
+	// the original is untouched. The mutations must use the same
+	// addressing the renderer / round-trip code would (index assignment
+	// on Columns / RefColumns, plain field overwrite for the scalars).
+	gotFK.Columns[0] = "mutated"
+	gotFK.RefColumns = append(gotFK.RefColumns, "extra")
+	gotFK.OnDelete = "CASCADE"
+
+	require.Equal(t, []string{"language_id"}, fk.Columns,
+		"original FK.Columns must be unaffected by clone mutation")
+	require.Equal(t, []string{"language_id"}, fk.RefColumns,
+		"original FK.RefColumns must be unaffected by clone mutation (append on clone reallocated)")
+	require.Empty(t, fk.OnDelete,
+		"original FK.OnDelete must be unaffected by clone mutation")
+
+	// The original Source's FK.Incoming back-ref must still point at
+	// the original FK, not at the (now-mutated) clone.
+	origLanguage := src.Table("language")
+	require.Len(t, origLanguage.FK.Incoming, 1)
+	require.Same(t, fk, origLanguage.FK.Incoming[0],
+		"original Source.FK.Incoming must still point at the original FK after clone mutation")
+	require.Equal(t, []string{"language_id"}, origLanguage.FK.Incoming[0].Columns,
+		"original Incoming view of FK.Columns must remain unchanged")
 }
 
 func TestUniqueConstraint_Clone(t *testing.T) {


### PR DESCRIPTION
## Summary

Adds the remaining P1/P2/P3 test coverage tracked in #616 so a driver-specific
regression in the `sq inspect` FK / unique-constraint / index loaders surfaces
locally instead of riding on the single cross-driver smoke check
(`TestSQLDriver_SourceMetadata_FieldCoverage`).

PR #600 introduced the metadata loaders across six SQL drivers; SQLite and
DuckDB were tested to a high standard, but the Postgres / MySQL / SQL Server /
Oracle loaders had no driver-specific coverage for composite-FK pairing,
referential actions, or quoted-identifier edge cases. This PR closes that gap.

**No production code changes** — pure test additions.

## What's covered

**Driver integration tests** (ad-hoc DDL, `tu.SkipShort(t, true)`-gated):

- `drivers/postgres/metadata_test.go` (extend) — composite-FK paired ordering
  (asymmetric `(b,a)` parent PK so swap-on-both-sides bugs fail), `ON DELETE
  CASCADE ON UPDATE SET NULL`, quoted reserved-word FK column (`"from"`)
- `drivers/mysql/metadata_test.go` (extend) — composite-FK paired ordering,
  `ON DELETE CASCADE ON UPDATE SET NULL` (looped across `sakila.MyAll()`)
- `drivers/sqlserver/metadata_test.go` (**new**) — composite-FK paired
  ordering, `ON DELETE CASCADE ON UPDATE SET NULL` exercising the loader's
  `REPLACE(..., '_', ' ')` normalization, same-catalog `RefCatalog`-empty pin
- `drivers/oracle/metadata_test.go` (**new**) — composite-FK paired ordering,
  `ON DELETE CASCADE` (Oracle exposes no `ON UPDATE` action — pinned as empty)
- `drivers/duckdb/metadata_test.go` (extend) — quoted reserved-word FK column
  (`"from"`), the DuckDB half of issue #616 row 11

**Shared metadata layer** (`libsq/source/metadata/metadata_test.go`):

- `TestLinkForeignKeys/self_referential_fk_pointer_identity` — self-ref FK
  appears in both `Outgoing` and `Incoming` with identical pointer identity
- `TestLinkForeignKeys/idempotence_clears_bogus_pointer` — a second
  `LinkForeignKeys` call clears a directly-injected bogus pointer; pins the
  pre-clear step in `LinkForeignKeys`
- `TestSource_Clone_FKMutationIsolated` — mutating a cloned FK's `Columns` /
  `RefColumns` / `OnDelete` leaves the original Source and its
  `FK.Incoming` back-refs untouched

**Renderer** (`cli/output/tablew/metadatawriter_test.go`):

- `TestPrintTablesVerbose_GoldenLayout` — pins the inspect verbose header
  order and the parens-wrap rendering of UC-backing indexes (which marks
  them as secondary to the `UNIQUE CONSTRAINTS` column). Uses
  `strings.Count == 1` to guard against double-wrap regressions.

## Scope decision

The P3 "Cross-catalog FK populating `RefCatalog`" item reframed as a
same-catalog assertion: SQL Server itself disallows declared cross-DB FK
constraints (only triggers/synonyms can fake them), so the current loader
never populates `RefCatalog`. `TestForeignKey_SameCatalog_SQLServer` pins
that behavior; a future loader change for cross-DB synonym refs can add a
sibling test populating `RefCatalog` explicitly. Documented inline in the
test's godoc.

## Test plan

- [x] `make lint` — 0 issues
- [x] `make lint-markdown` — 0 errors
- [x] `go test -short ./libsq/source/metadata/... ./cli/output/tablew/...
      ./drivers/duckdb/...`
- [x] `go test ./drivers/postgres/... -run TestForeignKey -v` (live sakiladb-pg)
- [x] `go test ./drivers/mysql/... -run TestForeignKey -v` (live sakiladb-my,
      MySQL 8 only — 5.6/5.7 skip without env vars)
- [x] `go test ./drivers/oracle/... -run TestForeignKey -v` (live sakiladb-or)
- [x] `go test ./drivers/duckdb/... -run TestTableMetadata_ReservedWordForeignKeyColumn -v`
- [ ] `go test ./drivers/sqlserver/... -run TestForeignKey -v` — requires a
      reachable sakiladb-ms container; vet-clean and short-mode-gated locally

Closes #616.