### PR TITLE
inspect: render '-' for source size when driver doesn't report it (gh744)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -128,6 +128,9 @@ Breaking changes are annotated with ☢️, and alpha/beta features with 🐥.
   and the resolved value was being copied verbatim into `metadata.Source.Location`; the
   inspect handler now overrides that field with the caller's view of `src.Location`, which
   is the placeholder by default and the resolved value only when `--expand` is set.
+- [#744]: `sq inspect` no longer reports `0.0B` size for sources whose driver doesn't expose
+  a database size (e.g. rqlite). The SIZE column renders `-` instead, and JSON / YAML output
+  omit the `size` field.
 
 ## [v0.53.0] - 2026-05-25
 
@@ -1705,6 +1708,7 @@ make working with lots of sources much easier.
 [#714]: https://github.com/neilotoole/sq/issues/714
 [#720]: https://github.com/neilotoole/sq/issues/720
 [#729]: https://github.com/neilotoole/sq/issues/729
+[#744]: https://github.com/neilotoole/sq/issues/744
 
 [v0.15.2]: https://github.com/neilotoole/sq/releases/tag/v0.15.2
 [v0.15.3]: https://github.com/neilotoole/sq/compare/v0.15.2...v0.15.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,7 +130,7 @@ Breaking changes are annotated with ☢️, and alpha/beta features with 🐥.
   is the placeholder by default and the resolved value only when `--expand` is set.
 - [#744]: `sq inspect` no longer reports `0.0B` size for sources whose driver doesn't expose
   a database size (e.g. rqlite). The SIZE column renders `-` instead, and JSON / YAML output
-  omit the `size` field.
+  omits the `size` field.
 
 ## [v0.53.0] - 2026-05-25
 

--- a/cli/cmd_inspect_test.go
+++ b/cli/cmd_inspect_test.go
@@ -118,6 +118,7 @@ func TestCmdInspect_json_yaml(t *testing.T) { //nolint:tparallel
 		{sakila.XLSX, sakila.AllTbls()},
 		{sakila.SL3, sakila.AllTbls()},
 		{sakila.Duck, sakila.AllTbls()},
+		{sakila.Rq, sakila.AllTbls()},
 		{sakila.Pg, lo.Without(sakila.AllTbls(), sakila.TblFilmText)}, // pg doesn't have film_text
 		{sakila.My, sakila.AllTbls()},
 		{sakila.MS, sakila.AllTbls()},
@@ -203,8 +204,12 @@ func TestCmdInspect_json_yaml(t *testing.T) { //nolint:tparallel
 						require.NotEmpty(t, srcMeta.DBDriver)
 						require.NotEmpty(t, srcMeta.DBProduct)
 						require.NotEmpty(t, srcMeta.DBVersion)
-						require.NotNil(t, srcMeta.Size)
-						require.NotZero(t, *srcMeta.Size)
+						if tc.handle == sakila.Rq {
+							require.Nil(t, srcMeta.Size, "rqlite shouldn't report a source size")
+						} else {
+							require.NotNil(t, srcMeta.Size)
+							require.NotZero(t, *srcMeta.Size)
+						}
 					})
 
 					t.Run("inspect_dbprops", func(t *testing.T) {

--- a/cli/cmd_inspect_test.go
+++ b/cli/cmd_inspect_test.go
@@ -203,7 +203,8 @@ func TestCmdInspect_json_yaml(t *testing.T) { //nolint:tparallel
 						require.NotEmpty(t, srcMeta.DBDriver)
 						require.NotEmpty(t, srcMeta.DBProduct)
 						require.NotEmpty(t, srcMeta.DBVersion)
-						require.NotZero(t, srcMeta.Size)
+						require.NotNil(t, srcMeta.Size)
+						require.NotZero(t, *srcMeta.Size)
 					})
 
 					t.Run("inspect_dbprops", func(t *testing.T) {

--- a/cli/diff/render.go
+++ b/cli/diff/render.go
@@ -18,7 +18,7 @@ func renderSourceMeta2YAML(sm *metadata.Source) (string, error) {
 
 	// sourceMeta holds values of metadata.Source in the structure
 	// that diff wants.
-	type sourceMeta struct {
+	type sourceMeta struct { //nolint:govet // YAML output ordering matters more than 8 bytes.
 		Handle     string          `json:"handle" yaml:"handle"`
 		Location   string          `json:"location" yaml:"location"`
 		Name       string          `json:"name" yaml:"name"`
@@ -29,7 +29,7 @@ func renderSourceMeta2YAML(sm *metadata.Source) (string, error) {
 		DBProduct  string          `json:"db_product" yaml:"db_product"`
 		DBVersion  string          `json:"db_version" yaml:"db_version"`
 		User       string          `json:"user,omitempty" yaml:"user,omitempty"`
-		Size       int64           `json:"size" yaml:"size"`
+		Size       *int64          `json:"size,omitempty" yaml:"size,omitempty"`
 		TableCount int64           `json:"table_count" yaml:"table_count"`
 		ViewCount  int64           `json:"view_count" yaml:"view_count"`
 	}

--- a/cli/output/htmlw/erd.go
+++ b/cli/output/htmlw/erd.go
@@ -135,7 +135,7 @@ func (w *metadataWriter) writeSourceOverview(buf *bytes.Buffer, md *metadata.Sou
 	addRow("DB version", md.DBVersion)
 	addRow("Schema", md.Schema)
 	addRow("Catalog", md.Catalog)
-	addRow("Size", stringz.ByteSized(md.Size, 1, ""))
+	addRow("Size", stringz.FormatSize(md.Size))
 	if showSchema {
 		addRow("Tables", strconv.FormatInt(md.TableCount, 10))
 		addRow("Views", strconv.FormatInt(md.ViewCount, 10))

--- a/cli/output/htmlw/metadatawriter_test.go
+++ b/cli/output/htmlw/metadatawriter_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/samber/lo"
 	"github.com/stretchr/testify/require"
 
 	"github.com/neilotoole/sq/cli/output"
@@ -63,7 +64,7 @@ func newTestSource() *metadata.Source {
 		}}},
 	}
 	src := &metadata.Source{
-		Handle: "@test", Name: "testdb", Schema: "main", Size: 1048576,
+		Handle: "@test", Name: "testdb", Schema: "main", Size: lo.ToPtr(int64(1048576)),
 		TableCount: 2, ViewCount: 0, Tables: []*metadata.Table{actor, filmActor},
 	}
 	metadata.LinkForeignKeys(nil, src)
@@ -170,7 +171,7 @@ func TestMetadataWriter_indexesAndUniqueConstraints(t *testing.T) {
 func TestMetadataWriter_views(t *testing.T) {
 	src := &metadata.Source{
 		Handle: "@test", Name: "db", Driver: drivertype.Type("sqlite3"),
-		Schema: "main", Size: 1024, TableCount: 1, ViewCount: 1,
+		Schema: "main", Size: lo.ToPtr(int64(1024)), TableCount: 1, ViewCount: 1,
 		Tables: []*metadata.Table{
 			{Name: "t_actor", TableType: "table", Columns: []*metadata.Column{{Name: "id", ColumnType: "int"}}},
 			{Name: "v_films", TableType: "view", Columns: []*metadata.Column{{Name: "id", ColumnType: "int"}}},

--- a/cli/output/htmlw/metadatawriter_test.go
+++ b/cli/output/htmlw/metadatawriter_test.go
@@ -135,6 +135,24 @@ func TestMetadataWriter_SourceMetadata_overview(t *testing.T) {
 	require.NotContains(t, got, `id="tables"`)
 }
 
+// TestMetadataWriter_SourceMetadata_nilSize verifies that a source whose
+// driver doesn't report a size renders "-" in the Size row rather than
+// "0.0B" (gh744). The row is still emitted so the key-value layout stays
+// consistent across sources.
+func TestMetadataWriter_SourceMetadata_nilSize(t *testing.T) {
+	src := newTestSource()
+	src.Size = nil
+
+	buf := &bytes.Buffer{}
+	w := htmlw.NewMetadataWriter(buf, output.NewPrinting(), false)
+	require.NoError(t, w.SourceMetadata(src, true))
+
+	got := buf.String()
+	// The Size key-value row is rendered with a literal "-" value.
+	require.Contains(t, got, "<tr><td>Size</td><td><code>-</code></td></tr>")
+	require.NotContains(t, got, "0.0B")
+}
+
 // TestMetadataWriter_indexesAndUniqueConstraints checks that indexes and
 // unique constraints render as <table> elements with the expected columns.
 func TestMetadataWriter_indexesAndUniqueConstraints(t *testing.T) {

--- a/cli/output/htmlw/metadatawriter_test.go
+++ b/cli/output/htmlw/metadatawriter_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/samber/lo"
 	"github.com/stretchr/testify/require"
 
 	"github.com/neilotoole/sq/cli/output"
@@ -63,8 +62,9 @@ func newTestSource() *metadata.Source {
 			RefTable: "actor", RefColumns: []string{"actor_id"},
 		}}},
 	}
+	var size int64 = 1048576
 	src := &metadata.Source{
-		Handle: "@test", Name: "testdb", Schema: "main", Size: lo.ToPtr(int64(1048576)),
+		Handle: "@test", Name: "testdb", Schema: "main", Size: &size,
 		TableCount: 2, ViewCount: 0, Tables: []*metadata.Table{actor, filmActor},
 	}
 	metadata.LinkForeignKeys(nil, src)
@@ -169,9 +169,10 @@ func TestMetadataWriter_indexesAndUniqueConstraints(t *testing.T) {
 // TestMetadataWriter_views checks the "Tables & views" heading and the
 // tinted view-chip class (sq-view) in the TOC; table chips stay plain.
 func TestMetadataWriter_views(t *testing.T) {
+	var size int64 = 1024
 	src := &metadata.Source{
 		Handle: "@test", Name: "db", Driver: drivertype.Type("sqlite3"),
-		Schema: "main", Size: lo.ToPtr(int64(1024)), TableCount: 1, ViewCount: 1,
+		Schema: "main", Size: &size, TableCount: 1, ViewCount: 1,
 		Tables: []*metadata.Table{
 			{Name: "t_actor", TableType: "table", Columns: []*metadata.Column{{Name: "id", ColumnType: "int"}}},
 			{Name: "v_films", TableType: "view", Columns: []*metadata.Column{{Name: "id", ColumnType: "int"}}},

--- a/cli/output/markdownw/metadatawriter.go
+++ b/cli/output/markdownw/metadatawriter.go
@@ -210,7 +210,7 @@ func (w *metadataWriter) writeSourceOverview(buf *bytes.Buffer, md *metadata.Sou
 	writeKVRow(buf, "DB version", md.DBVersion)
 	writeKVRow(buf, "Schema", md.Schema)
 	writeKVRow(buf, "Catalog", md.Catalog)
-	writeKVRow(buf, "Size", stringz.ByteSized(md.Size, 1, ""))
+	writeKVRow(buf, "Size", stringz.FormatSize(md.Size))
 	if showSchema {
 		writeKVRow(buf, "Tables", strconv.FormatInt(md.TableCount, 10))
 		writeKVRow(buf, "Views", strconv.FormatInt(md.ViewCount, 10))

--- a/cli/output/markdownw/metadatawriter_test.go
+++ b/cli/output/markdownw/metadatawriter_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/samber/lo"
 	"github.com/stretchr/testify/require"
 
 	"github.com/neilotoole/sq/cli/output"
@@ -52,12 +51,13 @@ func newTestSource() *metadata.Source {
 		},
 	}
 
+	var size int64 = 1048576
 	src := &metadata.Source{
 		Handle:     "@test",
 		Name:       "testdb",
 		Driver:     drivertype.Type("sqlite3"),
 		Schema:     "main",
-		Size:       lo.ToPtr(int64(1048576)),
+		Size:       &size,
 		TableCount: 2,
 		ViewCount:  0,
 		Tables:     []*metadata.Table{actor, filmActor},
@@ -233,9 +233,10 @@ func TestMetadataWriter_backtickIdentifier(t *testing.T) {
 // "Tables & views" heading and italicizes view links in the TOC (tables
 // stay plain).
 func TestMetadataWriter_views(t *testing.T) {
+	var size int64 = 1024
 	src := &metadata.Source{
 		Handle: "@test", Name: "db", Driver: drivertype.Type("sqlite3"),
-		Schema: "main", Size: lo.ToPtr(int64(1024)), TableCount: 1, ViewCount: 1,
+		Schema: "main", Size: &size, TableCount: 1, ViewCount: 1,
 		Tables: []*metadata.Table{
 			{Name: "t_actor", TableType: "table", Columns: []*metadata.Column{{Name: "id", ColumnType: "int"}}},
 			{Name: "v_films", TableType: "view", Columns: []*metadata.Column{{Name: "id", ColumnType: "int"}}},

--- a/cli/output/markdownw/metadatawriter_test.go
+++ b/cli/output/markdownw/metadatawriter_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/samber/lo"
 	"github.com/stretchr/testify/require"
 
 	"github.com/neilotoole/sq/cli/output"
@@ -56,7 +57,7 @@ func newTestSource() *metadata.Source {
 		Name:       "testdb",
 		Driver:     drivertype.Type("sqlite3"),
 		Schema:     "main",
-		Size:       1048576,
+		Size:       lo.ToPtr(int64(1048576)),
 		TableCount: 2,
 		ViewCount:  0,
 		Tables:     []*metadata.Table{actor, filmActor},
@@ -234,7 +235,7 @@ func TestMetadataWriter_backtickIdentifier(t *testing.T) {
 func TestMetadataWriter_views(t *testing.T) {
 	src := &metadata.Source{
 		Handle: "@test", Name: "db", Driver: drivertype.Type("sqlite3"),
-		Schema: "main", Size: 1024, TableCount: 1, ViewCount: 1,
+		Schema: "main", Size: lo.ToPtr(int64(1024)), TableCount: 1, ViewCount: 1,
 		Tables: []*metadata.Table{
 			{Name: "t_actor", TableType: "table", Columns: []*metadata.Column{{Name: "id", ColumnType: "int"}}},
 			{Name: "v_films", TableType: "view", Columns: []*metadata.Column{{Name: "id", ColumnType: "int"}}},

--- a/cli/output/markdownw/metadatawriter_test.go
+++ b/cli/output/markdownw/metadatawriter_test.go
@@ -179,6 +179,22 @@ func TestMetadataWriter_SourceMetadata_overview(t *testing.T) {
 	require.Equal(t, want, buf.String())
 }
 
+// TestMetadataWriter_SourceMetadata_nilSize verifies that a source whose
+// driver doesn't report a size renders "-" rather than "0.0B" (gh744).
+func TestMetadataWriter_SourceMetadata_nilSize(t *testing.T) {
+	src := newTestSource()
+	src.Size = nil
+
+	buf := &bytes.Buffer{}
+	w := markdownw.NewMetadataWriter(buf, output.NewPrinting())
+	require.NoError(t, w.SourceMetadata(src, true))
+
+	got := buf.String()
+	// The Size key-value row is emitted with a literal "-".
+	require.Contains(t, got, "| Size | `-` |")
+	require.NotContains(t, got, "0.0B")
+}
+
 // TestMetadataWriter_indexesAndUniqueConstraints checks that indexes and
 // unique constraints render as tables (the test source used elsewhere has
 // neither). Type is empty for one index, exercising the blank cell.

--- a/cli/output/mermaidw/metadatawriter_test.go
+++ b/cli/output/mermaidw/metadatawriter_test.go
@@ -5,6 +5,7 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/samber/lo"
 	"github.com/stretchr/testify/require"
 
 	"github.com/neilotoole/sq/cli/output"
@@ -87,7 +88,7 @@ func newTestSource() *metadata.Source {
 		Name:       "testdb",
 		Driver:     drivertype.Type("sqlite3"),
 		Schema:     "main",
-		Size:       1048576,
+		Size:       lo.ToPtr(int64(1048576)),
 		TableCount: 2,
 		ViewCount:  0,
 		Tables:     []*metadata.Table{actor, filmActor},

--- a/cli/output/mermaidw/metadatawriter_test.go
+++ b/cli/output/mermaidw/metadatawriter_test.go
@@ -5,7 +5,6 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/samber/lo"
 	"github.com/stretchr/testify/require"
 
 	"github.com/neilotoole/sq/cli/output"
@@ -83,12 +82,13 @@ func newTestSource() *metadata.Source {
 		},
 	}
 
+	var size int64 = 1048576
 	src := &metadata.Source{
 		Handle:     "@test",
 		Name:       "testdb",
 		Driver:     drivertype.Type("sqlite3"),
 		Schema:     "main",
-		Size:       lo.ToPtr(int64(1048576)),
+		Size:       &size,
 		TableCount: 2,
 		ViewCount:  0,
 		Tables:     []*metadata.Table{actor, filmActor},

--- a/cli/output/tablew/metadatawriter.go
+++ b/cli/output/tablew/metadatawriter.go
@@ -127,7 +127,7 @@ func (w *mdWriter) doSourceMetaNoSchema(md *metadata.Source) error {
 		md.Driver.String(),
 		md.Name,
 		md.FQName,
-		w.tbl.pr.Number.Sprint(stringz.ByteSized(md.Size, 1, "")),
+		w.tbl.pr.Number.Sprint(stringz.FormatSize(md.Size)),
 		loc,
 	}
 
@@ -486,7 +486,7 @@ func (w *mdWriter) doSourceMetaFull(md *metadata.Source) error {
 		md.Driver.String(),
 		md.Name,
 		md.FQName,
-		w.tbl.pr.Number.Sprint(stringz.ByteSized(md.Size, 1, "")),
+		w.tbl.pr.Number.Sprint(stringz.FormatSize(md.Size)),
 		strconv.FormatInt(md.TableCount, 10),
 		strconv.FormatInt(md.ViewCount, 10),
 		loc,

--- a/cli/output/tablew/metadatawriter_test.go
+++ b/cli/output/tablew/metadatawriter_test.go
@@ -33,7 +33,7 @@ func TestSourceMetadata_nilSize(t *testing.T) {
 	// SIZE is the 5th column (SOURCE, DRIVER, NAME, FQ NAME, SIZE, LOCATION).
 	// Locate the data row (contains the handle) and assert the SIZE cell is "-".
 	var dataRow string
-	for _, line := range strings.Split(got, "\n") {
+	for line := range strings.SplitSeq(got, "\n") {
 		if strings.Contains(line, "@test") {
 			dataRow = line
 			break

--- a/cli/output/tablew/metadatawriter_test.go
+++ b/cli/output/tablew/metadatawriter_test.go
@@ -30,8 +30,9 @@ func TestSourceMetadata_nilSize(t *testing.T) {
 	got := buf.String()
 	require.NotContains(t, got, "0.0B")
 
-	// SIZE is the 5th column (SOURCE, DRIVER, NAME, FQ NAME, SIZE, LOCATION).
-	// Locate the data row (contains the handle) and assert the SIZE cell is "-".
+	// With showSchema=true the source row is rendered by doSourceMetaFull
+	// with 8 columns: SOURCE, DRIVER, NAME, FQ NAME, SIZE, TABLES, VIEWS,
+	// LOCATION. SIZE is the 5th column (index 4).
 	var dataRow string
 	for line := range strings.SplitSeq(got, "\n") {
 		if strings.Contains(line, "@test") {
@@ -41,7 +42,7 @@ func TestSourceMetadata_nilSize(t *testing.T) {
 	}
 	require.NotEmpty(t, dataRow, "data row not found in tablew output")
 	fields := strings.Fields(dataRow)
-	require.GreaterOrEqual(t, len(fields), 6, "data row should have at least 6 fields")
+	require.Len(t, fields, 8, "data row should have 8 columns")
 	require.Equal(t, "-", fields[4], "SIZE column should render as dash for nil size")
 }
 

--- a/cli/output/tablew/metadatawriter_test.go
+++ b/cli/output/tablew/metadatawriter_test.go
@@ -28,8 +28,21 @@ func TestSourceMetadata_nilSize(t *testing.T) {
 	require.NoError(t, w.SourceMetadata(src, true))
 
 	got := buf.String()
-	require.Contains(t, got, "-", "expected dash for nil size")
 	require.NotContains(t, got, "0.0B")
+
+	// SIZE is the 5th column (SOURCE, DRIVER, NAME, FQ NAME, SIZE, LOCATION).
+	// Locate the data row (contains the handle) and assert the SIZE cell is "-".
+	var dataRow string
+	for _, line := range strings.Split(got, "\n") {
+		if strings.Contains(line, "@test") {
+			dataRow = line
+			break
+		}
+	}
+	require.NotEmpty(t, dataRow, "data row not found in tablew output")
+	fields := strings.Fields(dataRow)
+	require.GreaterOrEqual(t, len(fields), 6, "data row should have at least 6 fields")
+	require.Equal(t, "-", fields[4], "SIZE column should render as dash for nil size")
 }
 
 // TestIndexEntriesByColumn_TagMatrix pins the verbose-text dedup

--- a/cli/output/tablew/metadatawriter_test.go
+++ b/cli/output/tablew/metadatawriter_test.go
@@ -8,8 +8,29 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/neilotoole/sq/cli/output"
+	"github.com/neilotoole/sq/libsq/source/drivertype"
 	"github.com/neilotoole/sq/libsq/source/metadata"
 )
+
+// TestSourceMetadata_nilSize verifies that a source whose driver doesn't
+// report a size renders "-" in the SIZE column rather than "0.0B" (gh744).
+func TestSourceMetadata_nilSize(t *testing.T) {
+	src := &metadata.Source{
+		Handle: "@test", Driver: drivertype.SQLite, Name: "testdb",
+		FQName: "testdb", Location: "sqlite3:///tmp/testdb.db",
+		// Size left nil to simulate a driver that doesn't report it.
+	}
+
+	buf := &bytes.Buffer{}
+	pr := output.NewPrinting()
+	pr.EnableColor(false)
+	w := NewMetadataWriter(buf, pr)
+	require.NoError(t, w.SourceMetadata(src, true))
+
+	got := buf.String()
+	require.Contains(t, got, "-", "expected dash for nil size")
+	require.NotContains(t, got, "0.0B")
+}
 
 // TestIndexEntriesByColumn_TagMatrix pins the verbose-text dedup
 // contract for [indexEntriesByColumn]:

--- a/drivers/clickhouse/metadata.go
+++ b/drivers/clickhouse/metadata.go
@@ -72,7 +72,7 @@ func getSourceMetadata(ctx context.Context, src *source.Source, db sqlz.DB, noSc
 		return nil, errw(err)
 	}
 	if size.Valid {
-		md.Size = size.Int64
+		md.Size = &size.Int64
 	}
 
 	// DBProperties surfaces driver-level session/version values via the

--- a/drivers/clickhouse/metadata_test.go
+++ b/drivers/clickhouse/metadata_test.go
@@ -335,7 +335,8 @@ func TestMetadata_SourceMetadata(t *testing.T) {
 	require.Equal(t, "ClickHouse "+md.DBVersion, md.DBProduct)
 
 	require.Equal(t, "sakila", md.User)
-	require.Greater(t, md.Size, int64(0))
+	require.NotNil(t, md.Size)
+	require.Greater(t, *md.Size, int64(0))
 
 	require.NotEmpty(t, md.Tables)
 	require.Greater(t, md.TableCount, int64(0))

--- a/drivers/csv/csv.go
+++ b/drivers/csv/csv.go
@@ -154,10 +154,11 @@ func (g *grip) SourceMetadata(ctx context.Context, noSchema bool) (*metadata.Sou
 		return nil, err
 	}
 
-	md.Size, err = g.files.Filesize(ctx, g.src)
+	size, err := g.files.Filesize(ctx, g.src)
 	if err != nil {
 		return nil, err
 	}
+	md.Size = &size
 
 	md.FQName = md.Name
 	return md, nil

--- a/drivers/duckdb/metadata.go
+++ b/drivers/duckdb/metadata.go
@@ -226,7 +226,8 @@ func getSourceMetadata(ctx context.Context, src *source.Source, db sqlz.DB, noSc
 		if err != nil {
 			return nil, errz.Wrapf(err, "stat duckdb file for %s", src.Handle)
 		}
-		md.Size = fi.Size()
+		size := fi.Size()
+		md.Size = &size
 	}
 
 	if noSchema {

--- a/drivers/json/json.go
+++ b/drivers/json/json.go
@@ -190,10 +190,11 @@ func (g *grip) SourceMetadata(ctx context.Context, noSchema bool) (*metadata.Sou
 		return nil, err
 	}
 
-	md.Size, err = g.files.Filesize(ctx, g.src)
+	size, err := g.files.Filesize(ctx, g.src)
 	if err != nil {
 		return nil, err
 	}
+	md.Size = &size
 
 	md.FQName = md.Name
 	return md, nil

--- a/drivers/mysql/metadata.go
+++ b/drivers/mysql/metadata.go
@@ -722,7 +722,7 @@ func setSourceSummaryMeta(ctx context.Context, db sqlz.DB, md *metadata.Source) 
 	md.Schema = schema
 	md.FQName = md.Catalog + "." + schema
 	if size.Valid {
-		md.Size = size.Int64
+		md.Size = &size.Int64
 	}
 	md.DBVersion = version
 	md.DBProduct = fmt.Sprintf("%s %s / %s (%s)", versionComment, version, versionOS, versionArch)

--- a/drivers/oracle/metadata.go
+++ b/drivers/oracle/metadata.go
@@ -94,7 +94,9 @@ FROM DUAL`
 	var size sql.NullInt64
 	if err := db.QueryRowContext(ctx,
 		"SELECT NVL(SUM(bytes), 0) FROM user_segments").Scan(&size); err == nil {
-		md.Size = size.Int64
+		if size.Valid {
+			md.Size = &size.Int64
+		}
 	}
 
 	// DBProperties surfaces driver-level session/version values via the

--- a/drivers/postgres/metadata.go
+++ b/drivers/postgres/metadata.go
@@ -195,13 +195,18 @@ func getSourceMetadata(ctx context.Context, src *source.Source, db sqlz.DB, noSc
 	const summaryQuery = `SELECT current_catalog, current_schema(), pg_database_size(current_catalog),
 current_setting('server_version'), version(), "current_user"()`
 
+	var size sql.NullInt64
 	err := db.QueryRowContext(ctx, summaryQuery).
-		Scan(&md.Name, &schema, &md.Size, &md.DBVersion, &md.DBProduct, &md.User)
+		Scan(&md.Name, &schema, &size, &md.DBVersion, &md.DBProduct, &md.User)
 	if err != nil {
 		return nil, errw(err)
 	}
 	progress.Incr(ctx, 1)
 	debugz.DebugSleep(ctx)
+
+	if size.Valid {
+		md.Size = &size.Int64
+	}
 
 	if !schema.Valid {
 		return nil, errz.New("NULL value for current_schema(): check privileges and search_path")

--- a/drivers/rqlite/rqlite_test.go
+++ b/drivers/rqlite/rqlite_test.go
@@ -61,6 +61,10 @@ func TestSourceMetadata(t *testing.T) {
 	// metadata query runs. Assert the lower bound rather than equality.
 	require.GreaterOrEqual(t, md.TableCount, int64(16))
 	require.Equal(t, int64(5), md.ViewCount)
+	// rqlite's HTTP API doesn't expose a database file size, so the
+	// driver leaves Source.Size as nil (gh744). Asserting nil prevents a
+	// regression to the int64 zero value, which would render as "0.0B".
+	require.Nil(t, md.Size, "rqlite source size should not be reported")
 }
 
 // TestTableMetadata_Actor verifies the per-table metadata path:

--- a/drivers/sqlite3/grip.go
+++ b/drivers/sqlite3/grip.go
@@ -106,7 +106,8 @@ func (g *grip) getSourceMetadata(ctx context.Context, noSchema bool) (*metadata.
 		return nil, errw(err)
 	}
 
-	md.Size = fi.Size()
+	size := fi.Size()
+	md.Size = &size
 	md.Name = fi.Name()
 	md.FQName = fi.Name() + "." + md.Schema
 	// SQLite doesn't support catalog, but we conventionally set it to "default"

--- a/drivers/sqlite3/sqlite3_test.go
+++ b/drivers/sqlite3/sqlite3_test.go
@@ -449,6 +449,7 @@ func TestSourceMetadata_LocationWithConnParams(t *testing.T) {
 	md, err := roGrip.SourceMetadata(th.Context, true)
 	require.NoError(t, err, "SourceMetadata must succeed even when Location carries ?mode=ro")
 	require.Equal(t, "@ro", md.Handle)
-	require.NotZero(t, md.Size, "file size should be non-zero")
+	require.NotNil(t, md.Size, "file size should be non-nil")
+	require.NotZero(t, *md.Size, "file size should be non-zero")
 	require.Equal(t, filepath.Base(dbPath), md.Name)
 }

--- a/drivers/sqlserver/metadata.go
+++ b/drivers/sqlserver/metadata.go
@@ -128,13 +128,18 @@ GROUP BY database_id) AS total_size_bytes`
 	md.Location = src.Location
 
 	var catalog, schema string
+	var size sql.NullInt64
 	err := db.QueryRowContext(ctx, query).
-		Scan(&catalog, &schema, &md.DBVersion, &md.DBProduct, &md.Size)
+		Scan(&catalog, &schema, &md.DBVersion, &md.DBProduct, &size)
 	if err != nil {
 		return nil, errw(err)
 	}
 	progress.Incr(ctx, 1)
 	debugz.DebugSleep(ctx)
+
+	if size.Valid {
+		md.Size = &size.Int64
+	}
 
 	md.Name = catalog
 	md.FQName = catalog + "." + schema

--- a/drivers/xlsx/grip.go
+++ b/drivers/xlsx/grip.go
@@ -54,9 +54,11 @@ func (g *grip) SourceMetadata(ctx context.Context, noSchema bool) (*metadata.Sou
 	}
 	md.FQName = md.Name
 
-	if md.Size, err = g.files.Filesize(ctx, g.src); err != nil {
+	var size int64
+	if size, err = g.files.Filesize(ctx, g.src); err != nil {
 		return nil, err
 	}
+	md.Size = &size
 
 	return md, nil
 }

--- a/libsq/core/stringz/fmt.go
+++ b/libsq/core/stringz/fmt.go
@@ -102,6 +102,17 @@ func ByteSized(size int64, precision int, sep string) string {
 	return fmt.Sprintf(tpl+"B", f)
 }
 
+// FormatSize renders an optional byte size. Returns "-" when size is nil,
+// otherwise the human-readable form from [ByteSized] with precision 1 and
+// no separator (e.g. "2.0MB"). Mirrors the rendering convention used by
+// the text, html, and markdown metadata writers for "not reported" sizes.
+func FormatSize(size *int64) string {
+	if size == nil {
+		return "-"
+	}
+	return ByteSized(*size, 1, "")
+}
+
 const (
 	_          = iota // ignore first value by assigning to blank identifier
 	kb float64 = 1 << (10 * iota)

--- a/libsq/core/stringz/fmt_test.go
+++ b/libsq/core/stringz/fmt_test.go
@@ -77,6 +77,29 @@ func TestParseBool(t *testing.T) {
 	}
 }
 
+func TestFormatSize(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil_reports_dash", func(t *testing.T) {
+		t.Parallel()
+		require.Equal(t, "-", stringz.FormatSize(nil))
+	})
+
+	t.Run("zero_reports_zero_bytes", func(t *testing.T) {
+		t.Parallel()
+		var zero int64
+		got := stringz.FormatSize(&zero)
+		require.Equal(t, stringz.ByteSized(0, 1, ""), got)
+	})
+
+	t.Run("non_zero_matches_ByteSized", func(t *testing.T) {
+		t.Parallel()
+		v := int64(1048576)
+		got := stringz.FormatSize(&v)
+		require.Equal(t, stringz.ByteSized(v, 1, ""), got)
+	})
+}
+
 func TestPlu(t *testing.T) {
 	testCases := []struct {
 		s    string

--- a/libsq/driver/driver_test.go
+++ b/libsq/driver/driver_test.go
@@ -1023,7 +1023,8 @@ func TestSQLDriver_SourceMetadata_FieldCoverage(t *testing.T) {
 				require.NotEmpty(t, md.User, "User")
 			}
 			if tc.wantSize {
-				require.Positive(t, md.Size, "Size")
+				require.NotNil(t, md.Size, "Size")
+				require.Positive(t, *md.Size, "Size")
 			}
 			if tc.wantProps {
 				require.NotEmpty(t, md.DBProperties, "DBProperties")

--- a/libsq/source/metadata/metadata.go
+++ b/libsq/source/metadata/metadata.go
@@ -52,8 +52,9 @@ type Source struct { //nolint:govet // field alignment
 	User string `json:"user,omitempty" yaml:"user,omitempty"`
 
 	// Size is the physical size of the source in bytes, e.g. DB file size.
-	// A nil value means the size is not reported by the driver — this is
-	// distinct from a zero-sized source. Mirrors [Table.Size].
+	// A nil value means the size is not reported by the driver, distinct
+	// from a non-nil pointer to 0 (a genuinely zero-sized source).
+	// Mirrors [Table.Size].
 	Size *int64 `json:"size,omitempty" yaml:"size,omitempty"`
 
 	// TableCount is the count of tables (excluding views).

--- a/libsq/source/metadata/metadata.go
+++ b/libsq/source/metadata/metadata.go
@@ -52,7 +52,9 @@ type Source struct { //nolint:govet // field alignment
 	User string `json:"user,omitempty" yaml:"user,omitempty"`
 
 	// Size is the physical size of the source in bytes, e.g. DB file size.
-	Size int64 `json:"size" yaml:"size"`
+	// A nil value means the size is not reported by the driver — this is
+	// distinct from a zero-sized source. Mirrors [Table.Size].
+	Size *int64 `json:"size,omitempty" yaml:"size,omitempty"`
 
 	// TableCount is the count of tables (excluding views).
 	TableCount int64 `json:"table_count" yaml:"table_count"`

--- a/libsq/source/metadata/metadata_test.go
+++ b/libsq/source/metadata/metadata_test.go
@@ -172,6 +172,7 @@ func TestSource_Clone(t *testing.T) {
 		require.NotNil(t, got)
 		require.Nil(t, got.DBProperties)
 		require.Nil(t, got.Tables)
+		require.Nil(t, got.Size, "nil-Size source must clone with nil Size")
 	})
 }
 

--- a/libsq/source/metadata/metadata_test.go
+++ b/libsq/source/metadata/metadata_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/samber/lo"
 	"github.com/stretchr/testify/require"
 
 	"github.com/neilotoole/sq/libsq/core/kind"
@@ -115,7 +116,7 @@ func TestSource_Clone(t *testing.T) {
 			DBProduct:  "PostgreSQL 14.0",
 			DBVersion:  "14.0",
 			User:       "postgres",
-			Size:       1024,
+			Size:       lo.ToPtr(int64(1024)),
 			TableCount: 10,
 			ViewCount:  5,
 			DBProperties: map[string]any{

--- a/libsq/source/metadata/metadata_test.go
+++ b/libsq/source/metadata/metadata_test.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/samber/lo"
 	"github.com/stretchr/testify/require"
 
 	"github.com/neilotoole/sq/libsq/core/kind"
@@ -104,6 +103,7 @@ func TestSource_Clone(t *testing.T) {
 	})
 
 	t.Run("full_source", func(t *testing.T) {
+		var size int64 = 1024
 		src := &metadata.Source{
 			Handle:     "@sakila",
 			Location:   "postgres://localhost/sakila",
@@ -116,7 +116,7 @@ func TestSource_Clone(t *testing.T) {
 			DBProduct:  "PostgreSQL 14.0",
 			DBVersion:  "14.0",
 			User:       "postgres",
-			Size:       lo.ToPtr(int64(1024)),
+			Size:       &size,
 			TableCount: 10,
 			ViewCount:  5,
 			DBProperties: map[string]any{


### PR DESCRIPTION
## Summary

Promote `metadata.Source.Size` from `int64` to `*int64` so drivers that can't
compute a source-level size (rqlite today, future in-memory or HTTP-backed
sources tomorrow) stop misrendering as `0.0B`.

- Text writers (tablew, htmlw, markdownw) render nil as `-` via a new
  `stringz.FormatSize` helper.
- JSON / YAML output omits the `size` field for non-reporting drivers via
  `omitempty`.
- 10 driver call sites updated to use `*int64` semantics; rqlite (the bug
  source) keeps Size nil and now has explicit driver-level and end-to-end
  assertions guarding the contract.
- Mirrors the existing `metadata.Table.Size *int64` convention.

Before:

```
SOURCE      DRIVER  NAME  FQ NAME  SIZE  TABLES  VIEWS  LOCATION
@sakila/rq  rqlite  main  main     0.0B  16      5      rqlite://...
```

After:

```
SOURCE      DRIVER  NAME  FQ NAME  SIZE  TABLES  VIEWS  LOCATION
@sakila/rq  rqlite  main  main     -     16      5      rqlite://...
```

Closes #744.

## Test Plan

- [x] `make lint` clean
- [x] `make test` clean (incl. Docker-backed integration suite)
- [x] `sq inspect @sakila_rq` renders `-` in SIZE column
- [x] `sq inspect @sakila_rq --json | jq 'has("size")'` returns `false`
- [x] `sq inspect @sakila_rq --yaml` has no `size:` key
- [x] `sq inspect @sakila_sl3` still renders a real size (e.g. `5.6MB`)
- [x] New unit tests: `stringz.TestFormatSize`, writer nil-Size sub-tests
      for tablew/htmlw/markdownw, `Source.Clone` nil-Size sub-case
- [x] New end-to-end: `TestCmdInspect_json_yaml` covers rqlite with a
      per-driver nil-Size assertion