### PR TITLE
Ignore local agent plans directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,6 +80,7 @@ sakila_b*
 CLAUDE.local.md
 /.claude/*
 !/.claude/skills
+/.agents/plans/
 /docs/superpowers/
 
 ## Node / Bun (root markdown linting)


### PR DESCRIPTION
## Summary
- Add `/.agents/plans/` to `.gitignore` so maintainer draft plans stay local (like `CLAUDE.local.md`).

## Test plan
- [x] N/A — gitignore only