### PR TITLE
rqlite: localhost hint and clearer cluster-discovery DNS error (gh742)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,16 @@ Breaking changes are annotated with ☢️, and alpha/beta features with 🐥.
   - Subcommands that don't print a source location (e.g. [`sq sql`](https://sq.io/docs/cmd/sql),
     `sq slq`, `sq tbl`) accept `--expand` as a silent no-op, so a global alias like
     `alias sq='sq --reveal --expand'` is safe.
+- [#742]: The [rqlite driver](https://sq.io/docs/drivers/rqlite) now surfaces an
+  actionable hint when a single-node localhost setup hits gorqlite's cluster-discovery
+  default. [`sq add`](https://sq.io/docs/cmd/add) and [`sq ping`](https://sq.io/docs/cmd/ping)
+  on an `rqlite://` source whose host is loopback (e.g. `localhost`, `127.0.0.1`, `::1`)
+  log a one-line `WARN` pointing at `?disableClusterDiscovery=true` and the
+  [single-node-localhost docs](https://sq.io/docs/drivers/rqlite#single-node-localhost)
+  when the parameter is not explicitly set. If the actual peer-discovery DNS lookup
+  fails (`dial tcp: lookup <name>: no such host`), the error message is rewritten to
+  name the unreachable peer and suggest the same fix, instead of surfacing gorqlite's
+  raw `tried all peers unsuccessfully` text.
 
 ### Fixed
 
@@ -1705,6 +1715,7 @@ make working with lots of sources much easier.
 [#714]: https://github.com/neilotoole/sq/issues/714
 [#720]: https://github.com/neilotoole/sq/issues/720
 [#729]: https://github.com/neilotoole/sq/issues/729
+[#742]: https://github.com/neilotoole/sq/issues/742
 
 [v0.15.2]: https://github.com/neilotoole/sq/releases/tag/v0.15.2
 [v0.15.3]: https://github.com/neilotoole/sq/compare/v0.15.2...v0.15.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,12 +117,13 @@ Breaking changes are annotated with ☢️, and alpha/beta features with 🐥.
     `alias sq='sq --reveal --expand'` is safe.
 - [#742]: The [rqlite driver](https://sq.io/docs/drivers/rqlite) now surfaces an
   actionable hint when a single-node localhost setup hits gorqlite's cluster-discovery
-  default. [`sq add`](https://sq.io/docs/cmd/add) and [`sq ping`](https://sq.io/docs/cmd/ping)
-  on an `rqlite://` source whose host is loopback (e.g. `localhost`, `127.0.0.1`, `::1`)
-  log a one-line `WARN` pointing at `?disableClusterDiscovery=true` and the
+  default. Any command that opens an `rqlite://` source whose host is loopback
+  (e.g. `localhost`, `127.0.0.1`, `::1`), including [`sq add`](https://sq.io/docs/cmd/add)
+  and [`sq ping`](https://sq.io/docs/cmd/ping), logs a one-line `WARN` pointing at
+  `?disableClusterDiscovery=true` and the
   [single-node-localhost docs](https://sq.io/docs/drivers/rqlite#single-node-localhost)
-  when the parameter is not explicitly set. If the actual peer-discovery DNS lookup
-  fails (`dial tcp: lookup <name>: no such host`), the error message is rewritten to
+  when the parameter is not explicitly set to `true` or `false`. If the peer-discovery
+  DNS lookup actually fails with "no such host", the error message is rewritten to
   name the unreachable peer and suggest the same fix, instead of surfacing gorqlite's
   raw `tried all peers unsuccessfully` text.
 

--- a/drivers/rqlite/errors.go
+++ b/drivers/rqlite/errors.go
@@ -2,6 +2,7 @@ package rqlite
 
 import (
 	"context"
+	"errors"
 	"net"
 	"net/url"
 	"strings"
@@ -80,4 +81,46 @@ func isLoopbackHost(host string) bool {
 	return ip != nil && ip.IsLoopback()
 }
 
-// rewritePeerDNSError is added in Task 4 below.
+// rewritePeerDNSError rewrites a gorqlite cluster-discovery DNS
+// failure into an actionable message naming the unreachable peer and
+// pointing at ?disableClusterDiscovery=true and the docs. Pass-through
+// in every other case (nil err, non-DNS err, user-supplied host
+// matches the failing name, discovery already disabled, src.Location
+// unparseable).
+//
+// The rewrite preserves the underlying *net.DNSError so upstream
+// errors.As classification continues to work.
+func rewritePeerDNSError(err error, src *source.Source) error {
+	if err == nil {
+		return nil
+	}
+	var dnsErr *net.DNSError
+	if !errors.As(err, &dnsErr) {
+		return err
+	}
+	u, parseErr := url.Parse(src.Location)
+	if parseErr != nil {
+		// Defensive: doOpen validates this URL earlier, but if we
+		// somehow can't parse it here, pass the error through rather
+		// than producing a misleading rewrite.
+		return err
+	}
+	userHost := u.Hostname()
+	if dnsErr.Name == userHost {
+		// The failing hostname is the one the user typed. That's
+		// their problem to fix; suggesting disableClusterDiscovery
+		// would be wrong.
+		return err
+	}
+	if u.Query().Get("disableClusterDiscovery") == "true" {
+		// Discovery already off — failure is something else.
+		return err
+	}
+	return errz.Wrapf(err,
+		"rqlite: cluster-discovery failed to resolve advertised peer %q "+
+			"(not %q from the source URL); this usually means the rqlite "+
+			"node advertised an internal hostname not resolvable from the "+
+			"host. Try ?disableClusterDiscovery=true, or see "+docsLocalhostAnchor,
+		dnsErr.Name, userHost,
+	)
+}

--- a/drivers/rqlite/errors.go
+++ b/drivers/rqlite/errors.go
@@ -49,9 +49,12 @@ func maybeWarnLocalhostDiscovery(ctx context.Context, src *source.Source) {
 	if err != nil {
 		return
 	}
-	if u.Query().Has("disableClusterDiscovery") {
+	v := u.Query().Get("disableClusterDiscovery")
+	if strings.EqualFold(v, "true") || strings.EqualFold(v, "false") {
 		// User has made an explicit choice (true or false). Don't
-		// second-guess them.
+		// second-guess them. Empty or unrecognized values fall through
+		// to the warning so a typo like ?disableClusterDiscovery=yes
+		// still gets surfaced.
 		return
 	}
 	host := u.Hostname()
@@ -95,7 +98,12 @@ func rewritePeerDNSError(err error, src *source.Source) error {
 		return nil
 	}
 	var dnsErr *net.DNSError
-	if !errors.As(err, &dnsErr) {
+	if !errors.As(err, &dnsErr) || !dnsErr.IsNotFound {
+		// Only the "no such host" case (IsNotFound) is the
+		// cluster-discovery DNS failure we want to rewrite. DNS
+		// timeouts, temporary failures, and refusals are unrelated
+		// classes and shouldn't be rewritten into a
+		// disableClusterDiscovery suggestion.
 		return err
 	}
 	u, parseErr := url.Parse(src.Location)
@@ -112,8 +120,12 @@ func rewritePeerDNSError(err error, src *source.Source) error {
 		// would be wrong.
 		return err
 	}
-	if u.Query().Get("disableClusterDiscovery") == "true" {
+	if strings.EqualFold(u.Query().Get("disableClusterDiscovery"), "true") {
 		// Discovery already off; failure is something else.
+		// gorqlite's underlying parser treats "true"/"TRUE"/"True"
+		// equivalently, so match its case-insensitive interpretation
+		// rather than producing a misleading rewrite that suggests the
+		// user "try ?disableClusterDiscovery=true" when they already have.
 		return err
 	}
 	return errz.Wrapf(err,

--- a/drivers/rqlite/errors.go
+++ b/drivers/rqlite/errors.go
@@ -1,10 +1,16 @@
 package rqlite
 
 import (
+	"context"
+	"net"
+	"net/url"
 	"strings"
 
 	"github.com/neilotoole/sq/libsq/core/errz"
+	"github.com/neilotoole/sq/libsq/core/lg"
+	"github.com/neilotoole/sq/libsq/core/lg/lga"
 	"github.com/neilotoole/sq/libsq/driver"
+	"github.com/neilotoole/sq/libsq/source"
 )
 
 // errw wraps any error from the db. It should be called at every
@@ -22,3 +28,56 @@ func errw(err error) error {
 		return errz.Err(err)
 	}
 }
+
+// docsLocalhostAnchor is the docs URL for the single-node-localhost
+// case. Kept as a package-level constant so the add-time hint and the
+// DNS error rewrite point at the same place.
+const docsLocalhostAnchor = "https://sq.io/docs/drivers/rqlite#single-node-localhost"
+
+// maybeWarnLocalhostDiscovery emits a one-line Warn log when src's URL
+// host is loopback AND disableClusterDiscovery is not explicitly set on
+// the query string. Single-node localhost (Docker container reached
+// from the host) is the most common newcomer setup and gorqlite's
+// default cluster discovery fails opaquely there; a Warn at add/open
+// time provides a breadcrumb in the log file pointing at the docs.
+//
+// Best-effort: any failure to parse src.Location or extract the host
+// is a silent no-op. The warning must never affect Open behavior.
+func maybeWarnLocalhostDiscovery(ctx context.Context, src *source.Source) {
+	u, err := url.Parse(src.Location)
+	if err != nil {
+		return
+	}
+	if u.Query().Has("disableClusterDiscovery") {
+		// User has made an explicit choice (true or false). Don't
+		// second-guess them.
+		return
+	}
+	host := u.Hostname()
+	if host == "" {
+		return
+	}
+	if !isLoopbackHost(host) {
+		return
+	}
+	lg.FromContext(ctx).Warn(
+		"rqlite: source points at loopback but disableClusterDiscovery is not set; "+
+			"single-node localhost setups typically need ?disableClusterDiscovery=true "+
+			"to avoid peer-discovery failures from the host. See "+docsLocalhostAnchor,
+		lga.Src, src.Handle,
+	)
+}
+
+// isLoopbackHost reports whether host is a literal loopback reference.
+// Matches "localhost" (case-insensitive) and any IP whose net.IP
+// representation reports IsLoopback (covers 127.0.0.0/8, ::1, and
+// ::ffff:127.x.x.x mappings). No DNS resolution is performed.
+func isLoopbackHost(host string) bool {
+	if strings.EqualFold(host, "localhost") {
+		return true
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
+}
+
+// rewritePeerDNSError is added in Task 4 below.

--- a/drivers/rqlite/errors.go
+++ b/drivers/rqlite/errors.go
@@ -106,14 +106,14 @@ func rewritePeerDNSError(err error, src *source.Source) error {
 		return err
 	}
 	userHost := u.Hostname()
-	if dnsErr.Name == userHost {
+	if strings.EqualFold(dnsErr.Name, userHost) {
 		// The failing hostname is the one the user typed. That's
 		// their problem to fix; suggesting disableClusterDiscovery
 		// would be wrong.
 		return err
 	}
 	if u.Query().Get("disableClusterDiscovery") == "true" {
-		// Discovery already off — failure is something else.
+		// Discovery already off; failure is something else.
 		return err
 	}
 	return errz.Wrapf(err,

--- a/drivers/rqlite/internal_test.go
+++ b/drivers/rqlite/internal_test.go
@@ -1,8 +1,10 @@
 package rqlite
 
 import (
+	"bytes"
 	"context"
 	"database/sql"
+	"log/slog"
 	"testing"
 
 	_ "github.com/mattn/go-sqlite3" // For TestWriteAtomic_DBTypeCheck.
@@ -10,8 +12,11 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/neilotoole/sq/libsq/core/kind"
+	"github.com/neilotoole/sq/libsq/core/lg"
 	"github.com/neilotoole/sq/libsq/core/record"
 	"github.com/neilotoole/sq/libsq/core/schema"
+	"github.com/neilotoole/sq/libsq/source"
+	"github.com/neilotoole/sq/libsq/source/drivertype"
 	"github.com/neilotoole/sq/libsq/source/metadata"
 	"github.com/neilotoole/sq/testh/tu"
 )
@@ -338,4 +343,44 @@ func TestBuildCreateTableStmt_ForeignKey(t *testing.T) {
 	require.Contains(t, got, `ON DELETE CASCADE ON UPDATE CASCADE`)
 	require.Contains(t, got, `ON DELETE RESTRICT ON UPDATE SET NULL`)
 	require.Contains(t, got, `"film_id" INTEGER UNIQUE`)
+}
+
+func Test_maybeWarnLocalhostDiscovery(t *testing.T) {
+	testCases := []struct {
+		name    string
+		loc     string
+		wantLog bool
+	}{
+		{name: "localhost", loc: "rqlite://localhost:4001", wantLog: true},
+		{name: "localhost upper", loc: "rqlite://LOCALHOST:4001", wantLog: true},
+		{name: "127.0.0.1", loc: "rqlite://127.0.0.1:4001", wantLog: true},
+		{name: "ipv6 loopback", loc: "rqlite://[::1]:4001", wantLog: true},
+		{name: "127.0.0.5", loc: "rqlite://127.0.0.5:4001", wantLog: true},
+		{name: "remote host", loc: "rqlite://example.com:4001", wantLog: false},
+		{name: "discovery off explicit", loc: "rqlite://localhost:4001?disableClusterDiscovery=true", wantLog: false},
+		{name: "discovery on explicit", loc: "rqlite://localhost:4001?disableClusterDiscovery=false", wantLog: false},
+		{name: "localhost other params", loc: "rqlite://localhost:4001?level=strong", wantLog: true},
+		{name: "https loopback", loc: "rqlites://localhost:4001", wantLog: true},
+		{name: "malformed", loc: "rqlite://%zz", wantLog: false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			h := slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})
+			ctx := lg.NewContext(context.Background(), slog.New(h))
+
+			src := &source.Source{Handle: "@rq", Location: tc.loc, Type: drivertype.Rqlite}
+			maybeWarnLocalhostDiscovery(ctx, src)
+
+			got := buf.String()
+			if tc.wantLog {
+				require.Contains(t, got, "disableClusterDiscovery",
+					"expected warn mentioning disableClusterDiscovery, got: %s", got)
+				require.Contains(t, got, "level=WARN", "expected WARN level, got: %s", got)
+			} else {
+				require.Empty(t, got, "expected no log output, got: %s", got)
+			}
+		})
+	}
 }

--- a/drivers/rqlite/internal_test.go
+++ b/drivers/rqlite/internal_test.go
@@ -4,7 +4,10 @@ import (
 	"bytes"
 	"context"
 	"database/sql"
+	"errors"
+	"fmt"
 	"log/slog"
+	"net"
 	"testing"
 
 	_ "github.com/mattn/go-sqlite3" // For TestWriteAtomic_DBTypeCheck.
@@ -380,6 +383,107 @@ func Test_maybeWarnLocalhostDiscovery(t *testing.T) {
 				require.Contains(t, got, "level=WARN", "expected WARN level, got: %s", got)
 			} else {
 				require.Empty(t, got, "expected no log output, got: %s", got)
+			}
+		})
+	}
+}
+
+func Test_rewritePeerDNSError(t *testing.T) {
+	// fakeDNSErr builds a *net.DNSError with the given peer name.
+	// All real fields of net.DNSError (Err, Server, IsTimeout, etc.)
+	// are zero/false — only Name matters to the helper under test.
+	fakeDNSErr := func(name string) *net.DNSError {
+		return &net.DNSError{Err: "no such host", Name: name, IsNotFound: true}
+	}
+
+	const userLoc = "rqlite://localhost:4001"
+	const userLocOff = "rqlite://localhost:4001?disableClusterDiscovery=true"
+
+	testCases := []struct {
+		name          string
+		err           error
+		loc           string
+		wantRewrite   bool
+		wantSubstrAll []string // every substring must appear in the rewritten msg
+	}{
+		{
+			name:        "nil",
+			err:         nil,
+			loc:         userLoc,
+			wantRewrite: false,
+		},
+		{
+			name:        "non-dns error",
+			err:         errors.New("connection refused"),
+			loc:         userLoc,
+			wantRewrite: false,
+		},
+		{
+			name:          "discovered peer mismatch",
+			err:           fakeDNSErr("rqlite1"),
+			loc:           userLoc,
+			wantRewrite:   true,
+			wantSubstrAll: []string{"rqlite1", "localhost", "disableClusterDiscovery=true", "sq.io/docs/drivers/rqlite"},
+		},
+		{
+			name:          "discovered peer mismatch wrapped via fmt.Errorf",
+			err:           fmt.Errorf("Post \"http://rqlite1:4001/db/query\": dial tcp: lookup rqlite1: %w", fakeDNSErr("rqlite1")),
+			loc:           userLoc,
+			wantRewrite:   true,
+			wantSubstrAll: []string{"rqlite1", "disableClusterDiscovery=true"},
+		},
+		{
+			name:        "discovery already off",
+			err:         fakeDNSErr("rqlite1"),
+			loc:         userLocOff,
+			wantRewrite: false,
+		},
+		{
+			name:        "user host equals failed name",
+			err:         fakeDNSErr("localhost"),
+			loc:         userLoc,
+			wantRewrite: false,
+		},
+		{
+			name:        "malformed url",
+			err:         fakeDNSErr("rqlite1"),
+			loc:         "rqlite://%zz",
+			wantRewrite: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			src := &source.Source{Handle: "@rq", Location: tc.loc, Type: drivertype.Rqlite}
+			got := rewritePeerDNSError(tc.err, src)
+
+			if tc.err == nil {
+				require.Nil(t, got)
+				return
+			}
+
+			// errors.As must still find the underlying *net.DNSError
+			// (when there was one) — the rewrite must not break
+			// downstream classification.
+			var dnsErr *net.DNSError
+			origHadDNS := errors.As(tc.err, &dnsErr)
+			if origHadDNS {
+				var afterDNS *net.DNSError
+				require.True(t, errors.As(got, &afterDNS),
+					"errors.As must still reach *net.DNSError after rewrite")
+				require.Equal(t, dnsErr.Name, afterDNS.Name)
+			}
+
+			if !tc.wantRewrite {
+				// Pass-through: same instance returned.
+				require.Equal(t, tc.err.Error(), got.Error(),
+					"expected pass-through, got rewritten message")
+				return
+			}
+
+			msg := got.Error()
+			for _, sub := range tc.wantSubstrAll {
+				require.Contains(t, msg, sub, "rewritten message missing substring %q: %s", sub, msg)
 			}
 		})
 	}

--- a/drivers/rqlite/internal_test.go
+++ b/drivers/rqlite/internal_test.go
@@ -426,8 +426,11 @@ func Test_rewritePeerDNSError(t *testing.T) {
 			wantSubstrAll: []string{"rqlite1", "localhost", "disableClusterDiscovery=true", "sq.io/docs/drivers/rqlite"},
 		},
 		{
-			name:          "discovered peer mismatch wrapped via fmt.Errorf",
-			err:           fmt.Errorf("Post \"http://rqlite1:4001/db/query\": dial tcp: lookup rqlite1: %w", fakeDNSErr("rqlite1")),
+			name: "discovered peer mismatch wrapped via fmt.Errorf",
+			err: fmt.Errorf(
+				"Post \"http://rqlite1:4001/db/query\": dial tcp: lookup rqlite1: %w",
+				fakeDNSErr("rqlite1"),
+			),
 			loc:           userLoc,
 			wantRewrite:   true,
 			wantSubstrAll: []string{"rqlite1", "disableClusterDiscovery=true"},

--- a/drivers/rqlite/internal_test.go
+++ b/drivers/rqlite/internal_test.go
@@ -365,6 +365,11 @@ func Test_maybeWarnLocalhostDiscovery(t *testing.T) {
 		{name: "localhost other params", loc: "rqlite://localhost:4001?level=strong", wantLog: true},
 		{name: "https loopback", loc: "rqlites://localhost:4001", wantLog: true},
 		{name: "malformed", loc: "rqlite://%zz", wantLog: false},
+		{name: "discovery empty value", loc: "rqlite://localhost:4001?disableClusterDiscovery=", wantLog: true},
+		{name: "discovery bare key", loc: "rqlite://localhost:4001?disableClusterDiscovery", wantLog: true},
+		{name: "discovery upper TRUE", loc: "rqlite://localhost:4001?disableClusterDiscovery=TRUE", wantLog: false},
+		{name: "discovery upper FALSE", loc: "rqlite://localhost:4001?disableClusterDiscovery=False", wantLog: false},
+		{name: "discovery garbage value", loc: "rqlite://localhost:4001?disableClusterDiscovery=yes", wantLog: true},
 	}
 
 	for _, tc := range testCases {
@@ -394,6 +399,13 @@ func Test_rewritePeerDNSError(t *testing.T) {
 	// are zero/false — only Name matters to the helper under test.
 	fakeDNSErr := func(name string) *net.DNSError {
 		return &net.DNSError{Err: "no such host", Name: name, IsNotFound: true}
+	}
+	// fakeDNSTimeoutErr builds a *net.DNSError representing a DNS
+	// timeout (IsNotFound is false). The rewrite must pass these
+	// through unchanged: they're not the cluster-discovery "no such
+	// host" case the helper targets.
+	fakeDNSTimeoutErr := func(name string) *net.DNSError {
+		return &net.DNSError{Err: "i/o timeout", Name: name, IsTimeout: true}
 	}
 
 	const userLoc = "rqlite://localhost:4001"
@@ -457,6 +469,18 @@ func Test_rewritePeerDNSError(t *testing.T) {
 			name:        "malformed url",
 			err:         fakeDNSErr("rqlite1"),
 			loc:         "rqlite://%zz",
+			wantRewrite: false,
+		},
+		{
+			name:        "dns timeout passes through",
+			err:         fakeDNSTimeoutErr("rqlite1"),
+			loc:         userLoc,
+			wantRewrite: false,
+		},
+		{
+			name:        "discovery off upper TRUE",
+			err:         fakeDNSErr("rqlite1"),
+			loc:         "rqlite://localhost:4001?disableClusterDiscovery=TRUE",
 			wantRewrite: false,
 		},
 	}

--- a/drivers/rqlite/internal_test.go
+++ b/drivers/rqlite/internal_test.go
@@ -4,10 +4,12 @@ import (
 	"bytes"
 	"context"
 	"database/sql"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
 	"net"
+	"strings"
 	"testing"
 
 	_ "github.com/mattn/go-sqlite3" // For TestWriteAtomic_DBTypeCheck.
@@ -375,20 +377,25 @@ func Test_maybeWarnLocalhostDiscovery(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			var buf bytes.Buffer
-			h := slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})
+			h := slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})
 			ctx := lg.NewContext(context.Background(), slog.New(h))
 
 			src := &source.Source{Handle: "@rq", Location: tc.loc, Type: drivertype.Rqlite}
 			maybeWarnLocalhostDiscovery(ctx, src)
 
-			got := buf.String()
-			if tc.wantLog {
-				require.Contains(t, got, "disableClusterDiscovery",
-					"expected warn mentioning disableClusterDiscovery, got: %s", got)
-				require.Contains(t, got, "level=WARN", "expected WARN level, got: %s", got)
-			} else {
-				require.Empty(t, got, "expected no log output, got: %s", got)
+			raw := strings.TrimSpace(buf.String())
+			if !tc.wantLog {
+				require.Empty(t, raw, "expected no log output, got: %s", raw)
+				return
 			}
+
+			require.NotEmpty(t, raw, "expected one log entry, got none")
+			var entry map[string]any
+			require.NoError(t, json.Unmarshal([]byte(raw), &entry), "log line: %s", raw)
+			require.Equal(t, "WARN", entry["level"], "expected level=WARN, got: %v", entry["level"])
+			msg, _ := entry["msg"].(string)
+			require.Contains(t, msg, "disableClusterDiscovery",
+				"msg missing disableClusterDiscovery: %s", msg)
 		})
 	}
 }

--- a/drivers/rqlite/internal_test.go
+++ b/drivers/rqlite/internal_test.go
@@ -448,6 +448,12 @@ func Test_rewritePeerDNSError(t *testing.T) {
 			wantRewrite: false,
 		},
 		{
+			name:        "user host equals failed name case-insensitive",
+			err:         fakeDNSErr("localhost"),
+			loc:         "rqlite://LOCALHOST:4001",
+			wantRewrite: false,
+		},
+		{
 			name:        "malformed url",
 			err:         fakeDNSErr("rqlite1"),
 			loc:         "rqlite://%zz",

--- a/drivers/rqlite/internal_test.go
+++ b/drivers/rqlite/internal_test.go
@@ -475,9 +475,10 @@ func Test_rewritePeerDNSError(t *testing.T) {
 			}
 
 			if !tc.wantRewrite {
-				// Pass-through: same instance returned.
-				require.Equal(t, tc.err.Error(), got.Error(),
-					"expected pass-through, got rewritten message")
+				// Pass-through: helper must return the original error
+				// unchanged so callers can errors.Is against it.
+				require.True(t, errors.Is(got, tc.err),
+					"expected pass-through (errors.Is), got rewritten: %v", got)
 				return
 			}
 

--- a/drivers/rqlite/rqlite.go
+++ b/drivers/rqlite/rqlite.go
@@ -152,6 +152,8 @@ func (d *driveri) Open(ctx context.Context, src *source.Source) (driver.Grip, er
 }
 
 func (d *driveri) doOpen(ctx context.Context, src *source.Source) (*sql.DB, error) {
+	maybeWarnLocalhostDiscovery(ctx, src)
+
 	loc, portAdded, err := locationWithDefaultPort(src.Location)
 	if err != nil {
 		return nil, err
@@ -171,7 +173,8 @@ func (d *driveri) doOpen(ctx context.Context, src *source.Source) (*sql.DB, erro
 	db, err := sql.Open(sqDBDrvrName, dsn)
 	if err != nil {
 		// Don't include dsn in the error: it may carry credentials.
-		return nil, errz.Wrapf(errw(err), "failed to open rqlite source %s", src.Handle)
+		return nil, errz.Wrapf(rewritePeerDNSError(errw(err), src),
+			"failed to open rqlite source %s", src.Handle)
 	}
 
 	driver.ConfigureDB(ctx, db, src.Options)
@@ -243,7 +246,8 @@ func (d *driveri) Ping(ctx context.Context, src *source.Source) error {
 	defer lg.WarnIfCloseError(d.log, lgm.CloseDB, db)
 
 	if err = db.PingContext(ctx); err != nil {
-		return errz.Wrapf(errw(err), "ping %s: %s", src.Handle, src.RedactedLocation())
+		return errz.Wrapf(rewritePeerDNSError(errw(err), src),
+			"ping %s: %s", src.Handle, src.RedactedLocation())
 	}
 
 	return nil

--- a/drivers/rqlite/rqlite.go
+++ b/drivers/rqlite/rqlite.go
@@ -145,7 +145,7 @@ func (d *driveri) Open(ctx context.Context, src *source.Source) (driver.Grip, er
 	}
 
 	if err = driver.OpeningPing(ctx, src, db); err != nil {
-		return nil, err
+		return nil, rewritePeerDNSError(err, src)
 	}
 
 	return &grip{log: d.log, db: db, src: src, drvr: d}, nil

--- a/drivers/rqlite/sakila-start-rqlite-nodes.sh
+++ b/drivers/rqlite/sakila-start-rqlite-nodes.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+#
+# sakila-start-rqlite-nodes.sh
+#
+# Start a 3-node rqlite cluster on 127.0.0.1 (HTTP ports 4001/4003/4005,
+# Raft ports 4002/4004/4006) and load the Sakila sample database into
+# the leader. Because every node binds and advertises 127.0.0.1,
+# gorqlite's cluster discovery returns host-reachable addresses, so
+# `sq` can talk to the cluster WITHOUT ?disableClusterDiscovery=true,
+# exercising the real discovery + leader-redirect path.
+#
+# This is the local-machine analog of sakiladb/rqlite's
+# cluster-compose.yml, sidestepping the resolver problem that
+# Docker-based clusters hit when reached from the host (each container
+# advertises an internal hostname like rqlite1 that the host can't
+# resolve). For the equivalent single-node Docker setup with Sakila
+# preloaded, see sakila-start-local.sh at the repo root.
+#
+# Prerequisites: rqlited + curl on PATH. On macOS: `brew install rqlite`.
+# See https://rqlite.io/docs/install-rqlite/ for other platforms.
+#
+# Run in the foreground. Ctrl-C tears down all three nodes and removes
+# their data directory.
+
+set -euo pipefail
+
+command -v rqlited >/dev/null || {
+    echo "rqlited not found; on macOS install via 'brew install rqlite'" >&2
+    exit 1
+}
+command -v curl >/dev/null || {
+    echo "curl not found on PATH" >&2
+    exit 1
+}
+
+DATA_DIR="$(mktemp -d -t sakila-rq-nodes.XXXX)"
+
+cleanup() {
+    echo
+    echo "Stopping rqlite nodes..."
+    # Intentional word-splitting on the PID list.
+    # shellcheck disable=SC2046
+    kill $(jobs -p) 2>/dev/null || true
+    wait 2>/dev/null || true
+    rm -rf "$DATA_DIR"
+    echo "Done."
+}
+trap cleanup EXIT INT TERM HUP
+
+echo "Starting rqlite cluster (data dir: $DATA_DIR)"
+
+rqlited \
+    -node-id=1 \
+    -http-addr=127.0.0.1:4001 \
+    -raft-addr=127.0.0.1:4002 \
+    "$DATA_DIR/node1" &> "$DATA_DIR/node1.log" &
+
+# Let node1 bind its Raft port before node2/3 try to join.
+sleep 1
+
+rqlited \
+    -node-id=2 \
+    -http-addr=127.0.0.1:4003 \
+    -raft-addr=127.0.0.1:4004 \
+    -join=127.0.0.1:4002 \
+    "$DATA_DIR/node2" &> "$DATA_DIR/node2.log" &
+
+rqlited \
+    -node-id=3 \
+    -http-addr=127.0.0.1:4005 \
+    -raft-addr=127.0.0.1:4006 \
+    -join=127.0.0.1:4002 \
+    "$DATA_DIR/node3" &> "$DATA_DIR/node3.log" &
+
+# Wait up to 30s for the leader's /readyz to return 200.
+for _ in {1..30}; do
+    if curl -fsS http://127.0.0.1:4001/readyz >/dev/null 2>&1; then
+        break
+    fi
+    sleep 1
+done
+
+if ! curl -fsS http://127.0.0.1:4001/readyz >/dev/null 2>&1; then
+    echo "Leader did not become ready within 30s." >&2
+    echo "Inspect $DATA_DIR/node1.log for details." >&2
+    exit 1
+fi
+
+echo "Loading Sakila into leader..."
+sakila_db="$DATA_DIR/sakila.db"
+curl -fsSL https://sq.io/testdata/sakila.db -o "$sakila_db"
+curl -fsS -X POST 'http://127.0.0.1:4001/db/load' \
+    -H 'Content-Type: application/octet-stream' \
+    --data-binary "@$sakila_db" >/dev/null
+
+cat <<MSG
+
+Cluster ready: 3 nodes, leader on http://localhost:4001.
+
+Try it from another terminal (note: no disableClusterDiscovery):
+
+    sq add 'rqlite://localhost:4001' --handle @rq_local
+    sq inspect @rq_local
+
+Logs: $DATA_DIR/node{1,2,3}.log
+
+Press Ctrl-C here to stop the cluster.
+MSG
+
+wait

--- a/sakila-start-local.sh
+++ b/sakila-start-local.sh
@@ -16,9 +16,7 @@ docker run -d -p 3306:3306 --name sakiladb-my sakiladb/mysql:8 &>/dev/null
 docker run -d -p 9000:9000 --name sakiladb-ch sakiladb/clickhouse:25 &>/dev/null
 docker run -d -p 1521:1521 --name sakiladb-or sakiladb/oracle:23 &>/dev/null
 docker run -d -p 1433:1433 --name sakiladb-ms --platform=linux/amd64 sakiladb/sqlserver:2019 &>/dev/null
-# rqlite needs --add-host rqlite1:127.0.0.1 because its Raft state
-# advertises as rqlite1; without it the node fails to bootstrap.
-docker run -d -p 4001:4001 --add-host rqlite1:127.0.0.1 --name sakiladb-rq sakiladb/rqlite:10 &>/dev/null
+docker run -d -p 4001:4001 --name sakiladb-rq sakiladb/rqlite:10 &>/dev/null
 
 sleep 5
 

--- a/site/content/en/docs/drivers/rqlite.md
+++ b/site/content/en/docs/drivers/rqlite.md
@@ -230,10 +230,12 @@ loads Sakila into the leader. It requires the `rqlited` binary
 platforms):
 
 ```shell
-# In one terminal, fetch and run the helper. (Until this PR is merged to
-# master, the URL 404s; use the in-tree copy at
-# ./drivers/rqlite/sakila-start-rqlite-nodes.sh.)
-$ curl -fsSL https://raw.githubusercontent.com/neilotoole/sq/master/drivers/rqlite/sakila-start-rqlite-nodes.sh | bash
+# In one terminal, download the helper, take a look at it, and run it.
+$ curl -fsSL -o sakila-start-rqlite-nodes.sh \
+    https://raw.githubusercontent.com/neilotoole/sq/master/drivers/rqlite/sakila-start-rqlite-nodes.sh
+$ less sakila-start-rqlite-nodes.sh   # inspect before running
+$ chmod +x sakila-start-rqlite-nodes.sh
+$ ./sakila-start-rqlite-nodes.sh
 Starting rqlite cluster (data dir: /tmp/sakila-rq-nodes.XXXX)
 Loading Sakila into leader...
 

--- a/site/content/en/docs/drivers/rqlite.md
+++ b/site/content/en/docs/drivers/rqlite.md
@@ -189,3 +189,72 @@ endpoints, SQLite pragmas, and `sqlite_master`.
 | ----------- | ------------------------------------------------------- |
 | `row_count` | live `SELECT COUNT(*) FROM "tbl"` per table             |
 | `size`      | not reported. rqlite does not expose per-table storage. |
+
+## Example usage
+
+Both examples use the
+[`sakiladb/rqlite`](https://hub.docker.com/r/sakiladb/rqlite) image, which
+ships rqlite preloaded with the
+[Sakila](https://dev.mysql.com/doc/sakila/en/) sample database. Default
+credentials are `sakila` / `p_ssW0rd`.
+
+### Single node
+
+Start a single-node container, add the source, and inspect:
+
+```shell
+# Port 4001 is rqlite's HTTP API.
+$ docker run --rm -d --name sakila-rq -p 4001:4001 sakiladb/rqlite:latest
+
+# Add the source. ?disableClusterDiscovery=true is required when reaching
+# the container from the host (see Single-node localhost above).
+$ sq add 'rqlite://sakila:p_ssW0rd@localhost:4001?disableClusterDiscovery=true' \
+    --handle @rq
+
+$ sq inspect @rq
+
+# Tear down
+$ docker stop sakila-rq
+```
+
+### Multiple nodes
+
+The `sakiladb/rqlite` project publishes a three-node cluster compose file at
+[`cluster-compose.yml`](https://github.com/sakiladb/rqlite/blob/master/cluster-compose.yml).
+Fetch it and bring the cluster up:
+
+```shell
+$ curl -fLO https://raw.githubusercontent.com/sakiladb/rqlite/master/cluster-compose.yml
+$ docker compose -f cluster-compose.yml up -d
+```
+
+That brings up `rqlite1` (leader, host port `4001`), `rqlite2` (follower,
+host port `4003`), and `rqlite3` (follower, host port `4005`). The
+followers start with empty volumes and receive Sakila from the leader via
+Raft snapshot within a few seconds.
+
+Each node advertises its container hostname over `/status`, which isn't
+resolvable from the host. From a developer machine the simplest approach
+is to disable cluster discovery and point `sq` at one specific node. The
+SQL layer still works; `sq` just won't follow leader redirects.
+
+```shell
+$ sq add 'rqlite://sakila:p_ssW0rd@localhost:4001?disableClusterDiscovery=true' \
+    --handle @rq_cluster
+
+$ sq inspect @rq_cluster
+```
+
+In a real deployment where the node hostnames are resolvable from
+clients, leave discovery enabled (the default) so leader redirects and
+failover work automatically:
+
+```shell
+$ sq add 'rqlite://user:pass@rqlite1.internal:4001' --handle @rq_prod
+```
+
+Tear down the cluster:
+
+```shell
+$ docker compose -f cluster-compose.yml down -v
+```

--- a/site/content/en/docs/drivers/rqlite.md
+++ b/site/content/en/docs/drivers/rqlite.md
@@ -230,8 +230,10 @@ loads Sakila into the leader. It requires the `rqlited` binary
 platforms):
 
 ```shell
-# In one terminal:
-$ ./drivers/rqlite/sakila-start-rqlite-nodes.sh
+# In one terminal, fetch and run the helper. (Until this PR is merged to
+# master, the URL 404s; use the in-tree copy at
+# ./drivers/rqlite/sakila-start-rqlite-nodes.sh.)
+$ curl -fsSL https://raw.githubusercontent.com/neilotoole/sq/master/drivers/rqlite/sakila-start-rqlite-nodes.sh | bash
 Starting rqlite cluster (data dir: /tmp/sakila-rq-nodes.XXXX)
 Loading Sakila into leader...
 
@@ -260,5 +262,5 @@ Docker-based multi-node images such as `sakiladb/rqlite`'s
 advertise container-internal hostnames (`rqlite1`, `rqlite2`,
 `rqlite3`) that aren't resolvable from the host, so a host-side client
 would have to either disable discovery and point at one specific node,
-or rewrite the advertise addresses to host-reachable values plus add
+or rewrite the advertised addresses to host-reachable values plus add
 `/etc/hosts` entries. The bare-metal helper above sidesteps both.

--- a/site/content/en/docs/drivers/rqlite.md
+++ b/site/content/en/docs/drivers/rqlite.md
@@ -219,42 +219,46 @@ $ docker stop sakila-rq
 
 ### Multiple nodes
 
-The `sakiladb/rqlite` project publishes a three-node cluster compose file at
-[`cluster-compose.yml`](https://github.com/sakiladb/rqlite/blob/master/cluster-compose.yml).
-Fetch it and bring the cluster up:
+For a real local cluster that exercises gorqlite's discovery and
+leader redirects (i.e. WITHOUT `?disableClusterDiscovery=true`), the
+simplest approach on a developer machine is three native `rqlited`
+processes on `127.0.0.1`, each advertising a host-reachable address.
+The sq source tree includes a helper that brings the cluster up and
+loads Sakila into the leader. It requires the `rqlited` binary
+(`brew install rqlite` on macOS; see
+[rqlite.io](https://rqlite.io/docs/install-rqlite/) for other
+platforms):
 
 ```shell
-$ curl -fLO https://raw.githubusercontent.com/sakiladb/rqlite/master/cluster-compose.yml
-$ docker compose -f cluster-compose.yml up -d
+# In one terminal:
+$ ./drivers/rqlite/sakila-start-rqlite-nodes.sh
+Starting rqlite cluster (data dir: /tmp/sakila-rq-nodes.XXXX)
+Loading Sakila into leader...
+
+Cluster ready: 3 nodes, leader on http://localhost:4001.
+...
+Press Ctrl-C here to stop the cluster.
+
+# In another terminal:
+$ sq add 'rqlite://localhost:4001' --handle @rq_local
+$ sq inspect @rq_local
 ```
 
-That brings up `rqlite1` (leader, host port `4001`), `rqlite2` (follower,
-host port `4003`), and `rqlite3` (follower, host port `4005`). The
-followers start with empty volumes and receive Sakila from the leader via
-Raft snapshot within a few seconds.
+Ctrl-C in the first terminal tears the cluster down and removes its
+data directory.
 
-Each node advertises its container hostname over `/status`, which isn't
-resolvable from the host. From a developer machine the simplest approach
-is to disable cluster discovery and point `sq` at one specific node. The
-SQL layer still works; `sq` just won't follow leader redirects.
-
-```shell
-$ sq add 'rqlite://sakila:p_ssW0rd@localhost:4001?disableClusterDiscovery=true' \
-    --handle @rq_cluster
-
-$ sq inspect @rq_cluster
-```
-
-In a real deployment where the node hostnames are resolvable from
-clients, leave discovery enabled (the default) so leader redirects and
-failover work automatically:
+In a production deployment where node hostnames are resolvable from
+clients (typically via internal DNS), leave discovery enabled (the
+default) so leader redirects and failover work automatically:
 
 ```shell
 $ sq add 'rqlite://user:pass@rqlite1.internal:4001' --handle @rq_prod
 ```
 
-Tear down the cluster:
-
-```shell
-$ docker compose -f cluster-compose.yml down -v
-```
+Docker-based multi-node images such as `sakiladb/rqlite`'s
+[`cluster-compose.yml`](https://github.com/sakiladb/rqlite/blob/master/cluster-compose.yml)
+advertise container-internal hostnames (`rqlite1`, `rqlite2`,
+`rqlite3`) that aren't resolvable from the host, so a host-side client
+would have to either disable discovery and point at one specific node,
+or rewrite the advertise addresses to host-reachable values plus add
+`/etc/hosts` entries. The bare-metal helper above sidesteps both.


### PR DESCRIPTION
## Summary

- `sq add 'rqlite://localhost:4001'` (or `127.0.0.1`, `::1`, any loopback IP) now emits a one-line WARN log when `disableClusterDiscovery` isn't explicitly set, pointing at the [single-node-localhost docs](https://sq.io/docs/drivers/rqlite#single-node-localhost).
- When the cluster-discovery DNS lookup actually fails (`dial tcp: lookup <peer>: no such host`), the error is rewritten into an actionable message naming the unreachable peer and suggesting `?disableClusterDiscovery=true`, instead of surfacing gorqlite's raw `tried all peers unsuccessfully` text. Pass-through when the user typed an unresolvable host themselves or `disableClusterDiscovery=true` is already set.
- Implementation is driver-internal (two package-private helpers in `drivers/rqlite/errors.go`, called from `doOpen` and `Ping`). No new public driver interface; a generic cross-driver `AddHinter` mechanism is deferred to a follow-up issue.

Closes #742.

## Test plan

- [x] `go test -short ./drivers/rqlite` passes (15+ new sub-cases across `Test_maybeWarnLocalhostDiscovery` and `Test_rewritePeerDNSError`).
- [x] `make test-short` passes repo-wide.
- [x] `make lint` clean.
- [ ] Manual: `sq add 'rqlite://localhost:4001'` against single-node `rqlite/rqlite` Docker container; verify error message names the failing peer and points at the docs URL.
- [ ] Manual: `sq add 'rqlite://localhost:4001?disableClusterDiscovery=true'` against same container; verify no WARN, successful add.