### PR TITLE
gh752: sqlparser ColDef.Name strips all four SQLite ident-quote styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -157,6 +157,13 @@ keyring support) and support for [rqlite](https://sq.io/docs/drivers/rqlite).
 - [#744]: `sq inspect` no longer reports `0.0B` size for sources whose driver doesn't expose
   a database size (e.g. rqlite). The SIZE column renders `-` instead, and JSON / YAML output
   omits the `size` field.
+- [#752]: The SQLite [`sqlparser`](./drivers/sqlite3/sqlparser) now strips all four
+  legal SQLite identifier-quoting styles (`"name"`, `'name'`, `` `name` ``, `[name]`)
+  from `ColDef.Name`, not just double-quotes. Previously, `AlterTableColumnKinds`
+  on the [sqlite3](https://sq.io/docs/drivers/sqlite) and
+  [rqlite](https://sq.io/docs/drivers/rqlite) drivers failed with
+  `column not found in table DDL` when the original `CREATE TABLE` declared the
+  target column using backticks, single quotes, or square brackets.
 
 ## [v0.53.0] - 2026-05-25
 
@@ -1738,6 +1745,7 @@ make working with lots of sources much easier.
 [#737]: https://github.com/neilotoole/sq/issues/737
 [#742]: https://github.com/neilotoole/sq/issues/742
 [#744]: https://github.com/neilotoole/sq/issues/744
+[#752]: https://github.com/neilotoole/sq/issues/752
 
 [v0.15.2]: https://github.com/neilotoole/sq/releases/tag/v0.15.2
 [v0.15.3]: https://github.com/neilotoole/sq/compare/v0.15.2...v0.15.3

--- a/drivers/rqlite/rqlite_test.go
+++ b/drivers/rqlite/rqlite_test.go
@@ -397,6 +397,56 @@ func TestAlterTableColumnKinds(t *testing.T) {
 	require.Equal(t, "hello", gotB)
 }
 
+// TestAlterTableColumnKinds_QuotedIdentifier reproduces gh752: a column
+// declared with any of SQLite's four legal identifier-quoting styles
+// (double-quote, single-quote, backtick, square brackets) used to fail the
+// lookup in AlterTableColumnKinds when the parser's strip-quotes step only
+// handled double-quotes. The shared sqlparser now strips all four styles.
+func TestAlterTableColumnKinds_QuotedIdentifier(t *testing.T) {
+	tu.SkipShort(t, true)
+	t.Parallel()
+
+	testCases := []struct {
+		name    string
+		colDecl string
+	}{
+		{name: "double_quote", colDecl: `"age" INTEGER NOT NULL`},
+		{name: "single_quote", colDecl: `'age' INTEGER NOT NULL`},
+		{name: "backtick", colDecl: "`age` INTEGER NOT NULL"},
+		{name: "square_brackets", colDecl: `[age] INTEGER NOT NULL`},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			th := testh.New(t)
+			src := th.Source(sakila.Rq)
+			grip := th.Open(src)
+			drvr := grip.SQLDriver()
+			db, err := grip.DB(th.Context)
+			require.NoError(t, err)
+
+			tblName := "qident_" + stringz.Uniq8()
+			t.Cleanup(func() {
+				_ = drvr.DropTable(th.Context, db, tablefq.T{Table: tblName}, true)
+			})
+
+			_, err = db.ExecContext(th.Context,
+				fmt.Sprintf(`CREATE TABLE %q (%s)`, tblName, tc.colDecl))
+			require.NoError(t, err)
+
+			err = drvr.AlterTableColumnKinds(th.Context, db, tblName,
+				[]string{"age"}, []kind.Kind{kind.Text})
+			require.NoError(t, err)
+
+			md, err := grip.TableMetadata(th.Context, tblName)
+			require.NoError(t, err)
+			require.Equal(t, kind.Text, md.Column("age").Kind)
+		})
+	}
+}
+
 func TestPrepareInsertStmt(t *testing.T) {
 	tu.SkipShort(t, true)
 	t.Parallel()

--- a/drivers/sqlite3/sqlite3_test.go
+++ b/drivers/sqlite3/sqlite3_test.go
@@ -410,6 +410,50 @@ func TestDriveri_AlterTableColumnKinds(t *testing.T) {
 	require.Equal(t, kind.Float.String(), gotTblMeta.Column("weight").Kind.String())
 }
 
+// TestDriveri_AlterTableColumnKinds_QuotedIdentifier reproduces gh752: a
+// column declared with a non-double-quote SQLite identifier-quote style
+// (square brackets, backticks, or single quotes) used to fail the lookup in
+// AlterTableColumnKinds because sqlparser.ColDef.Name only stripped
+// double-quotes. The shared parser now strips all four legal styles.
+func TestDriveri_AlterTableColumnKinds_QuotedIdentifier(t *testing.T) {
+	testCases := []struct {
+		name    string
+		colDecl string
+	}{
+		{name: "double_quote", colDecl: `"age" INTEGER NOT NULL`},
+		{name: "single_quote", colDecl: `'age' INTEGER NOT NULL`},
+		{name: "backtick", colDecl: "`age` INTEGER NOT NULL"},
+		{name: "square_brackets", colDecl: `[age] INTEGER NOT NULL`},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			th := testh.New(t)
+			src := &source.Source{
+				Handle:   "@test",
+				Type:     drivertype.SQLite,
+				Location: "sqlite3://" + tu.TempFile(t, "test.db"),
+			}
+
+			grip := th.Open(src)
+			db, err := grip.DB(th.Context)
+			require.NoError(t, err)
+			drvr := grip.SQLDriver()
+
+			_, err = db.ExecContext(th.Context, `CREATE TABLE example (`+tc.colDecl+`)`)
+			require.NoError(t, err)
+
+			err = drvr.AlterTableColumnKinds(th.Context, db, "example",
+				[]string{"age"}, []kind.Kind{kind.Text})
+			require.NoError(t, err)
+
+			md, err := grip.TableMetadata(th.Context, "example")
+			require.NoError(t, err)
+			require.Equal(t, kind.Text.String(), md.Column("age").Kind.String())
+		})
+	}
+}
+
 // TestSourceMetadata_LocationWithConnParams reproduces gh720: a
 // source-level metadata read must succeed when the source location
 // carries a connection-string suffix (e.g. ?mode=ro). The previous

--- a/drivers/sqlite3/sqlparser/create_table.go
+++ b/drivers/sqlite3/sqlparser/create_table.go
@@ -6,7 +6,6 @@ import (
 	"github.com/neilotoole/sq/drivers/sqlite3/sqlparser/sqlite"
 	"github.com/neilotoole/sq/libsq/ast/antlrz"
 	"github.com/neilotoole/sq/libsq/core/errz"
-	"github.com/neilotoole/sq/libsq/core/stringz"
 )
 
 func parseCreateTableStmt(input string) (*sqlite.Create_table_stmtContext, error) {
@@ -97,7 +96,7 @@ func ExtractCreateTableStmtColDefs(stmt string) ([]*ColDef, error) {
 				DefCtx:  defCtx,
 				Raw:     tokx.Extract(defCtx),
 				RawName: tokx.Extract(defCtx.Column_name()),
-				Name:    stringz.StripDoubleQuote(defCtx.Column_name().GetText()),
+				Name:    trimIdentQuotes(defCtx.Column_name().GetText()),
 				RawType: tokx.Extract(defCtx.Type_name()),
 				Type:    defCtx.Type_name().GetText(),
 			}
@@ -120,10 +119,13 @@ type ColDef struct {
 	Raw string
 
 	// RawName is the raw text of the column name as it appeared in the input.
-	// It may be double-quoted.
+	// It may be quoted using any of SQLite's four legal identifier-quoting
+	// styles: double-quote, single-quote, backtick, or square brackets.
 	RawName string
 
-	// Name is the column name, stripped of any double-quotes.
+	// Name is the column name, stripped of any of SQLite's four legal
+	// identifier-quoting styles: double-quote ("name"), single-quote ('name'),
+	// backtick (`name`), and square brackets ([name]).
 	Name string
 
 	// RawType is the raw text of the column type as it appeared in the input.

--- a/drivers/sqlite3/sqlparser/sqlparser_test.go
+++ b/drivers/sqlite3/sqlparser/sqlparser_test.go
@@ -101,3 +101,50 @@ weight INTEGER NOT NULL
 	snippet = input[colDefs[2].InputOffset : colDefs[2].InputOffset+len(colDefs[2].Raw)]
 	require.Equal(t, colDefs[2].Raw, snippet)
 }
+
+// TestExtractCreateTableStmtColDefs_QuotedIdentifiers verifies that ColDef.Name
+// is stripped of all four SQLite legal identifier-quoting styles: double-quote,
+// single-quote, backtick, and square brackets. See issue #752.
+func TestExtractCreateTableStmtColDefs_QuotedIdentifiers(t *testing.T) {
+	testCases := []struct {
+		name        string
+		stmt        string
+		wantRawName string
+	}{
+		{
+			name:        "double_quote",
+			stmt:        `CREATE TABLE t ("age" INTEGER NOT NULL)`,
+			wantRawName: `"age"`,
+		},
+		{
+			name:        "single_quote",
+			stmt:        `CREATE TABLE t ('age' INTEGER NOT NULL)`,
+			wantRawName: `'age'`,
+		},
+		{
+			name:        "backtick",
+			stmt:        "CREATE TABLE t (`age` INTEGER NOT NULL)",
+			wantRawName: "`age`",
+		},
+		{
+			name:        "square_brackets",
+			stmt:        `CREATE TABLE t ([age] INTEGER NOT NULL)`,
+			wantRawName: `[age]`,
+		},
+		{
+			name:        "unquoted",
+			stmt:        `CREATE TABLE t (age INTEGER NOT NULL)`,
+			wantRawName: `age`,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			colDefs, err := sqlparser.ExtractCreateTableStmtColDefs(tc.stmt)
+			require.NoError(t, err)
+			require.Len(t, colDefs, 1)
+			require.Equal(t, tc.wantRawName, colDefs[0].RawName)
+			require.Equal(t, "age", colDefs[0].Name)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Fix `sqlparser.ColDef.Name` so it strips all four SQLite legal identifier-quoting styles (`"name"`, `'name'`, `` `name` ``, `[name]`), not only double-quotes. Previously, `AlterTableColumnKinds` on the sqlite3 and rqlite drivers failed with `column not found in table DDL` for columns originally declared with backticks, single quotes, or square brackets.
- The package already had `trimIdentQuotes` doing exactly the right thing; the parser just wasn't using it. Swap `stringz.StripDoubleQuote` -> `trimIdentQuotes` at the single call site in `ExtractCreateTableStmtColDefs`, and refresh the `ColDef.Name` / `RawName` godoc.
- Tests at both layers: a parser-level table test covering all four quoting styles plus unquoted, and driver-level smoke tests (sqlite3 always, rqlite under `SkipShort`) that reproduce the original `CREATE TABLE example ([age] INTEGER)` + `AlterTableColumnKinds(..., {"age"}, ...)` scenario from the issue.

Closes #752.

## Test plan

- [x] `go test ./drivers/sqlite3/sqlparser/... -run TestExtractCreateTableStmtColDefs` (all 6 subtests pass)
- [x] `go test -short ./drivers/sqlite3/... ./drivers/rqlite/...` (clean)
- [x] `make lint` (0 issues)
- [x] `make lint-markdown` (0 errors)
- [ ] CI runs the rqlite quoted-identifier smoke test against the sakiladb/rqlite container