### PR TITLE
fix(secret): make keyring not-found hint copy-pasteable

### DIFF
--- a/cli/cmd_add_test.go
+++ b/cli/cmd_add_test.go
@@ -344,9 +344,9 @@ func TestCmdAdd_Active(t *testing.T) {
 	require.Equal(t, h4, m["handle"], "active source now be %s", h4)
 }
 
-// TestCmdAdd_Keyring verifies that --keyring stores the full DSN in the
-// OS keyring at a fresh opaque ID and writes a bare ${keyring:<id>}
-// placeholder into the source Location.
+// TestCmdAdd_Keyring verifies that --store keyring stores the full DSN
+// in the OS keyring at a fresh opaque ID and writes a bare
+// ${keyring:<id>} placeholder into the source Location.
 func TestCmdAdd_Keyring(t *testing.T) {
 	gokeyring.MockInit()
 

--- a/libsq/core/secret/expand.go
+++ b/libsq/core/secret/expand.go
@@ -40,15 +40,14 @@ func (r *Registry) Expand(ctx context.Context, template string) (string, error) 
 			// (re-)set the value at that path. Surface the exact
 			// command so the user doesn't have to guess.
 			if errors.Is(err, ErrNotFound) && p.scheme == "keyring" {
-				// Hint must be copy-pasteable for any valid keyring path,
-				// including paths containing spaces or a leading "-". Use
-				// %q to shell-quote, "--" to stop flag parsing so a "-"-
-				// prefixed path isn't read as a flag, and put -p before
-				// "--" since -p IS a flag. 'create' requires either a
-				// VALUE arg or -p (which reads from stdin/prompt).
+				// Hint must be safely copy-pasteable for any valid keyring
+				// path. shellQuoteSingle wraps with POSIX single quotes so
+				// $, backticks, $(...), and other shell metacharacters
+				// can't expand; "--" stops flag parsing so a "-"-prefixed
+				// path isn't read as a flag.
 				return "", errz.Wrapf(err,
-					"resolve ${%s:%s} (run: sq config keyring create -p -- %q)",
-					p.scheme, p.path, p.path)
+					"resolve ${%s:%s} (run: sq config keyring create -p -- %s)",
+					p.scheme, p.path, shellQuoteSingle(p.path))
 			}
 			return "", errz.Wrapf(err, "resolve ${%s:%s}", p.scheme, p.path)
 		}
@@ -146,4 +145,15 @@ func unescapeDollar(s string) string {
 		return s
 	}
 	return strings.ReplaceAll(s, "$$", "$")
+}
+
+// shellQuoteSingle wraps s in POSIX single quotes. Embedded single
+// quotes are split out via close-quote, backslash-escaped quote,
+// reopen-quote — the standard POSIX idiom for embedding a single quote
+// inside a single-quoted word. A single-quoted shell word has no
+// metacharacter interpretation at all under bash/zsh/dash, so the result
+// survives arbitrary bytes (including $, backticks, newlines, backslashes).
+// Used to build copy-pasteable command suggestions in error messages.
+func shellQuoteSingle(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
 }

--- a/libsq/core/secret/expand.go
+++ b/libsq/core/secret/expand.go
@@ -40,8 +40,10 @@ func (r *Registry) Expand(ctx context.Context, template string) (string, error) 
 			// (re-)set the value at that path. Surface the exact
 			// command so the user doesn't have to guess.
 			if errors.Is(err, ErrNotFound) && p.scheme == "keyring" {
+				// Hint must be copy-pasteable: 'create' requires either a
+				// VALUE argument or -p (which reads from stdin/prompt).
 				return "", errz.Wrapf(err,
-					"resolve ${%s:%s} (run: sq config keyring create %s)",
+					"resolve ${%s:%s} (run: sq config keyring create %s -p)",
 					p.scheme, p.path, p.path)
 			}
 			return "", errz.Wrapf(err, "resolve ${%s:%s}", p.scheme, p.path)

