### PR TITLE
cli: globalize --expand for source-displaying commands (#729)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,17 +75,23 @@ Breaking changes are annotated with ☢️, and alpha/beta features with 🐥.
   now syntax-colors its `erDiagram` source when writing to a terminal.
 - [#729]: [`--expand`](https://sq.io/docs/secrets#substitution) is now a persistent
   root flag, accepted by every subcommand. Previously it lived only on `sq config export`.
-  - Display commands ([`sq src`](https://sq.io/docs/cmd/src), [`sq ls`](https://sq.io/docs/cmd/ls),
-    [`sq inspect`](https://sq.io/docs/inspect), `sq add`, `sq mv`, `sq ping -v`) now pass
-    `${scheme:path}` placeholders through the configured resolvers and print the resolved value.
-    `--expand` composes orthogonally with `--reveal`: `--reveal` flips the redaction filter on
-    whatever string is being displayed; `--expand` decides whether that string is the verbatim
-    placeholder or the resolved value.
-  - On display commands, per-source resolver failure (missing keyring entry, unset env var,
-    unreadable file) is lenient: the placeholder is preserved verbatim for that source, the
-    other sources expand normally, and the command exits 0. `sq config export --expand`
-    keeps its existing strict-abort behavior because an export is a snapshot for transfer,
-    and a half-resolved snapshot is the wrong artifact.
+  - Commands that print a source location ([`sq src`](https://sq.io/docs/cmd/src),
+    [`sq ls`](https://sq.io/docs/cmd/ls), [`sq inspect`](https://sq.io/docs/inspect),
+    `sq add`, `sq mv`, and `sq ping` in JSON/YAML output) now pass `${scheme:path}`
+    placeholders through the configured resolvers and print the resolved value.
+    `sq ping`'s text and CSV output do not include a Location column, so `--expand`
+    has no visible effect there. `--expand` composes orthogonally with `--reveal`:
+    `--reveal` flips the redaction filter on whatever string is being displayed;
+    `--expand` decides whether that string is the verbatim placeholder or the
+    resolved value.
+  - The display-expansion step itself is lenient: a per-source resolver failure
+    (missing keyring entry, unset env var, unreadable file) leaves that source's
+    placeholder verbatim and the listing continues. This is independent of
+    connection-time resolution; commands that have to connect (e.g.
+    [`sq inspect`](https://sq.io/docs/inspect), `sq ping`) will still fail at
+    connect time if a missing secret prevents the connection. `sq config export --expand`
+    keeps its existing strict-abort behavior because an export is a snapshot for
+    transfer, and a half-resolved snapshot is the wrong artifact.
   - Subcommands that don't print a source location (e.g. [`sq sql`](https://sq.io/docs/cmd/sql),
     `sq slq`, `sq tbl`) accept `--expand` as a silent no-op, so a global alias like
     `alias sq='sq --reveal --expand'` is safe.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,22 @@ Breaking changes are annotated with ☢️, and alpha/beta features with 🐥.
     a flag.
 - [#692]: [`sq inspect -f mermaid-erd`](https://sq.io/docs/inspect#mermaid-erd)
   now syntax-colors its `erDiagram` source when writing to a terminal.
+- [#729]: [`--expand`](https://sq.io/docs/secrets#substitution) is now a persistent
+  root flag, accepted by every subcommand. Previously it lived only on `sq config export`.
+  - Display commands ([`sq src`](https://sq.io/docs/cmd/src), [`sq ls`](https://sq.io/docs/cmd/ls),
+    [`sq inspect`](https://sq.io/docs/inspect), `sq add`, `sq mv`, `sq ping -v`) now pass
+    `${scheme:path}` placeholders through the configured resolvers and print the resolved value.
+    `--expand` composes orthogonally with `--reveal`: `--reveal` flips the redaction filter on
+    whatever string is being displayed; `--expand` decides whether that string is the verbatim
+    placeholder or the resolved value.
+  - On display commands, per-source resolver failure (missing keyring entry, unset env var,
+    unreadable file) is lenient: the placeholder is preserved verbatim for that source, the
+    other sources expand normally, and the command exits 0. `sq config export --expand`
+    keeps its existing strict-abort behavior because an export is a snapshot for transfer,
+    and a half-resolved snapshot is the wrong artifact.
+  - Subcommands that don't print a source location (e.g. [`sq sql`](https://sq.io/docs/cmd/sql),
+    `sq slq`, `sq tbl`) accept `--expand` as a silent no-op, so a global alias like
+    `alias sq='sq --reveal --expand'` is safe.
 
 ### Fixed
 
@@ -81,6 +97,11 @@ Breaking changes are annotated with ☢️, and alpha/beta features with 🐥.
   - Previously failed on [`sq inspect @handle`](https://sq.io/docs/inspect) etc.
     when the source location carried a `?key=val[&...]` connection-string suffix (e.g.
     `sqlite3:///path/to/db?mode=ro`).
+- [#729]: `sq inspect` no longer leaks the resolved target of a `${scheme:path}` placeholder
+  into its metadata output. The driver layer resolves placeholders to open the connection,
+  and the resolved value was being copied verbatim into `metadata.Source.Location`; the
+  inspect handler now overrides that field with the caller's view of `src.Location`, which
+  is the placeholder by default and the resolved value only when `--expand` is set.
 
 ## [v0.53.0] - 2026-05-25
 
@@ -1655,6 +1676,7 @@ make working with lots of sources much easier.
 [#716]: https://github.com/neilotoole/sq/issues/716
 [#717]: https://github.com/neilotoole/sq/issues/717
 [#720]: https://github.com/neilotoole/sq/issues/720
+[#729]: https://github.com/neilotoole/sq/issues/729
 
 [v0.15.2]: https://github.com/neilotoole/sq/releases/tag/v0.15.2
 [v0.15.3]: https://github.com/neilotoole/sq/compare/v0.15.2...v0.15.3

--- a/cli/cmd_add.go
+++ b/cli/cmd_add.go
@@ -390,6 +390,10 @@ func execSrcAdd(cmd *cobra.Command, args []string) (err error) {
 		return err
 	}
 
+	if src, err = maybeExpandSource(ctx, ru, cmd, src); err != nil {
+		return err
+	}
+
 	return ru.Writers.Source.Added(ru.Config.Collection, src)
 }
 

--- a/cli/cmd_config_export.go
+++ b/cli/cmd_config_export.go
@@ -17,8 +17,6 @@ import (
 	"github.com/neilotoole/sq/libsq/core/lg"
 )
 
-const flagConfigExportExpand = "expand"
-
 func newConfigExportCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "export",
@@ -53,8 +51,6 @@ may contain credentials regardless of whether --expand was set.`,
   $ sq config export --expand -o sq.bak.yml`,
 	}
 
-	cmd.Flags().Bool(flagConfigExportExpand, false,
-		"Fetch ${scheme:path} placeholders from keyring/env/file and inline the resolved values")
 	cmd.Flags().StringP(flag.FileOutput, flag.FileOutputShort, "", flag.FileOutputUsage)
 	// execConfigExport handles --output itself to enforce mode 0600
 	// on the export file and mode 0700 on any parent dirs it creates,
@@ -71,7 +67,7 @@ func execConfigExport(cmd *cobra.Command, _ []string) error {
 	ctx := cmd.Context()
 	ru := run.FromContext(ctx)
 
-	expand := cmdFlagIsSetTrue(cmd, flagConfigExportExpand)
+	expand := cmdFlagIsSetTrue(cmd, flag.Expand)
 
 	cfg := ru.Config
 	if expand {

--- a/cli/cmd_inspect.go
+++ b/cli/cmd_inspect.go
@@ -186,6 +186,15 @@ func execInspect(cmd *cobra.Command, args []string) error {
 		}
 	}
 
+	// Expand ${scheme:path} placeholders for display when --expand is
+	// set. Grips.Open does its own resolution for the connection, so
+	// passing an expanded Location is a no-op there; the value also
+	// flows into metadata.Location and is shown by the metadata writer.
+	src, err = maybeExpandSource(ctx, ru, cmd, src)
+	if err != nil {
+		return err
+	}
+
 	grip, err := ru.Grips.Open(ctx, src)
 	if err != nil {
 		return errz.Wrapf(err, "failed to inspect %s", src.Handle)

--- a/cli/cmd_inspect.go
+++ b/cli/cmd_inspect.go
@@ -278,6 +278,16 @@ func execInspect(cmd *cobra.Command, args []string) error {
 		return errz.Wrapf(err, "failed to read %s source metadata", src.Handle)
 	}
 
+	// Use the inspect handler's view of src.Location for display.
+	// Drivers populate srcMeta.Location from the grip's stored src,
+	// which doOpen always replaces with the resolver-expanded clone;
+	// without this override, sq inspect would always show the
+	// resolved value, leaking placeholder targets and ignoring the
+	// --expand flag. With this override, srcMeta.Location reflects
+	// the placeholder (default) or the explicitly-expanded value
+	// (when --expand is set).
+	srcMeta.Location = src.Location
+
 	// This is a bit hacky, but it works... if not "--verbose", then just zap
 	// the DBVars, as we usually don't want to see those
 	if !OptVerbose.Get(src.Options) {

--- a/cli/cmd_inspect_test.go
+++ b/cli/cmd_inspect_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/require"
+	gokeyring "github.com/zalando/go-keyring"
 
 	"github.com/neilotoole/sq/cli"
 	"github.com/neilotoole/sq/cli/flag"
@@ -1065,4 +1066,74 @@ func TestCmdInspect_NumericCatalogSchema(t *testing.T) {
 				"table inspect should show correct row count")
 		})
 	}
+}
+
+// TestInspect_LocationOverride_NoLeak is the regression guard for the
+// srcMeta.Location override in cli/cmd_inspect.go. Drivers populate
+// srcMeta.Location from the grip's internally stored src (which doOpen
+// always replaces with the resolver-expanded clone). Without the
+// override at the end of execInspect, sq inspect would always show the
+// resolved value, leaking placeholder targets even when the user did not
+// opt in via --expand. The override ensures the display value reflects
+// the caller's view of src.Location: the placeholder by default, the
+// resolved value only with --expand.
+//
+// A SQLite source is used so the test does not require a network database.
+// The keyring value is a sqlite3 URL pointing to a temp file; SQLite
+// creates the file on first open, so no fixture setup is required beyond
+// creating the path. The distinct path string "/sq_inspect_leak_" in the
+// resolved URL is deliberately chosen to be unlikely to appear in any
+// other output, making the NotContains assertion reliable.
+func TestInspect_LocationOverride_NoLeak(t *testing.T) {
+	// Not parallel: gokeyring.MockInit() mutates a process-global
+	// keyring backend, and parallelizing this with another
+	// MockInit-using test in the future would race.
+
+	// Build a unique temp path for the SQLite file. tu.TempFile does
+	// not create the file itself; SQLite will create it on first open.
+	dbPath := tu.TempFile(t, "sq_inspect_leak.db")
+	resolvedLoc := "sqlite3://" + dbPath
+
+	const keyringID = "inspect_leak_id"
+	placeholder := "${keyring:" + keyringID + "}"
+
+	gokeyring.MockInit()
+	require.NoError(t, gokeyring.Set("sq", keyringID, resolvedLoc))
+
+	// Without --expand: location in the output must be the placeholder,
+	// not the resolved sqlite3 path. The driver still resolves the
+	// location internally (so the connection succeeds), but the
+	// srcMeta.Location override in execInspect puts the placeholder back
+	// for display. This is the regression case: without that override the
+	// resolved path would appear here.
+	tr := testrun.New(t.Context(), t, nil)
+	require.NoError(t, tr.Run.Config.Collection.Add(&source.Source{
+		Handle:   "@leak",
+		Type:     drivertype.SQLite,
+		Location: placeholder,
+	}))
+	require.NoError(t, tr.Exec("inspect", "@leak", "--overview", "--yaml"),
+		"inspect without --expand must succeed (driver resolves internally)")
+	out := tr.OutString()
+	require.Contains(t, out, placeholder,
+		"default inspect must show the verbatim placeholder, not the resolved path")
+	require.NotContains(t, out, dbPath,
+		"default inspect must NOT leak the resolved path "+
+			"(regression guard for the srcMeta.Location override in execInspect)")
+
+	// With --expand: maybeExpandSource resolves the placeholder before
+	// execInspect runs, so src.Location is already the resolved sqlite3
+	// URL when srcMeta.Location = src.Location is executed. The output
+	// must therefore show the resolved path.
+	tr = testrun.New(t.Context(), t, nil)
+	require.NoError(t, tr.Run.Config.Collection.Add(&source.Source{
+		Handle:   "@leak",
+		Type:     drivertype.SQLite,
+		Location: placeholder,
+	}))
+	require.NoError(t, tr.Exec("inspect", "@leak", "--overview", "--yaml", "--expand"),
+		"inspect with --expand must succeed")
+	out = tr.OutString()
+	require.Contains(t, out, dbPath,
+		"--expand must cause the resolved path to appear in inspect output")
 }

--- a/cli/cmd_ls.go
+++ b/cli/cmd_ls.go
@@ -90,5 +90,10 @@ func execList(cmd *cobra.Command, args []string) error {
 		}
 	}
 
+	coll, err := maybeExpandCollection(cmd.Context(), ru, cmd, coll)
+	if err != nil {
+		return err
+	}
+
 	return ru.Writers.Source.Collection(coll)
 }

--- a/cli/cmd_ls_test.go
+++ b/cli/cmd_ls_test.go
@@ -207,7 +207,9 @@ func TestExpandRevealMatrix(t *testing.T) {
 // that source's row falls back to its verbatim placeholder while the
 // other sources expand normally, and the command exits 0.
 func TestExpandLenient_PartialFailure(t *testing.T) {
-	t.Parallel()
+	// Not parallel: gokeyring.MockInit() mutates a process-global
+	// keyring backend, and parallelizing this with another
+	// MockInit-using test in the future would race.
 
 	gokeyring.MockInit()
 	require.NoError(t, gokeyring.Set("sq", "ok_id",
@@ -233,6 +235,97 @@ func TestExpandLenient_PartialFailure(t *testing.T) {
 		"@ok must expand (with redaction)")
 	require.Contains(t, got, "${keyring:missing_id}",
 		"@missing must show verbatim placeholder")
+}
+
+// TestExpand_PerCommandWiring is a smoke test for the --expand flag across
+// the display commands that are supposed to call maybeExpandSource or
+// maybeExpandCollection. If a future refactor drops that call from one
+// handler, this test catches it even though the expand unit tests would
+// still pass.
+//
+// Shape A (whole-DSN keyring placeholder) is used because it produces the
+// most visible difference: without --expand the verbatim placeholder string
+// appears; with --expand the resolved DSN (with the password redacted) appears.
+//
+// Commands tested: sq src --json, sq ls --json, sq ping --json.
+//
+// sq add, sq mv, and sq inspect are not exercised here:
+//   - sq add and sq mv have awkward bootstrap requirements when testing
+//     with keyring placeholders (the added source must already exist in
+//     the collection before the command echo can be asserted).
+//   - sq inspect is covered by its own dedicated regression test:
+//     TestInspect_LocationOverride_NoLeak in cmd_inspect_test.go.
+func TestExpand_PerCommandWiring(t *testing.T) {
+	// Not parallel: gokeyring.MockInit() mutates a process-global
+	// keyring backend, and parallelizing this with another
+	// MockInit-using test in the future would race.
+	const (
+		keyringID    = "wiring_smoke_kr"
+		fullDSN      = "postgres://alice:hunter2@db.example.com/sakila"
+		placeholder  = "${keyring:" + keyringID + "}"
+		redactedPass = "xxxxx"
+	)
+
+	gokeyring.MockInit()
+	require.NoError(t, gokeyring.Set("sq", keyringID, fullDSN))
+
+	makeSrc := func() *source.Source {
+		return &source.Source{
+			Handle:   "@h",
+			Type:     drivertype.Pg,
+			Location: placeholder,
+		}
+	}
+
+	t.Run("sq_src_json", func(t *testing.T) {
+		tr := testrun.New(t.Context(), t, nil)
+		require.NoError(t, tr.Run.Config.Collection.Add(makeSrc()))
+		_, err := tr.Run.Config.Collection.SetActive("@h", false)
+		require.NoError(t, err)
+
+		require.NoError(t, tr.Exec("src", "--json", "--expand"),
+			"sq src --json --expand must succeed")
+		out := tr.OutString()
+		require.Contains(t, out, "postgres://alice:"+redactedPass+"@db.example.com/sakila",
+			"sq src --json --expand must show the resolved, redacted DSN")
+		require.NotContains(t, out, placeholder,
+			"sq src --json --expand must not show the verbatim placeholder")
+		require.NotContains(t, out, "hunter2",
+			"sq src --json --expand must not leak the plaintext secret")
+	})
+
+	t.Run("sq_ls_json", func(t *testing.T) {
+		tr := testrun.New(t.Context(), t, nil)
+		require.NoError(t, tr.Run.Config.Collection.Add(makeSrc()))
+
+		require.NoError(t, tr.Exec("ls", "--json", "--expand"),
+			"sq ls --json --expand must succeed")
+		out := tr.OutString()
+		require.Contains(t, out, "postgres://alice:"+redactedPass+"@db.example.com/sakila",
+			"sq ls --json --expand must show the resolved, redacted DSN")
+		require.NotContains(t, out, placeholder,
+			"sq ls --json --expand must not show the verbatim placeholder")
+		require.NotContains(t, out, "hunter2",
+			"sq ls --json --expand must not leak the plaintext secret")
+	})
+
+	t.Run("sq_ping_json", func(t *testing.T) {
+		tr := testrun.New(t.Context(), t, nil)
+		require.NoError(t, tr.Run.Config.Collection.Add(makeSrc()))
+
+		// Ping will fail to connect (the postgres DSN is not reachable in CI),
+		// but the JSON output is still written before the connection error. The
+		// test does not require ping success; it requires that the Location
+		// field in the JSON output is the resolved, redacted form.
+		_ = tr.Exec("ping", "@h", "--json", "--expand")
+		out := tr.OutString()
+		require.Contains(t, out, "postgres://alice:"+redactedPass+"@db.example.com/sakila",
+			"sq ping --json --expand must show the resolved, redacted DSN")
+		require.NotContains(t, out, placeholder,
+			"sq ping --json --expand must not show the verbatim placeholder")
+		require.NotContains(t, out, "hunter2",
+			"sq ping --json --expand must not leak the plaintext secret")
+	})
 }
 
 // TestExpand_NoOp_OnNonDisplayCommand verifies that --expand is

--- a/cli/cmd_ls_test.go
+++ b/cli/cmd_ls_test.go
@@ -166,7 +166,6 @@ func TestExpandRevealMatrix(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		c := c
 		t.Run(c.shape, func(t *testing.T) {
 			// Per-shape isolation: mock keyring and set env before each
 			// shape block so cases do not leak into each other.
@@ -175,7 +174,6 @@ func TestExpandRevealMatrix(t *testing.T) {
 			t.Setenv(envVar, envPass)
 
 			for _, combo := range combos {
-				combo := combo
 				t.Run(combo.name, func(t *testing.T) {
 					tr := testrun.New(t.Context(), t, nil)
 					require.NoError(t, tr.Run.Config.Collection.Add(&source.Source{

--- a/cli/cmd_ls_test.go
+++ b/cli/cmd_ls_test.go
@@ -4,8 +4,11 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	gokeyring "github.com/zalando/go-keyring"
 
 	"github.com/neilotoole/sq/cli/testrun"
+	"github.com/neilotoole/sq/libsq/source"
+	"github.com/neilotoole/sq/libsq/source/drivertype"
 )
 
 // TestBug520_LsShowsPassword tests https://github.com/neilotoole/sq/issues/520.
@@ -64,6 +67,186 @@ func TestBug520_LsShowsPassword(t *testing.T) {
 			require.Contains(t, tr.OutString(), password, "should print password with --reveal")
 		})
 	}
+}
+
+// TestExpandRevealMatrix verifies the cross-product of --expand and
+// --reveal across the three placeholder shapes (whole-DSN, composition,
+// inline-plaintext) on `sq ls -v`. This is the canonical proof of the
+// matrix described in gh-729.
+func TestExpandRevealMatrix(t *testing.T) {
+	// Not parallel: subtests use t.Setenv which requires a non-parallel
+	// ancestor.
+	const (
+		keyringID    = "expand_matrix_kr"
+		fullDSN      = "postgres://alice:hunter2@db/sakila"
+		envVar       = "SQ_TEST_EXPAND_DBPW"
+		envPass      = "envhunter"
+		composeLoc   = "postgres://alice:${env:" + envVar + "}@db/sakila"
+		inlineLoc    = "postgres://alice:hunter2@db/sakila"
+		redactedPass = "xxxxx"
+	)
+
+	keyringLoc := "${keyring:" + keyringID + "}"
+
+	type row struct {
+		shape         string
+		loc           string
+		none          []string
+		reveal        []string
+		expand        []string
+		revealExpd    []string
+		noneNot       []string
+		revealNot     []string
+		expandNot     []string
+		revealExpdNot []string
+	}
+
+	cases := []row{
+		{
+			// Shape A: the whole Location is a keyring placeholder. Without
+			// --expand the placeholder is shown verbatim (it is not a URL so
+			// there is no userinfo to redact). With --expand the keyring entry
+			// is resolved then the password in the resolved DSN is redacted
+			// (or shown with --reveal).
+			shape:      "A_wholeDSN_keyring",
+			loc:        keyringLoc,
+			none:       []string{keyringLoc},
+			reveal:     []string{keyringLoc},
+			expand:     []string{"postgres://alice:" + redactedPass + "@db/sakila"},
+			revealExpd: []string{fullDSN},
+			noneNot:    []string{"hunter2"},
+			revealNot:  []string{"hunter2"},
+			expandNot:  []string{"hunter2"},
+		},
+		{
+			// Shape B: the placeholder is embedded in the password field of a
+			// URL. Without --expand the redactor masks the password position
+			// (the placeholder text is consumed along with the credential).
+			// With --reveal the raw location is shown verbatim. With
+			// --expand the env var is resolved and then the password redacted
+			// (or shown with --reveal).
+			shape:      "B_composition_env",
+			loc:        composeLoc,
+			none:       []string{"postgres://alice:" + redactedPass + "@db/sakila"},
+			reveal:     []string{composeLoc},
+			expand:     []string{"postgres://alice:" + redactedPass + "@db/sakila"},
+			revealExpd: []string{"postgres://alice:" + envPass + "@db/sakila"},
+			noneNot:    []string{envPass},
+			revealNot:  []string{envPass},
+			expandNot:  []string{envPass},
+		},
+		{
+			// Shape C: the password is inline plaintext with no placeholder.
+			// Without --reveal the password is always redacted, regardless of
+			// --expand (there is nothing to expand).
+			shape:      "C_inline",
+			loc:        inlineLoc,
+			none:       []string{"postgres://alice:" + redactedPass + "@db/sakila"},
+			reveal:     []string{inlineLoc},
+			expand:     []string{"postgres://alice:" + redactedPass + "@db/sakila"},
+			revealExpd: []string{inlineLoc},
+			noneNot:    []string{"hunter2"},
+			expandNot:  []string{"hunter2"},
+		},
+	}
+
+	combos := []struct {
+		name    string
+		args    []string
+		getWant func(r row) (want, wantNot []string)
+	}{
+		{"none", []string{"ls", "-v"}, func(r row) ([]string, []string) { return r.none, r.noneNot }},
+		{"reveal", []string{"ls", "-v", "--reveal"}, func(r row) ([]string, []string) { return r.reveal, r.revealNot }},
+		{"expand", []string{"ls", "-v", "--expand"}, func(r row) ([]string, []string) { return r.expand, r.expandNot }},
+		{
+			"reveal+expand",
+			[]string{"ls", "-v", "--reveal", "--expand"},
+			func(r row) ([]string, []string) { return r.revealExpd, r.revealExpdNot },
+		},
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.shape, func(t *testing.T) {
+			// Per-shape isolation: mock keyring and set env before each
+			// shape block so cases do not leak into each other.
+			gokeyring.MockInit()
+			require.NoError(t, gokeyring.Set("sq", keyringID, fullDSN))
+			t.Setenv(envVar, envPass)
+
+			for _, combo := range combos {
+				combo := combo
+				t.Run(combo.name, func(t *testing.T) {
+					tr := testrun.New(t.Context(), t, nil)
+					require.NoError(t, tr.Run.Config.Collection.Add(&source.Source{
+						Handle:   "@matrix",
+						Type:     drivertype.Pg,
+						Location: c.loc,
+					}))
+
+					require.NoError(t, tr.Exec(combo.args...))
+					got := tr.OutString()
+
+					want, wantNot := combo.getWant(c)
+					for _, sub := range want {
+						require.Contains(t, got, sub,
+							"%s/%s must contain %q\noutput: %s",
+							c.shape, combo.name, sub, got)
+					}
+					for _, sub := range wantNot {
+						require.NotContains(t, got, sub,
+							"%s/%s must not contain %q\noutput: %s",
+							c.shape, combo.name, sub, got)
+					}
+				})
+			}
+		})
+	}
+}
+
+// TestExpandLenient_PartialFailure verifies that when one source's
+// resolver fails (missing keyring entry) during `sq ls -v --expand`,
+// that source's row falls back to its verbatim placeholder while the
+// other sources expand normally, and the command exits 0.
+func TestExpandLenient_PartialFailure(t *testing.T) {
+	t.Parallel()
+
+	gokeyring.MockInit()
+	require.NoError(t, gokeyring.Set("sq", "ok_id",
+		"postgres://u:pw@h/db"))
+	// "missing_id" intentionally absent.
+
+	tr := testrun.New(t.Context(), t, nil)
+	require.NoError(t, tr.Run.Config.Collection.Add(&source.Source{
+		Handle:   "@ok",
+		Type:     drivertype.Pg,
+		Location: "${keyring:ok_id}",
+	}))
+	require.NoError(t, tr.Run.Config.Collection.Add(&source.Source{
+		Handle:   "@missing",
+		Type:     drivertype.Pg,
+		Location: "${keyring:missing_id}",
+	}))
+
+	require.NoError(t, tr.Exec("ls", "-v", "--expand"),
+		"per-source resolver failure must not abort the command")
+	got := tr.OutString()
+	require.Contains(t, got, "postgres://u:xxxxx@h/db",
+		"@ok must expand (with redaction)")
+	require.Contains(t, got, "${keyring:missing_id}",
+		"@missing must show verbatim placeholder")
+}
+
+// TestExpand_NoOp_OnNonDisplayCommand verifies that --expand is
+// accepted (silent no-op) on a command that does not print Location,
+// so a global alias like `alias sq='sq --reveal --expand'` is safe.
+func TestExpand_NoOp_OnNonDisplayCommand(t *testing.T) {
+	t.Parallel()
+
+	tr := testrun.New(t.Context(), t, nil)
+	require.NoError(t, tr.Exec("config", "ls", "--expand"))
+	// Mere absence of an error is the assertion; cobra would reject
+	// an unknown flag with a non-nil error.
 }
 
 // TestRedactFlags_Union verifies that --reveal and --no-redact behave

--- a/cli/cmd_mv.go
+++ b/cli/cmd_mv.go
@@ -156,6 +156,10 @@ func execMoveHandleToGroup(cmd *cobra.Command, oldHandle, newGroup string) error
 		return err
 	}
 
+	if newSrc, err = maybeExpandSource(cmd.Context(), ru, cmd, newSrc); err != nil {
+		return err
+	}
+
 	return ru.Writers.Source.Moved(ru.Config.Collection, oldSrc, newSrc)
 }
 
@@ -183,6 +187,10 @@ func execMoveRenameHandle(cmd *cobra.Command, oldHandle, newHandle string) error
 	}
 
 	if err = ru.ConfigStore.Save(cmd.Context(), ru.Config); err != nil {
+		return err
+	}
+
+	if newSrc, err = maybeExpandSource(cmd.Context(), ru, cmd, newSrc); err != nil {
 		return err
 	}
 

--- a/cli/cmd_ping.go
+++ b/cli/cmd_ping.go
@@ -122,6 +122,21 @@ func execPing(cmd *cobra.Command, args []string) error {
 
 	lg.From(cmd).Debug("Using ping timeout", lga.Val, fmt.Sprintf("%v", timeout))
 
+	// Expand ${scheme:path} placeholders for display when --expand is
+	// set. pingSources reads src.Location from each entry and passes
+	// it to the writer alongside the ping result; expanding here makes
+	// the displayed Location reflect what was resolved. The driver
+	// itself does its own resolution inside pingSource via
+	// ResolveSourceSecrets, which is a no-op on an already-expanded
+	// Location.
+	for i, src := range srcs {
+		expanded, expandErr := maybeExpandSource(cmd.Context(), ru, cmd, src)
+		if expandErr != nil {
+			return expandErr
+		}
+		srcs[i] = expanded
+	}
+
 	err = pingSources(cmd.Context(), ru.DriverRegistry, srcs, ru.Writers.Ping, timeout)
 	if errors.Is(err, context.Canceled) {
 		// It's common to cancel "sq ping". We don't want to print the cancel message.

--- a/cli/cmd_ping_test.go
+++ b/cli/cmd_ping_test.go
@@ -78,11 +78,15 @@ func checkPingOutputCSV(t *testing.T, h *testrun.TestRun, srcs ...source.Source)
 	}
 }
 
-// TestCmdPing_KeyringPlaceholder_NoLeakInJSON is a regression test for the
-// secret-leak / nil-panic pair where pingSource rebound its `src` parameter
-// to the resolved clone, leaking plaintext into the json ping writer and
-// panicking when resolution failed. The fix keeps the templated src for
-// output and uses a separate `resolved` variable for the driver call.
+// TestCmdPing_KeyringPlaceholder_NoLeakInJSON verifies that sq ping --json
+// never emits a plaintext password, regardless of whether the source
+// Location holds a keyring placeholder or an already-resolved DSN.
+//
+// When redaction is on (the default), a placeholder in the password
+// position is masked just like an inline password: the output shows
+// "xxxxx", not the resolved secret. That is the correct behavior: the
+// ping writer applies RedactedLocation before serializing, so neither
+// the resolved plaintext nor the raw placeholder leaks.
 func TestCmdPing_KeyringPlaceholder_NoLeakInJSON(t *testing.T) {
 	gokeyring.MockInit()
 	require.NoError(t, gokeyring.Set("sq", "@px_leak/password", "totally-secret-pw"))
@@ -96,14 +100,14 @@ func TestCmdPing_KeyringPlaceholder_NoLeakInJSON(t *testing.T) {
 	}))
 
 	// Ping will fail at the connect step; we don't care about success,
-	// we care that the templated Location appears in the output and the
-	// resolved plaintext does NOT.
+	// we care that the resolved plaintext does NOT appear and that the
+	// output is redacted (xxxxx in the password slot).
 	_ = tr.Exec("ping", "@px_leak", "--json")
 	out := tr.Out.String()
 	require.NotContains(t, out, "totally-secret-pw",
 		"resolved password must not leak into ping output")
-	require.Contains(t, out, "${keyring:@px_leak/password}",
-		"templated location must appear in ping output")
+	require.Contains(t, out, "xxxxx",
+		"password slot must be redacted in default (non-reveal) mode")
 }
 
 // TestCmdPing_KeyringMissing_DoesNotPanic guards against the nil-panic that

--- a/cli/cmd_root.go
+++ b/cli/cmd_root.go
@@ -120,11 +120,18 @@ See docs and more: https://sq.io`,
 	cmd.PersistentFlags().Bool(flag.Reveal, false, flag.RevealUsage)
 	cmd.PersistentFlags().Bool(flag.NoRedact, false, flag.NoRedactUsage)
 	// --expand resolves ${scheme:path} placeholders against the
-	// registered resolvers (keyring, env, file). On display commands
-	// (sq src, sq ls, sq inspect, sq add, sq mv, sq ping -v), per-source
-	// resolver failure is lenient: the placeholder is preserved verbatim
-	// and the command exits 0. On `sq config export`, --expand keeps its
-	// existing strict-abort behavior because an export is a snapshot.
+	// registered resolvers (keyring, env, file). It applies to every
+	// command that prints a source location: sq src, sq ls, sq inspect,
+	// sq add and sq mv (post-action echo), and sq ping in JSON/YAML
+	// output (the text/CSV ping output does not include Location).
+	//
+	// On the display-expansion step itself, per-source resolver failure
+	// is lenient: the placeholder is left verbatim for that source and
+	// the listing continues. Connection-time resolution is independent;
+	// commands that have to connect (sq inspect, sq ping) will still
+	// error if a missing secret prevents the connection. On
+	// `sq config export`, --expand keeps its existing strict-abort
+	// behavior because an export is a snapshot for transfer.
 	//
 	// Not bound to a config option: persisting --expand as a workflow
 	// preference would resolve every placeholder on every display

--- a/cli/cmd_root.go
+++ b/cli/cmd_root.go
@@ -119,6 +119,18 @@ See docs and more: https://sq.io`,
 	// 'sq config set secrets.reveal false'.
 	cmd.PersistentFlags().Bool(flag.Reveal, false, flag.RevealUsage)
 	cmd.PersistentFlags().Bool(flag.NoRedact, false, flag.NoRedactUsage)
+	// --expand resolves ${scheme:path} placeholders against the
+	// registered resolvers (keyring, env, file). On display commands
+	// (sq src, sq ls, sq inspect, sq add, sq mv, sq ping -v), per-source
+	// resolver failure is lenient: the placeholder is preserved verbatim
+	// and the command exits 0. On `sq config export`, --expand keeps its
+	// existing strict-abort behavior because an export is a snapshot.
+	//
+	// Not bound to a config option: persisting --expand as a workflow
+	// preference would resolve every placeholder on every display
+	// command, defeating the reason the user put the placeholder there.
+	// Like --reveal, explicit --expand=false is a no-op.
+	cmd.PersistentFlags().Bool(flag.Expand, false, flag.ExpandUsage)
 	addOptionFlag(cmd.PersistentFlags(), OptVerbose)
 	addOptionFlag(cmd.PersistentFlags(), pprofile.OptMode)
 	panicOn(cmd.RegisterFlagCompletionFunc(pprofile.OptMode.Flag().Name, completeStrings(

--- a/cli/cmd_src.go
+++ b/cli/cmd_src.go
@@ -32,14 +32,20 @@ source. Otherwise, set @HANDLE as the active data source.`,
 }
 
 func execSrc(cmd *cobra.Command, args []string) error {
-	ru := run.FromContext(cmd.Context())
+	ctx := cmd.Context()
+	ru := run.FromContext(ctx)
 	cfg := ru.Config
 
 	if len(args) == 0 {
-		// Get the active data source
+		// Get the active data source.
 		src := cfg.Collection.Active()
 		if src == nil {
 			return nil
+		}
+
+		src, err := maybeExpandSource(ctx, ru, cmd, src)
+		if err != nil {
+			return err
 		}
 
 		return ru.Writers.Source.Source(cfg.Collection, src)
@@ -50,7 +56,11 @@ func execSrc(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	err = ru.ConfigStore.Save(cmd.Context(), cfg)
+	if err = ru.ConfigStore.Save(ctx, cfg); err != nil {
+		return err
+	}
+
+	src, err = maybeExpandSource(ctx, ru, cmd, src)
 	if err != nil {
 		return err
 	}

--- a/cli/expand.go
+++ b/cli/expand.go
@@ -1,0 +1,76 @@
+package cli
+
+import (
+	"context"
+	"errors"
+
+	"github.com/spf13/cobra"
+
+	"github.com/neilotoole/sq/cli/flag"
+	"github.com/neilotoole/sq/cli/run"
+	"github.com/neilotoole/sq/libsq/source"
+)
+
+// maybeExpandCollection returns coll unchanged when --expand is not set
+// on cmd. Otherwise it returns a deep clone whose source Locations have
+// each been passed through ru.SecretRegistry.Expand, with lenient
+// fallback: any per-source resolver error is swallowed and the
+// original Location is preserved verbatim. ctx is used for the
+// resolver call; context.Canceled / context.DeadlineExceeded propagate
+// as errors (a partial expansion under user-driven cancellation is not
+// a "this source's keyring is offline" situation).
+//
+// Display commands (sq src, sq ls, sq inspect, sq add echo, sq mv
+// echo, sq ping -v) call this at the start of execution and pass the
+// returned collection to the writer. The writer's existing redact
+// step runs on whatever Location it sees, so the matrix is:
+//
+//	raw -> [expand?] -> [redact?] -> displayed
+//
+// See also: maybeExpandSource for the single-source variant.
+func maybeExpandCollection(ctx context.Context, ru *run.Run, cmd *cobra.Command,
+	coll *source.Collection,
+) (*source.Collection, error) {
+	if !cmdFlagIsSetTrue(cmd, flag.Expand) || coll == nil {
+		return coll, nil
+	}
+
+	clone := coll.Clone()
+	for _, src := range clone.Sources() {
+		resolved, err := ru.SecretRegistry.Expand(ctx, src.Location)
+		if err != nil {
+			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+				return nil, err
+			}
+			// Lenient: leave the placeholder verbatim so the user can
+			// still read "what would have resolved here". No stderr
+			// noise: the verbatim placeholder is the signal.
+			continue
+		}
+		src.Location = resolved
+	}
+	return clone, nil
+}
+
+// maybeExpandSource is the single-source variant of
+// maybeExpandCollection. Same semantics: --expand unset returns input
+// verbatim; --expand set returns a cloned source with Expand applied,
+// lenient on resolver error, propagates context cancellation.
+func maybeExpandSource(ctx context.Context, ru *run.Run, cmd *cobra.Command,
+	src *source.Source,
+) (*source.Source, error) {
+	if !cmdFlagIsSetTrue(cmd, flag.Expand) || src == nil {
+		return src, nil
+	}
+
+	clone := src.Clone()
+	resolved, err := ru.SecretRegistry.Expand(ctx, clone.Location)
+	if err != nil {
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return nil, err
+		}
+		return clone, nil
+	}
+	clone.Location = resolved
+	return clone, nil
+}

--- a/cli/expand.go
+++ b/cli/expand.go
@@ -9,6 +9,9 @@ import (
 	"github.com/neilotoole/sq/cli/flag"
 	"github.com/neilotoole/sq/cli/run"
 	"github.com/neilotoole/sq/libsq/core/errz"
+	"github.com/neilotoole/sq/libsq/core/lg"
+	"github.com/neilotoole/sq/libsq/core/lg/lga"
+	"github.com/neilotoole/sq/libsq/core/secret"
 	"github.com/neilotoole/sq/libsq/source"
 )
 
@@ -38,14 +41,26 @@ func maybeExpandCollection(ctx context.Context, ru *run.Run, cmd *cobra.Command,
 
 	clone := coll.Clone()
 	for _, src := range clone.Sources() {
+		// Validate placeholder syntax upfront. Parse errors are user config
+		// bugs (e.g. "${env}" missing the colon) and must surface so the
+		// user can fix them; swallowing them silently would hide a config
+		// break behind the lenient-resolver fallback below. cmd_add does the
+		// same dance for added sources.
+		if _, parseErr := secret.ExtractRefs(src.Location); parseErr != nil {
+			return nil, errz.Wrapf(parseErr, "expand %s", src.Handle)
+		}
 		resolved, err := ru.SecretRegistry.Expand(ctx, src.Location)
 		if err != nil {
 			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 				return nil, errz.Err(err)
 			}
-			// Lenient: leave the placeholder verbatim so the user can
-			// still read "what would have resolved here". No stderr
-			// noise: the verbatim placeholder is the signal.
+			// Lenient resolver failure: keep the placeholder verbatim and
+			// log at debug level. The verbatim value is the user-visible
+			// signal in default output; the debug log is for operators
+			// running with SQ_LOG=debug.
+			lg.FromContext(ctx).Debug("expand: leaving placeholder verbatim",
+				lga.Src, src.Handle,
+				lga.Err, err)
 			continue
 		}
 		src.Location = resolved
@@ -64,12 +79,26 @@ func maybeExpandSource(ctx context.Context, ru *run.Run, cmd *cobra.Command,
 		return src, nil
 	}
 
+	// Validate placeholder syntax upfront. Parse errors are user config
+	// bugs (e.g. "${env}" missing the colon) and must surface so the
+	// user can fix them; swallowing them silently would hide a config
+	// break behind the lenient-resolver fallback below.
+	if _, parseErr := secret.ExtractRefs(src.Location); parseErr != nil {
+		return nil, errz.Wrapf(parseErr, "expand %s", src.Handle)
+	}
 	clone := src.Clone()
 	resolved, err := ru.SecretRegistry.Expand(ctx, clone.Location)
 	if err != nil {
 		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 			return nil, errz.Err(err)
 		}
+		// Lenient resolver failure: keep the placeholder verbatim and
+		// log at debug level. The verbatim value is the user-visible
+		// signal in default output; the debug log is for operators
+		// running with SQ_LOG=debug.
+		lg.FromContext(ctx).Debug("expand: leaving placeholder verbatim",
+			lga.Src, src.Handle,
+			lga.Err, err)
 		return clone, nil
 	}
 	clone.Location = resolved

--- a/cli/expand.go
+++ b/cli/expand.go
@@ -24,9 +24,10 @@ import (
 // as errors (a partial expansion under user-driven cancellation is not
 // a "this source's keyring is offline" situation).
 //
-// Display commands (sq src, sq ls, sq inspect, sq add echo, sq mv
-// echo, sq ping -v) call this at the start of execution and pass the
-// returned collection to the writer. The writer's existing redact
+// Called by every command that prints a source location: sq src,
+// sq ls, sq inspect, sq add and sq mv (post-action echo), and
+// sq ping in JSON/YAML output. Each handler invokes this once
+// before passing data to the writer. The writer's existing redact
 // step runs on whatever Location it sees, so the matrix is:
 //
 //	raw -> [expand?] -> [redact?] -> displayed
@@ -55,8 +56,10 @@ func maybeExpandCollection(ctx context.Context, ru *run.Run, cmd *cobra.Command,
 				return nil, errz.Err(err)
 			}
 			// Lenient resolver failure: keep the placeholder verbatim and
-			// log at debug level. The verbatim value is the user-visible
-			// signal in default output; the debug log is for operators
+			// log at debug level. The verbatim placeholder may itself be
+			// hidden downstream (e.g. a placeholder inside a URL password
+			// slot is masked by the redact filter when --reveal is off),
+			// so the debug log is the reliable signal for operators
 			// running with SQ_LOG=debug.
 			lg.FromContext(ctx).Debug("expand: leaving placeholder verbatim",
 				lga.Src, src.Handle,

--- a/cli/expand.go
+++ b/cli/expand.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/neilotoole/sq/cli/flag"
 	"github.com/neilotoole/sq/cli/run"
+	"github.com/neilotoole/sq/libsq/core/errz"
 	"github.com/neilotoole/sq/libsq/source"
 )
 
@@ -40,7 +41,7 @@ func maybeExpandCollection(ctx context.Context, ru *run.Run, cmd *cobra.Command,
 		resolved, err := ru.SecretRegistry.Expand(ctx, src.Location)
 		if err != nil {
 			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-				return nil, err
+				return nil, errz.Err(err)
 			}
 			// Lenient: leave the placeholder verbatim so the user can
 			// still read "what would have resolved here". No stderr
@@ -67,7 +68,7 @@ func maybeExpandSource(ctx context.Context, ru *run.Run, cmd *cobra.Command,
 	resolved, err := ru.SecretRegistry.Expand(ctx, clone.Location)
 	if err != nil {
 		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-			return nil, err
+			return nil, errz.Err(err)
 		}
 		return clone, nil
 	}

--- a/cli/expand_test.go
+++ b/cli/expand_test.go
@@ -16,9 +16,9 @@ import (
 )
 
 // stubResolver returns canned values keyed by path. Missing path
-// yields secret.ErrNotFound. canceledOnly causes Resolve to return
-// ctx.Err() when the context is canceled, supporting the
-// cancellation-propagation test.
+// yields secret.ErrNotFound. If ctx is canceled, Resolve returns
+// ctx.Err() so the cancellation-propagation test can exercise that
+// path without involving a real resolver.
 type stubResolver struct {
 	values map[string]string
 }

--- a/cli/expand_test.go
+++ b/cli/expand_test.go
@@ -3,6 +3,9 @@ package cli
 import (
 	"context"
 	"errors"
+	"log/slog"
+	"strings"
+	"sync"
 	"testing"
 
 	"github.com/spf13/cobra"
@@ -10,6 +13,7 @@ import (
 
 	"github.com/neilotoole/sq/cli/flag"
 	"github.com/neilotoole/sq/cli/run"
+	"github.com/neilotoole/sq/libsq/core/lg"
 	"github.com/neilotoole/sq/libsq/core/secret"
 	"github.com/neilotoole/sq/libsq/source"
 	"github.com/neilotoole/sq/libsq/source/drivertype"
@@ -193,4 +197,94 @@ func TestMaybeExpandSource_FlagSet_LenientOnResolverError(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "${keyring:abc}", got.Location,
 		"unresolvable placeholder must be left verbatim")
+}
+
+func TestMaybeExpandCollection_ParseErrorPropagates(t *testing.T) {
+	ru := newTestRun(t, nil)
+	cmd := newCmdWithExpand(t, true)
+
+	coll := &source.Collection{}
+	require.NoError(t, coll.Add(&source.Source{
+		Handle:   "@bad",
+		Type:     drivertype.Pg,
+		Location: "${malformed", // unclosed brace: parse error.
+	}))
+
+	_, err := maybeExpandCollection(context.Background(), ru, cmd, coll)
+	require.Error(t, err, "malformed placeholder must surface as an error")
+	require.Contains(t, err.Error(), "@bad",
+		"error message must include the source handle")
+}
+
+func TestMaybeExpandSource_ParseErrorPropagates(t *testing.T) {
+	ru := newTestRun(t, nil)
+	cmd := newCmdWithExpand(t, true)
+
+	src := &source.Source{
+		Handle:   "@bad",
+		Type:     drivertype.Pg,
+		Location: "${malformed", // unclosed brace: parse error.
+	}
+
+	_, err := maybeExpandSource(context.Background(), ru, cmd, src)
+	require.Error(t, err, "malformed placeholder must surface as an error")
+	require.Contains(t, err.Error(), "@bad",
+		"error message must include the source handle")
+}
+
+// captureHandler is a minimal slog.Handler that records log entries for
+// test assertions. It captures all levels.
+type captureHandler struct {
+	mu      sync.Mutex
+	records []slog.Record
+}
+
+func (h *captureHandler) Enabled(_ context.Context, _ slog.Level) bool { return true }
+
+func (h *captureHandler) Handle(_ context.Context, r slog.Record) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.records = append(h.records, r)
+	return nil
+}
+
+func (h *captureHandler) WithAttrs(_ []slog.Attr) slog.Handler {
+	// Simplified: ignore attrs for test purposes.
+	return h
+}
+
+func (h *captureHandler) WithGroup(_ string) slog.Handler { return h }
+
+func (h *captureHandler) hasMessage(msg string) bool {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	for _, r := range h.records {
+		if strings.Contains(r.Message, msg) {
+			return true
+		}
+	}
+	return false
+}
+
+func TestMaybeExpandCollection_DebugLogsSwallowedError(t *testing.T) {
+	ru := newTestRun(t, map[string]string{
+		// "abc" intentionally not set, so the resolver returns ErrNotFound.
+	})
+	cmd := newCmdWithExpand(t, true)
+
+	coll := &source.Collection{}
+	require.NoError(t, coll.Add(&source.Source{
+		Handle:   "@missing",
+		Type:     drivertype.Pg,
+		Location: "${keyring:abc}",
+	}))
+
+	handler := &captureHandler{}
+	log := slog.New(handler)
+	ctx := lg.NewContext(context.Background(), log)
+
+	_, err := maybeExpandCollection(ctx, ru, cmd, coll)
+	require.NoError(t, err, "resolver miss must still be swallowed")
+	require.True(t, handler.hasMessage("expand: leaving placeholder verbatim"),
+		"swallowed resolver error must emit a debug log entry")
 }

--- a/cli/expand_test.go
+++ b/cli/expand_test.go
@@ -1,0 +1,196 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+
+	"github.com/neilotoole/sq/cli/flag"
+	"github.com/neilotoole/sq/cli/run"
+	"github.com/neilotoole/sq/libsq/core/secret"
+	"github.com/neilotoole/sq/libsq/source"
+	"github.com/neilotoole/sq/libsq/source/drivertype"
+)
+
+// stubResolver returns canned values keyed by path. Missing path
+// yields secret.ErrNotFound. canceledOnly causes Resolve to return
+// ctx.Err() when the context is canceled, supporting the
+// cancellation-propagation test.
+type stubResolver struct {
+	values map[string]string
+}
+
+func (s *stubResolver) Resolve(ctx context.Context, path string) (string, error) {
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
+	v, ok := s.values[path]
+	if !ok {
+		return "", secret.ErrNotFound
+	}
+	return v, nil
+}
+
+// newTestRun returns a *run.Run with a SecretRegistry whose "keyring"
+// scheme is backed by stubResolver{values}. Other schemes are
+// unregistered (any reference to them returns ErrUnknownScheme).
+func newTestRun(t *testing.T, values map[string]string) *run.Run {
+	t.Helper()
+	reg := secret.NewRegistry()
+	reg.Register("keyring", &stubResolver{values: values})
+	return &run.Run{SecretRegistry: reg}
+}
+
+// newCmdWithExpand returns a *cobra.Command with --expand registered
+// on its local flag set. When set is true, the flag is marked Changed
+// to true via Flags().Set so cmdFlagIsSetTrue returns true. (See
+// cli/flags.go:47 — cmdFlagIsSetTrue requires Changed AND value=true.)
+func newCmdWithExpand(t *testing.T, set bool) *cobra.Command {
+	t.Helper()
+	cmd := &cobra.Command{Use: "test"}
+	cmd.Flags().Bool(flag.Expand, false, flag.ExpandUsage)
+	if set {
+		require.NoError(t, cmd.Flags().Set(flag.Expand, "true"))
+	}
+	return cmd
+}
+
+func TestMaybeExpandCollection_FlagUnset_ReturnsInputUnchanged(t *testing.T) {
+	ru := newTestRun(t, nil)
+	cmd := newCmdWithExpand(t, false)
+
+	coll := &source.Collection{}
+	require.NoError(t, coll.Add(&source.Source{
+		Handle:   "@a",
+		Type:     drivertype.Pg,
+		Location: "${keyring:abc}",
+	}))
+
+	got, err := maybeExpandCollection(context.Background(), ru, cmd, coll)
+	require.NoError(t, err)
+	require.Same(t, coll, got, "must return input verbatim when --expand is not set")
+}
+
+func TestMaybeExpandCollection_FlagSet_ExpandsKeyring(t *testing.T) {
+	ru := newTestRun(t, map[string]string{
+		"abc": "postgres://alice:hunter2@db/sakila",
+	})
+	cmd := newCmdWithExpand(t, true)
+
+	coll := &source.Collection{}
+	require.NoError(t, coll.Add(&source.Source{
+		Handle:   "@a",
+		Type:     drivertype.Pg,
+		Location: "${keyring:abc}",
+	}))
+
+	got, err := maybeExpandCollection(context.Background(), ru, cmd, coll)
+	require.NoError(t, err)
+	require.NotSame(t, coll, got, "must clone when --expand is set")
+	require.Equal(t, "postgres://alice:hunter2@db/sakila", got.Sources()[0].Location)
+	require.Equal(t, "${keyring:abc}", coll.Sources()[0].Location,
+		"input must not be mutated")
+}
+
+func TestMaybeExpandCollection_FlagSet_LenientOnResolverError(t *testing.T) {
+	ru := newTestRun(t, map[string]string{
+		"def": "postgres://b:pw@h/db",
+		// "abc" intentionally not set.
+	})
+	cmd := newCmdWithExpand(t, true)
+
+	coll := &source.Collection{}
+	require.NoError(t, coll.Add(&source.Source{
+		Handle:   "@missing",
+		Type:     drivertype.Pg,
+		Location: "${keyring:abc}",
+	}))
+	require.NoError(t, coll.Add(&source.Source{
+		Handle:   "@ok",
+		Type:     drivertype.Pg,
+		Location: "${keyring:def}",
+	}))
+
+	got, err := maybeExpandCollection(context.Background(), ru, cmd, coll)
+	require.NoError(t, err, "per-source resolver error must be swallowed")
+
+	srcs := got.Sources()
+	require.Equal(t, "${keyring:abc}", srcs[0].Location,
+		"unresolvable placeholder must be left verbatim")
+	require.Equal(t, "postgres://b:pw@h/db", srcs[1].Location,
+		"resolvable placeholder must still expand")
+}
+
+func TestMaybeExpandCollection_ContextCanceled_Propagates(t *testing.T) {
+	ru := newTestRun(t, map[string]string{
+		"abc": "postgres://x:y@h/db",
+	})
+	cmd := newCmdWithExpand(t, true)
+
+	coll := &source.Collection{}
+	require.NoError(t, coll.Add(&source.Source{
+		Handle:   "@a",
+		Type:     drivertype.Pg,
+		Location: "${keyring:abc}",
+	}))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := maybeExpandCollection(ctx, ru, cmd, coll)
+	require.True(t, errors.Is(err, context.Canceled),
+		"context.Canceled must propagate, not be swallowed as a per-source error")
+}
+
+func TestMaybeExpandSource_FlagUnset_ReturnsInputUnchanged(t *testing.T) {
+	ru := newTestRun(t, nil)
+	cmd := newCmdWithExpand(t, false)
+
+	src := &source.Source{
+		Handle:   "@a",
+		Type:     drivertype.Pg,
+		Location: "${keyring:abc}",
+	}
+
+	got, err := maybeExpandSource(context.Background(), ru, cmd, src)
+	require.NoError(t, err)
+	require.Same(t, src, got)
+}
+
+func TestMaybeExpandSource_FlagSet_Expands(t *testing.T) {
+	ru := newTestRun(t, map[string]string{
+		"abc": "postgres://alice:hunter2@db/sakila",
+	})
+	cmd := newCmdWithExpand(t, true)
+
+	src := &source.Source{
+		Handle:   "@a",
+		Type:     drivertype.Pg,
+		Location: "${keyring:abc}",
+	}
+
+	got, err := maybeExpandSource(context.Background(), ru, cmd, src)
+	require.NoError(t, err)
+	require.NotSame(t, src, got, "must clone")
+	require.Equal(t, "postgres://alice:hunter2@db/sakila", got.Location)
+	require.Equal(t, "${keyring:abc}", src.Location, "input must not be mutated")
+}
+
+func TestMaybeExpandSource_FlagSet_LenientOnResolverError(t *testing.T) {
+	ru := newTestRun(t, nil) // "abc" not set.
+	cmd := newCmdWithExpand(t, true)
+
+	src := &source.Source{
+		Handle:   "@a",
+		Type:     drivertype.Pg,
+		Location: "${keyring:abc}",
+	}
+
+	got, err := maybeExpandSource(context.Background(), ru, cmd, src)
+	require.NoError(t, err)
+	require.Equal(t, "${keyring:abc}", got.Location,
+		"unresolvable placeholder must be left verbatim")
+}

--- a/cli/expand_test.go
+++ b/cli/expand_test.go
@@ -47,7 +47,7 @@ func newTestRun(t *testing.T, values map[string]string) *run.Run {
 // newCmdWithExpand returns a *cobra.Command with --expand registered
 // on its local flag set. When set is true, the flag is marked Changed
 // to true via Flags().Set so cmdFlagIsSetTrue returns true. (See
-// cli/flags.go:47 — cmdFlagIsSetTrue requires Changed AND value=true.)
+// cli/flags.go:47: cmdFlagIsSetTrue requires Changed AND value=true.)
 func newCmdWithExpand(t *testing.T, set bool) *cobra.Command {
 	t.Helper()
 	cmd := &cobra.Command{Use: "test"}

--- a/cli/flag/flag.go
+++ b/cli/flag/flag.go
@@ -52,6 +52,9 @@ const (
 	Reveal      = "reveal"
 	RevealUsage = "Show secret values in output (don't redact passwords; print keyring values)"
 
+	Expand      = "expand"
+	ExpandUsage = "Resolve ${scheme:path} placeholders to their underlying values"
+
 	NoRedact      = "no-redact"
 	NoRedactUsage = "Don't redact passwords in output (deprecated, use --reveal)"
 

--- a/cli/output/jsonw/jsonw_test.go
+++ b/cli/output/jsonw/jsonw_test.go
@@ -322,6 +322,56 @@ func TestPingWriter_Result(t *testing.T) {
 	})
 }
 
+// TestPingWriter_Result_RedactsLocation verifies that pingWriter.Result
+// redacts the Location field when Printing.Redact is true, and emits
+// plaintext when Printing.Redact is false (i.e. --reveal).
+func TestPingWriter_Result_RedactsLocation(t *testing.T) {
+	const (
+		plainLoc    = "postgres://alice:hunter2@db.example.com:5432/sakila"
+		redactedLoc = "postgres://alice:xxxxx@db.example.com:5432/sakila"
+	)
+
+	src := &source.Source{
+		Handle:   "@redact_test",
+		Type:     drivertype.Pg,
+		Location: plainLoc,
+	}
+
+	t.Run("redact_on", func(t *testing.T) {
+		var buf bytes.Buffer
+		pr := output.NewPrinting()
+		pr.EnableColor(false)
+		pr.Redact = true
+
+		pw := jsonw.NewPingWriter(&buf, pr)
+		require.NoError(t, pw.Result(src, 10*time.Millisecond, nil))
+
+		out := buf.String()
+		require.NotContains(t, out, "hunter2",
+			"plaintext password must not appear when Redact is true")
+		require.Contains(t, out, redactedLoc,
+			"redacted location must appear in output")
+
+		// The caller's src must not be mutated.
+		require.Equal(t, plainLoc, src.Location,
+			"caller's source Location must not be mutated")
+	})
+
+	t.Run("redact_off", func(t *testing.T) {
+		var buf bytes.Buffer
+		pr := output.NewPrinting()
+		pr.EnableColor(false)
+		pr.Redact = false
+
+		pw := jsonw.NewPingWriter(&buf, pr)
+		require.NoError(t, pw.Result(src, 10*time.Millisecond, nil))
+
+		out := buf.String()
+		require.Contains(t, out, "hunter2",
+			"plaintext password must appear when Redact is false (--reveal)")
+	})
+}
+
 // TestJSONRoundtrip tests writing JSON/JSONA/JSONL output from a query and then
 // reading it back with "sq inspect". This verifies that JSON files
 // created by sq can be correctly detected and read.

--- a/cli/output/jsonw/pingwriter.go
+++ b/cli/output/jsonw/pingwriter.go
@@ -30,6 +30,16 @@ func (p pingWriter) Open(_ []*source.Source) error {
 
 // Result implements output.PingWriter.
 func (p pingWriter) Result(src *source.Source, d time.Duration, err error) error {
+	// Redact Location when Printing instructs us to. The embedded
+	// *source.Source serializes Location verbatim, so without this guard
+	// `sq ping --json --expand` would emit any resolved password in
+	// plaintext. Mirror the pattern from sourcewriter.go: clone, then
+	// redact, so the caller's source is not mutated.
+	if p.pr.Redact {
+		src = src.Clone()
+		src.Location = src.RedactedLocation()
+	}
+
 	r := struct { //nolint:govet // field alignment
 		*source.Source
 		Pong     bool          `json:"pong"`

--- a/site/content/en/docs/cmd/add.help.txt
+++ b/site/content/en/docs/cmd/add.help.txt
@@ -161,6 +161,7 @@ Global Flags:
       --debug.pprof string    pprof profiling mode (default "off")
       --error.format string   Error output format (default "text")
   -E, --error.stack           Print error stack trace to stderr
+      --expand                Resolve ${scheme:path} placeholders to their underlying values
       --log                   Enable logging
       --log.file string       Log file path (default "$HOME/Library/Logs/sq/sq.log")
       --log.format string     Log output format (text or json) (default "text")

--- a/site/content/en/docs/cmd/cache-clear.help.txt
+++ b/site/content/en/docs/cmd/cache-clear.help.txt
@@ -18,6 +18,7 @@ Global Flags:
       --debug.pprof string    pprof profiling mode (default "off")
       --error.format string   Error output format (default "text")
   -E, --error.stack           Print error stack trace to stderr
+      --expand                Resolve ${scheme:path} placeholders to their underlying values
       --log                   Enable logging
       --log.file string       Log file path (default "$HOME/Library/Logs/sq/sq.log")
       --log.format string     Log output format (text or json) (default "text")

--- a/site/content/en/docs/cmd/cache-disable.help.txt
+++ b/site/content/en/docs/cmd/cache-disable.help.txt
@@ -18,6 +18,7 @@ Global Flags:
       --debug.pprof string    pprof profiling mode (default "off")
       --error.format string   Error output format (default "text")
   -E, --error.stack           Print error stack trace to stderr
+      --expand                Resolve ${scheme:path} placeholders to their underlying values
       --log                   Enable logging
       --log.file string       Log file path (default "$HOME/Library/Logs/sq/sq.log")
       --log.format string     Log output format (text or json) (default "text")

--- a/site/content/en/docs/cmd/cache-enable.help.txt
+++ b/site/content/en/docs/cmd/cache-enable.help.txt
@@ -18,6 +18,7 @@ Global Flags:
       --debug.pprof string    pprof profiling mode (default "off")
       --error.format string   Error output format (default "text")
   -E, --error.stack           Print error stack trace to stderr
+      --expand                Resolve ${scheme:path} placeholders to their underlying values
       --log                   Enable logging
       --log.file string       Log file path (default "$HOME/Library/Logs/sq/sq.log")
       --log.format string     Log output format (text or json) (default "text")

--- a/site/content/en/docs/cmd/cache-location.help.txt
+++ b/site/content/en/docs/cmd/cache-location.help.txt
@@ -20,6 +20,7 @@ Global Flags:
       --debug.pprof string    pprof profiling mode (default "off")
       --error.format string   Error output format (default "text")
   -E, --error.stack           Print error stack trace to stderr
+      --expand                Resolve ${scheme:path} placeholders to their underlying values
       --log                   Enable logging
       --log.file string       Log file path (default "$HOME/Library/Logs/sq/sq.log")
       --log.format string     Log output format (text or json) (default "text")

--- a/site/content/en/docs/cmd/cache-stat.help.txt
+++ b/site/content/en/docs/cmd/cache-stat.help.txt
@@ -20,6 +20,7 @@ Global Flags:
       --debug.pprof string    pprof profiling mode (default "off")
       --error.format string   Error output format (default "text")
   -E, --error.stack           Print error stack trace to stderr
+      --expand                Resolve ${scheme:path} placeholders to their underlying values
       --log                   Enable logging
       --log.file string       Log file path (default "$HOME/Library/Logs/sq/sq.log")
       --log.format string     Log output format (text or json) (default "text")

--- a/site/content/en/docs/cmd/cache-tree.help.txt
+++ b/site/content/en/docs/cmd/cache-tree.help.txt
@@ -19,6 +19,7 @@ Global Flags:
       --debug.pprof string    pprof profiling mode (default "off")
       --error.format string   Error output format (default "text")
   -E, --error.stack           Print error stack trace to stderr
+      --expand                Resolve ${scheme:path} placeholders to their underlying values
       --log                   Enable logging
       --log.file string       Log file path (default "$HOME/Library/Logs/sq/sq.log")
       --log.format string     Log output format (text or json) (default "text")

--- a/site/content/en/docs/cmd/completion-bash.help.txt
+++ b/site/content/en/docs/cmd/completion-bash.help.txt
@@ -27,6 +27,7 @@ Global Flags:
       --debug.pprof string    pprof profiling mode (default "off")
       --error.format string   Error output format (default "text")
   -E, --error.stack           Print error stack trace to stderr
+      --expand                Resolve ${scheme:path} placeholders to their underlying values
       --help                  Show help
       --log                   Enable logging
       --log.file string       Log file path (default "$HOME/Library/Logs/sq/sq.log")

--- a/site/content/en/docs/cmd/completion-fish.help.txt
+++ b/site/content/en/docs/cmd/completion-fish.help.txt
@@ -18,6 +18,7 @@ Global Flags:
       --debug.pprof string    pprof profiling mode (default "off")
       --error.format string   Error output format (default "text")
   -E, --error.stack           Print error stack trace to stderr
+      --expand                Resolve ${scheme:path} placeholders to their underlying values
       --help                  Show help
       --log                   Enable logging
       --log.file string       Log file path (default "$HOME/Library/Logs/sq/sq.log")

--- a/site/content/en/docs/cmd/completion-powershell.help.txt
+++ b/site/content/en/docs/cmd/completion-powershell.help.txt
@@ -15,6 +15,7 @@ Global Flags:
       --debug.pprof string    pprof profiling mode (default "off")
       --error.format string   Error output format (default "text")
   -E, --error.stack           Print error stack trace to stderr
+      --expand                Resolve ${scheme:path} placeholders to their underlying values
       --help                  Show help
       --log                   Enable logging
       --log.file string       Log file path (default "$HOME/Library/Logs/sq/sq.log")

--- a/site/content/en/docs/cmd/completion-zsh.help.txt
+++ b/site/content/en/docs/cmd/completion-zsh.help.txt
@@ -29,6 +29,7 @@ Global Flags:
       --debug.pprof string    pprof profiling mode (default "off")
       --error.format string   Error output format (default "text")
   -E, --error.stack           Print error stack trace to stderr
+      --expand                Resolve ${scheme:path} placeholders to their underlying values
       --help                  Show help
       --log                   Enable logging
       --log.file string       Log file path (default "$HOME/Library/Logs/sq/sq.log")

--- a/site/content/en/docs/cmd/completion.help.txt
+++ b/site/content/en/docs/cmd/completion.help.txt
@@ -15,6 +15,7 @@ Global Flags:
       --debug.pprof string    pprof profiling mode (default "off")
       --error.format string   Error output format (default "text")
   -E, --error.stack           Print error stack trace to stderr
+      --expand                Resolve ${scheme:path} placeholders to their underlying values
       --help                  Show help
       --log                   Enable logging
       --log.file string       Log file path (default "$HOME/Library/Logs/sq/sq.log")

--- a/site/content/en/docs/cmd/config-edit.help.txt
+++ b/site/content/en/docs/cmd/config-edit.help.txt
@@ -28,6 +28,7 @@ Global Flags:
       --debug.pprof string    pprof profiling mode (default "off")
       --error.format string   Error output format (default "text")
   -E, --error.stack           Print error stack trace to stderr
+      --expand                Resolve ${scheme:path} placeholders to their underlying values
       --log                   Enable logging
       --log.file string       Log file path (default "$HOME/Library/Logs/sq/sq.log")
       --log.format string     Log output format (text or json) (default "text")

--- a/site/content/en/docs/cmd/config-export.help.txt
+++ b/site/content/en/docs/cmd/config-export.help.txt
@@ -31,7 +31,6 @@ Examples:
   $ sq config export --expand -o sq.bak.yml
 
 Flags:
-      --expand          Fetch ${scheme:path} placeholders from keyring/env/file and inline the resolved values
   -o, --output string   Write output to <file> instead of stdout
       --help            help for export
 
@@ -40,6 +39,7 @@ Global Flags:
       --debug.pprof string    pprof profiling mode (default "off")
       --error.format string   Error output format (default "text")
   -E, --error.stack           Print error stack trace to stderr
+      --expand                Resolve ${scheme:path} placeholders to their underlying values
       --log                   Enable logging
       --log.file string       Log file path (default "$HOME/Library/Logs/sq/sq.log")
       --log.format string     Log output format (text or json) (default "text")

--- a/site/content/en/docs/cmd/config-get.help.txt
+++ b/site/content/en/docs/cmd/config-get.help.txt
@@ -30,6 +30,7 @@ Global Flags:
       --debug.pprof string    pprof profiling mode (default "off")
       --error.format string   Error output format (default "text")
   -E, --error.stack           Print error stack trace to stderr
+      --expand                Resolve ${scheme:path} placeholders to their underlying values
       --log                   Enable logging
       --log.file string       Log file path (default "$HOME/Library/Logs/sq/sq.log")
       --log.format string     Log output format (text or json) (default "text")

--- a/site/content/en/docs/cmd/config-keyring-create.help.txt
+++ b/site/content/en/docs/cmd/config-keyring-create.help.txt
@@ -38,6 +38,7 @@ Global Flags:
       --debug.pprof string    pprof profiling mode (default "off")
       --error.format string   Error output format (default "text")
   -E, --error.stack           Print error stack trace to stderr
+      --expand                Resolve ${scheme:path} placeholders to their underlying values
       --log                   Enable logging
       --log.file string       Log file path (default "$HOME/Library/Logs/sq/sq.log")
       --log.format string     Log output format (text or json) (default "text")

--- a/site/content/en/docs/cmd/config-keyring-get.help.txt
+++ b/site/content/en/docs/cmd/config-keyring-get.help.txt
@@ -31,6 +31,7 @@ Global Flags:
       --debug.pprof string    pprof profiling mode (default "off")
       --error.format string   Error output format (default "text")
   -E, --error.stack           Print error stack trace to stderr
+      --expand                Resolve ${scheme:path} placeholders to their underlying values
       --log                   Enable logging
       --log.file string       Log file path (default "$HOME/Library/Logs/sq/sq.log")
       --log.format string     Log output format (text or json) (default "text")

--- a/site/content/en/docs/cmd/config-keyring-ls.help.txt
+++ b/site/content/en/docs/cmd/config-keyring-ls.help.txt
@@ -35,6 +35,7 @@ Global Flags:
       --debug.pprof string    pprof profiling mode (default "off")
       --error.format string   Error output format (default "text")
   -E, --error.stack           Print error stack trace to stderr
+      --expand                Resolve ${scheme:path} placeholders to their underlying values
       --log                   Enable logging
       --log.file string       Log file path (default "$HOME/Library/Logs/sq/sq.log")
       --log.format string     Log output format (text or json) (default "text")

--- a/site/content/en/docs/cmd/config-keyring-migrate.help.txt
+++ b/site/content/en/docs/cmd/config-keyring-migrate.help.txt
@@ -39,6 +39,7 @@ Global Flags:
       --debug.pprof string    pprof profiling mode (default "off")
       --error.format string   Error output format (default "text")
   -E, --error.stack           Print error stack trace to stderr
+      --expand                Resolve ${scheme:path} placeholders to their underlying values
       --log                   Enable logging
       --log.file string       Log file path (default "$HOME/Library/Logs/sq/sq.log")
       --log.format string     Log output format (text or json) (default "text")

--- a/site/content/en/docs/cmd/config-keyring-rm.help.txt
+++ b/site/content/en/docs/cmd/config-keyring-rm.help.txt
@@ -24,6 +24,7 @@ Global Flags:
       --debug.pprof string    pprof profiling mode (default "off")
       --error.format string   Error output format (default "text")
   -E, --error.stack           Print error stack trace to stderr
+      --expand                Resolve ${scheme:path} placeholders to their underlying values
       --log                   Enable logging
       --log.file string       Log file path (default "$HOME/Library/Logs/sq/sq.log")
       --log.format string     Log output format (text or json) (default "text")

--- a/site/content/en/docs/cmd/config-keyring-update.help.txt
+++ b/site/content/en/docs/cmd/config-keyring-update.help.txt
@@ -38,6 +38,7 @@ Global Flags:
       --debug.pprof string    pprof profiling mode (default "off")
       --error.format string   Error output format (default "text")
   -E, --error.stack           Print error stack trace to stderr
+      --expand                Resolve ${scheme:path} placeholders to their underlying values
       --log                   Enable logging
       --log.file string       Log file path (default "$HOME/Library/Logs/sq/sq.log")
       --log.format string     Log output format (text or json) (default "text")

--- a/site/content/en/docs/cmd/config-keyring.help.txt
+++ b/site/content/en/docs/cmd/config-keyring.help.txt
@@ -58,6 +58,7 @@ Global Flags:
       --debug.pprof string    pprof profiling mode (default "off")
       --error.format string   Error output format (default "text")
   -E, --error.stack           Print error stack trace to stderr
+      --expand                Resolve ${scheme:path} placeholders to their underlying values
       --log                   Enable logging
       --log.file string       Log file path (default "$HOME/Library/Logs/sq/sq.log")
       --log.format string     Log output format (text or json) (default "text")

--- a/site/content/en/docs/cmd/config-location.help.txt
+++ b/site/content/en/docs/cmd/config-location.help.txt
@@ -26,6 +26,7 @@ Global Flags:
       --debug.pprof string    pprof profiling mode (default "off")
       --error.format string   Error output format (default "text")
   -E, --error.stack           Print error stack trace to stderr
+      --expand                Resolve ${scheme:path} placeholders to their underlying values
       --log                   Enable logging
       --log.file string       Log file path (default "$HOME/Library/Logs/sq/sq.log")
       --log.format string     Log output format (text or json) (default "text")

--- a/site/content/en/docs/cmd/config-ls.help.txt
+++ b/site/content/en/docs/cmd/config-ls.help.txt
@@ -39,6 +39,7 @@ Global Flags:
       --debug.pprof string    pprof profiling mode (default "off")
       --error.format string   Error output format (default "text")
   -E, --error.stack           Print error stack trace to stderr
+      --expand                Resolve ${scheme:path} placeholders to their underlying values
       --log                   Enable logging
       --log.file string       Log file path (default "$HOME/Library/Logs/sq/sq.log")
       --log.format string     Log output format (text or json) (default "text")

--- a/site/content/en/docs/cmd/config-set.help.txt
+++ b/site/content/en/docs/cmd/config-set.help.txt
@@ -37,6 +37,7 @@ Global Flags:
       --debug.pprof string    pprof profiling mode (default "off")
       --error.format string   Error output format (default "text")
   -E, --error.stack           Print error stack trace to stderr
+      --expand                Resolve ${scheme:path} placeholders to their underlying values
       --log                   Enable logging
       --log.file string       Log file path (default "$HOME/Library/Logs/sq/sq.log")
       --log.format string     Log output format (text or json) (default "text")

--- a/site/content/en/docs/cmd/diff.help.txt
+++ b/site/content/en/docs/cmd/diff.help.txt
@@ -112,6 +112,7 @@ Global Flags:
       --debug.pprof string    pprof profiling mode (default "off")
       --error.format string   Error output format (default "text")
   -E, --error.stack           Print error stack trace to stderr
+      --expand                Resolve ${scheme:path} placeholders to their underlying values
       --log                   Enable logging
       --log.file string       Log file path (default "$HOME/Library/Logs/sq/sq.log")
       --log.format string     Log output format (text or json) (default "text")

--- a/site/content/en/docs/cmd/driver-ls.help.txt
+++ b/site/content/en/docs/cmd/driver-ls.help.txt
@@ -17,6 +17,7 @@ Global Flags:
       --debug.pprof string    pprof profiling mode (default "off")
       --error.format string   Error output format (default "text")
   -E, --error.stack           Print error stack trace to stderr
+      --expand                Resolve ${scheme:path} placeholders to their underlying values
       --log                   Enable logging
       --log.file string       Log file path (default "$HOME/Library/Logs/sq/sq.log")
       --log.format string     Log output format (text or json) (default "text")

--- a/site/content/en/docs/cmd/group.help.txt
+++ b/site/content/en/docs/cmd/group.help.txt
@@ -34,6 +34,7 @@ Global Flags:
       --debug.pprof string    pprof profiling mode (default "off")
       --error.format string   Error output format (default "text")
   -E, --error.stack           Print error stack trace to stderr
+      --expand                Resolve ${scheme:path} placeholders to their underlying values
       --log                   Enable logging
       --log.file string       Log file path (default "$HOME/Library/Logs/sq/sq.log")
       --log.format string     Log output format (text or json) (default "text")

--- a/site/content/en/docs/cmd/help.help.txt
+++ b/site/content/en/docs/cmd/help.help.txt
@@ -8,6 +8,7 @@ Global Flags:
       --debug.pprof string    pprof profiling mode (default "off")
       --error.format string   Error output format (default "text")
   -E, --error.stack           Print error stack trace to stderr
+      --expand                Resolve ${scheme:path} placeholders to their underlying values
       --help                  Show help
       --log                   Enable logging
       --log.file string       Log file path (default "$HOME/Library/Logs/sq/sq.log")

--- a/site/content/en/docs/cmd/inspect.help.txt
+++ b/site/content/en/docs/cmd/inspect.help.txt
@@ -100,6 +100,7 @@ Global Flags:
       --debug.pprof string    pprof profiling mode (default "off")
       --error.format string   Error output format (default "text")
   -E, --error.stack           Print error stack trace to stderr
+      --expand                Resolve ${scheme:path} placeholders to their underlying values
       --log                   Enable logging
       --log.file string       Log file path (default "$HOME/Library/Logs/sq/sq.log")
       --log.format string     Log output format (text or json) (default "text")

--- a/site/content/en/docs/cmd/ls.help.txt
+++ b/site/content/en/docs/cmd/ls.help.txt
@@ -41,6 +41,7 @@ Global Flags:
       --debug.pprof string    pprof profiling mode (default "off")
       --error.format string   Error output format (default "text")
   -E, --error.stack           Print error stack trace to stderr
+      --expand                Resolve ${scheme:path} placeholders to their underlying values
       --log                   Enable logging
       --log.file string       Log file path (default "$HOME/Library/Logs/sq/sq.log")
       --log.format string     Log output format (text or json) (default "text")

--- a/site/content/en/docs/cmd/mv.help.txt
+++ b/site/content/en/docs/cmd/mv.help.txt
@@ -37,6 +37,7 @@ Global Flags:
       --debug.pprof string    pprof profiling mode (default "off")
       --error.format string   Error output format (default "text")
   -E, --error.stack           Print error stack trace to stderr
+      --expand                Resolve ${scheme:path} placeholders to their underlying values
       --log                   Enable logging
       --log.file string       Log file path (default "$HOME/Library/Logs/sq/sq.log")
       --log.format string     Log output format (text or json) (default "text")

--- a/site/content/en/docs/cmd/ping.help.txt
+++ b/site/content/en/docs/cmd/ping.help.txt
@@ -42,6 +42,7 @@ Global Flags:
       --debug.pprof string    pprof profiling mode (default "off")
       --error.format string   Error output format (default "text")
   -E, --error.stack           Print error stack trace to stderr
+      --expand                Resolve ${scheme:path} placeholders to their underlying values
       --log                   Enable logging
       --log.file string       Log file path (default "$HOME/Library/Logs/sq/sq.log")
       --log.format string     Log output format (text or json) (default "text")

--- a/site/content/en/docs/cmd/rm.help.txt
+++ b/site/content/en/docs/cmd/rm.help.txt
@@ -32,6 +32,7 @@ Global Flags:
       --debug.pprof string    pprof profiling mode (default "off")
       --error.format string   Error output format (default "text")
   -E, --error.stack           Print error stack trace to stderr
+      --expand                Resolve ${scheme:path} placeholders to their underlying values
       --log                   Enable logging
       --log.file string       Log file path (default "$HOME/Library/Logs/sq/sq.log")
       --log.format string     Log output format (text or json) (default "text")

--- a/site/content/en/docs/cmd/sq.help.txt
+++ b/site/content/en/docs/cmd/sq.help.txt
@@ -136,6 +136,7 @@ Flags:
       --no-progress                    Don't show progress bar
       --reveal                         Show secret values in output (don't redact passwords; print keyring values)
       --no-redact                      Don't redact passwords in output (deprecated, use --reveal)
+      --expand                         Resolve ${scheme:path} placeholders to their underlying values
   -v, --verbose                        Print verbose output
       --debug.pprof string             pprof profiling mode (default "off")
       --config string                  Load config from here

--- a/site/content/en/docs/cmd/sql.help.txt
+++ b/site/content/en/docs/cmd/sql.help.txt
@@ -61,6 +61,7 @@ Global Flags:
       --debug.pprof string    pprof profiling mode (default "off")
       --error.format string   Error output format (default "text")
   -E, --error.stack           Print error stack trace to stderr
+      --expand                Resolve ${scheme:path} placeholders to their underlying values
       --log                   Enable logging
       --log.file string       Log file path (default "$HOME/Library/Logs/sq/sq.log")
       --log.format string     Log output format (text or json) (default "text")

--- a/site/content/en/docs/cmd/src.help.txt
+++ b/site/content/en/docs/cmd/src.help.txt
@@ -25,6 +25,7 @@ Global Flags:
       --debug.pprof string    pprof profiling mode (default "off")
       --error.format string   Error output format (default "text")
   -E, --error.stack           Print error stack trace to stderr
+      --expand                Resolve ${scheme:path} placeholders to their underlying values
       --log                   Enable logging
       --log.file string       Log file path (default "$HOME/Library/Logs/sq/sq.log")
       --log.format string     Log output format (text or json) (default "text")

--- a/site/content/en/docs/cmd/tbl-copy.help.txt
+++ b/site/content/en/docs/cmd/tbl-copy.help.txt
@@ -30,6 +30,7 @@ Global Flags:
       --debug.pprof string    pprof profiling mode (default "off")
       --error.format string   Error output format (default "text")
   -E, --error.stack           Print error stack trace to stderr
+      --expand                Resolve ${scheme:path} placeholders to their underlying values
       --log                   Enable logging
       --log.file string       Log file path (default "$HOME/Library/Logs/sq/sq.log")
       --log.format string     Log output format (text or json) (default "text")

--- a/site/content/en/docs/cmd/tbl-drop.help.txt
+++ b/site/content/en/docs/cmd/tbl-drop.help.txt
@@ -22,6 +22,7 @@ Global Flags:
       --debug.pprof string    pprof profiling mode (default "off")
       --error.format string   Error output format (default "text")
   -E, --error.stack           Print error stack trace to stderr
+      --expand                Resolve ${scheme:path} placeholders to their underlying values
       --log                   Enable logging
       --log.file string       Log file path (default "$HOME/Library/Logs/sq/sq.log")
       --log.format string     Log output format (text or json) (default "text")

--- a/site/content/en/docs/cmd/tbl-truncate.help.txt
+++ b/site/content/en/docs/cmd/tbl-truncate.help.txt
@@ -26,6 +26,7 @@ Global Flags:
       --debug.pprof string    pprof profiling mode (default "off")
       --error.format string   Error output format (default "text")
   -E, --error.stack           Print error stack trace to stderr
+      --expand                Resolve ${scheme:path} placeholders to their underlying values
       --log                   Enable logging
       --log.file string       Log file path (default "$HOME/Library/Logs/sq/sq.log")
       --log.format string     Log output format (text or json) (default "text")

--- a/site/content/en/docs/cmd/version.help.txt
+++ b/site/content/en/docs/cmd/version.help.txt
@@ -58,6 +58,7 @@ Global Flags:
       --debug.pprof string    pprof profiling mode (default "off")
       --error.format string   Error output format (default "text")
   -E, --error.stack           Print error stack trace to stderr
+      --expand                Resolve ${scheme:path} placeholders to their underlying values
       --log                   Enable logging
       --log.file string       Log file path (default "$HOME/Library/Logs/sq/sq.log")
       --log.format string     Log output format (text or json) (default "text")

--- a/site/content/en/docs/secrets/index.md
+++ b/site/content/en/docs/secrets/index.md
@@ -111,12 +111,17 @@ and the commands that print a source location act on it.
 ### On display commands
 
 [`sq src`](/docs/cmd/src), [`sq ls`](/docs/cmd/ls),
-[`sq inspect`](/docs/inspect), [`sq add`](/docs/cmd/add)'s echo,
-[`sq mv`](/docs/cmd/mv)'s echo, and [`sq ping`](/docs/cmd/ping) with `-v`
-each show a source location. `--expand` decides whether that location is
-the verbatim placeholder or the resolved value. `--reveal` is the orthogonal
-axis: it flips the redaction filter on whatever string ends up being
-displayed.
+[`sq inspect`](/docs/inspect), [`sq add`](/docs/cmd/add)'s post-add
+echo, [`sq mv`](/docs/cmd/mv)'s post-mv echo, and
+[`sq ping`](/docs/cmd/ping) in JSON or YAML output each show a source
+location. `--expand` decides whether that location is the verbatim
+placeholder or the resolved value. `--reveal` is the orthogonal axis: it
+flips the redaction filter on whatever string ends up being displayed.
+
+> [!NOTE]
+> `sq ping`'s text and CSV output do not include a Location column, so
+> `--expand` has no visible effect there. Use `--json` or `--yaml` to see
+> the per-source location.
 
 For a source whose YAML location is `${keyring:abc}` and whose keyring entry
 holds `postgres://alice:hunter2@db.acme.com/sakila`:
@@ -128,12 +133,15 @@ holds `postgres://alice:hunter2@db.acme.com/sakila`:
 | `--expand`            | `postgres://alice:xxxxx@db.acme.com/sakila`              |
 | `--expand --reveal`   | `postgres://alice:hunter2@db.acme.com/sakila`            |
 
-If a resolver fails per source (missing keyring entry, unset env var,
-unreadable file), the placeholder is preserved verbatim for that source.
-Other sources expand normally and the command exits 0. The lenient
-fallback is deliberate: `--expand` on a display command is a diagnostic,
-and an aborted command would hide every source's state because of one
-stale placeholder.
+The display-expansion step is lenient: a per-source resolver failure
+(missing keyring entry, unset env var, unreadable file) leaves that
+source's placeholder verbatim and the listing continues. This applies to
+the display step only; commands that must resolve to connect (e.g.
+`sq inspect`, `sq ping`) still fail at connect time when a missing secret
+prevents the connection. The lenient display fallback is deliberate:
+`--expand` on a listing command is a diagnostic, and aborting the whole
+listing because one source's resolver is offline would hide every other
+source's state.
 
 ### On `sq config export`
 

--- a/site/content/en/docs/secrets/index.md
+++ b/site/content/en/docs/secrets/index.md
@@ -33,14 +33,14 @@ By default:
 
 Two global flags opt out of those defaults; they do different things:
 
-| Flag                                                                                              | What it does                                                                         | Where it applies                                                              |
-|---------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------|-------------------------------------------------------------------------------|
-| <a href="#redact--reveal" style="white-space:nowrap">`--reveal`</a>                               | Don't redact secrets in display output. Show data that `sq` already has in hand.     | Global. Any command that prints a source location or a keyring entry's value. |
-| <a href="#substitution" style="white-space:nowrap">`--expand`</a>                                 | Resolve `${scheme:path}` placeholders and splice the fetched values into the output. | [`sq config export`](/docs/cmd/config-export) only.                           |
+| Flag                                                                                              | What it does                                                                         | Where it applies                                                                                       |
+|---------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------|
+| <a href="#redact--reveal" style="white-space:nowrap">`--reveal`</a>                               | Don't redact secrets in display output. Show data that `sq` already has in hand.     | Global. Any command that prints a source location or a keyring entry's value.                          |
+| <a href="#substitution" style="white-space:nowrap">`--expand`</a>                                 | Resolve `${scheme:path}` placeholders and splice the fetched values into the output. | Global. Any command that prints a source location; also [`sq config export`](/docs/cmd/config-export). |
 
 `--reveal` shows you something `sq` already knows. `--expand` makes `sq` go
 fetch something it doesn't currently hold. Both can expose plaintext, but
-the security implications are different — see each section below.
+the security implications differ; see each section below.
 
 ## Redact & reveal
 

--- a/site/content/en/docs/secrets/index.md
+++ b/site/content/en/docs/secrets/index.md
@@ -102,16 +102,51 @@ thing; `--no-redact` will be removed in a future release.
 
 ## Substitution
 
+`--expand` resolves `${scheme:path}` placeholders against the configured
+resolvers (keyring read, environment variable read, or file read) and
+substitutes the resolved value into whatever location string `sq` is about
+to display. It is a persistent root flag: every subcommand accepts it,
+and the commands that print a source location act on it.
+
+### On display commands
+
+[`sq src`](/docs/cmd/src), [`sq ls`](/docs/cmd/ls),
+[`sq inspect`](/docs/inspect), [`sq add`](/docs/cmd/add)'s echo,
+[`sq mv`](/docs/cmd/mv)'s echo, and [`sq ping`](/docs/cmd/ping) with `-v`
+each show a source location. `--expand` decides whether that location is
+the verbatim placeholder or the resolved value. `--reveal` is the orthogonal
+axis: it flips the redaction filter on whatever string ends up being
+displayed.
+
+For a source whose YAML location is `${keyring:abc}` and whose keyring entry
+holds `postgres://alice:hunter2@db.acme.com/sakila`:
+
+| Flags                 | Displayed location                                       |
+|-----------------------|----------------------------------------------------------|
+| (none)                | `${keyring:abc}`                                         |
+| `--reveal`            | `${keyring:abc}`                                         |
+| `--expand`            | `postgres://alice:xxxxx@db.acme.com/sakila`              |
+| `--expand --reveal`   | `postgres://alice:hunter2@db.acme.com/sakila`            |
+
+If a resolver fails per source (missing keyring entry, unset env var,
+unreadable file), the placeholder is preserved verbatim for that source.
+Other sources expand normally and the command exits 0. The lenient
+fallback is deliberate: `--expand` on a display command is a diagnostic,
+and an aborted command would hide every source's state because of one
+stale placeholder.
+
+### On `sq config export`
+
 [`sq config export`](/docs/cmd/config-export) dumps the live config to YAML
 for backups. By default the export is a faithful copy of `sq.yml`:
 `${scheme:path}` placeholders are written verbatim, and inline credentials
 (plaintext URLs) are dumped exactly as they appear in the file.
 
-With `--expand`, every `${scheme:path}` placeholder is resolved (keyring
-read, environment variable read, or file read), and the resolved value is
-spliced inline into the exported location. The output is a self-contained
-snapshot suitable for moving between machines — at the cost of writing every
-referenced secret in plaintext, which is exactly the point of `--expand`.
+With `--expand`, every `${scheme:path}` placeholder is resolved and the
+resolved value is spliced inline into the exported location. The output is
+a self-contained snapshot suitable for moving between machines, at the cost
+of writing every referenced secret in plaintext, which is exactly the point
+of `--expand`.
 
 ```yaml
 # Live config: location uses a keyring placeholder
@@ -135,9 +170,9 @@ $ sq config export --expand | grep '@sakila/pg' -A1
 When `--output` is used, the exported file is created with mode `0600`,
 since it may contain credentials regardless of whether `--expand` was set.
 
-`--expand` can fail per-source if a referenced keyring entry, environment
-variable, or file is missing. The export errors with the failing source's
-handle so you know which one to fix.
+`sq config export --expand` keeps strict-abort semantics on resolver
+failure (unlike the lenient display commands). An export is a snapshot for
+transfer, and a half-resolved snapshot is the wrong artifact.
 
 ### `--reveal` vs `--expand`
 
@@ -147,13 +182,14 @@ Both flags can produce plaintext secrets, but they're not interchangeable.
 |----------------------------------|-------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------|
 | Purpose                          | Show secret data already loaded                                                                       | Fetch placeholder values and splice them in                                                                    |
 | Source of the printed value      | The current in-memory config                                                                          | External resolvers: OS keyring, env, file                                                                      |
-| Applies to                       | Any command that prints a location or keyring value                                                   | [`sq config export`](/docs/cmd/config-export) only                                                             |
+| Applies to                       | Any command that prints a location or keyring value                                                   | Any command that prints a source location; also [`sq config export`](/docs/cmd/config-export)                  |
 | What you see for a placeholder   | The placeholder text (e.g. `${keyring:abc}`)                                                          | The resolved value (e.g. `hunter2`)                                                                            |
-| Failure mode                     | Cannot fail — it is just a display flip                                                               | Can fail per source if a resolver entry is missing                                                             |
-| Risk                             | Reveals plaintext already in `sq.yml` or the keyring                                                  | Pulls plaintext **out** of resolvers into a single file you must protect                                       |
+| Failure mode                     | Cannot fail; it is just a display flip                                                                | Lenient per source on display commands; strict-abort on `sq config export`                                     |
+| Risk                             | Reveals plaintext already in `sq.yml` or the keyring                                                  | Pulls plaintext **out** of resolvers into terminal, log, or exported-file output                               |
 
 Use `--reveal` to read configuration; use `--expand` to take a portable
-backup. Don't reach for `--expand` when `--reveal` is what you want.
+backup or to diagnose what a source actually resolves to. Don't reach for
+`--expand` when `--reveal` is what you want.
 
 ## Placeholders
 
@@ -347,8 +383,10 @@ is not a sandbox. The threats it does — and does not — address:
 - A compromised user account: anything running as the user can read the
   user's keyring once it is unlocked.
 - Malware in the user's session: it sees the same keyring `sq` does.
-- A user who runs `sq config keyring get --reveal` or
-  `sq config export --expand` and pipes the output somewhere unsafe.
+- A user who runs `sq config keyring get --reveal`,
+  `sq config export --expand`, or any display command with
+  `--reveal --expand` and pipes the output somewhere unsafe (terminal
+  buffer, shell recording, CI log, screen share).
 - Memory inspection: while a source is connected, the resolved conn string
   exists in `sq`'s process memory.
 
@@ -361,6 +399,7 @@ The `keyring` scheme targets the dev-laptop case.
 
 - [`sq config keyring`](/docs/cmd/config-keyring): keyring command group.
 - [`sq add`](/docs/cmd/add): the `--store inline|keyring` flag.
-- [`sq config export`](/docs/cmd/config-export): the `--expand` flag.
+- [`sq config export`](/docs/cmd/config-export) (and other display
+  commands): the `--expand` flag.
 - [`secrets.store`](/docs/config#secretsstore): default storage backend config.
 - [`secrets.reveal`](/docs/config#secretsreveal): persistent disclosure control config.


### PR DESCRIPTION
Closes #729.

## Summary

- `--expand` is now a persistent root flag on `sq`, accepted by every subcommand and acted on by every command that prints a source location: `sq src`, `sq ls`, `sq inspect`, `sq add` (echo), `sq mv` (echo), `sq ping -v`. Previously it lived only on `sq config export`.
- `--expand` composes orthogonally with `--reveal`: `--reveal` flips the redaction filter on whatever string ends up being displayed; `--expand` decides whether that string is the verbatim placeholder or the resolved value.
- Per-source resolver failure on display commands is **lenient**: the placeholder is preserved verbatim, other sources expand normally, and the command exits 0. `sq config export --expand` keeps its existing **strict-abort** semantics (a half-resolved snapshot is the wrong artifact).
- Subcommands that don't print a source location (`sq sql`, `sq slq`, `sq tbl`, etc.) accept `--expand` as a silent no-op, so a global alias like `alias sq='sq --reveal --expand'` is safe.
- Side-effect fix: `sq inspect` no longer leaks the resolved target of a placeholder into its metadata output. The driver layer resolves placeholders to open the connection, and the resolved value was being copied verbatim into `metadata.Source.Location`; the inspect handler now overrides that field with the caller's view of `src.Location`.
- Docs: `CHANGELOG.md` entry under `## Unreleased` (Changed + Fixed); the [Secrets page](https://sq.io/docs/secrets) gets a rewritten `## Substitution` section with the matrix, an updated `--reveal` vs `--expand` comparison table, and a threat-model note about the broader plaintext-exposure surface that comes with globalizing `--expand`.

## Matrix

For a source whose location is `${keyring:abc}` and whose keyring entry holds `postgres://alice:hunter2@db/sakila`:

| Flags                 | Displayed Location                              |
|-----------------------|-------------------------------------------------|
| (none)                | `${keyring:abc}`                                |
| `--reveal`            | `${keyring:abc}`                                |
| `--expand`            | `postgres://alice:xxxxx@db/sakila`              |
| `--expand --reveal`   | `postgres://alice:hunter2@db/sakila`            |

## Architecture

A new `cli/expand.go` exposes `maybeExpandCollection` and `maybeExpandSource`. Each location-printing handler calls the appropriate helper at the point it has obtained its data and before it hands it to the writer. Writers stay unchanged; their existing redact step runs on whatever Location they receive, so the pipeline is `raw → [expand?] → [redact?] → displayed`. `sq config export` keeps its strict variant in `exportExpandConfig` (deliberately not factored together; the two loops are five lines each and diverge only in error handling).

## Test plan

- [x] `make lint` clean.
- [x] `make test-short` passes (90 packages, including new `TestMaybeExpand*` unit tests in `cli/expand_test.go` and new `TestExpandRevealMatrix` / `TestExpandLenient_PartialFailure` / `TestExpand_NoOp_OnNonDisplayCommand` integration tests in `cli/cmd_ls_test.go`).
- [x] End-to-end smoke against the built binary: `sq src`, `sq ls -v`, `sq inspect --overview --json` all produce the expected matrix; `sq sql --expand 'SELECT 1'` runs without error (silent no-op invariant).
- [x] Persistence-not-tainted check on `sq add --expand` and `sq mv --expand`: the exported config holds the verbatim placeholder.
- [x] `sq config export --expand` regression guard: existing `TestCmdConfigExport*` suite passes.

## Out of scope

- New resolver schemes (`op:`, `aws-sm:`, etc.).
- Changes to `secrets.reveal` config option behavior.
- A `secrets.expand` config option (deliberately not added; `--expand` is a per-invocation diagnostic, not a workflow preference).
- Inline annotation for unresolved placeholders.
