### PR TITLE
site: secrets docs cleanup (typo, anchors, keyring relocation)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,7 +60,7 @@ Breaking changes are annotated with ☢️, and alpha/beta features with 🐥.
   (`--format=svg-erd` / `--format=png-erd`).
   - The diagram is laid out and rendered natively via an embedded [Graphviz](https://graphviz.org)
     engine, so image export needs no external tool, browser, or network.
-- [#717]: New global [`--reveal`](https://sq.io/docs/secrets#redact--reveal) flag opts
+- [#717]: New global [`--reveal`](https://sq.io/docs/secrets#redaction) flag opts
   into showing secret values in output.
   - It supersedes the legacy `--no-redact` (still functional, now marked deprecated, will be removed
     at some point in the future).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ Breaking changes are annotated with ☢️, and alpha/beta features with 🐥.
   YAML, primarily for backups. See [Secrets](https://sq.io/docs/secrets) for the bigger picture.
   - By default, output is a faithful-ish copy of the live config: `${scheme:path}` placeholders are
     written verbatim.
-  - With [`--expand`](https://sq.io/docs/secrets#substitution), every placeholder is
+  - With [`--expand`](https://sq.io/docs/secrets#expanding-placeholders), every placeholder is
     fetched from its resolver (`keyring`, `env`, `file`, or `op`) and the resolved value
     is spliced in-line: a self-contained snapshot at the cost of writing every referenced
     secret in plaintext (which is exactly the point of `--expand`).
@@ -83,7 +83,7 @@ Breaking changes are annotated with ☢️, and alpha/beta features with 🐥.
     a flag.
 - [#692]: [`sq inspect -f mermaid-erd`](https://sq.io/docs/inspect#mermaid-erd)
   now syntax-colors its `erDiagram` source when writing to a terminal.
-- [#729]: [`--expand`](https://sq.io/docs/secrets#substitution) is now a persistent
+- [#729]: [`--expand`](https://sq.io/docs/secrets#expanding-placeholders) is now a persistent
   root flag, accepted by every subcommand. Previously it lived only on `sq config export`.
   - Commands that print a source location ([`sq src`](https://sq.io/docs/cmd/src),
     [`sq ls`](https://sq.io/docs/cmd/ls), [`sq inspect`](https://sq.io/docs/inspect),

--- a/site/content/en/docs/cmd/config-export.md
+++ b/site/content/en/docs/cmd/config-export.md
@@ -40,8 +40,8 @@ $ sq config export --expand -o sq.bak.yml
 If a referenced keyring entry, environment variable, or file is missing,
 the export errors with the failing source's handle.
 
-For the broader picture — how `--expand` differs from `--reveal`, the
-placeholder grammar, and the threat model — see
+For the broader picture (how `--expand` differs from `--reveal`, the
+placeholder grammar, the threat model), see
 [Secrets](/docs/secrets#expanding-placeholders).
 
 See the [config](/docs/config) section for an overview of `sq`

--- a/site/content/en/docs/cmd/config-export.md
+++ b/site/content/en/docs/cmd/config-export.md
@@ -42,7 +42,7 @@ the export errors with the failing source's handle.
 
 For the broader picture — how `--expand` differs from `--reveal`, the
 placeholder grammar, and the threat model — see
-[Secrets](/docs/secrets#substitution).
+[Secrets](/docs/secrets#expanding-placeholders).
 
 See the [config](/docs/config) section for an overview of `sq`
 configuration.

--- a/site/content/en/docs/cmd/config-keyring-create.md
+++ b/site/content/en/docs/cmd/config-keyring-create.md
@@ -10,8 +10,8 @@ weight: 2038
 toc: false
 url: /docs/cmd/config-keyring-create
 ---
-See [Secrets](/docs/secrets#managing-keyring-entries) for an overview of
-the `sq config keyring` command group. Most users let
+Part of the [`sq config keyring`](/docs/cmd/config-keyring) command group;
+see [Secrets](/docs/secrets) for the broader picture. Most users let
 [`sq add --store keyring`](/docs/cmd/add) create entries automatically;
 this command is for hand-crafted paths used by composition or shared
 keyring references.

--- a/site/content/en/docs/cmd/config-keyring-get.md
+++ b/site/content/en/docs/cmd/config-keyring-get.md
@@ -10,9 +10,9 @@ weight: 2038
 toc: false
 url: /docs/cmd/config-keyring-get
 ---
-See [Secrets](/docs/secrets#managing-keyring-entries) for an overview of
-the `sq config keyring` command group. By default this prints only that
-the entry exists; pass [`--reveal`](/docs/secrets#redact--reveal)
+Part of the [`sq config keyring`](/docs/cmd/config-keyring) command group;
+see [Secrets](/docs/secrets) for the broader picture. By default this
+prints only that the entry exists; pass [`--reveal`](/docs/secrets#redaction)
 to print the stored value.
 
 ## Reference

--- a/site/content/en/docs/cmd/config-keyring-ls.md
+++ b/site/content/en/docs/cmd/config-keyring-ls.md
@@ -10,8 +10,8 @@ weight: 2038
 toc: false
 url: /docs/cmd/config-keyring-ls
 ---
-See [Secrets](/docs/secrets#managing-keyring-entries) for an overview of
-the `sq config keyring` command group.
+Part of the [`sq config keyring`](/docs/cmd/config-keyring) command group;
+see [Secrets](/docs/secrets) for the broader picture.
 
 ## Reference
 

--- a/site/content/en/docs/cmd/config-keyring-migrate.md
+++ b/site/content/en/docs/cmd/config-keyring-migrate.md
@@ -10,8 +10,8 @@ weight: 2038
 toc: false
 url: /docs/cmd/config-keyring-migrate
 ---
-See [Secrets](/docs/secrets#managing-keyring-entries) for an overview of
-the `sq config keyring` command group. `migrate` is a bulk operation
+Part of the [`sq config keyring`](/docs/cmd/config-keyring) command group;
+see [Secrets](/docs/secrets) for the broader picture. `migrate` is a bulk operation
 that walks the source collection, writes each inline-password conn string to a
 fresh opaque keyring ID, and replaces the YAML location with a bare
 `${keyring:<id>}` placeholder. Use `--dry-run` first to preview.

--- a/site/content/en/docs/cmd/config-keyring-rm.md
+++ b/site/content/en/docs/cmd/config-keyring-rm.md
@@ -10,8 +10,8 @@ weight: 2038
 toc: false
 url: /docs/cmd/config-keyring-rm
 ---
-See [Secrets](/docs/secrets#managing-keyring-entries) for an overview of
-the `sq config keyring` command group. `rm` only deletes the keyring
+Part of the [`sq config keyring`](/docs/cmd/config-keyring) command group;
+see [Secrets](/docs/secrets) for the broader picture. `rm` only deletes the keyring
 entry; any `${keyring:PATH}` reference left in `sq.yml` will fail to
 resolve at connect time. Run
 [`sq config keyring ls`](/docs/cmd/config-keyring-ls) first to find

--- a/site/content/en/docs/cmd/config-keyring-update.md
+++ b/site/content/en/docs/cmd/config-keyring-update.md
@@ -10,8 +10,8 @@ weight: 2038
 toc: false
 url: /docs/cmd/config-keyring-update
 ---
-See [Secrets](/docs/secrets#managing-keyring-entries) for an overview of
-the `sq config keyring` command group. Typical use is to rotate a
+Part of the [`sq config keyring`](/docs/cmd/config-keyring) command group;
+see [Secrets](/docs/secrets) for the broader picture. Typical use is to rotate a
 credential: pass the same `PATH` that already appears in a source's
 location, with a new value.
 

--- a/site/content/en/docs/cmd/config-keyring.md
+++ b/site/content/en/docs/cmd/config-keyring.md
@@ -10,9 +10,36 @@ weight: 2038
 toc: false
 url: /docs/cmd/config-keyring
 ---
-See [Secrets](/docs/secrets) for an overview of how `sq` handles secrets,
-and [Managing keyring entries](/docs/secrets#managing-keyring-entries) for
-the role of this command group.
+The `sq config keyring` command group manages keyring entries directly.
+Most users never need it: [`sq add --store keyring`](/docs/cmd/add) and the
+[`secrets.store`](/docs/config#secretsstore) option write entries
+automatically. Reach for these subcommands when you need to rotate a
+credential, migrate inline passwords in bulk, or inspect what's already
+stored.
+
+See [Secrets](/docs/secrets) for an overview of how `sq` handles secrets
+and how the keyring scheme fits in.
+
+## Commands
+
+| Command                                                         | What it does                                                   |
+|-----------------------------------------------------------------|----------------------------------------------------------------|
+| [`sq config keyring ls`](/docs/cmd/config-keyring-ls)           | List `${keyring:<path>}` references found in source locations. |
+| [`sq config keyring create`](/docs/cmd/config-keyring-create)   | Create a new entry at `PATH`. Errors if `PATH` already exists. |
+| [`sq config keyring update`](/docs/cmd/config-keyring-update)   | Rotate the value at an existing `PATH`.                        |
+| [`sq config keyring get`](/docs/cmd/config-keyring-get)         | Check an entry exists; with `--reveal`, print its value.       |
+| [`sq config keyring rm`](/docs/cmd/config-keyring-rm)           | Delete an entry. Does not touch sources that reference it.     |
+| [`sq config keyring migrate`](/docs/cmd/config-keyring-migrate) | Move inline-password sources to the keyring in bulk.           |
+
+`sq config keyring ls` walks the YAML config; it lists only `keyring`
+placeholders that some source references. Orphan entries (entries in the
+keyring that no source uses) are not surfaced. Enumerating them requires
+keyring-wide iteration, which is deferred to a future release.
+
+`sq config keyring rm` deletes the keyring entry only; any remaining
+`${keyring:PATH}` reference in `sq.yml` will fail to resolve on the next
+connect. Run [`sq config keyring ls`](/docs/cmd/config-keyring-ls) first to
+find references.
 
 ## Reference
 

--- a/site/content/en/docs/config/index.md
+++ b/site/content/en/docs/config/index.md
@@ -377,7 +377,7 @@ $ sq src -v
 ```
 
 `secrets.reveal` is the persistent form of the global
-[`--reveal`](/docs/secrets#redact--reveal) flag. The earlier `--no-redact`
+[`--reveal`](/docs/secrets#redaction) flag. The earlier `--no-redact`
 flag still works but is deprecated; use `--reveal` in new scripts.
 
 See [Secrets](/docs/secrets) for the full picture, including how `--reveal`
@@ -407,7 +407,7 @@ $ sq config set secrets.store keyring
 ```
 
 The `--store` flag on `sq add` overrides this option per invocation. See
-[Secrets](/docs/secrets#keyring-scheme) for the keyring scheme and the
+[Secrets](/docs/secrets#keyring) for the keyring scheme and the
 threat model.
 
 {{< readfile file="../cmd/options/secrets.store.help.txt" code="true" lang="text" >}}

--- a/site/content/en/docs/secrets/index.md
+++ b/site/content/en/docs/secrets/index.md
@@ -171,7 +171,7 @@ running `sq`.
 [gnome-keyring]: https://wiki.gnome.org/Projects/GnomeKeyring
 [kwallet]: https://apps.kde.org/kwalletmanager5/
 
-The typical pattern is [`sq add DSN --store keyring`](/docs/cmd/add), which
+The typical pattern is [`sq add --store keyring DSN`](/docs/cmd/add), which
 mints an opaque 10-character ID (e.g. `j2k7m3pxtz`), writes the full conn
 string to the keyring at that ID, and stores a bare placeholder in YAML:
 

--- a/site/content/en/docs/secrets/index.md
+++ b/site/content/en/docs/secrets/index.md
@@ -8,31 +8,47 @@ weight: 1037
 toc: true
 url: /docs/secrets
 ---
-`sq` treats credentials with two complementary mechanisms: **redaction**, which
-keeps secrets out of display output, and **placeholders**, which keep secrets
-out of the [config](../config) file itself. This page explains both, and how
-the global `--reveal` and `--expand` flags fit in.
+`sq` treats credentials with two independent mechanisms: **redaction** keeps
+secrets out of display output, and **placeholders** keep secrets out of the
+[config](../config) file itself. The two compose: a placeholder-backed source
+is still redacted in `sq ls`. This page explains both, plus the `--reveal`
+and `--expand` flags that opt out.
 
 ## Overview
 
-By default:
+Redaction is the display default. Anywhere `sq` prints a source location,
+URL-style passwords show as `xxxxx`:
 
-- URL-style passwords inside a source [`location`](/docs/source#add) are
-  **redacted** in display output: `sq ls`, `sq inspect`, `sq src`,
-  `sq config ls`, error messages, and so on.
-- [`sq config export`](/docs/cmd/config-export) is a backup tool, not a
-  display tool, and writes locations **verbatim**: placeholders are
-  preserved and inline plaintext is dumped as-is. Treat the exported
-  file the same as `sq.yml` itself (mode `0600` by default).
-- Source locations may contain **`${scheme:path}` placeholders** that fetch
-  the real value at connect time from an external resolver. Four schemes
-  ship in the box: [`keyring`](#keyring), [`env`](#env),
-  [`file`](#file), and [`op`](#op).
+```text
+@sakila/pg  postgres  postgres://alice:xxxxx@db.acme.com/sakila
+```
 
-Two global flags opt out of those defaults; they do different things.
-`--reveal` shows you something `sq` already knows. `--expand` makes `sq` go
-fetch something it doesn't currently hold. Both can expose plaintext, but
-the security implications differ; see each section below.
+Placeholders are opt-in. Replace an inline credential with `${scheme:path}`
+and `sq` fetches the real value at connect time:
+
+```yaml
+location: postgres://alice:${keyring:j2k7m3pxtz}@db.acme.com/sakila
+```
+
+The password isn't in `sq.yml`; `sq` reads it from the OS keyring at the
+opaque ID `j2k7m3pxtz` whenever the source connects. Four schemes ship in
+the box: [`keyring`](#keyring), [`env`](#env), [`file`](#file), and
+[`op`](#op) for 1Password.
+
+Two global flags opt out of the defaults:
+
+- [`--reveal`](#redaction) prints the redacted secret instead of `xxxxx`.
+- [`--expand`](#expanding-placeholders) resolves placeholders and prints the
+  value they fetch.
+
+Both can expose plaintext, but in different ways: `--reveal` shows what
+`sq` already has loaded, while `--expand` pulls plaintext **out** of an
+external resolver into the display.
+
+[`sq config export`](/docs/cmd/config-export) is a backup tool, not a
+display tool, and writes locations verbatim: placeholders are preserved
+and inline plaintext is dumped as-is. Treat the exported file the same as
+`sq.yml` itself (mode `0600` by default).
 
 ## Redaction
 
@@ -85,106 +101,6 @@ $ sq config set secrets.reveal true
 command.
 {{< /alert >}}
 
-## Substitution
-
-`--expand` resolves `${scheme:path}` placeholders against the configured
-resolvers (`keyring`, `env`, `file`, or `op` for 1Password), and
-substitutes the resolved value into whatever location string `sq` is about
-to display. It is a persistent root flag: every subcommand accepts it,
-and the commands that print a source location act on it.
-
-### On display commands
-
-[`sq src`](/docs/cmd/src), [`sq ls`](/docs/cmd/ls),
-[`sq inspect`](/docs/cmd/inspect), [`sq add`](/docs/cmd/add)'s post-add
-echo, [`sq mv`](/docs/cmd/mv)'s post-mv echo, and
-[`sq ping`](/docs/cmd/ping) in JSON or YAML output each show a source
-location. `--expand` decides whether that location is the verbatim
-placeholder or the resolved value. `--reveal` is the orthogonal axis: it
-flips the redaction filter on whatever string ends up being displayed.
-
-{{< alert icon="👉" >}}
-`sq ping`'s text and CSV output do not include a Location column, so
-`--expand` has no visible effect there. Use `--json` or `--yaml` to see
-the per-source location.
-{{< /alert >}}
-
-For a source whose YAML location is `${keyring:abc}` and whose keyring entry
-holds `postgres://alice:hunter2@db.acme.com/sakila`:
-
-| Flags                 | Displayed location                                       |
-|-----------------------|----------------------------------------------------------|
-| (none)                | `${keyring:abc}`                                         |
-| `--reveal`            | `${keyring:abc}`                                         |
-| `--expand`            | `postgres://alice:xxxxx@db.acme.com/sakila`              |
-| `--expand --reveal`   | `postgres://alice:hunter2@db.acme.com/sakila`            |
-
-The display-expansion step is lenient: a per-source resolver failure
-(missing keyring entry, unset env var, unreadable file) leaves that
-source's placeholder verbatim and the listing continues. This applies to
-the display step only; commands that must resolve to connect (e.g.
-`sq inspect`, `sq ping`) still fail at connect time when a missing secret
-prevents the connection. The lenient display fallback is deliberate:
-`--expand` on a listing command is a diagnostic, and aborting the whole
-listing because one source's resolver is offline would hide every other
-source's state.
-
-### On `sq config export`
-
-[`sq config export`](/docs/cmd/config-export) dumps the live config to YAML
-for backups. By default the export is a faithful copy of `sq.yml`:
-`${scheme:path}` placeholders are written verbatim, and inline credentials
-(plaintext URLs) are dumped exactly as they appear in the file.
-
-With `--expand`, every `${scheme:path}` placeholder is resolved and the
-resolved value is spliced inline into the exported location. The output is
-a self-contained snapshot suitable for moving between machines, at the cost
-of writing every referenced secret in plaintext (which is exactly the point
-of `--expand`).
-
-```yaml
-# Live config: location uses a keyring placeholder
-- handle: '@sakila/pg'
-  driver: postgres
-  location: postgres://alice:${keyring:j2k7m3pxtz}@db.acme.com/sakila
-```
-
-```shell
-# Default: placeholder preserved
-$ sq config export | grep '@sakila/pg' -A1
-- handle: '@sakila/pg'
-  location: postgres://alice:${keyring:j2k7m3pxtz}@db.acme.com/sakila
-
-# --expand: keyring value fetched and inlined
-$ sq config export --expand | grep '@sakila/pg' -A1
-- handle: '@sakila/pg'
-  location: postgres://alice:hunter2@db.acme.com/sakila
-```
-
-When `--output` is used, the exported file is created with mode `0600`,
-since it may contain credentials regardless of whether `--expand` was set.
-
-`sq config export --expand` keeps strict-abort semantics on resolver
-failure (unlike the lenient display commands). An export is a snapshot for
-transfer, and a half-resolved snapshot is the wrong artifact.
-
-## Reveal vs expand
-
-Both flags can produce plaintext secrets, but they're not interchangeable.
-
-| Concern                          | `--reveal`                                                                                            | `--expand`                                                                                                     |
-|----------------------------------|-------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------|
-| Purpose                          | Show secret data already loaded                                                                       | Fetch placeholder values and splice them in                                                                    |
-| Source of the printed value      | The current in-memory config                                                                          | External resolvers: OS keyring, env, file                                                                      |
-| Applies to                       | Any command that prints a location or keyring value                                                   | Any command that prints a source location; also [`sq config export`](/docs/cmd/config-export)                  |
-| What you see for a placeholder   | The placeholder text (e.g. `${keyring:abc}`)                                                          | The resolved value (e.g. `hunter2`)                                                                            |
-| Failure mode                     | Cannot fail; it is just a display flip                                                                | Lenient per source on display commands; strict-abort on `sq config export`                                     |
-| Risk                             | Reveals plaintext already in `sq.yml` or the keyring                                                  | Pulls plaintext **out** of resolvers into terminal, log, or exported-file output                               |
-
-Use `--reveal` to read configuration; use `--expand` to take a portable
-backup or to diagnose what a source actually resolves to. Don't reach for
-`--expand` when `--reveal` is what you want.
-
 ## Placeholders
 
 A source's `location` may contain one or more `${scheme:path}` placeholders.
@@ -209,11 +125,11 @@ location: postgres://alice:${env:DB_PW}@db.acme.com/sakila
 
 `sq` ships with four schemes: `keyring`, `env`, `file`, and `op`.
 
-<a id="url-encoding"></a>
-{{< alert icon="👉" >}}
+### URL encoding
+
 When a placeholder lands inside URL userinfo (the `user:password@host` part),
 `sq` automatically percent-encodes the resolved value so that characters
-URL-reserves (`@`, `:`, `/`, `?`, `#`, `&`, `+`, `%`, etc.) round-trip
+URL reserves (`@`, `:`, `/`, `?`, `#`, `&`, `+`, `%`, etc.) round-trip
 correctly. Store the raw, unencoded password in the resolver; do not
 pre-encode it, or you'll end up with a double-encoded value at connect
 time.
@@ -222,7 +138,18 @@ Whole-conn-string placement (`location: ${keyring:abc}`) skips userinfo
 splicing entirely: the resolved value is used as the complete location
 string, so the resolver is responsible for any escaping the driver
 requires.
-{{< /alert >}}
+
+### Choosing a scheme
+
+| Environment            | Recommended scheme    | Why                                                                               |
+|------------------------|-----------------------|-----------------------------------------------------------------------------------|
+| Dev laptop             | [`keyring`](#keyring) | Plaintext never lives on disk; OS handles the storage and prompting.              |
+| CI runner              | [`env`](#env)         | CI systems already inject secrets as environment variables.                       |
+| Container / Kubernetes | [`file`](#file)       | Secrets are typically mounted into the container as files (e.g. `/run/secrets/`). |
+| Shared / team secrets  | [`op`](#op)           | 1Password is the team source of truth; `sq` reads it via the `op` CLI.            |
+
+The schemes are not mutually exclusive: an `sq.yml` may use `keyring` for one
+source, `env` for another, and inline plaintext for a third.
 
 ### `keyring`
 
@@ -334,11 +261,9 @@ Notes:
 - "Item not found" surfaces as the standard `secret not found` message;
   other failures (not signed in, network) surface `op`'s own stderr.
 
-#### `sq add` sugar for `op`
-
-[`sq add`](/docs/cmd/add) accepts the bare `op://<vault>/<item>/<field>` form
-that 1Password's "Copy Secret Reference" puts on the clipboard, as sugar for
-the full `${op://...}` placeholder:
+**`sq add` shortcut.** [`sq add`](/docs/cmd/add) accepts the bare
+`op://<vault>/<item>/<field>` form that 1Password's "Copy Secret Reference"
+puts on the clipboard, as sugar for the full `${op://...}` placeholder:
 
 ```shell
 # Both forms are equivalent; the bare form is stored as ${op://...} in sq.yml.
@@ -355,27 +280,9 @@ the placeholder and points at the three recovery paths:
 2. Use composition: `sq add 'postgres://alice:${op://Private/sakila/password}@db/sakila'`.
 3. Pass `--driver <type>` to skip driver inference entirely.
 
-### Choosing a scheme
+<a id="verifying-a-source"></a>
 
-| Environment            | Recommended scheme           | Why                                                                               |
-|------------------------|------------------------------|-----------------------------------------------------------------------------------|
-| Dev laptop             | [`keyring`](#keyring)        | Plaintext never lives on disk; OS handles the storage and prompting.              |
-| CI runner              | [`env`](#env)                | CI systems already inject secrets as environment variables.                       |
-| Container / Kubernetes | [`file`](#file)              | Secrets are typically mounted into the container as files (e.g. `/run/secrets/`). |
-| Shared / team secrets  | [`op`](#op)                  | 1Password is the team source of truth; `sq` reads it via the `op` CLI.            |
-
-The schemes are not mutually exclusive: an `sq.yml` may use `keyring` for one
-source, `env` for another, and inline plaintext for a third.
-
-## Managing keyring entries
-
-Most users never touch the keyring directly: [`sq add --store keyring`](/docs/cmd/add)
-and the [`secrets.store`](/docs/config#secretsstore) option write entries
-automatically. For management operations (rotate, migrate inline passwords,
-list references), see the [`sq config keyring`](/docs/cmd/config-keyring)
-command group.
-
-## Verifying a source
+### Verifying placeholders resolve
 
 Once a source uses placeholders, the obvious question is "did sq actually
 resolve them correctly?" The answer is [`sq ping`](/docs/cmd/ping):
@@ -390,6 +297,116 @@ placeholder in the source's location. If a keyring entry is missing, an
 env var is unset, or a file path doesn't exist, `sq ping` returns the
 underlying error with the failing source's handle. There is no separate
 `verify` or `test` subcommand: `sq ping` is the end-to-end check.
+
+<a id="substitution"></a>
+
+## Expanding placeholders
+
+`--expand` resolves `${scheme:path}` placeholders against the configured
+resolvers (`keyring`, `env`, `file`, or `op` for 1Password), and
+substitutes the resolved value into whatever location string `sq` is about
+to display. It is a persistent root flag: every subcommand accepts it,
+and the commands that print a source location act on it.
+
+### On display commands
+
+[`sq src`](/docs/cmd/src), [`sq ls`](/docs/cmd/ls),
+[`sq inspect`](/docs/cmd/inspect), [`sq add`](/docs/cmd/add)'s post-add
+echo, [`sq mv`](/docs/cmd/mv)'s post-mv echo, and
+[`sq ping`](/docs/cmd/ping) in JSON or YAML output each show a source
+location. `--expand` decides whether that location is the verbatim
+placeholder or the resolved value. `--reveal` is the orthogonal axis: it
+flips the redaction filter on whatever string ends up being displayed.
+
+{{< alert icon="👉" >}}
+`sq ping`'s text and CSV output do not include a Location column, so
+`--expand` has no visible effect there. Use `--json` or `--yaml` to see
+the per-source location.
+{{< /alert >}}
+
+For a source whose YAML location is `${keyring:abc}` and whose keyring entry
+holds `postgres://alice:hunter2@db.acme.com/sakila`:
+
+| Flags                 | Displayed location                                       |
+|-----------------------|----------------------------------------------------------|
+| (none)                | `${keyring:abc}`                                         |
+| `--reveal`            | `${keyring:abc}`                                         |
+| `--expand`            | `postgres://alice:xxxxx@db.acme.com/sakila`              |
+| `--expand --reveal`   | `postgres://alice:hunter2@db.acme.com/sakila`            |
+
+The display-expansion step is lenient: a per-source resolver failure
+(missing keyring entry, unset env var, unreadable file) leaves that
+source's placeholder verbatim and the listing continues. This applies to
+the display step only; commands that must resolve to connect (e.g.
+`sq inspect`, `sq ping`) still fail at connect time when a missing secret
+prevents the connection. The lenient display fallback is deliberate:
+`--expand` on a listing command is a diagnostic, and aborting the whole
+listing because one source's resolver is offline would hide every other
+source's state.
+
+### On `sq config export`
+
+[`sq config export`](/docs/cmd/config-export) dumps the live config to YAML
+for backups. By default the export is a faithful copy of `sq.yml`:
+`${scheme:path}` placeholders are written verbatim, and inline credentials
+(plaintext URLs) are dumped exactly as they appear in the file.
+
+With `--expand`, every `${scheme:path}` placeholder is resolved and the
+resolved value is spliced inline into the exported location. The output is
+a self-contained snapshot suitable for moving between machines, at the cost
+of writing every referenced secret in plaintext (which is exactly the point
+of `--expand`).
+
+```yaml
+# Live config: location uses a keyring placeholder
+- handle: '@sakila/pg'
+  driver: postgres
+  location: postgres://alice:${keyring:j2k7m3pxtz}@db.acme.com/sakila
+```
+
+```shell
+# Default: placeholder preserved
+$ sq config export | grep '@sakila/pg' -A1
+- handle: '@sakila/pg'
+  location: postgres://alice:${keyring:j2k7m3pxtz}@db.acme.com/sakila
+
+# --expand: keyring value fetched and inlined
+$ sq config export --expand | grep '@sakila/pg' -A1
+- handle: '@sakila/pg'
+  location: postgres://alice:hunter2@db.acme.com/sakila
+```
+
+When `--output` is used, the exported file is created with mode `0600`,
+since it may contain credentials regardless of whether `--expand` was set.
+
+`sq config export --expand` keeps strict-abort semantics on resolver
+failure (unlike the lenient display commands). An export is a snapshot for
+transfer, and a half-resolved snapshot is the wrong artifact.
+
+### Reveal vs expand
+
+Both flags can produce plaintext secrets, but they're not interchangeable.
+
+| Concern                          | `--reveal`                                                                                            | `--expand`                                                                                                     |
+|----------------------------------|-------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------|
+| Purpose                          | Show secret data already loaded                                                                       | Fetch placeholder values and splice them in                                                                    |
+| Source of the printed value      | The current in-memory config                                                                          | External resolvers: OS keyring, env, file                                                                      |
+| Applies to                       | Any command that prints a location or keyring value                                                   | Any command that prints a source location; also [`sq config export`](/docs/cmd/config-export)                  |
+| What you see for a placeholder   | The placeholder text (e.g. `${keyring:abc}`)                                                          | The resolved value (e.g. `hunter2`)                                                                            |
+| Failure mode                     | Cannot fail; it is just a display flip                                                                | Lenient per source on display commands; strict-abort on `sq config export`                                     |
+| Risk                             | Reveals plaintext already in `sq.yml` or the keyring                                                  | Pulls plaintext **out** of resolvers into terminal, log, or exported-file output                               |
+
+Use `--reveal` to read configuration; use `--expand` to take a portable
+backup or to diagnose what a source actually resolves to. Don't reach for
+`--expand` when `--reveal` is what you want.
+
+## Managing keyring entries
+
+Most users never touch the keyring directly: [`sq add --store keyring`](/docs/cmd/add)
+and the [`secrets.store`](/docs/config#secretsstore) option write entries
+automatically. For management operations (rotate, migrate inline passwords,
+list references), see the [`sq config keyring`](/docs/cmd/config-keyring)
+command group.
 
 ## Threat model
 

--- a/site/content/en/docs/secrets/index.md
+++ b/site/content/en/docs/secrets/index.md
@@ -10,9 +10,8 @@ url: /docs/secrets
 ---
 `sq` treats credentials with two independent mechanisms: **redaction** keeps
 secrets out of display output, and **placeholders** keep secrets out of the
-[config](../config) file itself. The two compose: a placeholder-backed source
-is still redacted in `sq ls`. This page explains both, plus the `--reveal`
-and `--expand` flags that opt out.
+[config](../config) file itself. The two stack rather than compete. This page
+explains both, plus the `--reveal` and `--expand` flags that opt out.
 
 ## Overview
 

--- a/site/content/en/docs/secrets/index.md
+++ b/site/content/en/docs/secrets/index.md
@@ -11,7 +11,7 @@ url: /docs/secrets
 `sq` treats credentials with two complementary mechanisms: **redaction**, which
 keeps secrets out of display output, and **placeholders**, which keep secrets
 out of the [config](../config) file itself. This page explains both, and how
-the global `--reveal` flag and the `sq config export --expand` flag fit in.
+the global `--reveal` and `--expand` flags fit in.
 
 ## Overview
 
@@ -21,15 +21,13 @@ By default:
   **redacted** in display output: `sq ls`, `sq inspect`, `sq src`,
   `sq config ls`, error messages, and so on.
 - [`sq config export`](/docs/cmd/config-export) is a backup tool, not a
-  display tool, and writes locations **verbatim** — placeholders are
+  display tool, and writes locations **verbatim**: placeholders are
   preserved and inline plaintext is dumped as-is. Treat the exported
   file the same as `sq.yml` itself (mode `0600` by default).
 - Source locations may contain **`${scheme:path}` placeholders** that fetch
   the real value at connect time from an external resolver. Four schemes
   ship in the box: [`keyring`](#keyring-scheme), [`env`](#env-scheme),
   [`file`](#file-scheme), and [`op`](#op-scheme).
-- [`sq config export`](/docs/cmd/config-export) writes placeholders to the
-  output **verbatim** — what the YAML says is what the export contains.
 
 Two global flags opt out of those defaults; they do different things:
 
@@ -95,7 +93,7 @@ command.
 
 <a id="--no-redact"></a>
 {{< alert icon="👉" >}}
-The earlier flag `--no-redact` still works, but is deprecated and prints a
+The earlier flag `--no-redact` still works, but is deprecated and logs a
 deprecation hint. Use `--reveal` in new scripts. Both flags do the same
 thing; `--no-redact` will be removed in a future release.
 {{< /alert >}}
@@ -103,7 +101,7 @@ thing; `--no-redact` will be removed in a future release.
 ## Substitution
 
 `--expand` resolves `${scheme:path}` placeholders against the configured
-resolvers (keyring read, environment variable read, or file read) and
+resolvers (`keyring`, `env`, `file`, or `op` for 1Password), and
 substitutes the resolved value into whatever location string `sq` is about
 to display. It is a persistent root flag: every subcommand accepts it,
 and the commands that print a source location act on it.
@@ -111,17 +109,18 @@ and the commands that print a source location act on it.
 ### On display commands
 
 [`sq src`](/docs/cmd/src), [`sq ls`](/docs/cmd/ls),
-[`sq inspect`](/docs/inspect), [`sq add`](/docs/cmd/add)'s post-add
+[`sq inspect`](/docs/cmd/inspect), [`sq add`](/docs/cmd/add)'s post-add
 echo, [`sq mv`](/docs/cmd/mv)'s post-mv echo, and
 [`sq ping`](/docs/cmd/ping) in JSON or YAML output each show a source
 location. `--expand` decides whether that location is the verbatim
 placeholder or the resolved value. `--reveal` is the orthogonal axis: it
 flips the redaction filter on whatever string ends up being displayed.
 
-> [!NOTE]
-> `sq ping`'s text and CSV output do not include a Location column, so
-> `--expand` has no visible effect there. Use `--json` or `--yaml` to see
-> the per-source location.
+{{< alert icon="👉" >}}
+`sq ping`'s text and CSV output do not include a Location column, so
+`--expand` has no visible effect there. Use `--json` or `--yaml` to see
+the per-source location.
+{{< /alert >}}
 
 For a source whose YAML location is `${keyring:abc}` and whose keyring entry
 holds `postgres://alice:hunter2@db.acme.com/sakila`:
@@ -379,8 +378,8 @@ external: `sq` reads them at connect time and has nothing to manage.
 | [`sq config keyring migrate`](/docs/cmd/config-keyring-migrate)                   | Move inline-password sources to the keyring in bulk.                          |
 
 `sq config keyring ls` walks the YAML config; it lists only `keyring`
-placeholders that some source references. Orphan entries — entries in the
-keyring that no source uses — are not surfaced. Enumerating them requires
+placeholders that some source references. Orphan entries (entries in the
+keyring that no source uses) are not surfaced. Enumerating them requires
 keyring-wide iteration, which is deferred to a future release.
 
 `sq config keyring rm` deletes the keyring entry only; any remaining
@@ -401,8 +400,8 @@ location becomes a bare placeholder:
 ```
 
 The driver type stays in YAML (so `sq` can pick the right driver before
-resolving the keyring), but everything else — username, host, port,
-database, password, query parameters — lives in the keyring entry. One
+resolving the keyring), but everything else (username, host, port,
+database, password, query parameters) lives in the keyring entry. One
 keyring entry, one source, no composition. The same layout is produced
 by [`sq config keyring migrate`](/docs/cmd/config-keyring-migrate).
 
@@ -429,7 +428,7 @@ underlying error with the failing source's handle. There is no separate
 ## Threat model
 
 The keyring scheme is a useful step up from plaintext in `sq.yml`, but it
-is not a sandbox. The threats it does — and does not — address:
+is not a sandbox. The threats it does, and does not, address:
 
 **Protects against:**
 

--- a/site/content/en/docs/secrets/index.md
+++ b/site/content/en/docs/secrets/index.md
@@ -26,21 +26,15 @@ By default:
   file the same as `sq.yml` itself (mode `0600` by default).
 - Source locations may contain **`${scheme:path}` placeholders** that fetch
   the real value at connect time from an external resolver. Four schemes
-  ship in the box: [`keyring`](#keyring-scheme), [`env`](#env-scheme),
-  [`file`](#file-scheme), and [`op`](#op-scheme).
+  ship in the box: [`keyring`](#keyring), [`env`](#env),
+  [`file`](#file), and [`op`](#op).
 
-Two global flags opt out of those defaults; they do different things:
-
-| Flag                                                                                              | What it does                                                                         | Where it applies                                                                                       |
-|---------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------|
-| <a href="#redact--reveal" style="white-space:nowrap">`--reveal`</a>                               | Don't redact secrets in display output. Show data that `sq` already has in hand.     | Global. Any command that prints a source location or a keyring entry's value.                          |
-| <a href="#substitution" style="white-space:nowrap">`--expand`</a>                                 | Resolve `${scheme:path}` placeholders and splice the fetched values into the output. | Global. Any command that prints a source location; also [`sq config export`](/docs/cmd/config-export). |
-
+Two global flags opt out of those defaults; they do different things.
 `--reveal` shows you something `sq` already knows. `--expand` makes `sq` go
 fetch something it doesn't currently hold. Both can expose plaintext, but
 the security implications differ; see each section below.
 
-## Redact & reveal
+## Redaction
 
 `sq` redacts URL-style passwords in the location of a source when that
 location is printed. For a source
@@ -77,8 +71,7 @@ whether the stored value is printed.
 itself, not the keyring value. Use [`sq config keyring get`](/docs/cmd/config-keyring-get)
 to inspect a keyring value directly.
 
-### `secrets.reveal` config option
-
+{{< alert icon="👉" >}}
 The [`secrets.reveal`](/docs/config#secretsreveal) config option (default
 `false`) controls the same behavior persistently:
 
@@ -90,12 +83,6 @@ $ sq config set secrets.reveal true
 `--reveal` is the per-invocation form of the same control. Setting
 `secrets.reveal: true` is equivalent to passing `--reveal` on every
 command.
-
-<a id="--no-redact"></a>
-{{< alert icon="👉" >}}
-The earlier flag `--no-redact` still works, but is deprecated and logs a
-deprecation hint. Use `--reveal` in new scripts. Both flags do the same
-thing; `--no-redact` will be removed in a future release.
 {{< /alert >}}
 
 ## Substitution
@@ -152,8 +139,8 @@ for backups. By default the export is a faithful copy of `sq.yml`:
 With `--expand`, every `${scheme:path}` placeholder is resolved and the
 resolved value is spliced inline into the exported location. The output is
 a self-contained snapshot suitable for moving between machines, at the cost
-of writing every referenced secret in plaintext, which is exactly the point
-of `--expand`.
+of writing every referenced secret in plaintext (which is exactly the point
+of `--expand`).
 
 ```yaml
 # Live config: location uses a keyring placeholder
@@ -181,7 +168,7 @@ since it may contain credentials regardless of whether `--expand` was set.
 failure (unlike the lenient display commands). An export is a snapshot for
 transfer, and a half-resolved snapshot is the wrong artifact.
 
-### `--reveal` vs `--expand`
+## Reveal vs expand
 
 Both flags can produce plaintext secrets, but they're not interchangeable.
 
@@ -222,8 +209,8 @@ location: postgres://alice:${env:DB_PW}@db.acme.com/sakila
 
 `sq` ships with four schemes: `keyring`, `env`, `file`, and `op`.
 
-### URL encoding
-
+<a id="url-encoding"></a>
+{{< alert icon="👉" >}}
 When a placeholder lands inside URL userinfo (the `user:password@host` part),
 `sq` automatically percent-encodes the resolved value so that characters
 URL-reserves (`@`, `:`, `/`, `?`, `#`, `&`, `+`, `%`, etc.) round-trip
@@ -235,8 +222,9 @@ Whole-conn-string placement (`location: ${keyring:abc}`) skips userinfo
 splicing entirely: the resolved value is used as the complete location
 string, so the resolver is responsible for any escaping the driver
 requires.
+{{< /alert >}}
 
-### `keyring` scheme
+### `keyring`
 
 An *OS keyring* is the operating system's encrypted credential store, unlocked
 by the user's login session and reachable by apps running as that user.
@@ -256,25 +244,41 @@ running `sq`.
 [gnome-keyring]: https://wiki.gnome.org/Projects/GnomeKeyring
 [kwallet]: https://apps.kde.org/kwalletmanager5/
 
-`sq` ships read **and** write commands for the keyring under
-[`sq config keyring`](/docs/cmd/config-keyring). Typical usage is
-[`sq add --store keyring`](/docs/cmd/add), which mints an opaque 10-character
-ID (e.g. `j2k7m3pxtz`), writes the full conn string to the keyring at that ID,
-and stores `location: ${keyring:j2k7m3pxtz}` in YAML.
+The typical pattern is [`sq add DSN --store keyring`](/docs/cmd/add), which
+mints an opaque 10-character ID (e.g. `j2k7m3pxtz`), writes the full conn
+string to the keyring at that ID, and stores a bare placeholder in YAML:
 
-You can also hand-create entries:
-
-```shell
-# Create an entry; the value is whatever you want stored
-$ sq config keyring create my_db_pw -p < secret.txt
-
-# Reference it by hand in sq.yml:
-#   location: postgres://alice:${keyring:my_db_pw}@db/sakila
+```yaml
+- handle: '@sakila/pg'
+  driver: postgres
+  location: ${keyring:j2k7m3pxtz}
 ```
 
-See [Managing keyring entries](#managing-keyring-entries) below.
+The driver type stays in YAML (so `sq` can pick the right driver before
+resolving the keyring), but everything else (username, host, port,
+database, password, query parameters) lives in the keyring entry. One
+keyring entry, one source, no composition. The same layout is produced
+by [`sq config keyring migrate`](/docs/cmd/config-keyring-migrate).
 
-### `env` scheme
+For shared credentials or password-only composition (e.g.
+`postgres://alice:${keyring:my_db_pw}@db/sakila`), hand-create an entry
+with a meaningful path:
+
+```shell
+$ sq config keyring create my_db_pw -p < secret.txt
+```
+
+then reference it by hand in `sq.yml`:
+
+```yaml
+location: postgres://alice:${keyring:my_db_pw}@db/sakila
+```
+
+For management operations (rotate, migrate inline passwords, list
+references), see the [`sq config keyring`](/docs/cmd/config-keyring)
+command group.
+
+### `env`
 
 `${env:<VAR>}` reads the named environment variable at connect time.
 
@@ -286,7 +290,7 @@ location: ${env:DB_PROD_CONN_STR}
 If the variable is unset, the source fails to connect with an error naming
 the variable. `env` is read-only: `sq` consults the value but never sets it.
 
-### `file` scheme
+### `file`
 
 `${file:<path>}` reads file contents at connect time, trimming a single
 trailing newline. Path forms accepted:
@@ -299,7 +303,7 @@ Relative paths and remote `file://host/path` forms are rejected.
 
 `file` is read-only: `sq` consults the file but never writes to it.
 
-### `op` scheme
+### `op`
 
 `${op://<vault>/<item>/[<section>/]<field>}` reads a value from 1Password
 via the [`op` CLI](https://developer.1password.com/docs/cli/) using
@@ -330,7 +334,7 @@ Notes:
 - "Item not found" surfaces as the standard `secret not found` message;
   other failures (not signed in, network) surface `op`'s own stderr.
 
-#### `sq add` shortcuts for `op://`
+#### `sq add` sugar for `op`
 
 [`sq add`](/docs/cmd/add) accepts the bare `op://<vault>/<item>/<field>` form
 that 1Password's "Copy Secret Reference" puts on the clipboard, as sugar for
@@ -344,7 +348,8 @@ $ sq add '${op://Private/sakila/dsn}'
 
 If the resolved value is a bare credential rather than a full DSN (1Password's
 default field is named `password`, so people commonly drop a DSN into it
-verbatim), `sq add` returns a hint pointing at the three options:
+verbatim), `sq add` fails with an error and adds no source. The error names
+the placeholder and points at the three recovery paths:
 
 1. Store a full DSN at that field, e.g. `postgres://alice:hunter2@db/sakila`.
 2. Use composition: `sq add 'postgres://alice:${op://Private/sakila/password}@db/sakila'`.
@@ -354,60 +359,21 @@ verbatim), `sq add` returns a hint pointing at the three options:
 
 | Environment            | Recommended scheme           | Why                                                                               |
 |------------------------|------------------------------|-----------------------------------------------------------------------------------|
-| Dev laptop             | [`keyring`](#keyring-scheme) | Plaintext never lives on disk; OS handles the storage and prompting.              |
-| CI runner              | [`env`](#env-scheme)         | CI systems already inject secrets as environment variables.                       |
-| Container / Kubernetes | [`file`](#file-scheme)       | Secrets are typically mounted into the container as files (e.g. `/run/secrets/`). |
-| Shared / team secrets  | [`op`](#op-scheme)           | 1Password is the team source of truth; `sq` reads it via the `op` CLI.            |
+| Dev laptop             | [`keyring`](#keyring)        | Plaintext never lives on disk; OS handles the storage and prompting.              |
+| CI runner              | [`env`](#env)                | CI systems already inject secrets as environment variables.                       |
+| Container / Kubernetes | [`file`](#file)              | Secrets are typically mounted into the container as files (e.g. `/run/secrets/`). |
+| Shared / team secrets  | [`op`](#op)                  | 1Password is the team source of truth; `sq` reads it via the `op` CLI.            |
 
 The schemes are not mutually exclusive: an `sq.yml` may use `keyring` for one
 source, `env` for another, and inline plaintext for a third.
 
 ## Managing keyring entries
 
-The [`sq config keyring`](/docs/cmd/config-keyring) command group covers the
-keyring scheme end to end. The other three schemes (`env`, `file`, `op`) are
-external: `sq` reads them at connect time and has nothing to manage.
-
-| Command                                                                           | What it does                                                                  |
-|-----------------------------------------------------------------------------------|-------------------------------------------------------------------------------|
-| [`sq config keyring ls`](/docs/cmd/config-keyring-ls)                             | List `${keyring:<path>}` references found in source locations.                |
-| [`sq config keyring create`](/docs/cmd/config-keyring-create)                     | Create a new entry at `PATH`. Errors if `PATH` already exists.                |
-| [`sq config keyring update`](/docs/cmd/config-keyring-update)                     | Rotate the value at an existing `PATH`.                                       |
-| [`sq config keyring get`](/docs/cmd/config-keyring-get)                           | Check an entry exists; with `--reveal`, print its value.                      |
-| [`sq config keyring rm`](/docs/cmd/config-keyring-rm)                             | Delete an entry. Does not touch sources that reference it.                    |
-| [`sq config keyring migrate`](/docs/cmd/config-keyring-migrate)                   | Move inline-password sources to the keyring in bulk.                          |
-
-`sq config keyring ls` walks the YAML config; it lists only `keyring`
-placeholders that some source references. Orphan entries (entries in the
-keyring that no source uses) are not surfaced. Enumerating them requires
-keyring-wide iteration, which is deferred to a future release.
-
-`sq config keyring rm` deletes the keyring entry only; any remaining
-`${keyring:PATH}` reference in `sq.yml` will fail to resolve on the next
-connect. Run [`sq config keyring ls`](/docs/cmd/config-keyring-ls) first to
-find references.
-
-### How `--store keyring` lays out an entry
-
-When [`sq add --store keyring`](/docs/cmd/add) creates an entry, it stores
-the **entire conn string** at a fresh opaque 10-character ID. The YAML
-location becomes a bare placeholder:
-
-```yaml
-- handle: '@sakila/pg'
-  driver: postgres
-  location: ${keyring:j2k7m3pxtz}
-```
-
-The driver type stays in YAML (so `sq` can pick the right driver before
-resolving the keyring), but everything else (username, host, port,
-database, password, query parameters) lives in the keyring entry. One
-keyring entry, one source, no composition. The same layout is produced
-by [`sq config keyring migrate`](/docs/cmd/config-keyring-migrate).
-
-For shared credentials or password-only composition (e.g.
-`postgres://alice:${keyring:my_db_pw}@db/sakila`), hand-create an entry
-with a meaningful path: `sq config keyring create my_db_pw`.
+Most users never touch the keyring directly: [`sq add --store keyring`](/docs/cmd/add)
+and the [`secrets.store`](/docs/config#secretsstore) option write entries
+automatically. For management operations (rotate, migrate inline passwords,
+list references), see the [`sq config keyring`](/docs/cmd/config-keyring)
+command group.
 
 ## Verifying a source
 


### PR DESCRIPTION
## Summary

In-progress cleanup of the Secrets docs surface. Two commits so far, with more
TOC simplification planned (see Follow-ups below).

### `15d36170` site: fix --expand typo and dash usage in secrets docs

- Typo fix: `-expand` -> `--expand` in the opening paragraph (only single-dash
  reference on the page).
- Replace em dashes with parens/colons per the repo prose style.
- Drop a duplicate Overview bullet about `sq config export`.
- Point the inspect link at `/docs/cmd/inspect` for parity with sibling
  command links.

### `797e2d47` site: relocate keyring management content; fix stale anchors

- **Relocation.** Move the `## Managing keyring entries` table and operational
  caveats from `/docs/secrets` to `/docs/cmd/config-keyring`, where the command
  group's overview belongs. Most secrets-page readers use `sq add --store keyring`
  or `secrets.store: keyring` and never touch the underlying subcommands.
- Collapse the secrets-page section to a short pointer at the cmd group page.
- Fold the `### How --store keyring lays out an entry` subsection into the
  `### keyring` scheme section, where it conceptually belongs.
- **Stale-anchor fixes** that fell out of recent heading renames:
  - `#redact--reveal` -> `#redaction` (cmd/config-keyring-get, config/index,
    CHANGELOG entry for #717).
  - `#managing-keyring-entries` boilerplate intro -> `/docs/cmd/config-keyring`
    on the six subcommand pages whose openers pointed back at the now-thin
    secrets section.

## Test plan

- [x] `bun run lint:markdown` clean (0 errors across 77 site files).
- [ ] Visual check of the rendered Secrets page on Netlify deploy preview.
- [ ] Spot-check the cmd group page renders the command table correctly.
- [ ] Verify the `#redaction` anchor resolves in deploy preview.

## Follow-ups (not in this PR)

Pending discussion on further TOC simplification of the Secrets page:

- Demote `## Reveal vs expand` back to `### Reveal vs expand` under
  `## Substitution`.
- Fold `## Verifying a source` into Placeholders as a subsection.
- Drop the `#### sq add sugar for op` heading; inline into `### op`.
- Shorten `### How --store keyring lays out an entry` (now part of `### keyring`)
  if the embedded structure needs it.