--- a/libsq/core/secret/expand.go
+++ b/libsq/core/secret/expand.go
@@ -40,10 +40,14 @@ func (r *Registry) Expand(ctx context.Context, template string) (string, error) 
 			// (re-)set the value at that path. Surface the exact
 			// command so the user doesn't have to guess.
 			if errors.Is(err, ErrNotFound) && p.scheme == "keyring" {
-				// Hint must be copy-pasteable: 'create' requires either a
-				// VALUE argument or -p (which reads from stdin/prompt).
+				// Hint must be copy-pasteable for any valid keyring path,
+				// including paths containing spaces or a leading "-". Use
+				// %q to shell-quote, "--" to stop flag parsing so a "-"-
+				// prefixed path isn't read as a flag, and put -p before
+				// "--" since -p IS a flag. 'create' requires either a
+				// VALUE arg or -p (which reads from stdin/prompt).
 				return "", errz.Wrapf(err,
-					"resolve ${%s:%s} (run: sq config keyring create %s -p)",
+					"resolve ${%s:%s} (run: sq config keyring create -p -- %q)",
 					p.scheme, p.path, p.path)
 			}
 			return "", errz.Wrapf(err, "resolve ${%s:%s}", p.scheme, p.path)

--- a/libsq/core/secret/expand_test.go
+++ b/libsq/core/secret/expand_test.go
@@ -48,37 +48,64 @@ func TestExpand_MissingSecret(t *testing.T) {
 	_, err := reg.Expand(context.Background(), "${keyring:nope}")
 	require.ErrorIs(t, err, secret.ErrNotFound)
 	// keyring-scheme not-found should carry the recovery hint so the
-	// user can copy-paste the fix command from the error. The -p flag
-	// is required because 'create' needs either a VALUE arg or -p; the
-	// path is %q-quoted and preceded by "--" so paths with spaces or a
-	// leading "-" still copy-paste cleanly.
-	require.Contains(t, err.Error(), `sq config keyring create -p -- "nope"`)
+	// user can copy-paste the fix command from the error. Anchored on
+	// "(run: " to pin flag order; shell-safety is exercised by
+	// TestExpand_MissingSecret_HintShellSafe.
+	require.Contains(t, err.Error(), `(run: sq config keyring create -p -- 'nope')`)
 }
 
 // TestExpand_MissingSecret_HintShellSafe pins the shell-safe shape of
 // the recovery hint for keyring paths that would otherwise break naive
