### PR TITLE
sqlite3: support connection-string params in source-level commands (#720)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,7 +73,7 @@ Breaking changes are annotated with ☢️, and alpha/beta features with 🐥.
   with `stat /path/to/db?key=val: no such file or directory` on source-level
   metadata commands ([`sq inspect @handle`](https://sq.io/docs/inspect),
   `sq inspect @handle --overview`) when the source location carries a
-  `?key=val[&…]` connection-string suffix
+  `?key=val[&...]` connection-string suffix
   (e.g. `sqlite3:///path/to/db?mode=ro`). Connection-string parameters
   documented in the
   [SQLite driver page](https://sq.io/docs/drivers/sqlite) — including

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,7 +81,10 @@ Breaking changes are annotated with ☢️, and alpha/beta features with 🐥.
   end-to-end. Unblocks the long-standing request in
   [#443](https://github.com/neilotoole/sq/discussions/443) to query a
   live (locked) SQLite database, e.g. Firefox cookies, by setting
-  `?immutable=1`.
+  `?immutable=1`. As part of the same change, the SQLite driver's
+  open and location-parse error messages no longer echo the
+  connection-string suffix, so secret params (e.g. `_auth_pass`)
+  don't surface in logs.
 
 ## [v0.53.0] - 2026-05-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,22 @@ Breaking changes are annotated with ☢️, and alpha/beta features with 🐥.
   Server", dropping the trailing "/ Azure SQL Edge" (Azure SQL Edge was retired by
   Microsoft on 2025-09-30).
 
+### Fixed
+
+- [#720]: The [SQLite driver](https://sq.io/docs/drivers/sqlite) no longer fails
+  with `stat /path/to/db?key=val: no such file or directory` on source-level
+  metadata commands ([`sq inspect @handle`](https://sq.io/docs/inspect),
+  `sq inspect @handle --overview`) when the source location carries a
+  `?key=val[&…]` connection-string suffix
+  (e.g. `sqlite3:///path/to/db?mode=ro`). Connection-string parameters
+  documented in the
+  [SQLite driver page](https://sq.io/docs/drivers/sqlite) — including
+  `mode`, `cache`, and `mattn/go-sqlite3`'s `immutable=1` — now flow
+  end-to-end. Unblocks the long-standing request in
+  [#443](https://github.com/neilotoole/sq/discussions/443) to query a
+  live (locked) SQLite database, e.g. Firefox cookies, by setting
+  `?immutable=1`.
+
 ## [v0.53.0] - 2026-05-25
 
 ### Added
@@ -1637,6 +1653,7 @@ make working with lots of sources much easier.
 [#441]: https://github.com/neilotoole/sq/issues/441
 [#660]: https://github.com/neilotoole/sq/issues/660
 [#692]: https://github.com/neilotoole/sq/issues/692
+[#720]: https://github.com/neilotoole/sq/issues/720
 
 [v0.15.2]: https://github.com/neilotoole/sq/releases/tag/v0.15.2
 [v0.15.3]: https://github.com/neilotoole/sq/compare/v0.15.2...v0.15.3

--- a/drivers/sqlite3/grip.go
+++ b/drivers/sqlite3/grip.go
@@ -86,7 +86,7 @@ func (g *grip) getSourceMetadata(ctx context.Context, noSchema bool) (*metadata.
 
 	md := &metadata.Source{Handle: g.src.Handle, Driver: drivertype.SQLite, DBDriver: dbDrvr}
 
-	dsn, err := PathFromLocation(g.src)
+	fp, err := PathFromLocation(g.src)
 	if err != nil {
 		return nil, err
 	}
@@ -101,7 +101,7 @@ func (g *grip) getSourceMetadata(ctx context.Context, noSchema bool) (*metadata.
 
 	md.DBProduct = "SQLite3 v" + md.DBVersion
 
-	fi, err := os.Stat(dsn)
+	fi, err := os.Stat(fp)
 	if err != nil {
 		return nil, errw(err)
 	}

--- a/drivers/sqlite3/internal_test.go
+++ b/drivers/sqlite3/internal_test.go
@@ -59,3 +59,24 @@ func TestDsnFromLocation(t *testing.T) {
 		})
 	}
 }
+
+func TestFilePathFromLocation(t *testing.T) {
+	testCases := []struct {
+		loc  string
+		want string
+	}{
+		{loc: "", want: ""},
+		{loc: "duckdb:///foo.db", want: ""},
+		{loc: Prefix, want: ""},
+		{loc: Prefix + "/path/to/foo.db", want: "/path/to/foo.db"},
+		{loc: Prefix + "/path/to/foo.db?mode=ro", want: "/path/to/foo.db"},
+		{loc: Prefix + "/path/to/foo.db?cache=shared&mode=rw", want: "/path/to/foo.db"},
+		{loc: Prefix + "/path/to/foo.db?immutable=1", want: "/path/to/foo.db"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tu.Name(tc.loc), func(t *testing.T) {
+			require.Equal(t, tc.want, filePathFromLocation(tc.loc))
+		})
+	}
+}

--- a/drivers/sqlite3/internal_test.go
+++ b/drivers/sqlite3/internal_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/neilotoole/sq/testh/tu"
 )
 
 var (
@@ -28,5 +30,32 @@ func TestPlaceholders(t *testing.T) {
 	for _, tc := range testCases {
 		got := placeholders(tc.numCols, tc.numRows)
 		require.Equal(t, tc.want, got)
+	}
+}
+
+func TestDsnFromLocation(t *testing.T) {
+	testCases := []struct {
+		loc     string
+		want    string
+		wantErr bool
+	}{
+		{loc: "", wantErr: true},
+		{loc: "duckdb://x", wantErr: true},
+		{loc: Prefix + "/path/to/foo.db", want: "/path/to/foo.db"},
+		{loc: Prefix + "/path/to/foo.db?mode=ro", want: "/path/to/foo.db?mode=ro"},
+		{loc: Prefix + "/path/to/foo.db?cache=shared&mode=rw", want: "/path/to/foo.db?cache=shared&mode=rw"},
+		{loc: Prefix + "/path/to/foo.db?immutable=1", want: "/path/to/foo.db?immutable=1"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tu.Name(tc.loc), func(t *testing.T) {
+			got, err := dsnFromLocation(tc.loc)
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got)
+		})
 	}
 }

--- a/drivers/sqlite3/sqlite3.go
+++ b/drivers/sqlite3/sqlite3.go
@@ -1084,11 +1084,16 @@ func MungeLocation(loc string) (string, error) {
 	loc2 = strings.TrimPrefix(loc2, "sqlite3://")
 	loc2 = strings.TrimPrefix(loc2, "sqlite3:")
 
-	fp, err := filepath.Abs(loc2)
+	pathPart, queryPart, hasQuery := strings.Cut(loc2, "?")
+
+	fp, err := filepath.Abs(pathPart)
 	if err != nil {
 		return "", errz.Wrapf(errw(err), "invalid location: %s", loc)
 	}
 
 	fp = filepath.ToSlash(fp)
+	if hasQuery {
+		return "sqlite3://" + fp + "?" + queryPart, nil
+	}
 	return "sqlite3://" + fp, nil
 }

--- a/drivers/sqlite3/sqlite3.go
+++ b/drivers/sqlite3/sqlite3.go
@@ -1035,7 +1035,9 @@ func PathFromLocation(src *source.Source) (string, error) {
 // https://github.com/mattn/go-sqlite3#connection-string.
 func dsnFromLocation(loc string) (string, error) {
 	if !strings.HasPrefix(loc, Prefix) {
-		return "", errz.Errorf("invalid sqlite3 location: %q", loc)
+		// Don't echo loc: it may carry secret connection params
+		// (e.g. _auth_pass) in a "?key=val" suffix.
+		return "", errz.Errorf("invalid sqlite3 location: missing %q prefix", Prefix)
 	}
 	return loc[len(Prefix):], nil
 }
@@ -1095,7 +1097,9 @@ func MungeLocation(loc string) (string, error) {
 
 	fp, err := filepath.Abs(pathPart)
 	if err != nil {
-		return "", errz.Wrapf(errw(err), "invalid location: %s", loc)
+		// Use pathPart, not loc: the original may contain secret
+		// connection params (e.g. _auth_pass) in the query suffix.
+		return "", errz.Wrapf(errw(err), "invalid location: %s", pathPart)
 	}
 
 	fp = filepath.ToSlash(fp)

--- a/drivers/sqlite3/sqlite3.go
+++ b/drivers/sqlite3/sqlite3.go
@@ -146,7 +146,9 @@ func (d *driveri) doOpen(ctx context.Context, src *source.Source) (*sql.DB, erro
 
 	db, err := sql.Open(dbDrvr, dsn)
 	if err != nil {
-		return nil, errz.Wrapf(errw(err), "failed to open sqlite3 source with DSN: %s", dsn)
+		// Don't include dsn in the error: it may contain secret
+		// connection params (e.g. _auth_pass).
+		return nil, errz.Wrapf(errw(err), "failed to open sqlite3 source %s", src.Handle)
 	}
 
 	driver.ConfigureDB(ctx, db, src.Options)
@@ -1041,8 +1043,9 @@ func dsnFromLocation(loc string) (string, error) {
 // filePathFromLocation returns the on-disk file path for a sqlite3
 // location, or "" for a malformed location or one whose path component
 // is empty. Any "?key=val&..." DSN query suffix is stripped. The
-// returned path is not cleaned; callers that need an absolute,
-// platform-normalized path should run it through filepath.Clean.
+// returned path is neither normalized nor absolutized; callers that
+// need normalization should run it through filepath.Clean, and callers
+// that need an absolute path should use filepath.Abs.
 func filePathFromLocation(loc string) string {
 	if !strings.HasPrefix(loc, Prefix) {
 		return ""
@@ -1064,6 +1067,10 @@ func filePathFromLocation(loc string) string {
 //	sqlite3:sakila.db 						--> sqlite3:///current/working/dir/sakila.db
 //	sakila.db											--> sqlite3:///current/working/dir/sakila.db
 //	/path/to/sakila.db						--> sqlite3:///path/to/sakila.db
+//
+// An optional "?key=val[&...]" connection-string suffix is preserved
+// verbatim. The first '?' is always treated as the path/query separator,
+// so paths whose POSIX filename legally contains '?' are not supported.
 //
 // The final form is particularly nice for shell completion etc.
 //

--- a/drivers/sqlite3/sqlite3.go
+++ b/drivers/sqlite3/sqlite3.go
@@ -1005,10 +1005,10 @@ func NewScratchSource(ctx context.Context, fpath string) (src *source.Source, cl
 }
 
 // PathFromLocation returns the absolute file path from the source location,
-// which should have the "sqlite3://" prefix.
+// which must have the "sqlite3://" prefix. Any "?key=val&..." connection-string
+// suffix is stripped; callers that need the full DSN should use
+// dsnFromLocation instead.
 func PathFromLocation(src *source.Source) (string, error) {
-	// FIXME: Does this actually work with query params in the path?
-	// Probably not? Maybe refactor use dburl.Parse or such.
 	if src.Type != drivertype.SQLite {
 		return "", errz.Errorf("driver {%s} does not support {%s}", drivertype.SQLite, src.Type)
 	}
@@ -1017,13 +1017,12 @@ func PathFromLocation(src *source.Source) (string, error) {
 		return "", errz.Errorf("sqlite3 source location must begin with {%s} but was: %s", Prefix, src.RedactedLocation())
 	}
 
-	loc := strings.TrimPrefix(src.Location, Prefix)
+	loc := filePathFromLocation(src.Location)
 	if len(loc) < 2 {
 		return "", errz.Errorf("sqlite3 source location is too short: %s", src.RedactedLocation())
 	}
 
-	loc = filepath.Clean(loc)
-	return loc, nil
+	return filepath.Clean(loc), nil
 }
 
 // dsnFromLocation converts an sq location string

--- a/drivers/sqlite3/sqlite3.go
+++ b/drivers/sqlite3/sqlite3.go
@@ -1039,6 +1039,22 @@ func dsnFromLocation(loc string) (string, error) {
 	return loc[len(Prefix):], nil
 }
 
+// filePathFromLocation returns the on-disk file path for a sqlite3
+// location, or "" for a malformed location or one whose path component
+// is empty. Any "?key=val&..." DSN query suffix is stripped. The
+// returned path is not cleaned; callers that need an absolute,
+// platform-normalized path should run it through filepath.Clean.
+func filePathFromLocation(loc string) string {
+	if !strings.HasPrefix(loc, Prefix) {
+		return ""
+	}
+	p := loc[len(Prefix):]
+	if i := strings.IndexByte(p, '?'); i >= 0 {
+		p = p[:i]
+	}
+	return p
+}
+
 // MungeLocation takes a location argument (as received from the user)
 // and builds a sqlite3 location URL. Each of these forms are allowed:
 //

--- a/drivers/sqlite3/sqlite3.go
+++ b/drivers/sqlite3/sqlite3.go
@@ -1026,6 +1026,19 @@ func PathFromLocation(src *source.Source) (string, error) {
 	return loc, nil
 }
 
+// dsnFromLocation converts an sq location string
+// ("sqlite3:///path/to/foo.db?mode=ro") into the DSN form expected by
+// mattn/go-sqlite3. Requires the "sqlite3://" prefix; preserves the rest
+// verbatim (including any "?key=val&..." query suffix). mattn/go-sqlite3
+// parses the query suffix itself; see
+// https://github.com/mattn/go-sqlite3#connection-string.
+func dsnFromLocation(loc string) (string, error) {
+	if !strings.HasPrefix(loc, Prefix) {
+		return "", errz.Errorf("invalid sqlite3 location: %q", loc)
+	}
+	return loc[len(Prefix):], nil
+}
+
 // MungeLocation takes a location argument (as received from the user)
 // and builds a sqlite3 location URL. Each of these forms are allowed:
 //

--- a/drivers/sqlite3/sqlite3.go
+++ b/drivers/sqlite3/sqlite3.go
@@ -139,14 +139,14 @@ func (d *driveri) Open(ctx context.Context, src *source.Source) (driver.Grip, er
 }
 
 func (d *driveri) doOpen(ctx context.Context, src *source.Source) (*sql.DB, error) {
-	fp, err := PathFromLocation(src)
+	dsn, err := dsnFromLocation(src.Location)
 	if err != nil {
 		return nil, err
 	}
 
-	db, err := sql.Open(dbDrvr, fp)
+	db, err := sql.Open(dbDrvr, dsn)
 	if err != nil {
-		return nil, errz.Wrapf(errw(err), "failed to open sqlite3 source with DSN: %s", fp)
+		return nil, errz.Wrapf(errw(err), "failed to open sqlite3 source with DSN: %s", dsn)
 	}
 
 	driver.ConfigureDB(ctx, db, src.Options)

--- a/drivers/sqlite3/sqlite3_test.go
+++ b/drivers/sqlite3/sqlite3_test.go
@@ -203,6 +203,10 @@ func TestPathFromLocation(t *testing.T) {
 		{loc: "sqlite3:///test.db", want: "/test.db"},
 		{loc: "postgres:///test.db", wantErr: true},
 		{loc: `sqlite3://C:/dir/sakila.db`, want: `C:/dir/sakila.db`},
+		// gh720: connection-string parameters must be stripped.
+		{loc: "sqlite3:///test.db?mode=ro", want: "/test.db"},
+		{loc: "sqlite3:///test.db?cache=shared&mode=rw", want: "/test.db"},
+		{loc: "sqlite3:///test.db?immutable=1", want: "/test.db"},
 	}
 
 	for _, tc := range testCases {

--- a/drivers/sqlite3/sqlite3_test.go
+++ b/drivers/sqlite3/sqlite3_test.go
@@ -409,3 +409,46 @@ func TestDriveri_AlterTableColumnKinds(t *testing.T) {
 	require.Equal(t, kind.Text.String(), gotTblMeta.Column("age").Kind.String())
 	require.Equal(t, kind.Float.String(), gotTblMeta.Column("weight").Kind.String())
 }
+
+// TestSourceMetadata_LocationWithConnParams reproduces gh720: a
+// source-level metadata read must succeed when the source location
+// carries a connection-string suffix (e.g. ?mode=ro). The previous
+// behavior was os.Stat returning "no such file or directory" because
+// PathFromLocation passed through the literal "path?mode=ro" string.
+func TestSourceMetadata_LocationWithConnParams(t *testing.T) {
+	t.Parallel()
+
+	th := testh.New(t)
+
+	dbPath := tu.TempFile(t, "gh720.db")
+
+	// First, create a tiny db with no conn params.
+	bootSrc := &source.Source{
+		Handle:   "@bootstrap",
+		Type:     drivertype.SQLite,
+		Location: "sqlite3://" + filepath.ToSlash(dbPath),
+	}
+	bootGrip := th.Open(bootSrc)
+	bootDB, err := bootGrip.DB(th.Context)
+	require.NoError(t, err)
+	_, err = bootDB.ExecContext(th.Context, `CREATE TABLE t (id INTEGER); INSERT INTO t VALUES (1);`)
+	require.NoError(t, err)
+	require.NoError(t, bootGrip.Close())
+
+	// Now open with ?mode=ro and read source metadata — this used to fail.
+	roLoc, err := sqlite3.MungeLocation("sqlite3://" + filepath.ToSlash(dbPath) + "?mode=ro")
+	require.NoError(t, err)
+
+	roSrc := &source.Source{
+		Handle:   "@ro",
+		Type:     drivertype.SQLite,
+		Location: roLoc,
+	}
+	roGrip := th.Open(roSrc)
+
+	md, err := roGrip.SourceMetadata(th.Context, true)
+	require.NoError(t, err, "SourceMetadata must succeed even when Location carries ?mode=ro")
+	require.Equal(t, "@ro", md.Handle)
+	require.NotZero(t, md.Size, "file size should be non-zero")
+	require.Equal(t, filepath.Base(dbPath), md.Name)
+}

--- a/drivers/sqlite3/sqlite3_test.go
+++ b/drivers/sqlite3/sqlite3_test.go
@@ -282,6 +282,23 @@ func TestMungeLocation(t *testing.T) {
 			in:   "/path/to/sakila.db",
 			want: "sqlite3://" + root + "path/to/sakila.db",
 		},
+		// gh720: connection-string parameters must round-trip cleanly.
+		{
+			in:   "sqlite3:///path/to/sakila.db?mode=ro",
+			want: "sqlite3://" + root + "path/to/sakila.db?mode=ro",
+		},
+		{
+			in:   "sqlite3:///path/to/sakila.db?cache=shared&mode=rw",
+			want: "sqlite3://" + root + "path/to/sakila.db?cache=shared&mode=rw",
+		},
+		{
+			in:   "sakila.db?mode=ro",
+			want: cwdWant + "?mode=ro",
+		},
+		{
+			in:   "sqlite3:sakila.db?immutable=1",
+			want: cwdWant + "?immutable=1",
+		},
 		{
 			in:   `C:/Users/neil/work/sq/drivers/sqlite3/testdata/sakila.db`,
 			want: `sqlite3://C:/Users/neil/work/sq/drivers/sqlite3/testdata/sakila.db`,

--- a/site/content/en/docs/drivers/sqlite.md
+++ b/site/content/en/docs/drivers/sqlite.md
@@ -33,10 +33,19 @@ $ sq add --driver=sqlite3 ./sakila.db
 ```
 
 Use the connection string form with prefix `sqlite3://` to specify
-connection [parameters](https://github.com/mattn/go-sqlite3#connection-string).
+connection [parameters](https://github.com/mattn/go-sqlite3#connection-string):
 
 ```shell
+# Read/write with a shared cache.
 $ sq add 'sqlite3://sakila.db?cache=shared&mode=rw'
+
+# Read-only — any write fails at the SQLite layer.
+$ sq add 'sqlite3://sakila.db?mode=ro'
+
+# Treat the file as immutable so SQLite skips locking. Useful for
+# inspecting a live database while another process holds it open —
+# for example, a Firefox cookies DB while the browser is running.
+$ sq add 'sqlite3://cookies.sqlite?immutable=1' --handle @cookies
 ```
 
 The full set of supported parameters can be found in the `mattn/sqlite3`


### PR DESCRIPTION
## Summary

- Fixes #720. Source-level commands (`sq inspect @handle`, `sq inspect @handle --overview`) failed with `stat /path/to/db?key=val: no such file or directory` when a SQLite location carried connection-string parameters (`?mode=ro`, `?cache=shared&mode=rw`, `?immutable=1`, ...). The driver advertised support via `ConnParams`, the docs at `site/content/en/docs/drivers/sqlite.md` showed it, and a literal `FIXME` flagged it — `PathFromLocation` returned the path-with-query verbatim, which works for `sql.Open` but breaks `os.Stat`.
- Mirrors the helper split already used by the DuckDB driver: `dsnFromLocation` (DSN, used by `sql.Open` in `doOpen`) and `filePathFromLocation` (clean path, used by `PathFromLocation` and in turn `os.Stat` in `grip.getSourceMetadata`). `MungeLocation` now splits path from query before `filepath.Abs` so the stored location is well-formed.
- Adds unit tests for the new helpers, extends the existing `TestPathFromLocation` / `TestMungeLocation` matrices with query-string cases, and adds a `SourceMetadata` integration test that fails on the pre-fix code with exactly the issue's `stat` error. Unblocks the long-standing ask in #443 (query a live/locked SQLite DB with `?immutable=1`).
- Tightens sqlite3 driver error messages so they no longer echo the connection-string suffix: `dsnFromLocation`'s invalid-location error names only the expected prefix; `MungeLocation`'s `filepath.Abs` wrap uses `pathPart`; `doOpen`'s open-failure error names the source handle. Prevents secret connection params (e.g. `_auth_pass`) from surfacing in logs.

## Test plan

- [x] `go test ./drivers/sqlite3/...` (added + existing) — PASS
- [x] `go test -short ./...` — PASS
- [x] `make lint` and `make lint-markdown` — clean
- [x] Manual repro from the issue: `sq add 'sqlite3:///tmp/sqimm.db?mode=ro'` → `sq inspect @sq_ro` → `sq inspect @sq_ro --overview` all succeed
- [x] Documented multi-param form: `sq add 'sqlite3://sakila.db?cache=shared&mode=rw'` works end-to-end
- [x] `?immutable=1` (locked-DB use case from #443) works end-to-end