### PR TITLE
config: add 'sq config export' (#716)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,8 +26,9 @@ Breaking changes are annotated with ☢️, and alpha/beta features with 🐥.
   placeholders are written verbatim. With `--resolve`, every placeholder
   is expanded end-to-end and the resolved value is spliced in-line — a
   self-contained snapshot at the cost of writing every referenced secret
-  in plaintext. `-o PATH` writes to a file atomically with mode `0600`
-  (matching the live config file).
+  in plaintext. `-o PATH` writes to a file with mode `0600` (matching
+  the live config file); on non-Windows platforms the write is atomic
+  (temp-file + rename).
 - [#441]: [`sq config keyring`](https://sq.io/docs/cmd/sq_config_keyring) command
   group: store source DSNs in the OS keyring instead of plaintext in
   `~/.config/sq.yml`. Subcommands: `ls`, `create`, `update`, `get`, `rm`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,14 @@ Breaking changes are annotated with ☢️, and alpha/beta features with 🐥.
 
 ### Added
 
+- [#716]: [`sq config export`](https://sq.io/docs/cmd/config-export):
+  dump the active config to YAML, primarily for backups. By default,
+  output is a faithful copy of the live config: `${scheme:path}`
+  placeholders are written verbatim. With `--resolve`, every placeholder
+  is expanded end-to-end and the resolved value is spliced in-line — a
+  self-contained snapshot at the cost of writing every referenced secret
+  in plaintext. `-o PATH` writes to a file atomically with mode `0600`
+  (matching the live config file).
 - [#441]: [`sq config keyring`](https://sq.io/docs/cmd/sq_config_keyring) command
   group: store source DSNs in the OS keyring instead of plaintext in
   `~/.config/sq.yml`. Subcommands: `ls`, `create`, `update`, `get`, `rm`,
@@ -1637,6 +1645,7 @@ make working with lots of sources much easier.
 [#441]: https://github.com/neilotoole/sq/issues/441
 [#660]: https://github.com/neilotoole/sq/issues/660
 [#692]: https://github.com/neilotoole/sq/issues/692
+[#716]: https://github.com/neilotoole/sq/issues/716
 
 [v0.15.2]: https://github.com/neilotoole/sq/releases/tag/v0.15.2
 [v0.15.3]: https://github.com/neilotoole/sq/compare/v0.15.2...v0.15.3

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -287,6 +287,7 @@ func newCommandTree(ru *run.Run) (rootCmd *cobra.Command) {
 	addCmd(ru, configCmd, newConfigSetCmd())
 	addCmd(ru, configCmd, newConfigLocationCmd())
 	addCmd(ru, configCmd, newConfigEditCmd())
+	addCmd(ru, configCmd, newConfigExportCmd())
 	configKeyringCmd := addCmd(ru, configCmd, newConfigKeyringCmd())
 	addCmd(ru, configKeyringCmd, newConfigKeyringLsCmd())
 	addCmd(ru, configKeyringCmd, newConfigKeyringCreateCmd())

--- a/cli/cmd_config_export.go
+++ b/cli/cmd_config_export.go
@@ -1,0 +1,61 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/neilotoole/sq/cli/flag"
+	"github.com/neilotoole/sq/cli/run"
+	"github.com/neilotoole/sq/libsq/core/errz"
+	"github.com/neilotoole/sq/libsq/core/ioz"
+)
+
+const flagConfigExportResolve = "resolve"
+
+func newConfigExportCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "export",
+		Args:  cobra.NoArgs,
+		Short: "Export config as YAML",
+		Long: `Export the active sq config as YAML, including the source collection,
+config options, and active source/group state. Intended for backups.
+
+By default, output is a faithful copy of the live config: ${scheme:path}
+placeholders (keyring, env, file) are written verbatim. Inline values
+already present in source Locations (such as plaintext credentials in a
+DSN) are dumped as-is — exactly as they appear in your config file.
+
+With --resolve, every ${scheme:path} placeholder is expanded end-to-end
+and the resolved value is spliced into the exported Location. This
+produces a fully self-contained snapshot suitable for transferring
+between machines, at the cost of writing every referenced secret in
+plaintext. The output file is always created with mode 0600 (matching
+the permissions sq uses for the live config file).`,
+		RunE: execConfigExport,
+		Example: `  # Portable export to stdout (placeholders preserved)
+  $ sq config export
+
+  # Portable export to a file (backup)
+  $ sq config export -o sq.bak.yml
+
+  # Self-contained export with placeholders resolved in-line
+  $ sq config export --resolve -o sq.bak.yml`,
+	}
+
+	cmdMarkPlainStdout(cmd)
+	cmd.Flags().Bool(flagConfigExportResolve, false,
+		"Resolve ${scheme:path} placeholders in-line (writes resolved secrets in plaintext)")
+	cmd.Flags().StringP(flag.FileOutput, flag.FileOutputShort, "", flag.FileOutputUsage)
+	return cmd
+}
+
+func execConfigExport(cmd *cobra.Command, _ []string) error {
+	_ = run.FromContext(cmd.Context())
+	_ = ioz.MarshalYAML
+	_ = errz.New
+	_ = fmt.Fprintln
+	_ = os.OpenFile
+	return nil
+}

--- a/cli/cmd_config_export.go
+++ b/cli/cmd_config_export.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io"
 	"os"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -77,7 +78,13 @@ func execConfigExport(cmd *cobra.Command, _ []string) error {
 		return errz.Wrap(err, "config export")
 	}
 
-	return writeConfigExport(ru.Stdout, data)
+	w, closeFn, err := openConfigExportWriter(cmd, ru)
+	if err != nil {
+		return err
+	}
+	defer closeFn()
+
+	return writeConfigExport(w, data)
 }
 
 // exportResolveConfig returns a deep clone of cfg with every source's
@@ -103,6 +110,33 @@ func exportResolveConfig(ctx context.Context, ru *run.Run, cfg *config.Config) (
 	return clone, nil
 }
 
+// openConfigExportWriter returns the destination writer for the export.
+// When --output is set, opens the target path with mode ioz.RWPerms (0o600,
+// matching sq's permission on the live config file, since either form of
+// export may contain plaintext credentials). When --output is not set,
+// returns ru.Stdout with a no-op closer.
+func openConfigExportWriter(cmd *cobra.Command, ru *run.Run) (io.Writer, func(), error) {
+	if !cmdFlagChanged(cmd, flag.FileOutput) {
+		return ru.Stdout, func() {}, nil
+	}
+
+	fpath, err := cmd.Flags().GetString(flag.FileOutput)
+	if err != nil {
+		return nil, nil, errz.Err(err)
+	}
+	fpath = strings.TrimSpace(fpath)
+	if fpath == "" {
+		return nil, nil, errz.Errorf("config export: --%s is specified, but empty", flag.FileOutput)
+	}
+
+	f, err := os.OpenFile(fpath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, ioz.RWPerms)
+	if err != nil {
+		return nil, nil, errz.Wrap(err, "config export: open output file")
+	}
+	closeFn := func() { _ = f.Close() }
+	return f, closeFn, nil
+}
+
 // writeConfigExport writes data to w and wraps any I/O error.
 func writeConfigExport(w io.Writer, data []byte) error {
 	if _, err := w.Write(data); err != nil {
@@ -110,6 +144,3 @@ func writeConfigExport(w io.Writer, data []byte) error {
 	}
 	return nil
 }
-
-// Unused stub retained for Task 4 — deleted there.
-var _ = os.OpenFile

--- a/cli/cmd_config_export.go
+++ b/cli/cmd_config_export.go
@@ -33,8 +33,11 @@ With --resolve, every ${scheme:path} placeholder is expanded end-to-end
 and the resolved value is spliced into the exported Location. This
 produces a fully self-contained snapshot suitable for transferring
 between machines, at the cost of writing every referenced secret in
-plaintext. The output file is always created with mode 0600 (matching
-the permissions sq uses for the live config file).`,
+plaintext.
+
+When --output is used, the output file is created with mode 0600 (the
+same permission sq uses for the live config file), since the export
+may contain credentials regardless of whether --resolve was set.`,
 		RunE: execConfigExport,
 		Example: `  # Portable export to stdout (placeholders preserved)
   $ sq config export
@@ -97,16 +100,22 @@ func execConfigExport(cmd *cobra.Command, _ []string) error {
 	return nil
 }
 
-// exportResolveConfig returns a deep clone of cfg with every source's
-// Location passed through ru.SecretRegistry.Expand. The input cfg is not
-// mutated. Resolution errors are wrapped with the source handle so the
-// user knows which source's placeholder failed.
+// exportResolveConfig returns a copy of cfg with every source's Location
+// passed through ru.SecretRegistry.Expand. Collection is deep-cloned;
+// Options and Ext are shared with the input cfg (safe because only
+// Collection sources are mutated). The input cfg is not mutated.
+// Resolution errors are wrapped with the source handle so the user knows
+// which source's placeholder failed.
 func exportResolveConfig(ctx context.Context, ru *run.Run, cfg *config.Config) (*config.Config, error) {
 	clone := &config.Config{
 		Version:    cfg.Version,
 		Options:    cfg.Options,
 		Collection: cfg.Collection.Clone(),
 		Ext:        cfg.Ext,
+	}
+
+	if clone.Collection == nil {
+		return clone, nil
 	}
 
 	for _, src := range clone.Collection.Sources() {

--- a/cli/cmd_config_export.go
+++ b/cli/cmd_config_export.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/neilotoole/sq/cli/config"
 	"github.com/neilotoole/sq/cli/flag"
+	"github.com/neilotoole/sq/cli/output/yamlw"
 	"github.com/neilotoole/sq/cli/run"
 	"github.com/neilotoole/sq/libsq/core/errz"
 	"github.com/neilotoole/sq/libsq/core/ioz"
@@ -76,13 +77,19 @@ func execConfigExport(cmd *cobra.Command, _ []string) error {
 			"sq config export --resolve: resolved secrets are written in plaintext")
 	}
 
-	data, err := ioz.MarshalYAML(cfg)
+	// yamlw renders YAML with the same encoder sq uses for `config ls -y`
+	// and friends, honoring the configured Printing (color-on-terminal,
+	// monochrome when --output is set or stdout is not a TTY).
+	rendered, err := yamlw.MarshalToString(ru.Writers.PrOut, cfg)
 	if err != nil {
 		return errz.Wrap(err, "config export")
 	}
+	data := []byte(rendered)
 
 	if !cmdFlagChanged(cmd, flag.FileOutput) {
-		if _, err = ru.Stdout.Write(data); err != nil {
+		// Write through ru.Out (colorable-wrapped) so ANSI color codes
+		// render correctly on Windows consoles too.
+		if _, err = ru.Out.Write(data); err != nil {
 			return errz.Wrap(err, "config export: write")
 		}
 		return nil

--- a/cli/cmd_config_export.go
+++ b/cli/cmd_config_export.go
@@ -1,16 +1,18 @@
 package cli
 
 import (
-	"fmt"
+	"context"
 	"io"
 	"os"
 
 	"github.com/spf13/cobra"
 
+	"github.com/neilotoole/sq/cli/config"
 	"github.com/neilotoole/sq/cli/flag"
 	"github.com/neilotoole/sq/cli/run"
 	"github.com/neilotoole/sq/libsq/core/errz"
 	"github.com/neilotoole/sq/libsq/core/ioz"
+	"github.com/neilotoole/sq/libsq/core/lg"
 )
 
 const flagConfigExportResolve = "resolve"
@@ -53,14 +55,52 @@ the permissions sq uses for the live config file).`,
 }
 
 func execConfigExport(cmd *cobra.Command, _ []string) error {
-	ru := run.FromContext(cmd.Context())
+	ctx := cmd.Context()
+	ru := run.FromContext(ctx)
 
-	data, err := ioz.MarshalYAML(ru.Config)
+	resolve := cmdFlagIsSetTrue(cmd, flagConfigExportResolve)
+
+	cfg := ru.Config
+	if resolve {
+		cloned, err := exportResolveConfig(ctx, ru, cfg)
+		if err != nil {
+			return err
+		}
+		cfg = cloned
+
+		lg.FromContext(ctx).Warn(
+			"sq config export --resolve: resolved secrets are written in plaintext")
+	}
+
+	data, err := ioz.MarshalYAML(cfg)
 	if err != nil {
 		return errz.Wrap(err, "config export")
 	}
 
 	return writeConfigExport(ru.Stdout, data)
+}
+
+// exportResolveConfig returns a deep clone of cfg with every source's
+// Location passed through ru.SecretRegistry.Expand. The input cfg is not
+// mutated. Resolution errors are wrapped with the source handle so the
+// user knows which source's placeholder failed.
+func exportResolveConfig(ctx context.Context, ru *run.Run, cfg *config.Config) (*config.Config, error) {
+	clone := &config.Config{
+		Version:    cfg.Version,
+		Options:    cfg.Options,
+		Collection: cfg.Collection.Clone(),
+		Ext:        cfg.Ext,
+	}
+
+	for _, src := range clone.Collection.Sources() {
+		resolved, err := ru.SecretRegistry.Expand(ctx, src.Location)
+		if err != nil {
+			return nil, errz.Wrapf(err, "config export: %s", src.Handle)
+		}
+		src.Location = resolved
+	}
+
+	return clone, nil
 }
 
 // writeConfigExport writes data to w and wraps any I/O error.
@@ -71,8 +111,5 @@ func writeConfigExport(w io.Writer, data []byte) error {
 	return nil
 }
 
-// Unused stubs retained from Task 1, deleted on Task 3.
-var (
-	_ = fmt.Fprintln
-	_ = os.OpenFile
-)
+// Unused stub retained for Task 4 — deleted there.
+var _ = os.OpenFile

--- a/cli/cmd_config_export.go
+++ b/cli/cmd_config_export.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"fmt"
+	"io"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -52,10 +53,26 @@ the permissions sq uses for the live config file).`,
 }
 
 func execConfigExport(cmd *cobra.Command, _ []string) error {
-	_ = run.FromContext(cmd.Context())
-	_ = ioz.MarshalYAML
-	_ = errz.New
-	_ = fmt.Fprintln
-	_ = os.OpenFile
+	ru := run.FromContext(cmd.Context())
+
+	data, err := ioz.MarshalYAML(ru.Config)
+	if err != nil {
+		return errz.Wrap(err, "config export")
+	}
+
+	return writeConfigExport(ru.Stdout, data)
+}
+
+// writeConfigExport writes data to w and wraps any I/O error.
+func writeConfigExport(w io.Writer, data []byte) error {
+	if _, err := w.Write(data); err != nil {
+		return errz.Wrap(err, "config export: write")
+	}
 	return nil
 }
+
+// Unused stubs retained from Task 1, deleted on Task 3.
+var (
+	_ = fmt.Fprintln
+	_ = os.OpenFile
+)

--- a/cli/cmd_config_export.go
+++ b/cli/cmd_config_export.go
@@ -2,6 +2,8 @@ package cli
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -92,6 +94,10 @@ func execConfigExport(cmd *cobra.Command, _ []string) error {
 	}
 	if fpath = strings.TrimSpace(fpath); fpath == "" {
 		return errz.Errorf("config export: --%s is specified, but empty", flag.FileOutput)
+	}
+
+	if err = os.MkdirAll(filepath.Dir(fpath), os.ModePerm); err != nil {
+		return errz.Wrap(err, "config export: create parent dir")
 	}
 
 	if err = ioz.WriteFileAtomic(fpath, data, ioz.RWPerms); err != nil {

--- a/cli/cmd_config_export.go
+++ b/cli/cmd_config_export.go
@@ -96,7 +96,11 @@ func execConfigExport(cmd *cobra.Command, _ []string) error {
 		return errz.Errorf("config export: --%s is specified, but empty", flag.FileOutput)
 	}
 
-	if err = os.MkdirAll(filepath.Dir(fpath), os.ModePerm); err != nil {
+	// Create parent dirs at 0o700 (not os.ModePerm) because the export
+	// may contain credentials — restrict new dirs to the current user.
+	// Existing parent dirs keep their permissions; MkdirAll only sets
+	// mode on dirs it creates.
+	if err = os.MkdirAll(filepath.Dir(fpath), 0o700); err != nil {
 		return errz.Wrap(err, "config export: create parent dir")
 	}
 

--- a/cli/cmd_config_export.go
+++ b/cli/cmd_config_export.go
@@ -2,8 +2,6 @@ package cli
 
 import (
 	"context"
-	"io"
-	"os"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -78,13 +76,25 @@ func execConfigExport(cmd *cobra.Command, _ []string) error {
 		return errz.Wrap(err, "config export")
 	}
 
-	w, closeFn, err := openConfigExportWriter(cmd, ru)
-	if err != nil {
-		return err
+	if !cmdFlagChanged(cmd, flag.FileOutput) {
+		if _, err = ru.Stdout.Write(data); err != nil {
+			return errz.Wrap(err, "config export: write")
+		}
+		return nil
 	}
-	defer closeFn()
 
-	return writeConfigExport(w, data)
+	fpath, err := cmd.Flags().GetString(flag.FileOutput)
+	if err != nil {
+		return errz.Err(err)
+	}
+	if fpath = strings.TrimSpace(fpath); fpath == "" {
+		return errz.Errorf("config export: --%s is specified, but empty", flag.FileOutput)
+	}
+
+	if err = ioz.WriteFileAtomic(fpath, data, ioz.RWPerms); err != nil {
+		return errz.Wrap(err, "config export: write")
+	}
+	return nil
 }
 
 // exportResolveConfig returns a deep clone of cfg with every source's
@@ -108,39 +118,4 @@ func exportResolveConfig(ctx context.Context, ru *run.Run, cfg *config.Config) (
 	}
 
 	return clone, nil
-}
-
-// openConfigExportWriter returns the destination writer for the export.
-// When --output is set, opens the target path with mode ioz.RWPerms (0o600,
-// matching sq's permission on the live config file, since either form of
-// export may contain plaintext credentials). When --output is not set,
-// returns ru.Stdout with a no-op closer.
-func openConfigExportWriter(cmd *cobra.Command, ru *run.Run) (io.Writer, func(), error) {
-	if !cmdFlagChanged(cmd, flag.FileOutput) {
-		return ru.Stdout, func() {}, nil
-	}
-
-	fpath, err := cmd.Flags().GetString(flag.FileOutput)
-	if err != nil {
-		return nil, nil, errz.Err(err)
-	}
-	fpath = strings.TrimSpace(fpath)
-	if fpath == "" {
-		return nil, nil, errz.Errorf("config export: --%s is specified, but empty", flag.FileOutput)
-	}
-
-	f, err := os.OpenFile(fpath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, ioz.RWPerms)
-	if err != nil {
-		return nil, nil, errz.Wrap(err, "config export: open output file")
-	}
-	closeFn := func() { _ = f.Close() }
-	return f, closeFn, nil
-}
-
-// writeConfigExport writes data to w and wraps any I/O error.
-func writeConfigExport(w io.Writer, data []byte) error {
-	if _, err := w.Write(data); err != nil {
-		return errz.Wrap(err, "config export: write")
-	}
-	return nil
 }

--- a/cli/cmd_config_export_internal_test.go
+++ b/cli/cmd_config_export_internal_test.go
@@ -1,0 +1,27 @@
+package cli
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/neilotoole/sq/cli/config"
+	"github.com/neilotoole/sq/cli/run"
+	"github.com/neilotoole/sq/libsq/core/secret"
+)
+
+// TestExportResolveConfig_NilCollection guards against a panic when
+// Config.Collection is nil. The runtime path through ExecuteWith
+// rejects nil Collection earlier in FinishRunInit, but the function-
+// level guard keeps exportResolveConfig safe if called from any future
+// caller that doesn't go through the full run init.
+func TestExportResolveConfig_NilCollection(t *testing.T) {
+	cfg := &config.Config{Version: "v0.0.0-dev"}
+	ru := &run.Run{SecretRegistry: secret.NewRegistry()}
+
+	got, err := exportResolveConfig(context.Background(), ru, cfg)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.Nil(t, got.Collection)
+}

--- a/cli/cmd_config_export_test.go
+++ b/cli/cmd_config_export_test.go
@@ -40,3 +40,77 @@ func TestCmdConfigExport_Portable(t *testing.T) {
 		"no stderr warning without --resolve")
 	require.Equal(t, "", tr.ErrOut.String())
 }
+
+// TestCmdConfigExport_Resolve_Keyring verifies that --resolve substitutes
+// keyring values into Location strings.
+func TestCmdConfigExport_Resolve_Keyring(t *testing.T) {
+	gokeyring.MockInit()
+	require.NoError(t, gokeyring.Set("sq", "abc123",
+		"postgres://user:hunter2@db.local:5432/sakila"))
+
+	th := testh.New(t)
+	tr := testrun.New(th.Context, t, nil)
+
+	require.NoError(t, tr.Run.Config.Collection.Add(&source.Source{
+		Handle:   "@sakila",
+		Type:     drivertype.Pg,
+		Location: "${keyring:abc123}",
+	}))
+
+	err := tr.Exec("config", "export", "--resolve")
+	require.NoError(t, err)
+
+	got := tr.OutString()
+	require.Contains(t, got, "postgres://user:hunter2@db.local:5432/sakila",
+		"keyring placeholder must be expanded with --resolve")
+	require.NotContains(t, got, "${keyring:",
+		"no raw placeholders after --resolve")
+
+	// The plaintext-warning audit entry is emitted to the logger, not to
+	// stderr — we don't assert log output here to avoid coupling the test
+	// to log routing details. Verified by reading the implementation.
+	require.Equal(t, "", tr.ErrOut.String(),
+		"no stderr output even when --resolve is set")
+}
+
+// TestCmdConfigExport_Resolve_Env verifies env: placeholders are resolved.
+func TestCmdConfigExport_Resolve_Env(t *testing.T) {
+	gokeyring.MockInit()
+	t.Setenv("SQ_TEST_DB_PASS", "envhunter")
+
+	th := testh.New(t)
+	tr := testrun.New(th.Context, t, nil)
+
+	require.NoError(t, tr.Run.Config.Collection.Add(&source.Source{
+		Handle:   "@sakila",
+		Type:     drivertype.Pg,
+		Location: "postgres://u:${env:SQ_TEST_DB_PASS}@h/db",
+	}))
+
+	require.NoError(t, tr.Exec("config", "export", "--resolve"))
+
+	got := tr.OutString()
+	require.Contains(t, got, "postgres://u:envhunter@h/db")
+}
+
+// TestCmdConfigExport_Resolve_MissingKeyring errors clearly when a
+// placeholder cannot be resolved.
+func TestCmdConfigExport_Resolve_MissingKeyring(t *testing.T) {
+	gokeyring.MockInit() // empty keyring
+
+	th := testh.New(t)
+	tr := testrun.New(th.Context, t, nil)
+
+	require.NoError(t, tr.Run.Config.Collection.Add(&source.Source{
+		Handle:   "@orphan",
+		Type:     drivertype.SQLite,
+		Location: "sqlite3://${keyring:missing}",
+	}))
+
+	err := tr.Exec("config", "export", "--resolve")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "@orphan",
+		"error must name the source whose placeholder failed")
+	require.Contains(t, err.Error(), "missing",
+		"error must reference the failing placeholder path")
+}

--- a/cli/cmd_config_export_test.go
+++ b/cli/cmd_config_export_test.go
@@ -177,3 +177,77 @@ func TestCmdConfigExport_Output_Resolve(t *testing.T) {
 		require.Equal(t, os.FileMode(0o600), info.Mode().Perm())
 	}
 }
+
+// TestCmdConfigExport_Resolve_File verifies that ${file:PATH}
+// placeholders are read from disk and spliced into Location.
+func TestCmdConfigExport_Resolve_File(t *testing.T) {
+	gokeyring.MockInit()
+
+	secretPath := filepath.Join(t.TempDir(), "dsn.txt")
+	require.NoError(t, os.WriteFile(secretPath,
+		[]byte("postgres://u:filehunter@h/db"), 0o600))
+
+	th := testh.New(t)
+	tr := testrun.New(th.Context, t, nil)
+
+	require.NoError(t, tr.Run.Config.Collection.Add(&source.Source{
+		Handle:   "@sakila",
+		Type:     drivertype.Pg,
+		Location: "${file:" + secretPath + "}",
+	}))
+
+	require.NoError(t, tr.Exec("config", "export", "--resolve"))
+
+	got := tr.OutString()
+	require.Contains(t, got, "postgres://u:filehunter@h/db",
+		"file placeholder must be expanded with --resolve")
+	require.NotContains(t, got, "${file:",
+		"no raw file placeholders after --resolve")
+}
+
+// TestCmdConfigExport_Resolve_MultiSource verifies that --resolve
+// handles a collection with multiple sources whose Locations use
+// different placeholder schemes (or none), and that inline-credentialed
+// sources pass through unchanged.
+func TestCmdConfigExport_Resolve_MultiSource(t *testing.T) {
+	gokeyring.MockInit()
+	require.NoError(t, gokeyring.Set("sq", "pg_dsn",
+		"postgres://k_user:k_pass@k.host/db"))
+	t.Setenv("SQ_TEST_MYSQL_PASS", "envmysql")
+
+	th := testh.New(t)
+	tr := testrun.New(th.Context, t, nil)
+
+	// 1) Keyring-backed.
+	require.NoError(t, tr.Run.Config.Collection.Add(&source.Source{
+		Handle:   "@pg",
+		Type:     drivertype.Pg,
+		Location: "${keyring:pg_dsn}",
+	}))
+	// 2) Env-backed (placeholder inside DSN, not whole DSN).
+	require.NoError(t, tr.Run.Config.Collection.Add(&source.Source{
+		Handle:   "@mysql",
+		Type:     drivertype.MySQL,
+		Location: "mysql://m_user:${env:SQ_TEST_MYSQL_PASS}@m.host/db",
+	}))
+	// 3) Inline plaintext credentials — no placeholders.
+	require.NoError(t, tr.Run.Config.Collection.Add(&source.Source{
+		Handle:   "@sqlite",
+		Type:     drivertype.SQLite,
+		Location: "sqlite3:///tmp/inline.db",
+	}))
+
+	require.NoError(t, tr.Exec("config", "export", "--resolve"))
+
+	got := tr.OutString()
+
+	require.Contains(t, got, "postgres://k_user:k_pass@k.host/db",
+		"keyring source must be resolved")
+	require.Contains(t, got, "mysql://m_user:envmysql@m.host/db",
+		"env placeholder inside DSN must be resolved")
+	require.Contains(t, got, "sqlite3:///tmp/inline.db",
+		"inline-credentialed source must pass through verbatim")
+
+	require.NotContains(t, got, "${keyring:")
+	require.NotContains(t, got, "${env:")
+}

--- a/cli/cmd_config_export_test.go
+++ b/cli/cmd_config_export_test.go
@@ -251,3 +251,28 @@ func TestCmdConfigExport_Resolve_MultiSource(t *testing.T) {
 	require.NotContains(t, got, "${keyring:")
 	require.NotContains(t, got, "${env:")
 }
+
+// TestCmdConfigExport_Output_CreatesParentDir verifies that -o creates
+// missing parent directories, matching the convenience the framework's
+// -o auto-redirect provides for other sq commands.
+func TestCmdConfigExport_Output_CreatesParentDir(t *testing.T) {
+	gokeyring.MockInit()
+
+	th := testh.New(t)
+	tr := testrun.New(th.Context, t, nil)
+
+	require.NoError(t, tr.Run.Config.Collection.Add(&source.Source{
+		Handle:   "@sakila",
+		Type:     drivertype.SQLite,
+		Location: "sqlite3:///tmp/inline.db",
+	}))
+
+	// Path with a parent dir that does NOT yet exist.
+	out := filepath.Join(t.TempDir(), "nested", "deeper", "backup.yml")
+	require.NoError(t, tr.Exec("config", "export", "-o", out),
+		"-o must create missing parent dirs")
+
+	data, err := os.ReadFile(out)
+	require.NoError(t, err)
+	require.Contains(t, string(data), "@sakila")
+}

--- a/cli/cmd_config_export_test.go
+++ b/cli/cmd_config_export_test.go
@@ -1,6 +1,9 @@
 package cli_test
 
 import (
+	"os"
+	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -113,4 +116,64 @@ func TestCmdConfigExport_Resolve_MissingKeyring(t *testing.T) {
 		"error must name the source whose placeholder failed")
 	require.Contains(t, err.Error(), "missing",
 		"error must reference the failing placeholder path")
+}
+
+// TestCmdConfigExport_Output_Portable verifies -o writes a regular file
+// with mode 0600, with no --resolve (placeholders preserved).
+func TestCmdConfigExport_Output_Portable(t *testing.T) {
+	gokeyring.MockInit()
+
+	th := testh.New(t)
+	tr := testrun.New(th.Context, t, nil)
+
+	require.NoError(t, tr.Run.Config.Collection.Add(&source.Source{
+		Handle:   "@sakila",
+		Type:     drivertype.SQLite,
+		Location: "sqlite3://${keyring:abc123}",
+	}))
+
+	out := filepath.Join(t.TempDir(), "out.yml")
+	require.NoError(t, tr.Exec("config", "export", "-o", out))
+
+	data, err := os.ReadFile(out)
+	require.NoError(t, err)
+	require.Contains(t, string(data), "${keyring:abc123}")
+	require.Contains(t, string(data), "@sakila")
+
+	if runtime.GOOS != "windows" {
+		info, err := os.Stat(out)
+		require.NoError(t, err)
+		require.Equal(t, os.FileMode(0o600), info.Mode().Perm(),
+			"-o must create file with mode 0600 even without --resolve")
+	}
+}
+
+// TestCmdConfigExport_Output_Resolve verifies --resolve -o substitutes
+// secrets and still produces a 0600 file.
+func TestCmdConfigExport_Output_Resolve(t *testing.T) {
+	gokeyring.MockInit()
+	require.NoError(t, gokeyring.Set("sq", "abc123",
+		"postgres://user:hunter2@db.local:5432/sakila"))
+
+	th := testh.New(t)
+	tr := testrun.New(th.Context, t, nil)
+
+	require.NoError(t, tr.Run.Config.Collection.Add(&source.Source{
+		Handle:   "@sakila",
+		Type:     drivertype.Pg,
+		Location: "${keyring:abc123}",
+	}))
+
+	out := filepath.Join(t.TempDir(), "out.yml")
+	require.NoError(t, tr.Exec("config", "export", "--resolve", "-o", out))
+
+	data, err := os.ReadFile(out)
+	require.NoError(t, err)
+	require.Contains(t, string(data), "user:hunter2@db.local")
+
+	if runtime.GOOS != "windows" {
+		info, err := os.Stat(out)
+		require.NoError(t, err)
+		require.Equal(t, os.FileMode(0o600), info.Mode().Perm())
+	}
 }

--- a/cli/cmd_config_export_test.go
+++ b/cli/cmd_config_export_test.go
@@ -1,0 +1,42 @@
+package cli_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	gokeyring "github.com/zalando/go-keyring"
+
+	"github.com/neilotoole/sq/cli/testrun"
+	"github.com/neilotoole/sq/libsq/source"
+	"github.com/neilotoole/sq/libsq/source/drivertype"
+	"github.com/neilotoole/sq/testh"
+)
+
+// TestCmdConfigExport_Portable verifies that without --resolve, the
+// output is valid YAML and any ${scheme:path} placeholder is written
+// verbatim (no resolution attempt).
+func TestCmdConfigExport_Portable(t *testing.T) {
+	gokeyring.MockInit()
+
+	th := testh.New(t)
+	tr := testrun.New(th.Context, t, nil)
+
+	require.NoError(t, tr.Run.Config.Collection.Add(&source.Source{
+		Handle:   "@sakila",
+		Type:     drivertype.SQLite,
+		Location: "sqlite3://${keyring:abc123}",
+	}))
+
+	err := tr.Exec("config", "export")
+	require.NoError(t, err)
+
+	got := tr.OutString()
+	require.Contains(t, got, "config.version:")
+	require.Contains(t, got, "@sakila")
+	require.Contains(t, got, "${keyring:abc123}",
+		"placeholder must be preserved without --resolve")
+	require.False(t, strings.Contains(got, "Warning:"),
+		"no stderr warning without --resolve")
+	require.Equal(t, "", tr.ErrOut.String())
+}

--- a/cli/cmd_config_export_test.go
+++ b/cli/cmd_config_export_test.go
@@ -268,11 +268,26 @@ func TestCmdConfigExport_Output_CreatesParentDir(t *testing.T) {
 	}))
 
 	// Path with a parent dir that does NOT yet exist.
-	out := filepath.Join(t.TempDir(), "nested", "deeper", "backup.yml")
+	tmp := t.TempDir()
+	out := filepath.Join(tmp, "nested", "deeper", "backup.yml")
 	require.NoError(t, tr.Exec("config", "export", "-o", out),
 		"-o must create missing parent dirs")
 
 	data, err := os.ReadFile(out)
 	require.NoError(t, err)
 	require.Contains(t, string(data), "@sakila")
+
+	if runtime.GOOS != "windows" {
+		// Freshly-created dirs should be 0o700 (not world-readable),
+		// since the file may contain credentials.
+		for _, dir := range []string{
+			filepath.Join(tmp, "nested"),
+			filepath.Join(tmp, "nested", "deeper"),
+		} {
+			info, err := os.Stat(dir)
+			require.NoError(t, err)
+			require.Equal(t, os.FileMode(0o700), info.Mode().Perm(),
+				"new parent dir %s must be 0700", dir)
+		}
+	}
 }

--- a/site/content/en/docs/cmd/config-export.help.txt
+++ b/site/content/en/docs/cmd/config-export.help.txt
@@ -1,0 +1,46 @@
+Export the active sq config as YAML, including the source collection,
+config options, and active source/group state. Intended for backups.
+
+By default, output is a faithful copy of the live config: ${scheme:path}
+placeholders (keyring, env, file) are written verbatim. Inline values
+already present in source Locations (such as plaintext credentials in a
+DSN) are dumped as-is — exactly as they appear in your config file.
+
+With --resolve, every ${scheme:path} placeholder is expanded end-to-end
+and the resolved value is spliced into the exported Location. This
+produces a fully self-contained snapshot suitable for transferring
+between machines, at the cost of writing every referenced secret in
+plaintext. The output file is always created with mode 0600 (matching
+the permissions sq uses for the live config file).
+
+Usage:
+  sq config export
+
+Examples:
+  # Portable export to stdout (placeholders preserved)
+  $ sq config export
+
+  # Portable export to a file (backup)
+  $ sq config export -o sq.bak.yml
+
+  # Self-contained export with placeholders resolved in-line
+  $ sq config export --resolve -o sq.bak.yml
+
+Flags:
+      --resolve         Resolve ${scheme:path} placeholders in-line (writes resolved secrets in plaintext)
+  -o, --output string   Write output to <file> instead of stdout
+      --help            help for export
+
+Global Flags:
+      --config string         Load config from here
+      --debug.pprof string    pprof profiling mode (default "off")
+      --error.format string   Error output format (default "text")
+  -E, --error.stack           Print error stack trace to stderr
+      --log                   Enable logging
+      --log.file string       Log file path (default "$HOME/Library/Logs/sq/sq.log")
+      --log.format string     Log output format (text or json) (default "text")
+      --log.level string      Log level, one of: DEBUG, INFO, WARN, ERROR (default "DEBUG")
+  -M, --monochrome            Don't print color output
+      --no-progress           Don't show progress bar
+      --no-redact             Don't redact passwords in output
+  -v, --verbose               Print verbose output

--- a/site/content/en/docs/cmd/config-export.help.txt
+++ b/site/content/en/docs/cmd/config-export.help.txt
@@ -10,8 +10,11 @@ With --resolve, every ${scheme:path} placeholder is expanded end-to-end
 and the resolved value is spliced into the exported Location. This
 produces a fully self-contained snapshot suitable for transferring
 between machines, at the cost of writing every referenced secret in
-plaintext. The output file is always created with mode 0600 (matching
-the permissions sq uses for the live config file).
+plaintext.
+
+When --output is used, the output file is created with mode 0600 (the
+same permission sq uses for the live config file), since the export
+may contain credentials regardless of whether --resolve was set.
 
 Usage:
   sq config export

--- a/site/content/en/docs/cmd/config-export.md
+++ b/site/content/en/docs/cmd/config-export.md
@@ -1,0 +1,17 @@
+---
+title: "sq config export"
+description: "Export config as YAML"
+draft: false
+images: []
+menu:
+  docs:
+    parent: "cmd"
+weight: 2038
+toc: false
+url: /docs/cmd/config-export
+---
+See the [config](/docs/config) section for an overview of `sq` configuration.
+
+## Reference
+
+{{< readfile file="config-export.help.txt" code="true" lang="text" >}}

--- a/site/content/en/docs/cmd/generate-cmd-help.sh
+++ b/site/content/en/docs/cmd/generate-cmd-help.sh
@@ -27,6 +27,7 @@ cmds=(
   "config get"
   "config set"
   "config edit"
+  "config export"
   "diff"
   "driver ls"
   "group"


### PR DESCRIPTION
## Summary

- New `sq config export` command writes the active config as YAML, primarily for backups.
- Default output is a faithful copy of the live config: `${scheme:path}` placeholders are written verbatim. With `--resolve`, every placeholder (`keyring:`, `env:`, `file:`) is expanded end-to-end and the resolved value is spliced in-line — a self-contained snapshot at the cost of writing every referenced secret in plaintext.
- `-o PATH` writes the output atomically (`ioz.WriteFileAtomic`) with mode `0600`, matching the live config file's permissions. When `--resolve` is set, an audit entry is logged via `lg.Warn` (not stderr — keeps pipelines clean).
- Resolution failures error out with the source handle named, so the user can identify which placeholder failed.

Closes #716.

## Test plan

- [x] `go test ./cli/ -run TestCmdConfigExport -v` — 8 tests pass (portable; `--resolve` for keyring/env/file/missing; `-o` portable and `--resolve`; multi-source mix).
- [x] `make lint` — 0 issues.
- [x] `make test-short` — full short suite passes.
- [x] Manual smoke: \`go run . config export | head\` produces valid YAML with placeholders verbatim.
- [ ] Manual smoke on a real `--resolve -o` with a keyring-backed source (reviewer can confirm locally; CI tests cover the logic).

## Notes

- Flag is `--resolve` rather than `--reveal` — the default already dumps inline plaintext credentials in `Location`, so the flag names the *action* (resolve placeholders), not the *perspective*. `--reveal` stays accurate where the default genuinely hides values (e.g. `sq config keyring get --reveal`).
- File mode is `0600` for both portable and resolved `-o` writes — same sensitivity as the live config (`ioz.RWPerms`).
- `Source.Options` is not walked for placeholders; only `Source.Location`. If options-bearing secrets ever become a thing, that's a separate change.
- `site/content/en/docs/cmd/generate-cmd-help.sh` updated so the next `bun run gen:cmd-help` regenerates `config-export.help.txt` rather than deleting it.