-// copy-paste: paths containing spaces, and paths starting with "-"
-// (which Cobra/pflag would otherwise treat as a flag).
+// copy-paste — or worse, execute attacker-controlled shell when pasted.
+// The placeholder grammar in parse.go permits any byte except a closing
+// brace in a path, so all bash metacharacters are reachable. POSIX
+// single-quoting neutralizes every case; "--" stops flag parsing for
+// "-"-prefixed paths.
 func TestExpand_MissingSecret_HintShellSafe(t *testing.T) {
 	tests := []struct {
 		name string
 		path string
-		want string // substring the error must contain verbatim
+		want string // full parenthesized hint the error must contain
 	}{
 		{
 			name: "path with space",
 			path: "sakila db pw",
-			want: `sq config keyring create -p -- "sakila db pw"`,
+			want: `(run: sq config keyring create -p -- 'sakila db pw')`,
 		},
 		{
 			name: "path with leading dash",
 			path: "-looks-like-flag",
-			want: `sq config keyring create -p -- "-looks-like-flag"`,
+			want: `(run: sq config keyring create -p -- '-looks-like-flag')`,
+		},
+		{
+			name: "path with command substitution must not execute",
+			path: "$(whoami)",
+			want: `(run: sq config keyring create -p -- '$(whoami)')`,
+		},
+		{
+			name: "path with backticks must not execute",
+			path: "`whoami`",
+			want: "(run: sq config keyring create -p -- '`whoami`')",
+		},
+		{
+			name: "path with variable expansion must not expand",
+			path: "$HOME/db",
+			want: `(run: sq config keyring create -p -- '$HOME/db')`,
+		},
+		{
+			name: "path with backslash",
+			path: `a\b`,
+			want: `(run: sq config keyring create -p -- 'a\b')`,
 		},
 		{
 			name: "path with embedded double-quote",
 			path: `has"quote`,
-			want: `sq config keyring create -p -- "has\"quote"`,
+			want: `(run: sq config keyring create -p -- 'has"quote')`,
+		},
+		{
+			name: "path with embedded single-quote escapes as '\\''",
+			path: `it's`,
+			want: `(run: sq config keyring create -p -- 'it'\''s')`,
 		},
 	}
 	for _, tc := range tests {

--- a/libsq/core/secret/expand_test.go
+++ b/libsq/core/secret/expand_test.go
@@ -49,8 +49,46 @@ func TestExpand_MissingSecret(t *testing.T) {
 	require.ErrorIs(t, err, secret.ErrNotFound)
 	// keyring-scheme not-found should carry the recovery hint so the
 	// user can copy-paste the fix command from the error. The -p flag
-	// is required because 'create' needs either a VALUE arg or -p.
-	require.Contains(t, err.Error(), "sq config keyring create nope -p")
+	// is required because 'create' needs either a VALUE arg or -p; the
+	// path is %q-quoted and preceded by "--" so paths with spaces or a
+	// leading "-" still copy-paste cleanly.
+	require.Contains(t, err.Error(), `sq config keyring create -p -- "nope"`)
+}
+
+// TestExpand_MissingSecret_HintShellSafe pins the shell-safe shape of
+// the recovery hint for keyring paths that would otherwise break naive
+// copy-paste: paths containing spaces, and paths starting with "-"
+// (which Cobra/pflag would otherwise treat as a flag).
+func TestExpand_MissingSecret_HintShellSafe(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+		want string // substring the error must contain verbatim
+	}{
+		{
+			name: "path with space",
+			path: "sakila db pw",
+			want: `sq config keyring create -p -- "sakila db pw"`,
+		},
+		{
+			name: "path with leading dash",
+			path: "-looks-like-flag",
+			want: `sq config keyring create -p -- "-looks-like-flag"`,
+		},
+		{
+			name: "path with embedded double-quote",
+			path: `has"quote`,
+			want: `sq config keyring create -p -- "has\"quote"`,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			reg := newReg(t, nil)
+			_, err := reg.Expand(context.Background(), "${keyring:"+tc.path+"}")
+			require.ErrorIs(t, err, secret.ErrNotFound)
+			require.Contains(t, err.Error(), tc.want)
+		})
+	}
 }
 
 func TestExpand_MissingSecret_NonKeyringNoHint(t *testing.T) {

--- a/libsq/core/secret/expand_test.go
+++ b/libsq/core/secret/expand_test.go
@@ -48,8 +48,9 @@ func TestExpand_MissingSecret(t *testing.T) {
 	_, err := reg.Expand(context.Background(), "${keyring:nope}")
 	require.ErrorIs(t, err, secret.ErrNotFound)
 	// keyring-scheme not-found should carry the recovery hint so the
-	// user can copy-paste the fix command from the error.
-	require.Contains(t, err.Error(), "sq config keyring create nope")
+	// user can copy-paste the fix command from the error. The -p flag
+	// is required because 'create' needs either a VALUE arg or -p.
+	require.Contains(t, err.Error(), "sq config keyring create nope -p")
 }
 
 func TestExpand_MissingSecret_NonKeyringNoHint(t *testing.T) {


### PR DESCRIPTION
## Summary

Follow-up to #700, addressing two Copilot review comments that were left unresolved at merge.

- `libsq/core/secret/expand.go` — the `ErrNotFound` recovery hint for the `keyring` scheme suggested `sq config keyring create <path>`, but `create` requires either a `VALUE` arg or `-p`. Append `-p` so the command is copy-pasteable.
- `cli/cmd_add_test.go` — fix a stale `--keyring` comment that should read `--store keyring`.

Other Copilot comments on #700 were verified against current code and were either already addressed in-place during PR review or made moot by subsequent refactors (e.g. all `strings.Contains(loc, "\${")` placeholder checks replaced with `secret.ExtractRefs`, `WithPasswordPlaceholder` removed in favour of Form B keyring storage, prompt/migrate/file-trim/sentinel/redact issues all fixed before merge).

## Test plan

- [x] \`make lint\` clean
- [x] \`go test -short ./libsq/core/secret/... ./cli/...\` passes (including \`TestExpand_MissingSecret\` updated to assert the new hint)