### PR TITLE
secret: add op:// 1Password resolver scheme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,11 @@ Breaking changes are annotated with ☢️, and alpha/beta features with 🐥.
       1Password's
       [secret-reference syntax](https://developer.1password.com/docs/cli/secret-reference-syntax/);
       the user must already be signed in (biometric, `op signin`, or `OP_SERVICE_ACCOUNT_TOKEN`).
+      `sq add` accepts the bare `op://...` form (the literal "Copy Secret Reference"
+      output) as a shortcut for the wrapped `${op://...}` placeholder.
+      If a placeholder resolves to a bare value rather than a full DSN, `sq add`
+      surfaces an actionable error naming the placeholder and pointing at composition,
+      a full-DSN secret, or `--driver` as the three recovery paths.
 - [#441]: [`sq config keyring`](https://sq.io/docs/cmd/config-keyring) command group: store
   source conn strings in the OS keyring instead of plaintext in `sq.yml`.
   - Subcommands: `ls`, `create`, `update`, `get`, `rm`, `migrate`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,9 @@ Breaking changes are annotated with ☢️, and alpha/beta features with 🐥.
     - `env`: environment variable, e.g. `${env:DB_PROD_PW}` or `${env:DB_CONN_STR}`.
     - `file`: file contents, e.g. `${file:/run/secrets/db_pw}` or `${file:~/.sq/db_connstr}`.
     - [#714]: `op`: 1Password CLI, e.g. `${op://Private/sakila/dsn}`. Shells out to
-      [`op read`](https://developer.1password.com/docs/cli/secret-reference-syntax/);
+      [`op read`](https://developer.1password.com/docs/cli/reference/commands/read/) using
+      1Password's
+      [secret-reference syntax](https://developer.1password.com/docs/cli/secret-reference-syntax/);
       the user must already be signed in (biometric, `op signin`, or `OP_SERVICE_ACCOUNT_TOKEN`).
 - [#441]: [`sq config keyring`](https://sq.io/docs/cmd/config-keyring) command group: store
   source conn strings in the OS keyring instead of plaintext in `sq.yml`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,9 +25,9 @@ Breaking changes are annotated with ☢️, and alpha/beta features with 🐥.
   - By default, output is a faithful-ish copy of the live config: `${scheme:path}` placeholders are
     written verbatim.
   - With [`--expand`](https://sq.io/docs/secrets#substitution), every placeholder is
-    fetched from its resolver (`keyring`, `env`, or `file`) and the resolved value is spliced
-    in-line: a self-contained snapshot at the cost of writing every referenced secret in
-    plaintext (which is exactly the point of `--expand`).
+    fetched from its resolver (`keyring`, `env`, `file`, or `op`) and the resolved value
+    is spliced in-line: a self-contained snapshot at the cost of writing every referenced
+    secret in plaintext (which is exactly the point of `--expand`).
 - [#441]: [`sq add`](https://sq.io/docs/cmd/add) gains a `--store inline|keyring`
   flag, and a new [`secrets.store`](https://sq.io/docs/config#secretsstore) config option
   controls the default; existing behavior is preserved (`inline`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,9 @@ Breaking changes are annotated with ☢️, and alpha/beta features with 🐥.
     - `keyring`: OS keychain, managed via `sq config keyring`.
     - `env`: environment variable, e.g. `${env:DB_PROD_PW}` or `${env:DB_CONN_STR}`.
     - `file`: file contents, e.g. `${file:/run/secrets/db_pw}` or `${file:~/.sq/db_connstr}`.
+    - [#714]: `op`: 1Password CLI, e.g. `${op://Private/sakila/dsn}`. Shells out to
+      [`op read`](https://developer.1password.com/docs/cli/secret-reference-syntax/);
+      the user must already be signed in (biometric, `op signin`, or `OP_SERVICE_ACCOUNT_TOKEN`).
 - [#441]: [`sq config keyring`](https://sq.io/docs/cmd/config-keyring) command group: store
   source conn strings in the OS keyring instead of plaintext in `sq.yml`.
   - Subcommands: `ls`, `create`, `update`, `get`, `rm`, `migrate`.
@@ -1654,6 +1657,7 @@ make working with lots of sources much easier.
 [#692]: https://github.com/neilotoole/sq/issues/692
 [#716]: https://github.com/neilotoole/sq/issues/716
 [#717]: https://github.com/neilotoole/sq/issues/717
+[#714]: https://github.com/neilotoole/sq/issues/714
 [#720]: https://github.com/neilotoole/sq/issues/720
 
 [v0.15.2]: https://github.com/neilotoole/sq/releases/tag/v0.15.2

--- a/cli/cmd_add.go
+++ b/cli/cmd_add.go
@@ -227,6 +227,7 @@ func execSrcAdd(cmd *cobra.Command, args []string) (err error) {
 	}()
 
 	loc := location.Abs(strings.TrimSpace(args[0]))
+	loc = wrapBareSecretURI(loc)
 	var typ drivertype.Type
 
 	var handle string
@@ -467,6 +468,24 @@ func applyPassword(ctx context.Context, cmd *cobra.Command, ru *run.Run, loc str
 	return loc, "", nil
 }
 
+// wrapBareSecretURI normalizes location forms that look like a URL but
+// whose scheme belongs to an external secret resolver. Today that means
+// 1Password: "op://vault/item/field" (the literal "Copy Secret Reference"
+// output from the op CLI and 1Password's app UI) is rewritten as
+// "${op://vault/item/field}" so the rest of the add flow treats it as
+// a placeholder. The bare form is unambiguous because "op" is not a sq
+// database driver scheme.
+//
+// Other resolver schemes (env, file, keyring) don't have a URL-style
+// "scheme://" form so there is nothing to normalize for them: their bare
+// natural forms ("VAR", "/path/to/file", "abc") are not URL-shaped.
+func wrapBareSecretURI(loc string) string {
+	if strings.HasPrefix(loc, "op://") {
+		return "${" + loc + "}"
+	}
+	return loc
+}
+
 // resolveDriverType determines the driver type for a `sq add` invocation.
 // Three branches, in priority order:
 //
@@ -506,12 +525,15 @@ func resolveDriverType(
 		// of which would leak the plaintext resolved DSN (including
 		// password) into debug logs and stderr.
 		typ, err := driverTypeFromResolved(ctx, ru, handle, resolved)
-		if err != nil {
-			// Generic error — must not include the resolved value.
-			return "", errz.Errorf("could not infer driver from resolved location (pass --%s)", flag.AddDriver)
-		}
-		if typ == drivertype.None {
-			return "", errz.Errorf("could not infer driver from resolved location: use --%s flag", flag.AddDriver)
+		if err != nil || typ == drivertype.None {
+			// Error and placeholder path are safe to echo (caller typed
+			// them); the resolved value is not, so it is never included.
+			return "", errz.Errorf(
+				"could not infer driver from %s: resolved value is not a DSN. "+
+					"Either store a full DSN in the secret (e.g. postgres://alice:pw@db/sakila), "+
+					"compose the placeholder into a DSN (e.g. postgres://alice:%s@db/sakila), "+
+					"or pass --%s",
+				location.Redact(loc), location.Redact(loc), flag.AddDriver)
 		}
 		return typ, nil
 	}

--- a/cli/cmd_add_test.go
+++ b/cli/cmd_add_test.go
@@ -663,6 +663,59 @@ func TestCmdAdd_Placeholder_AutoResolve_Env(t *testing.T) {
 	require.Equal(t, drivertype.Pg, src.Type)
 }
 
+// TestCmdAdd_BareOpURI_IsAutoWrapped verifies the 1Password copy-paste
+// shortcut: a bare "op://..." location (the literal form emitted by
+// 1Password's "Copy Secret Reference" and by `op item get --format`)
+// is treated as a sugar for the canonical "${op://...}" placeholder,
+// so users don't have to add the ${} themselves.
+func TestCmdAdd_BareOpURI_IsAutoWrapped(t *testing.T) {
+	th := testh.New(t)
+	tr := testrun.New(th.Context, t, nil)
+
+	// --driver short-circuits add-time resolution, so the test does
+	// not need a live op CLI or stub.
+	const handle = "@sakila_pg"
+	err := tr.Exec("add", "op://Private/sakila_pg/dsn",
+		"--handle", handle,
+		"--driver", "postgres",
+		"--skip-verify")
+	require.NoError(t, err)
+
+	src, err := tr.Run.Config.Collection.Get(handle)
+	require.NoError(t, err)
+	// The location stored in YAML is the canonical wrapped form.
+	require.Equal(t, "${op://Private/sakila_pg/dsn}", src.Location)
+	require.Equal(t, drivertype.Pg, src.Type)
+}
+
+// TestCmdAdd_Placeholder_NonDSNResolved_GuidesUser verifies that when a
+// placeholder's resolved value is a bare value (e.g. just a password,
+// not a full DSN), the error names the placeholder, lists the three
+// recovery paths, and never leaks the resolved value.
+func TestCmdAdd_Placeholder_NonDSNResolved_GuidesUser(t *testing.T) {
+	// Resolved value is a bare password, not a DSN. Field name is
+	// deliberately "password" — the shape of the value is what matters
+	// for inference, not the field name.
+	t.Setenv("SQ_TEST_DSN_FOR_ADD_BARE_PW", "hunter2-secret-not-a-dsn")
+
+	th := testh.New(t)
+	tr := testrun.New(th.Context, t, nil)
+
+	err := tr.Exec("add", "${env:SQ_TEST_DSN_FOR_ADD_BARE_PW}", "--handle", "@x")
+	require.Error(t, err)
+	msg := err.Error()
+	require.Contains(t, msg, "${env:SQ_TEST_DSN_FOR_ADD_BARE_PW}",
+		"error should name the placeholder so the user knows which secret failed")
+	require.NotContains(t, msg, "hunter2-secret-not-a-dsn",
+		"error must not leak the resolved value")
+	require.Contains(t, msg, "compose",
+		"error should mention composition as a recovery path")
+	require.Contains(t, msg, "--driver",
+		"error should mention --driver as a recovery path")
+	require.Contains(t, msg, "postgres://",
+		"error should include a concrete DSN example")
+}
+
 // TestCmdAdd_Placeholder_ExplicitDriver verifies that --driver short-circuits
 // add-time resolution. The Location need not even resolve at add time.
 func TestCmdAdd_Placeholder_ExplicitDriver(t *testing.T) {

--- a/cli/run.go
+++ b/cli/run.go
@@ -41,6 +41,7 @@ import (
 	"github.com/neilotoole/sq/libsq/core/secret/env"
 	"github.com/neilotoole/sq/libsq/core/secret/file"
 	"github.com/neilotoole/sq/libsq/core/secret/keyring"
+	"github.com/neilotoole/sq/libsq/core/secret/op"
 	"github.com/neilotoole/sq/libsq/driver"
 	"github.com/neilotoole/sq/libsq/files"
 	"github.com/neilotoole/sq/libsq/source"
@@ -222,6 +223,7 @@ func preRun(cmd *cobra.Command, ru *run.Run) error {
 	ru.SecretRegistry.Register("keyring", keyring.NewStore())
 	ru.SecretRegistry.Register("env", env.NewResolver())
 	ru.SecretRegistry.Register("file", file.NewResolver())
+	ru.SecretRegistry.Register("op", op.NewResolver())
 	ctx = secret.NewContext(ctx, ru.SecretRegistry)
 	cmd.SetContext(ctx)
 

--- a/libsq/core/secret/op/op.go
+++ b/libsq/core/secret/op/op.go
@@ -80,9 +80,10 @@ func (r *Resolver) Resolve(ctx context.Context, path string) (string, error) {
 	}
 }
 
-// runOpRead is the cache-miss path: locate "op", run "op read op:<path>",
-// classify the result, and on success populate the cache and return the
-// trimmed value.
+// runOpRead is the cache-miss path: locate "op", run
+// "op read op://<rest>" (where path already begins with "//"),
+// classify the result, and on success populate the cache and return
+// the trimmed value.
 func (r *Resolver) runOpRead(ctx context.Context, path string) (string, error) {
 	opPath, err := exec.LookPath("op")
 	if err != nil {

--- a/libsq/core/secret/op/op.go
+++ b/libsq/core/secret/op/op.go
@@ -95,9 +95,13 @@ func (r *Resolver) runOpRead(ctx context.Context, path string) (string, error) {
 		if ctxErr := ctx.Err(); ctxErr != nil {
 			return "", errz.Wrapf(ctxErr, "op read %s", path)
 		}
-		stderrStr := strings.TrimSpace(stderr.String())
+		// Trim only trailing newlines so op's stderr is preserved
+		// otherwise verbatim in the wrapped error message.
+		stderrStr := strings.TrimRight(stderr.String(), "\r\n")
 		if isNotFoundStderr(stderrStr) {
-			return "", errz.Wrapf(secret.ErrNotFound, "op read %s", path)
+			// Bare sentinel, matching env/file/keyring; expand.go adds
+			// "resolve ${op:<path>}" context at the outer layer.
+			return "", secret.ErrNotFound
 		}
 		if stderrStr == "" {
 			return "", errz.Wrapf(err, "op read %s", path)

--- a/libsq/core/secret/op/op.go
+++ b/libsq/core/secret/op/op.go
@@ -3,10 +3,10 @@
 // value 1Password's "op" CLI returns for that secret reference. The path
 // is passed through to "op read" verbatim; sq does not parse it.
 //
-// Auth is "op"'s problem: the user must already be signed in (op signin,
-// biometric prompt, or a service-account token in OP_SERVICE_ACCOUNT_TOKEN).
-// sq surfaces "op"'s stderr verbatim when authentication or connectivity
-// fails. Read-only: sq never writes to 1Password.
+// Auth is "op"'s problem: the user must already be signed in (biometric,
+// op signin, or a service-account token in OP_SERVICE_ACCOUNT_TOKEN).
+// sq surfaces "op"'s stderr in the wrapped error when authentication or
+// connectivity fails. Read-only: sq never writes to 1Password.
 //
 // Minimum supported "op" version: v2 (the version where "op read" landed).
 package op
@@ -18,6 +18,8 @@ import (
 	"strings"
 	"sync"
 
+	"golang.org/x/sync/singleflight"
+
 	"github.com/neilotoole/sq/libsq/core/errz"
 	"github.com/neilotoole/sq/libsq/core/secret"
 )
@@ -25,9 +27,12 @@ import (
 // Resolver implements secret.Resolver by shelling out to the 1Password
 // "op" CLI. A single Resolver caches successful resolutions for its
 // lifetime so repeated placeholders within one sq invocation only call
-// "op" once per path.
+// "op" once per path. Concurrent Resolve calls for the same path are
+// coalesced via singleflight so the user never sees duplicate biometric
+// prompts.
 type Resolver struct {
-	cache sync.Map // path -> string
+	flight singleflight.Group
+	cache  sync.Map // path -> string
 }
 
 // NewResolver returns a Resolver. Callers register the result with a
@@ -47,24 +52,52 @@ func (r *Resolver) Resolve(ctx context.Context, path string) (string, error) {
 	if v, ok := r.cache.Load(path); ok {
 		return v.(string), nil
 	}
+	v, err, _ := r.flight.Do(path, func() (any, error) {
+		// Re-check the cache: a concurrent flight may have populated it
+		// while this caller was waiting on the singleflight lock.
+		if v, ok := r.cache.Load(path); ok {
+			return v.(string), nil
+		}
+		return r.runOpRead(ctx, path)
+	})
+	if err != nil {
+		return "", err
+	}
+	return v.(string), nil
+}
 
-	if _, err := exec.LookPath("op"); err != nil {
+// runOpRead is the cache-miss path: locate "op", run "op read op:<path>",
+// classify the result, and on success populate the cache and return the
+// trimmed value.
+func (r *Resolver) runOpRead(ctx context.Context, path string) (string, error) {
+	opPath, err := exec.LookPath("op")
+	if err != nil {
 		return "", errz.Wrap(err,
 			"1Password 'op' CLI not found on PATH; install it from "+
 				"https://developer.1password.com/docs/cli/get-started/")
 	}
 
-	// G204: binary name "op" is a literal; path comes from sq's own YAML
-	// config (a placeholder body), so this is not an untrusted external input.
-	cmd := exec.CommandContext(ctx, "op", "read", "op:"+path) //nolint:gosec // G204: see comment above.
+	// opPath is the absolute path resolved by LookPath for the literal
+	// "op"; the read URI is sq's own placeholder body. Neither is
+	// untrusted external input.
+	cmd := exec.CommandContext(ctx, opPath, "read", "op:"+path)
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {
-		if isNotFoundStderr(stderr.String()) {
-			return "", secret.ErrNotFound
+		// Honor context cancellation before any stderr-based classification:
+		// when the child is killed by ctx, stderr is typically empty.
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return "", errz.Wrapf(ctxErr, "op read %s", path)
 		}
-		return "", errz.Wrapf(err, "op read: %s", strings.TrimSpace(stderr.String()))
+		stderrStr := strings.TrimSpace(stderr.String())
+		if isNotFoundStderr(stderrStr) {
+			return "", errz.Wrapf(secret.ErrNotFound, "op read %s", path)
+		}
+		if stderrStr == "" {
+			return "", errz.Wrapf(err, "op read %s", path)
+		}
+		return "", errz.Wrapf(err, "op read %s: %s", path, stderrStr)
 	}
 
 	out := stdout.String()
@@ -80,13 +113,16 @@ func (r *Resolver) Resolve(ctx context.Context, path string) (string, error) {
 
 // notFoundMarkers are the stderr substrings 1Password's "op" CLI uses to
 // indicate the referenced item, vault, section, or field does not exist.
-// Matching is a small, conservative set; unknown error text is surfaced
-// verbatim rather than misclassified.
+// Matching is a small, conservative set kept item-scoped on purpose:
+// generic markers like "couldn't find" would also match account / vault
+// access failures and silently misclassify them as not-found. Unknown
+// error text is surfaced verbatim rather than misclassified.
 var notFoundMarkers = []string{
 	"isn't an item",
 	"item not found",
 	"no item found",
-	"couldn't find",
+	"couldn't find the item",
+	"couldn't find an item",
 }
 
 func isNotFoundStderr(s string) bool {

--- a/libsq/core/secret/op/op.go
+++ b/libsq/core/secret/op/op.go
@@ -57,7 +57,11 @@ func (r *Resolver) Resolve(ctx context.Context, path string) (string, error) {
 	if v, ok := r.cache.Load(path); ok {
 		return v.(string), nil
 	}
-	v, err, _ := r.flight.Do(path, func() (any, error) {
+	// DoChan (not Do) so each caller can honor its own ctx while waiting:
+	// the shared "op read" runs with the first caller's context, but later
+	// callers with a tighter deadline can abort independently without
+	// affecting the in-flight invocation.
+	ch := r.flight.DoChan(path, func() (any, error) {
 		// Re-check the cache: a concurrent flight may have populated it
 		// while this caller was waiting on the singleflight lock.
 		if v, ok := r.cache.Load(path); ok {
@@ -65,10 +69,15 @@ func (r *Resolver) Resolve(ctx context.Context, path string) (string, error) {
 		}
 		return r.runOpRead(ctx, path)
 	})
-	if err != nil {
-		return "", err
+	select {
+	case res := <-ch:
+		if res.Err != nil {
+			return "", res.Err
+		}
+		return res.Val.(string), nil
+	case <-ctx.Done():
+		return "", errz.Wrapf(ctx.Err(), "op read %s", path)
 	}
-	return v.(string), nil
 }
 
 // runOpRead is the cache-miss path: locate "op", run "op read op:<path>",

--- a/libsq/core/secret/op/op.go
+++ b/libsq/core/secret/op/op.go
@@ -55,7 +55,10 @@ func (r *Resolver) Resolve(ctx context.Context, path string) (string, error) {
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {
-		return "", errz.Wrap(err, "op read")
+		if isNotFoundStderr(stderr.String()) {
+			return "", secret.ErrNotFound
+		}
+		return "", errz.Wrapf(err, "op read: %s", strings.TrimSpace(stderr.String()))
 	}
 
 	out := stdout.String()
@@ -66,7 +69,26 @@ func (r *Resolver) Resolve(ctx context.Context, path string) (string, error) {
 		out = out[:len(out)-1]
 	}
 	r.cache.Store(path, out)
-	// T4 maps op's "not an item" stderr to secret.ErrNotFound; keep the import live.
-	_ = secret.ErrNotFound
 	return out, nil
+}
+
+// notFoundMarkers are the stderr substrings 1Password's "op" CLI uses to
+// indicate the referenced item, vault, section, or field does not exist.
+// Matching is a small, conservative set; unknown error text is surfaced
+// verbatim rather than misclassified.
+var notFoundMarkers = []string{
+	"isn't an item",
+	"item not found",
+	"no item found",
+	"couldn't find",
+}
+
+func isNotFoundStderr(s string) bool {
+	s = strings.ToLower(s)
+	for _, m := range notFoundMarkers {
+		if strings.Contains(s, m) {
+			return true
+		}
+	}
+	return false
 }

--- a/libsq/core/secret/op/op.go
+++ b/libsq/core/secret/op/op.go
@@ -58,8 +58,13 @@ func (r *Resolver) Resolve(ctx context.Context, path string) (string, error) {
 		return "", errz.Wrap(err, "op read")
 	}
 
-	out := strings.TrimRight(stdout.String(), "\n")
-	out = strings.TrimRight(out, "\r")
+	out := stdout.String()
+	switch {
+	case strings.HasSuffix(out, "\r\n"):
+		out = out[:len(out)-2]
+	case strings.HasSuffix(out, "\n"):
+		out = out[:len(out)-1]
+	}
 	r.cache.Store(path, out)
 	// T4 maps op's "not an item" stderr to secret.ErrNotFound; keep the import live.
 	_ = secret.ErrNotFound

--- a/libsq/core/secret/op/op.go
+++ b/libsq/core/secret/op/op.go
@@ -48,6 +48,12 @@ func (r *Resolver) Resolve(ctx context.Context, path string) (string, error) {
 		return v.(string), nil
 	}
 
+	if _, err := exec.LookPath("op"); err != nil {
+		return "", errz.Wrap(err,
+			"1Password 'op' CLI not found on PATH; install it from "+
+				"https://developer.1password.com/docs/cli/get-started/")
+	}
+
 	// G204: binary name "op" is a literal; path comes from sq's own YAML
 	// config (a placeholder body), so this is not an untrusted external input.
 	cmd := exec.CommandContext(ctx, "op", "read", "op:"+path) //nolint:gosec // G204: see comment above.

--- a/libsq/core/secret/op/op.go
+++ b/libsq/core/secret/op/op.go
@@ -1,0 +1,65 @@
+// Package op is the 1Password CLI backend for libsq/core/secret. A
+// ${op://<vault>/<item>/[<section>/]<field>} placeholder resolves to the
+// value 1Password's "op" CLI returns for that secret reference. The path
+// is passed through to "op read" verbatim — sq does not parse it.
+//
+// Auth is "op"'s problem: the user must already be signed in (op signin,
+// biometric prompt, or a service-account token in OP_SERVICE_ACCOUNT_TOKEN).
+// sq surfaces "op"'s stderr verbatim when authentication or connectivity
+// fails. Read-only: sq never writes to 1Password.
+//
+// Minimum supported "op" version: v2 (the version where "op read" landed).
+package op
+
+import (
+	"bytes"
+	"context"
+	"os/exec"
+	"strings"
+	"sync"
+
+	"github.com/neilotoole/sq/libsq/core/errz"
+	"github.com/neilotoole/sq/libsq/core/secret"
+)
+
+// Resolver implements secret.Resolver by shelling out to the 1Password
+// "op" CLI. A single Resolver caches successful resolutions for its
+// lifetime so repeated placeholders within one sq invocation only call
+// "op" once per path.
+type Resolver struct {
+	cache sync.Map // path -> string
+}
+
+// NewResolver returns a Resolver. Callers register the result with a
+// secret.Registry under the "op" scheme.
+func NewResolver() *Resolver {
+	return &Resolver{}
+}
+
+// Resolve invokes "op read" for the placeholder body path (which includes
+// the leading "//" — e.g. "//Private/sakila/dsn"). The "op:" scheme is
+// reattached, so "op" receives the full URI "op://Private/sakila/dsn".
+//
+// Successful values are cached per-instance. A single trailing LF or CRLF
+// is trimmed from the output, matching 1Password CLI behavior and the
+// secret/file resolver convention.
+func (r *Resolver) Resolve(ctx context.Context, path string) (string, error) {
+	if v, ok := r.cache.Load(path); ok {
+		return v.(string), nil
+	}
+
+	// path is a user-supplied secret reference, intentionally forwarded to op.
+	cmd := exec.CommandContext(ctx, "op", "read", "op:"+path) //nolint:gosec
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", errz.Wrap(err, "op read")
+	}
+
+	out := strings.TrimRight(stdout.String(), "\n")
+	out = strings.TrimRight(out, "\r")
+	r.cache.Store(path, out)
+	_ = secret.ErrNotFound // referenced in later tasks; keep import live
+	return out, nil
+}

--- a/libsq/core/secret/op/op.go
+++ b/libsq/core/secret/op/op.go
@@ -1,7 +1,7 @@
 // Package op is the 1Password CLI backend for libsq/core/secret. A
 // ${op://<vault>/<item>/[<section>/]<field>} placeholder resolves to the
 // value 1Password's "op" CLI returns for that secret reference. The path
-// is passed through to "op read" verbatim — sq does not parse it.
+// is passed through to "op read" verbatim; sq does not parse it.
 //
 // Auth is "op"'s problem: the user must already be signed in (op signin,
 // biometric prompt, or a service-account token in OP_SERVICE_ACCOUNT_TOKEN).
@@ -37,7 +37,7 @@ func NewResolver() *Resolver {
 }
 
 // Resolve invokes "op read" for the placeholder body path (which includes
-// the leading "//" — e.g. "//Private/sakila/dsn"). The "op:" scheme is
+// the leading "//", e.g. "//Private/sakila/dsn"). The "op:" scheme is
 // reattached, so "op" receives the full URI "op://Private/sakila/dsn".
 //
 // Successful values are cached per-instance. A single trailing LF or CRLF
@@ -48,8 +48,9 @@ func (r *Resolver) Resolve(ctx context.Context, path string) (string, error) {
 		return v.(string), nil
 	}
 
-	// path is a user-supplied secret reference, intentionally forwarded to op.
-	cmd := exec.CommandContext(ctx, "op", "read", "op:"+path) //nolint:gosec
+	// G204: binary name "op" is a literal; path comes from sq's own YAML
+	// config (a placeholder body), so this is not an untrusted external input.
+	cmd := exec.CommandContext(ctx, "op", "read", "op:"+path) //nolint:gosec // G204: see comment above.
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
@@ -60,6 +61,7 @@ func (r *Resolver) Resolve(ctx context.Context, path string) (string, error) {
 	out := strings.TrimRight(stdout.String(), "\n")
 	out = strings.TrimRight(out, "\r")
 	r.cache.Store(path, out)
-	_ = secret.ErrNotFound // referenced in later tasks; keep import live
+	// T4 maps op's "not an item" stderr to secret.ErrNotFound; keep the import live.
+	_ = secret.ErrNotFound
 	return out, nil
 }

--- a/libsq/core/secret/op/op.go
+++ b/libsq/core/secret/op/op.go
@@ -83,8 +83,9 @@ func (r *Resolver) runOpRead(ctx context.Context, path string) (string, error) {
 	}
 
 	// opPath is the absolute path resolved by LookPath for the literal
-	// "op"; the read URI is sq's own placeholder body. Neither is
-	// untrusted external input.
+	// "op", and the read URI is passed as a separate argv entry, not
+	// through a shell, so a hostile placeholder body cannot break out
+	// into command injection.
 	cmd := exec.CommandContext(ctx, opPath, "read", "op:"+path)
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout

--- a/libsq/core/secret/op/op.go
+++ b/libsq/core/secret/op/op.go
@@ -76,7 +76,7 @@ func (r *Resolver) Resolve(ctx context.Context, path string) (string, error) {
 		}
 		return res.Val.(string), nil
 	case <-ctx.Done():
-		return "", errz.Wrapf(ctx.Err(), "op read %s", path)
+		return "", errz.Wrapf(ctx.Err(), "op read op:%s", path)
 	}
 }
 
@@ -96,7 +96,8 @@ func (r *Resolver) runOpRead(ctx context.Context, path string) (string, error) {
 	// "op", and the read URI is passed as a separate argv entry, not
 	// through a shell, so a hostile placeholder body cannot break out
 	// into command injection.
-	cmd := exec.CommandContext(ctx, opPath, "read", "op:"+path)
+	uri := "op:" + path
+	cmd := exec.CommandContext(ctx, opPath, "read", uri)
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
@@ -104,7 +105,7 @@ func (r *Resolver) runOpRead(ctx context.Context, path string) (string, error) {
 		// Honor context cancellation before any stderr-based classification:
 		// when the child is killed by ctx, stderr is typically empty.
 		if ctxErr := ctx.Err(); ctxErr != nil {
-			return "", errz.Wrapf(ctxErr, "op read %s", path)
+			return "", errz.Wrapf(ctxErr, "op read %s", uri)
 		}
 		// Trim only trailing newlines so op's stderr is preserved
 		// otherwise verbatim in the wrapped error message.
@@ -115,9 +116,9 @@ func (r *Resolver) runOpRead(ctx context.Context, path string) (string, error) {
 			return "", secret.ErrNotFound
 		}
 		if stderrStr == "" {
-			return "", errz.Wrapf(err, "op read %s", path)
+			return "", errz.Wrapf(err, "op read %s", uri)
 		}
-		return "", errz.Wrapf(err, "op read %s: %s", path, stderrStr)
+		return "", errz.Wrapf(err, "op read %s: %s", uri, stderrStr)
 	}
 
 	out := stdout.String()

--- a/libsq/core/secret/op/op.go
+++ b/libsq/core/secret/op/op.go
@@ -48,6 +48,11 @@ func NewResolver() *Resolver {
 // Successful values are cached per-instance. A single trailing LF or CRLF
 // is trimmed from the output, matching 1Password CLI behavior and the
 // secret/file resolver convention.
+//
+// Concurrent callers for the same path share one in-flight "op read"
+// invocation; a transient failure (network blip, op timeout) is replayed
+// to every waiter in that flight, but is not cached, so a sequential
+// retry reaches op again.
 func (r *Resolver) Resolve(ctx context.Context, path string) (string, error) {
 	if v, ok := r.cache.Load(path); ok {
 		return v.(string), nil

--- a/libsq/core/secret/op/op_test.go
+++ b/libsq/core/secret/op/op_test.go
@@ -32,7 +32,7 @@ import (
 //	notfound  -> writes "isn't an item" to stderr, exit 1
 //	stderr    -> writes $SQ_TEST_OP_STDERR verbatim to stderr, exit 1
 //	unauthed  -> writes a 1Password sign-in message to stderr, exit 1
-//	hang      -> sleeps 60s (used for cancellation tests)
+//	hang      -> touches $SQ_TEST_OP_STARTED_FILE (if set) then sleeps 60s
 //	count     -> appends "x" to $SQ_TEST_OP_COUNT_FILE then prints $SQ_TEST_OP_VALUE with "\n", exit 0
 func installStubOp(t *testing.T) {
 	t.Helper()
@@ -44,7 +44,7 @@ case "$SQ_TEST_OP_MODE" in
   notfound) echo "[ERROR] \"$2\" isn't an item. Specify the item by its name or ID." >&2; exit 1 ;;
   stderr)   printf '%s\n' "$SQ_TEST_OP_STDERR" >&2; exit 1 ;;
   unauthed) echo "[ERROR] you aren't signed in. Run 'op signin' to sign in." >&2; exit 1 ;;
-  hang)     sleep 60 ;;
+  hang)     if [ -n "$SQ_TEST_OP_STARTED_FILE" ]; then : >"$SQ_TEST_OP_STARTED_FILE"; fi; sleep 60 ;;
   count)    printf 'x' >>"$SQ_TEST_OP_COUNT_FILE"; printf '%s\n' "$SQ_TEST_OP_VALUE" ;;
   *)        echo "stub op: unknown mode '$SQ_TEST_OP_MODE'" >&2; exit 2 ;;
 esac
@@ -240,6 +240,9 @@ func TestResolver_PerCallerCtxCancel(t *testing.T) {
 	installStubOp(t)
 	t.Setenv("SQ_TEST_OP_MODE", "hang")
 
+	startedFile := filepath.Join(t.TempDir(), "started")
+	t.Setenv("SQ_TEST_OP_STARTED_FILE", startedFile)
+
 	r := op.NewResolver()
 	// First call uses the test-scoped context and is intentionally not
 	// awaited; it pins the in-flight "op read" inside the singleflight
@@ -250,8 +253,12 @@ func TestResolver_PerCallerCtxCancel(t *testing.T) {
 		_, _ = r.Resolve(leaderCtx, "//v/i/f")
 	}()
 
-	// Give the leader time to enter singleflight.
-	time.Sleep(50 * time.Millisecond)
+	// Wait deterministically for the leader to enter singleflight: the
+	// stub touches startedFile right before sleeping.
+	require.Eventually(t, func() bool {
+		_, err := os.Stat(startedFile)
+		return err == nil
+	}, 5*time.Second, 10*time.Millisecond, "leader op stub never started")
 
 	// Second caller has a tight deadline; it must abort on its own ctx
 	// without waiting for the leader's hang to complete.

--- a/libsq/core/secret/op/op_test.go
+++ b/libsq/core/secret/op/op_test.go
@@ -233,6 +233,41 @@ func TestResolver_ContextCancellation(t *testing.T) {
 		"error should chain to a context sentinel; got %v", err)
 }
 
+// TestResolver_PerCallerCtxCancel verifies that a caller waiting on a
+// coalesced singleflight can bail when its own context expires, even
+// when the shared "op read" is still hanging.
+func TestResolver_PerCallerCtxCancel(t *testing.T) {
+	installStubOp(t)
+	t.Setenv("SQ_TEST_OP_MODE", "hang")
+
+	r := op.NewResolver()
+	// First call uses the test-scoped context and is intentionally not
+	// awaited; it pins the in-flight "op read" inside the singleflight
+	// closure so the second caller is forced to wait. t.Context() is
+	// cancelled at test cleanup, which kills the hanging op process.
+	leaderCtx := t.Context()
+	go func() {
+		_, _ = r.Resolve(leaderCtx, "//v/i/f")
+	}()
+
+	// Give the leader time to enter singleflight.
+	time.Sleep(50 * time.Millisecond)
+
+	// Second caller has a tight deadline; it must abort on its own ctx
+	// without waiting for the leader's hang to complete.
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	start := time.Now()
+	_, err := r.Resolve(ctx, "//v/i/f")
+	elapsed := time.Since(start)
+	require.Error(t, err)
+	require.Less(t, elapsed, time.Second,
+		"follower must bail on its own ctx, not wait for leader")
+	require.True(t,
+		errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled),
+		"follower error should chain to a context sentinel; got %v", err)
+}
+
 func TestResolver_OpBinaryMissing(t *testing.T) {
 	// Point PATH at an empty directory so "op" is not found anywhere.
 	t.Setenv("PATH", t.TempDir())

--- a/libsq/core/secret/op/op_test.go
+++ b/libsq/core/secret/op/op_test.go
@@ -16,7 +16,7 @@ import (
 // behavior is selected by the SQ_TEST_OP_MODE env var (set by each test via
 // t.Setenv):
 //
-//	value    -> prints $SQ_TEST_OP_VALUE then "\n", exit 0
+//	value    -> prints $SQ_TEST_OP_VALUE exactly (no added newline), exit 0
 //	echo     -> prints argv[2] then "\n", exit 0 (used to assert pass-through)
 //	notfound -> writes a 1Password "not an item" message to stderr, exit 1
 //	unauthed -> writes a 1Password sign-in message to stderr, exit 1
@@ -27,7 +27,7 @@ func installStubOp(t *testing.T) {
 	dir := t.TempDir()
 	script := `#!/bin/sh
 case "$SQ_TEST_OP_MODE" in
-  value)    printf '%s\n' "$SQ_TEST_OP_VALUE" ;;
+  value)    printf '%s' "$SQ_TEST_OP_VALUE" ;;
   echo)     printf '%s\n' "$2" ;;
   notfound) echo "[ERROR] \"$2\" isn't an item. Specify the item by its name or ID." >&2; exit 1 ;;
   unauthed) echo "[ERROR] you aren't signed in. Run 'op signin' to sign in." >&2; exit 1 ;;
@@ -62,4 +62,27 @@ func TestResolver_PassesThroughURI(t *testing.T) {
 	// the path (which already begins with "//"). A naive "op://"+path
 	// would yield op:////Private/...; this asserts the bug is absent.
 	require.Equal(t, "op://Private/sakila/dsn", got)
+}
+
+func TestResolver_TrimsTrailingNewline(t *testing.T) {
+	cases := []struct {
+		name, value, want string
+	}{
+		{"lf", "hunter2\n", "hunter2"},
+		{"crlf", "hunter2\r\n", "hunter2"},
+		{"no_trailing", "hunter2", "hunter2"},
+		{"double_lf", "hunter2\n\n", "hunter2\n"}, // only one trim
+		{"embedded_lf", "line1\nline2\n", "line1\nline2"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			installStubOp(t)
+			t.Setenv("SQ_TEST_OP_MODE", "value")
+			t.Setenv("SQ_TEST_OP_VALUE", tc.value)
+
+			got, err := op.NewResolver().Resolve(context.Background(), "//v/i/f")
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got)
+		})
+	}
 }

--- a/libsq/core/secret/op/op_test.go
+++ b/libsq/core/secret/op/op_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -95,6 +96,22 @@ func TestResolver_TrimsTrailingNewline(t *testing.T) {
 			require.Equal(t, tc.want, got)
 		})
 	}
+}
+
+func TestResolver_ContextCancellation(t *testing.T) {
+	installStubOp(t)
+	t.Setenv("SQ_TEST_OP_MODE", "hang")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	_, err := op.NewResolver().Resolve(ctx, "//v/i/f")
+	elapsed := time.Since(start)
+
+	require.Error(t, err)
+	require.Less(t, elapsed, 2*time.Second,
+		"cancellation should kill the op process promptly")
 }
 
 func TestResolver_OpBinaryMissing(t *testing.T) {

--- a/libsq/core/secret/op/op_test.go
+++ b/libsq/core/secret/op/op_test.go
@@ -1,7 +1,15 @@
+// The tests in this file install a POSIX shell stub on PATH to drive the
+// op resolver without a live 1Password binary. The stub is a "#!/bin/sh"
+// script and is therefore not executable on Windows (PATHEXT does not
+// match "op", and Windows cannot exec a shebang). The op resolver itself
+// is platform-independent; only this test harness is Unix-only.
+//go:build !windows
+
 package op_test
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -19,12 +27,13 @@ import (
 // behavior is selected by the SQ_TEST_OP_MODE env var (set by each test via
 // t.Setenv):
 //
-//	value    -> prints $SQ_TEST_OP_VALUE exactly (no added newline), exit 0
-//	echo     -> prints argv[2] then "\n", exit 0 (used to assert pass-through)
-//	notfound -> writes a 1Password "not an item" message to stderr, exit 1
-//	unauthed -> writes a 1Password sign-in message to stderr, exit 1
-//	hang     -> sleeps 60s (used for cancellation tests)
-//	count    -> appends "x" to $SQ_TEST_OP_COUNT_FILE then prints value
+//	value     -> prints $SQ_TEST_OP_VALUE exactly (no added newline), exit 0
+//	echo      -> prints argv[2] then "\n", exit 0 (used to assert pass-through)
+//	notfound  -> writes "isn't an item" to stderr, exit 1
+//	stderr    -> writes $SQ_TEST_OP_STDERR verbatim to stderr, exit 1
+//	unauthed  -> writes a 1Password sign-in message to stderr, exit 1
+//	hang      -> sleeps 60s (used for cancellation tests)
+//	count     -> appends "x" to $SQ_TEST_OP_COUNT_FILE then prints $SQ_TEST_OP_VALUE with "\n", exit 0
 func installStubOp(t *testing.T) {
 	t.Helper()
 	dir := t.TempDir()
@@ -33,6 +42,7 @@ case "$SQ_TEST_OP_MODE" in
   value)    printf '%s' "$SQ_TEST_OP_VALUE" ;;
   echo)     printf '%s\n' "$2" ;;
   notfound) echo "[ERROR] \"$2\" isn't an item. Specify the item by its name or ID." >&2; exit 1 ;;
+  stderr)   printf '%s\n' "$SQ_TEST_OP_STDERR" >&2; exit 1 ;;
   unauthed) echo "[ERROR] you aren't signed in. Run 'op signin' to sign in." >&2; exit 1 ;;
   hang)     sleep 60 ;;
   count)    printf 'x' >>"$SQ_TEST_OP_COUNT_FILE"; printf '%s\n' "$SQ_TEST_OP_VALUE" ;;
@@ -60,10 +70,11 @@ func TestResolver_PassesThroughURI(t *testing.T) {
 
 	got, err := op.NewResolver().Resolve(context.Background(), "//Private/sakila/dsn")
 	require.NoError(t, err)
-	// The stub echoes argv[2], which is the second positional arg to
-	// "op read". The resolver must reconstitute the full op:// URI from
-	// the path (which already begins with "//"). A naive "op://"+path
-	// would yield op:////Private/...; this asserts the bug is absent.
+	// The stub echoes shell $2, which is the single argument to the
+	// "read" subcommand. The resolver must reconstitute the full op://
+	// URI from the path (which already begins with "//"). A naive
+	// "op://"+path would yield op:////Private/...; this asserts the
+	// bug is absent.
 	require.Equal(t, "op://Private/sakila/dsn", got)
 }
 
@@ -75,6 +86,48 @@ func TestResolver_NotFound(t *testing.T) {
 	require.ErrorIs(t, err, secret.ErrNotFound)
 }
 
+// TestResolver_NotFoundMarkers drives every entry of the resolver's
+// notFoundMarkers list against the classifier, plus a confounding
+// auth-style message that must NOT classify as not-found.
+func TestResolver_NotFoundMarkers(t *testing.T) {
+	cases := []struct {
+		name, stderr string
+		wantNotFound bool
+	}{
+		{"isn't_an_item", "[ERROR] \"op://v/i/f\" isn't an item.", true},
+		{"item_not_found", "ERROR: item not found", true},
+		{"no_item_found", "ERROR: no item found with that name", true},
+		{"couldnt_find_the_item", "[ERROR] couldn't find the item", true},
+		{"couldnt_find_an_item", "[ERROR] couldn't find an item matching that query", true},
+		{"mixed_case", "ERROR: ISN'T AN ITEM matches the lowercase marker", true},
+
+		// Negative: an auth-style "Couldn't find your account" must not
+		// be misclassified as ErrNotFound. This guards against the
+		// previous over-broad "couldn't find" marker regressing.
+		{"couldnt_find_account", "[ERROR] Couldn't find your account. Run 'op signin'.", false},
+		{"network", "[ERROR] connection refused dialing https://my.1password.com", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			installStubOp(t)
+			t.Setenv("SQ_TEST_OP_MODE", "stderr")
+			t.Setenv("SQ_TEST_OP_STDERR", tc.stderr)
+
+			_, err := op.NewResolver().Resolve(context.Background(), "//v/i/f")
+			require.Error(t, err)
+			if tc.wantNotFound {
+				require.ErrorIs(t, err, secret.ErrNotFound,
+					"stderr %q must classify as ErrNotFound", tc.stderr)
+			} else {
+				require.NotErrorIs(t, err, secret.ErrNotFound,
+					"stderr %q must NOT classify as ErrNotFound", tc.stderr)
+				require.Contains(t, err.Error(), strings.TrimSpace(tc.stderr),
+					"stderr must be surfaced verbatim in the error message")
+			}
+		})
+	}
+}
+
 func TestResolver_TrimsTrailingNewline(t *testing.T) {
 	cases := []struct {
 		name, value, want string
@@ -84,6 +137,7 @@ func TestResolver_TrimsTrailingNewline(t *testing.T) {
 		{"no_trailing", "hunter2", "hunter2"},
 		{"double_lf", "hunter2\n\n", "hunter2\n"}, // only one trim
 		{"embedded_lf", "line1\nline2\n", "line1\nline2"},
+		{"bare_cr", "hunter2\r", "hunter2\r"}, // bare CR is preserved
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -137,6 +191,27 @@ func TestResolver_CacheIsKeyedByPath(t *testing.T) {
 		"distinct paths must each invoke op")
 }
 
+// TestResolver_ErrorsAreNotCached pins the contract that failed
+// resolutions do not poison the cache: a subsequent retry must reach op
+// again rather than replaying the prior error.
+func TestResolver_ErrorsAreNotCached(t *testing.T) {
+	installStubOp(t)
+	t.Setenv("SQ_TEST_OP_MODE", "notfound")
+
+	r := op.NewResolver()
+	_, err := r.Resolve(context.Background(), "//v/i/f")
+	require.ErrorIs(t, err, secret.ErrNotFound)
+
+	// Switch the stub to success. If errors were cached, this call
+	// would return the prior ErrNotFound without re-invoking op.
+	t.Setenv("SQ_TEST_OP_MODE", "value")
+	t.Setenv("SQ_TEST_OP_VALUE", "hunter2")
+
+	got, err := r.Resolve(context.Background(), "//v/i/f")
+	require.NoError(t, err)
+	require.Equal(t, "hunter2", got)
+}
+
 func TestResolver_ContextCancellation(t *testing.T) {
 	installStubOp(t)
 	t.Setenv("SQ_TEST_OP_MODE", "hang")
@@ -151,6 +226,11 @@ func TestResolver_ContextCancellation(t *testing.T) {
 	require.Error(t, err)
 	require.Less(t, elapsed, 2*time.Second,
 		"cancellation should kill the op process promptly")
+	require.NotErrorIs(t, err, secret.ErrNotFound,
+		"cancellation must not be misclassified as not-found")
+	require.True(t,
+		errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled),
+		"error should chain to a context sentinel; got %v", err)
 }
 
 func TestResolver_OpBinaryMissing(t *testing.T) {

--- a/libsq/core/secret/op/op_test.go
+++ b/libsq/core/secret/op/op_test.go
@@ -98,6 +98,45 @@ func TestResolver_TrimsTrailingNewline(t *testing.T) {
 	}
 }
 
+func TestResolver_CachesAcrossCalls(t *testing.T) {
+	installStubOp(t)
+	countFile := filepath.Join(t.TempDir(), "calls")
+	t.Setenv("SQ_TEST_OP_MODE", "count")
+	t.Setenv("SQ_TEST_OP_COUNT_FILE", countFile)
+	t.Setenv("SQ_TEST_OP_VALUE", "hunter2")
+
+	r := op.NewResolver()
+	for range 3 {
+		got, err := r.Resolve(context.Background(), "//v/i/f")
+		require.NoError(t, err)
+		require.Equal(t, "hunter2", got)
+	}
+
+	data, err := os.ReadFile(countFile)
+	require.NoError(t, err)
+	require.Equal(t, "x", string(data),
+		"three Resolve calls for the same path must invoke op exactly once")
+}
+
+func TestResolver_CacheIsKeyedByPath(t *testing.T) {
+	installStubOp(t)
+	countFile := filepath.Join(t.TempDir(), "calls")
+	t.Setenv("SQ_TEST_OP_MODE", "count")
+	t.Setenv("SQ_TEST_OP_COUNT_FILE", countFile)
+	t.Setenv("SQ_TEST_OP_VALUE", "hunter2")
+
+	r := op.NewResolver()
+	_, err := r.Resolve(context.Background(), "//v/i1/f")
+	require.NoError(t, err)
+	_, err = r.Resolve(context.Background(), "//v/i2/f")
+	require.NoError(t, err)
+
+	data, err := os.ReadFile(countFile)
+	require.NoError(t, err)
+	require.Equal(t, "xx", string(data),
+		"distinct paths must each invoke op")
+}
+
 func TestResolver_ContextCancellation(t *testing.T) {
 	installStubOp(t)
 	t.Setenv("SQ_TEST_OP_MODE", "hang")

--- a/libsq/core/secret/op/op_test.go
+++ b/libsq/core/secret/op/op_test.go
@@ -95,3 +95,15 @@ func TestResolver_TrimsTrailingNewline(t *testing.T) {
 		})
 	}
 }
+
+func TestResolver_UnauthedSurfacesStderr(t *testing.T) {
+	installStubOp(t)
+	t.Setenv("SQ_TEST_OP_MODE", "unauthed")
+
+	_, err := op.NewResolver().Resolve(context.Background(), "//Private/sakila/dsn")
+	require.Error(t, err)
+	require.NotErrorIs(t, err, secret.ErrNotFound,
+		"sign-in failures must not be misclassified as not-found")
+	require.Contains(t, err.Error(), "you aren't signed in",
+		"the op CLI stderr must be surfaced so the user knows what to do")
+}

--- a/libsq/core/secret/op/op_test.go
+++ b/libsq/core/secret/op/op_test.go
@@ -50,3 +50,16 @@ func TestResolver_HappyPath(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "hunter2", got)
 }
+
+func TestResolver_PassesThroughURI(t *testing.T) {
+	installStubOp(t)
+	t.Setenv("SQ_TEST_OP_MODE", "echo")
+
+	got, err := op.NewResolver().Resolve(context.Background(), "//Private/sakila/dsn")
+	require.NoError(t, err)
+	// The stub echoes argv[2], which is the second positional arg to
+	// "op read". The resolver must reconstitute the full op:// URI from
+	// the path (which already begins with "//"). A naive "op://"+path
+	// would yield op:////Private/...; this asserts the bug is absent.
+	require.Equal(t, "op://Private/sakila/dsn", got)
+}

--- a/libsq/core/secret/op/op_test.go
+++ b/libsq/core/secret/op/op_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -94,6 +95,20 @@ func TestResolver_TrimsTrailingNewline(t *testing.T) {
 			require.Equal(t, tc.want, got)
 		})
 	}
+}
+
+func TestResolver_OpBinaryMissing(t *testing.T) {
+	// Point PATH at an empty directory so "op" is not found anywhere.
+	t.Setenv("PATH", t.TempDir())
+
+	_, err := op.NewResolver().Resolve(context.Background(), "//v/i/f")
+	require.Error(t, err)
+	require.NotErrorIs(t, err, secret.ErrNotFound)
+	msg := err.Error()
+	require.Contains(t, msg, "op",
+		"error must mention the missing binary by name")
+	require.Contains(t, strings.ToLower(msg), "1password",
+		"error hint should point the user at 1Password")
 }
 
 func TestResolver_UnauthedSurfacesStderr(t *testing.T) {

--- a/libsq/core/secret/op/op_test.go
+++ b/libsq/core/secret/op/op_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/neilotoole/sq/libsq/core/secret"
 	"github.com/neilotoole/sq/libsq/core/secret/op"
 )
 
@@ -62,6 +63,14 @@ func TestResolver_PassesThroughURI(t *testing.T) {
 	// the path (which already begins with "//"). A naive "op://"+path
 	// would yield op:////Private/...; this asserts the bug is absent.
 	require.Equal(t, "op://Private/sakila/dsn", got)
+}
+
+func TestResolver_NotFound(t *testing.T) {
+	installStubOp(t)
+	t.Setenv("SQ_TEST_OP_MODE", "notfound")
+
+	_, err := op.NewResolver().Resolve(context.Background(), "//Private/nope/field")
+	require.ErrorIs(t, err, secret.ErrNotFound)
 }
 
 func TestResolver_TrimsTrailingNewline(t *testing.T) {

--- a/libsq/core/secret/op/op_test.go
+++ b/libsq/core/secret/op/op_test.go
@@ -1,0 +1,52 @@
+package op_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/neilotoole/sq/libsq/core/secret/op"
+)
+
+// installStubOp writes a POSIX-shell stub binary named "op" into a fresh
+// t.TempDir and prepends that dir to PATH for the duration of t. The stub's
+// behavior is selected by the SQ_TEST_OP_MODE env var (set by each test via
+// t.Setenv):
+//
+//	value    -> prints $SQ_TEST_OP_VALUE then "\n", exit 0
+//	echo     -> prints argv[2] then "\n", exit 0 (used to assert pass-through)
+//	notfound -> writes a 1Password "not an item" message to stderr, exit 1
+//	unauthed -> writes a 1Password sign-in message to stderr, exit 1
+//	hang     -> sleeps 60s (used for cancellation tests)
+//	count    -> appends "x" to $SQ_TEST_OP_COUNT_FILE then prints value
+func installStubOp(t *testing.T) {
+	t.Helper()
+	dir := t.TempDir()
+	script := `#!/bin/sh
+case "$SQ_TEST_OP_MODE" in
+  value)    printf '%s\n' "$SQ_TEST_OP_VALUE" ;;
+  echo)     printf '%s\n' "$2" ;;
+  notfound) echo "[ERROR] \"$2\" isn't an item. Specify the item by its name or ID." >&2; exit 1 ;;
+  unauthed) echo "[ERROR] you aren't signed in. Run 'op signin' to sign in." >&2; exit 1 ;;
+  hang)     sleep 60 ;;
+  count)    printf 'x' >>"$SQ_TEST_OP_COUNT_FILE"; printf '%s\n' "$SQ_TEST_OP_VALUE" ;;
+  *)        echo "stub op: unknown mode '$SQ_TEST_OP_MODE'" >&2; exit 2 ;;
+esac
+`
+	path := filepath.Join(dir, "op")
+	require.NoError(t, os.WriteFile(path, []byte(script), 0o755))
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+}
+
+func TestResolver_HappyPath(t *testing.T) {
+	installStubOp(t)
+	t.Setenv("SQ_TEST_OP_MODE", "value")
+	t.Setenv("SQ_TEST_OP_VALUE", "hunter2")
+
+	got, err := op.NewResolver().Resolve(context.Background(), "//Private/sakila/password")
+	require.NoError(t, err)
+	require.Equal(t, "hunter2", got)
+}

--- a/site/content/en/docs/secrets/index.md
+++ b/site/content/en/docs/secrets/index.md
@@ -331,6 +331,26 @@ Notes:
 - "Item not found" surfaces as the standard `secret not found` message;
   other failures (not signed in, network) surface `op`'s own stderr.
 
+#### `sq add` shortcuts for `op://`
+
+[`sq add`](/docs/cmd/add) accepts the bare `op://<vault>/<item>/<field>` form
+that 1Password's "Copy Secret Reference" puts on the clipboard, as sugar for
+the full `${op://...}` placeholder:
+
+```shell
+# Both forms are equivalent; the bare form is stored as ${op://...} in sq.yml.
+$ sq add 'op://Private/sakila/dsn'
+$ sq add '${op://Private/sakila/dsn}'
+```
+
+If the resolved value is a bare credential rather than a full DSN (1Password's
+default field is named `password`, so people commonly drop a DSN into it
+verbatim), `sq add` returns a hint pointing at the three options:
+
+1. Store a full DSN at that field, e.g. `postgres://alice:hunter2@db/sakila`.
+2. Use composition: `sq add 'postgres://alice:${op://Private/sakila/password}@db/sakila'`.
+3. Pass `--driver <type>` to skip driver inference entirely.
+
 ### Choosing a scheme
 
 | Environment            | Recommended scheme           | Why                                                                               |

--- a/site/content/en/docs/secrets/index.md
+++ b/site/content/en/docs/secrets/index.md
@@ -25,9 +25,9 @@ By default:
   preserved and inline plaintext is dumped as-is. Treat the exported
   file the same as `sq.yml` itself (mode `0600` by default).
 - Source locations may contain **`${scheme:path}` placeholders** that fetch
-  the real value at connect time from an external resolver. Three schemes
-  ship in the box: [`keyring`](#keyring-scheme), [`env`](#env-scheme), and
-  [`file`](#file-scheme).
+  the real value at connect time from an external resolver. Four schemes
+  ship in the box: [`keyring`](#keyring-scheme), [`env`](#env-scheme),
+  [`file`](#file-scheme), and [`op`](#op-scheme).
 - [`sq config export`](/docs/cmd/config-export) writes placeholders to the
   output **verbatim** — what the YAML says is what the export contains.
 
@@ -177,7 +177,7 @@ location: ${keyring:j2k7m3pxtz}
 location: postgres://alice:${env:DB_PW}@db.acme.com/sakila
 ```
 
-`sq` ships with three schemes: `keyring`, `env`, and `file`.
+`sq` ships with four schemes: `keyring`, `env`, `file`, and `op`.
 
 ### URL encoding
 

--- a/site/content/en/docs/secrets/index.md
+++ b/site/content/en/docs/secrets/index.md
@@ -451,9 +451,10 @@ is not a sandbox. The threats it does — and does not — address:
   exists in `sq`'s process memory.
 
 For the higher bar (per-application secrets, hardware-backed keys, rotated
-short-lived credentials), an external secret manager — referenced via the
-`env` or `file` scheme from CI / container runtime — is the right answer.
-The `keyring` scheme targets the dev-laptop case.
+short-lived credentials), an external secret manager is the right answer:
+referenced via the `env` or `file` scheme from a CI / container runtime,
+or via the `op` scheme on a dev laptop with 1Password. The `keyring` scheme
+targets the dev-laptop case when no external manager is in use.
 
 ## Related
 

--- a/site/content/en/docs/secrets/index.md
+++ b/site/content/en/docs/secrets/index.md
@@ -256,6 +256,37 @@ Relative paths and remote `file://host/path` forms are rejected.
 
 `file` is read-only: `sq` consults the file but never writes to it.
 
+### `op` scheme
+
+`${op://<vault>/<item>/[<section>/]<field>}` reads a value from 1Password
+via the [`op` CLI](https://developer.1password.com/docs/cli/) using
+1Password's
+[secret-reference syntax](https://developer.1password.com/docs/cli/secret-reference-syntax/)
+verbatim. The user must already be signed in: biometric, `op signin`, or a
+service-account token in `OP_SERVICE_ACCOUNT_TOKEN`.
+
+```yaml
+- handle: '@sakila'
+  driver: postgres
+  location: ${op://Private/sakila/dsn}                       # whole DSN
+- handle: '@sakila/composed'
+  driver: postgres
+  location: postgres://alice:${op://Private/sakila/password}@db/sakila
+```
+
+Notes:
+
+- Requires `op` v2 or newer on `PATH`.
+- The URI body is passed to `op read` verbatim; `sq` does not parse vault,
+  item, section, or field names.
+- Within one `sq` invocation, the same `${op://...}` placeholder is
+  resolved at most once (per-process cache), so biometric prompts and
+  network round-trips do not multiply.
+- `op` is read-only: `--store op` is not a thing. To put a secret into
+  1Password, use the `op` CLI directly.
+- "Item not found" surfaces as the standard `secret not found` message;
+  other failures (not signed in, network) surface `op`'s own stderr.
+
 ### Choosing a scheme
 
 | Environment            | Recommended scheme           | Why                                                                               |
@@ -263,6 +294,7 @@ Relative paths and remote `file://host/path` forms are rejected.
 | Dev laptop             | [`keyring`](#keyring-scheme) | Plaintext never lives on disk; OS handles the storage and prompting.              |
 | CI runner              | [`env`](#env-scheme)         | CI systems already inject secrets as environment variables.                       |
 | Container / Kubernetes | [`file`](#file-scheme)       | Secrets are typically mounted into the container as files (e.g. `/run/secrets/`). |
+| Shared / team secrets  | [`op`](#op-scheme)           | 1Password is the team source of truth; `sq` reads it via the `op` CLI.            |
 
 The schemes are not mutually exclusive: an `sq.yml` may use `keyring` for one
 source, `env` for another, and inline plaintext for a third.
@@ -270,8 +302,8 @@ source, `env` for another, and inline plaintext for a third.
 ## Managing keyring entries
 
 The [`sq config keyring`](/docs/cmd/config-keyring) command group covers the
-keyring scheme end to end. The other two schemes (`env`, `file`) are
-external — `sq` reads them at connect time and has nothing to manage.
+keyring scheme end to end. The other three schemes (`env`, `file`, `op`) are
+external: `sq` reads them at connect time and has nothing to manage.
 
 | Command                                                                           | What it does                                                                  |
 |-----------------------------------------------------------------------------------|-------------------------------------------------------------------------------|


### PR DESCRIPTION
## Summary

- Adds an `op://` resolver scheme to `libsq/core/secret`, shelling out to the
  1Password `op` CLI (v2+). The placeholder body is passed verbatim to
  `op read` per 1Password's secret-reference syntax.
- Registers the resolver alongside `keyring`, `env`, `file` in `cli/run.go`.
- Per-instance cache keyed by the placeholder path so a single `sq` command
  triggers at most one `op read` per path (avoids repeat biometric prompts).
- Maps "item not found" stderr to `secret.ErrNotFound`. Other failures
  surface `op`'s stderr verbatim. Friendly install hint when `op` is not on
  PATH.

Closes #714.

## Test plan

- [x] `make lint` clean
- [x] `make test` clean (Oracle integration test flaked once and passed on rerun; unrelated to this change)
- [x] `make lint-markdown` and `bun run lint:markdown` (site) clean
- [x] `go test -race ./libsq/core/secret/op/...` clean
- [ ] Manual: `sq add '\${op://Private/<item>/dsn}'` while signed in
- [ ] Manual: `sq add '\${op://...}' --driver postgres` while signed out
- [ ] Manual: `op` not installed → friendly install-hint error, no panic