### PR TITLE
gh750: sqlparser offsets + ApplyEdits replace strings.Replace in DDL rewrites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -164,6 +164,16 @@ keyring support) and support for [rqlite](https://sq.io/docs/drivers/rqlite).
   [rqlite](https://sq.io/docs/drivers/rqlite) drivers failed with
   `column not found in table DDL` when the original `CREATE TABLE` declared the
   target column using backticks, single quotes, or square brackets.
+- [#750]: `AlterTableColumnKinds` and `CopyTable` on the
+  [sqlite3](https://sq.io/docs/drivers/sqlite) and
+  [rqlite](https://sq.io/docs/drivers/rqlite) drivers now rewrite identifier and
+  type tokens by byte offset rather than `strings.Replace`. The old approach
+  could clobber the wrong token when a column name shared a prefix with its type
+  (e.g. `TEXT_DATA TEXT`), or when the table identifier recurred elsewhere in
+  the DDL (CHECK expressions, DEFAULT literals, comments). The shared
+  `sqlparser` package now exposes `ColDef.RawNameOffset` / `ColDef.RawTypeOffset`,
+  a `TableIdent` struct with token offsets, and an `ApplyEdits` helper for
+  non-overlapping byte-range splicing.
 
 ## [v0.53.0] - 2026-05-25
 
@@ -1745,6 +1755,7 @@ make working with lots of sources much easier.
 [#737]: https://github.com/neilotoole/sq/issues/737
 [#742]: https://github.com/neilotoole/sq/issues/742
 [#744]: https://github.com/neilotoole/sq/issues/744
+[#750]: https://github.com/neilotoole/sq/issues/750
 [#752]: https://github.com/neilotoole/sq/issues/752
 
 [v0.15.2]: https://github.com/neilotoole/sq/releases/tag/v0.15.2

--- a/drivers/rqlite/rqlite.go
+++ b/drivers/rqlite/rqlite.go
@@ -408,17 +408,28 @@ func (d *driveri) CopyTable(ctx context.Context, db sqlz.DB,
 			"rqlite: copy table: failed to read DDL for {%s}", fromTbl.Table)
 	}
 
-	ogSchema, ogTblIdent, err := sqlparser.ExtractTableIdentFromCreateTableStmt(ogDDL, false)
+	// Extract the table identifier with byte offsets so we can splice the
+	// new identifier in place without unanchored strings.Replace, which
+	// can misfire when the identifier recurs in CHECK exprs, default
+	// literals, or column names. Mirrors the sqlite3 driver's approach.
+	ogIdent, err := sqlparser.ExtractTableIdentFromCreateTableStmt(ogDDL)
 	if err != nil {
 		return 0, errz.Wrap(err, "rqlite: copy table")
 	}
-	replaceTarget := ogTblIdent
-	if ogSchema != "" {
-		replaceTarget = ogSchema + "." + ogTblIdent
+	identStart := ogIdent.TableOffset
+	if ogIdent.SchemaOffset >= 0 {
+		identStart = ogIdent.SchemaOffset
 	}
+	identEnd := ogIdent.TableOffset + len(ogIdent.RawTable)
 
-	destDDL := strings.Replace(ogDDL, replaceTarget,
-		toTbl.Render(stringz.DoubleQuote), 1)
+	destDDL, err := sqlparser.ApplyEdits(ogDDL, []sqlparser.Edit{{
+		Start:       identStart,
+		End:         identEnd,
+		Replacement: toTbl.Render(stringz.DoubleQuote),
+	}})
+	if err != nil {
+		return 0, errz.Wrap(err, "rqlite: copy table: failed to apply DDL rewrites")
+	}
 
 	if !copyData {
 		if _, err = db.ExecContext(ctx, destDDL); err != nil {
@@ -836,15 +847,34 @@ func (d *driveri) AlterTableColumnKinds(ctx context.Context, db sqlz.DB,
 		colDefs = append(colDefs, found)
 	}
 
-	nuDDL := ogDDL
-	for i, colDef := range colDefs {
-		wantType := DBTypeForKind(kinds[i])
-		wantColDefText := strings.Replace(colDef.Raw, colDef.RawType, wantType, 1)
-		nuDDL = strings.Replace(nuDDL, colDef.Raw, wantColDefText, 1)
+	// Locate the table identifier in the original DDL so its byte offset
+	// is known. Avoids unanchored strings.Replace, which can misfire when
+	// the table name appears earlier as a column-name prefix or inside a
+	// comment / default literal. Mirrors the sqlite3 driver.
+	tblIdent, err := sqlparser.ExtractTableIdentFromCreateTableStmt(ogDDL)
+	if err != nil {
+		return errz.Wrap(err, "rqlite: alter table: failed to extract table identifier from DDL")
 	}
 
 	tmpName := "tmp_tbl_alter_" + stringz.Uniq8()
-	nuDDL = strings.Replace(nuDDL, tbl, tmpName, 1)
+	edits := make([]sqlparser.Edit, 0, len(colDefs)+1)
+	for i, colDef := range colDefs {
+		edits = append(edits, sqlparser.Edit{
+			Start:       colDef.RawTypeOffset,
+			End:         colDef.RawTypeOffset + len(colDef.RawType),
+			Replacement: DBTypeForKind(kinds[i]),
+		})
+	}
+	edits = append(edits, sqlparser.Edit{
+		Start:       tblIdent.TableOffset,
+		End:         tblIdent.TableOffset + len(tblIdent.RawTable),
+		Replacement: stringz.DoubleQuote(tmpName),
+	})
+
+	nuDDL, err := sqlparser.ApplyEdits(ogDDL, edits)
+	if err != nil {
+		return errz.Wrap(err, "rqlite: alter table: failed to apply DDL rewrites")
+	}
 
 	// Read the prior foreign_keys pragma so we can restore it at the
 	// end of the atomic batch rather than blindly forcing it on.

--- a/drivers/rqlite/rqlite_test.go
+++ b/drivers/rqlite/rqlite_test.go
@@ -447,6 +447,115 @@ func TestAlterTableColumnKinds_QuotedIdentifier(t *testing.T) {
 	}
 }
 
+// TestAlterTableColumnKinds_ColumnNamePrefixesType reproduces gh750: a
+// column whose name shares its declared-case prefix with the type token
+// (e.g. `text_data text`) caused the old
+// `strings.Replace(colDef.Raw, colDef.RawType, wantType, 1)` to clobber
+// the name's prefix instead of the actual type. The offset-based rewrite
+// targets the parsed RawType position directly, so the name is
+// preserved. Mirrors the sqlite3 driver test.
+func TestAlterTableColumnKinds_ColumnNamePrefixesType(t *testing.T) {
+	tu.SkipShort(t, true)
+	t.Parallel()
+
+	testCases := []struct {
+		name    string
+		colDecl string
+		colName string
+	}{
+		{
+			name:    "lowercase_prefix",
+			colDecl: `text_data text NOT NULL`,
+			colName: "text_data",
+		},
+		{
+			name:    "uppercase_prefix",
+			colDecl: `TEXT_DATA TEXT NOT NULL`,
+			colName: "TEXT_DATA",
+		},
+		{
+			name:    "bracket_quoted_prefix",
+			colDecl: `[TEXT_DATA] TEXT NOT NULL`,
+			colName: "TEXT_DATA",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			th := testh.New(t)
+			src := th.Source(sakila.Rq)
+			grip := th.Open(src)
+			drvr := grip.SQLDriver()
+			db, err := grip.DB(th.Context)
+			require.NoError(t, err)
+
+			tblName := "collide_" + stringz.Uniq8()
+			t.Cleanup(func() {
+				_ = drvr.DropTable(th.Context, db, tablefq.T{Table: tblName}, true)
+			})
+
+			_, err = db.ExecContext(th.Context,
+				fmt.Sprintf(`CREATE TABLE %q (%s)`, tblName, tc.colDecl))
+			require.NoError(t, err)
+
+			err = drvr.AlterTableColumnKinds(th.Context, db, tblName,
+				[]string{tc.colName}, []kind.Kind{kind.Int})
+			require.NoError(t, err)
+
+			md, err := grip.TableMetadata(th.Context, tblName)
+			require.NoError(t, err)
+			require.Len(t, md.Columns, 1, "the column should still exist after alter")
+			require.Equal(t, tc.colName, md.Columns[0].Name,
+				"the column name must survive the alter; substring-replace would have clobbered it")
+			require.Equal(t, kind.Int, md.Column(tc.colName).Kind)
+		})
+	}
+}
+
+// TestCopyTable_TableIdentInDefaultLiteral verifies that CopyTable
+// rewrites only the table identifier and leaves a substring-matching
+// occurrence inside a column DEFAULT expression untouched. Mirrors the
+// sqlite3 driver test.
+func TestCopyTable_TableIdentInDefaultLiteral(t *testing.T) {
+	tu.SkipShort(t, true)
+	t.Parallel()
+
+	th := testh.New(t)
+	src := th.Source(sakila.Rq)
+	grip := th.Open(src)
+	drvr := grip.SQLDriver()
+	db, err := grip.DB(th.Context)
+	require.NoError(t, err)
+
+	srcName := "actor_" + stringz.Uniq8()
+	dstName := "actor_bak_" + stringz.Uniq8()
+	t.Cleanup(func() {
+		_ = drvr.DropTable(th.Context, db, tablefq.T{Table: srcName}, true)
+		_ = drvr.DropTable(th.Context, db, tablefq.T{Table: dstName}, true)
+	})
+
+	_, err = db.ExecContext(th.Context,
+		fmt.Sprintf(`CREATE TABLE %q (id INTEGER, tag TEXT DEFAULT '%s_tag')`,
+			srcName, srcName))
+	require.NoError(t, err)
+
+	_, err = drvr.CopyTable(th.Context, db,
+		tablefq.T{Table: srcName}, tablefq.T{Table: dstName}, false)
+	require.NoError(t, err)
+
+	_, err = db.ExecContext(th.Context,
+		fmt.Sprintf(`INSERT INTO %q (id) VALUES (1)`, dstName))
+	require.NoError(t, err)
+
+	var tag string
+	require.NoError(t, db.QueryRowContext(th.Context,
+		fmt.Sprintf(`SELECT tag FROM %q WHERE id=1`, dstName)).Scan(&tag))
+	require.Equal(t, srcName+"_tag", tag,
+		"the DEFAULT literal must not be rewritten by the table-identifier substitution")
+}
+
 func TestPrepareInsertStmt(t *testing.T) {
 	tu.SkipShort(t, true)
 	t.Parallel()

--- a/drivers/sqlite3/alter.go
+++ b/drivers/sqlite3/alter.go
@@ -92,7 +92,7 @@ func (d *driveri) AlterTableColumnKinds(ctx context.Context, db sqlz.DB,
 	// comment / default literal.
 	tblIdent, err := sqlparser.ExtractTableIdentFromCreateTableStmt(ogDDL)
 	if err != nil {
-		return errz.Wrapf(err, "sqlite3: alter table: failed to extract table identifier from DDL")
+		return errz.Wrap(err, "sqlite3: alter table: failed to extract table identifier from DDL")
 	}
 
 	nuTblName := "tmp_tbl_alter_" + stringz.Uniq32()
@@ -112,7 +112,7 @@ func (d *driveri) AlterTableColumnKinds(ctx context.Context, db sqlz.DB,
 
 	nuDDL, err := sqlparser.ApplyEdits(ogDDL, edits)
 	if err != nil {
-		return errz.Wrapf(err, "sqlite3: alter table: failed to apply DDL rewrites")
+		return errz.Wrap(err, "sqlite3: alter table: failed to apply DDL rewrites")
 	}
 
 	if _, err = db.ExecContext(ctx, nuDDL); err != nil {

--- a/drivers/sqlite3/alter.go
+++ b/drivers/sqlite3/alter.go
@@ -3,7 +3,6 @@ package sqlite3
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/neilotoole/sq/drivers/sqlite3/sqlparser"
 	"github.com/neilotoole/sq/libsq/core/errz"
@@ -87,15 +86,34 @@ func (d *driveri) AlterTableColumnKinds(ctx context.Context, db sqlz.DB,
 		}
 	}
 
-	nuDDL := ogDDL
-	for i, colDef := range colDefs {
-		wantType := DBTypeForKind(kinds[i])
-		wantColDefText := strings.Replace(colDef.Raw, colDef.RawType, wantType, 1)
-		nuDDL = strings.Replace(nuDDL, colDef.Raw, wantColDefText, 1)
+	// Locate the table identifier in the original DDL so its byte offset
+	// is known. Avoids unanchored strings.Replace, which can misfire when
+	// the table name also appears as a column-name prefix or inside a
+	// comment / default literal.
+	tblIdent, err := sqlparser.ExtractTableIdentFromCreateTableStmt(ogDDL)
+	if err != nil {
+		return errz.Wrapf(err, "sqlite3: alter table: failed to extract table identifier from DDL")
 	}
 
 	nuTblName := "tmp_tbl_alter_" + stringz.Uniq32()
-	nuDDL = strings.Replace(nuDDL, tblName, nuTblName, 1)
+	edits := make([]sqlparser.Edit, 0, len(colDefs)+1)
+	for i, colDef := range colDefs {
+		edits = append(edits, sqlparser.Edit{
+			Start:       colDef.RawTypeOffset,
+			End:         colDef.RawTypeOffset + len(colDef.RawType),
+			Replacement: DBTypeForKind(kinds[i]),
+		})
+	}
+	edits = append(edits, sqlparser.Edit{
+		Start:       tblIdent.TableOffset,
+		End:         tblIdent.TableOffset + len(tblIdent.RawTable),
+		Replacement: stringz.DoubleQuote(nuTblName),
+	})
+
+	nuDDL, err := sqlparser.ApplyEdits(ogDDL, edits)
+	if err != nil {
+		return errz.Wrapf(err, "sqlite3: alter table: failed to apply DDL rewrites")
+	}
 
 	if _, err = db.ExecContext(ctx, nuDDL); err != nil {
 		return errz.Wrapf(err, "sqlite3: alter table: failed to create temporary table")

--- a/drivers/sqlite3/sqlite3.go
+++ b/drivers/sqlite3/sqlite3.go
@@ -306,28 +306,29 @@ func (d *driveri) CopyTable(ctx context.Context, db sqlz.DB,
 		return 0, errw(err)
 	}
 
-	// Next, we extract the table identifier from the CREATE TABLE statement.
-	// For example, "main"."actor". Note that the schema part may be empty.
-	ogSchema, ogTbl, err := sqlparser.ExtractTableIdentFromCreateTableStmt(ogTblCreateStmt,
-		false)
+	// Extract the table identifier (with byte offsets) from the
+	// CREATE TABLE statement. Offsets let us splice the new identifier
+	// without strings.Replace, which is fragile when the identifier
+	// recurs elsewhere in the DDL (CHECK exprs, default literals, etc.).
+	ogIdent, err := sqlparser.ExtractTableIdentFromCreateTableStmt(ogTblCreateStmt)
 	if err != nil {
 		return 0, errw(err)
 	}
 
-	// Now we know what text to replace in ogTblCreateStmt.
-	replaceTarget := ogTbl
-	if ogSchema != "" {
-		replaceTarget = ogSchema + "." + ogTbl
+	identStart := ogIdent.TableOffset
+	if ogIdent.SchemaOffset >= 0 {
+		identStart = ogIdent.SchemaOffset
 	}
+	identEnd := ogIdent.TableOffset + len(ogIdent.RawTable)
 
-	// Replace the old table identifier with the new one, and, voila,
-	// we have our new CREATE TABLE statement.
-	destTblCreateStmt := strings.Replace(
-		ogTblCreateStmt,
-		replaceTarget,
-		toTbl.Render(stringz.DoubleQuote),
-		1,
-	)
+	destTblCreateStmt, err := sqlparser.ApplyEdits(ogTblCreateStmt, []sqlparser.Edit{{
+		Start:       identStart,
+		End:         identEnd,
+		Replacement: toTbl.Render(stringz.DoubleQuote),
+	}})
+	if err != nil {
+		return 0, errz.Wrapf(err, "sqlite3: copy table: failed to apply DDL rewrites")
+	}
 
 	_, err = db.ExecContext(ctx, destTblCreateStmt)
 	if err != nil {

--- a/drivers/sqlite3/sqlite3.go
+++ b/drivers/sqlite3/sqlite3.go
@@ -327,7 +327,7 @@ func (d *driveri) CopyTable(ctx context.Context, db sqlz.DB,
 		Replacement: toTbl.Render(stringz.DoubleQuote),
 	}})
 	if err != nil {
-		return 0, errz.Wrapf(err, "sqlite3: copy table: failed to apply DDL rewrites")
+		return 0, errz.Wrap(err, "sqlite3: copy table: failed to apply DDL rewrites")
 	}
 
 	_, err = db.ExecContext(ctx, destTblCreateStmt)

--- a/drivers/sqlite3/sqlite3_test.go
+++ b/drivers/sqlite3/sqlite3_test.go
@@ -454,6 +454,110 @@ func TestDriveri_AlterTableColumnKinds_QuotedIdentifier(t *testing.T) {
 	}
 }
 
+// TestDriveri_AlterTableColumnKinds_ColumnNamePrefixesType reproduces
+// gh750: a column whose name shares its declared-case prefix with the
+// type token (e.g. `text_data text`) caused the old
+// `strings.Replace(colDef.Raw, colDef.RawType, wantType, 1)` to clobber
+// the name's prefix instead of the actual type. The offset-based rewrite
+// targets the parsed RawType position directly, so the name is
+// preserved.
+func TestDriveri_AlterTableColumnKinds_ColumnNamePrefixesType(t *testing.T) {
+	testCases := []struct {
+		name    string
+		colDecl string
+		colName string
+	}{
+		{
+			// Name and type both lowercase, name is the type's prefix.
+			name:    "lowercase_prefix",
+			colDecl: `text_data text NOT NULL`,
+			colName: "text_data",
+		},
+		{
+			// Name and type both uppercase, name is the type's prefix.
+			name:    "uppercase_prefix",
+			colDecl: `TEXT_DATA TEXT NOT NULL`,
+			colName: "TEXT_DATA",
+		},
+		{
+			// Square-bracket quoted name that contains the type token.
+			name:    "bracket_quoted_prefix",
+			colDecl: `[TEXT_DATA] TEXT NOT NULL`,
+			colName: "TEXT_DATA",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			th := testh.New(t)
+			src := &source.Source{
+				Handle:   "@test",
+				Type:     drivertype.SQLite,
+				Location: "sqlite3://" + tu.TempFile(t, "test.db"),
+			}
+
+			grip := th.Open(src)
+			db, err := grip.DB(th.Context)
+			require.NoError(t, err)
+			drvr := grip.SQLDriver()
+
+			_, err = db.ExecContext(th.Context, `CREATE TABLE collide (`+tc.colDecl+`)`)
+			require.NoError(t, err)
+
+			err = drvr.AlterTableColumnKinds(th.Context, db, "collide",
+				[]string{tc.colName}, []kind.Kind{kind.Int})
+			require.NoError(t, err)
+
+			md, err := grip.TableMetadata(th.Context, "collide")
+			require.NoError(t, err)
+			require.Len(t, md.Columns, 1, "the column should still exist after alter")
+			require.Equal(t, tc.colName, md.Columns[0].Name,
+				"the column name must survive the alter; substring-replace would have clobbered it")
+			require.Equal(t, kind.Int.String(), md.Column(tc.colName).Kind.String())
+		})
+	}
+}
+
+// TestDriveri_CopyTable_TableIdentInDefaultLiteral verifies that CopyTable
+// rewrites only the table identifier and leaves a substring-matching
+// occurrence inside a column DEFAULT expression untouched. Regression
+// safeguard for gh750's offset-based identifier rewrite.
+func TestDriveri_CopyTable_TableIdentInDefaultLiteral(t *testing.T) {
+	th := testh.New(t)
+	src := &source.Source{
+		Handle:   "@test",
+		Type:     drivertype.SQLite,
+		Location: "sqlite3://" + tu.TempFile(t, "test.db"),
+	}
+
+	grip := th.Open(src)
+	db, err := grip.DB(th.Context)
+	require.NoError(t, err)
+	drvr := grip.SQLDriver()
+
+	// Source table "actor" with a column whose DEFAULT literal contains
+	// the substring "actor".
+	_, err = db.ExecContext(th.Context,
+		`CREATE TABLE actor (id INTEGER, tag TEXT DEFAULT 'actor_tag')`)
+	require.NoError(t, err)
+	_, err = db.ExecContext(th.Context, `INSERT INTO actor (id) VALUES (1)`)
+	require.NoError(t, err)
+
+	_, err = drvr.CopyTable(th.Context, db,
+		tablefq.T{Table: "actor"}, tablefq.T{Table: "actor_bak"}, true)
+	require.NoError(t, err)
+
+	// Destination table exists; the DEFAULT literal's 'actor_tag'
+	// substring must have been preserved (not rewritten to 'actor_bak_tag').
+	_, err = db.ExecContext(th.Context, `INSERT INTO actor_bak (id) VALUES (2)`)
+	require.NoError(t, err)
+	var tag string
+	require.NoError(t, db.QueryRowContext(th.Context,
+		`SELECT tag FROM actor_bak WHERE id=2`).Scan(&tag))
+	require.Equal(t, "actor_tag", tag,
+		"the DEFAULT literal must not be rewritten by the table-identifier substitution")
+}
+
 // TestSourceMetadata_LocationWithConnParams reproduces gh720: a
 // source-level metadata read must succeed when the source location
 // carries a connection-string suffix (e.g. ?mode=ro). The previous

--- a/drivers/sqlite3/sqlparser/create_table.go
+++ b/drivers/sqlite3/sqlparser/create_table.go
@@ -211,8 +211,10 @@ type Edit struct {
 // its Replacement. Edits may be supplied in any order; they are applied in
 // reverse start order so pre-edit offsets remain valid throughout.
 //
-// Returns an error if any edit has End < Start, ranges overlap, or any
-// range falls outside [0, len(input)].
+// Returns an error if any edit has End < Start, any range falls outside
+// [0, len(input)], two edits overlap, or two edits share the same Start
+// (which would make the relative apply order ambiguous when one or both
+// is an insertion, since sort.Slice is not stable on equal Start values).
 func ApplyEdits(input string, edits []Edit) (string, error) {
 	if len(edits) == 0 {
 		return input, nil
@@ -224,11 +226,19 @@ func ApplyEdits(input string, edits []Edit) (string, error) {
 
 	for i, e := range sorted {
 		if e.Start < 0 || e.End > len(input) || e.End < e.Start {
-			return "", errz.Errorf("sqlparser: ApplyEdits: edit %d out of range [%d:%d) for input length %d",
-				i, e.Start, e.End, len(input))
+			return "", errz.Errorf("sqlparser: ApplyEdits: edit out of range [%d:%d) for input length %d",
+				e.Start, e.End, len(input))
 		}
-		if i > 0 && e.Start < sorted[i-1].End {
-			return "", errz.Errorf("sqlparser: ApplyEdits: edits %d and %d overlap", i-1, i)
+		if i == 0 {
+			continue
+		}
+		prev := sorted[i-1]
+		if e.Start < prev.End {
+			return "", errz.Errorf("sqlparser: ApplyEdits: edits overlap at byte offset %d", e.Start)
+		}
+		if e.Start == prev.Start {
+			return "", errz.Errorf("sqlparser: ApplyEdits: two edits share Start=%d (ambiguous when one is an insertion)",
+				e.Start)
 		}
 	}
 

--- a/drivers/sqlite3/sqlparser/create_table.go
+++ b/drivers/sqlite3/sqlparser/create_table.go
@@ -1,6 +1,8 @@
 package sqlparser
 
 import (
+	"sort"
+
 	antlr "github.com/antlr4-go/antlr/v4"
 
 	"github.com/neilotoole/sq/drivers/sqlite3/sqlparser/sqlite"
@@ -32,41 +34,75 @@ func parseCreateTableStmt(input string) (*sqlite.Create_table_stmtContext, error
 	return qCtx.(*sqlite.Create_table_stmtContext), nil
 }
 
-// ExtractTableIdentFromCreateTableStmt extracts table name (and the
-// table's schema if specified) from a CREATE TABLE statement.
-// If err is nil, table is guaranteed to be non-empty. If arg unescape is
-// true, any surrounding quotation chars are trimmed from the returned values.
+// TableIdent holds an extracted table identifier from a CREATE TABLE
+// statement, including the byte offsets of the schema and table tokens
+// in the original input.
+type TableIdent struct {
+	// Schema is the table's schema, with any of SQLite's four legal
+	// identifier-quoting styles (double-quote, single-quote, backtick,
+	// square brackets) stripped. Empty if no schema part was present.
+	Schema string
+
+	// Table is the table name, with any of SQLite's four legal
+	// identifier-quoting styles stripped. Always non-empty.
+	Table string
+
+	// RawSchema is the raw text of the schema token as it appeared in the
+	// input, preserving any surrounding quotes. Empty if no schema part was
+	// present.
+	RawSchema string
+
+	// RawTable is the raw text of the table token as it appeared in the
+	// input, preserving any surrounding quotes.
+	RawTable string
+
+	// SchemaOffset is the byte offset of RawSchema in the input.
+	// -1 if no schema part was present.
+	SchemaOffset int
+
+	// TableOffset is the byte offset of RawTable in the input.
+	TableOffset int
+}
+
+// ExtractTableIdentFromCreateTableStmt extracts the table identifier
+// (schema, table, and the byte offsets of each token in the input) from
+// a CREATE TABLE statement.
 //
-//	CREATE TABLE "sakila"."actor" ( actor_id INTEGER NOT NULL)  -->  sakila, actor, nil
-func ExtractTableIdentFromCreateTableStmt(stmt string, unescape bool) (schema, table string, err error) {
+//	CREATE TABLE "sakila"."actor" ( actor_id INTEGER NOT NULL)
+//	--> &TableIdent{Schema:"sakila", Table:"actor", RawSchema:`"sakila"`,
+//	                RawTable:`"actor"`, SchemaOffset:13, TableOffset:22}
+//
+// Returns an error if no table identifier can be extracted.
+func ExtractTableIdentFromCreateTableStmt(stmt string) (*TableIdent, error) {
 	stmtCtx, err := parseCreateTableStmt(stmt)
 	if err != nil {
-		return "", "", err
+		return nil, err
 	}
+
+	tokx := antlrz.NewTokenExtractor(stmt)
+	ident := &TableIdent{SchemaOffset: -1}
 
 	if n, ok := stmtCtx.Schema_name().(*sqlite.Schema_nameContext); ok {
 		if n.Any_name() != nil && !n.Any_name().IsEmpty() && n.Any_name().IDENTIFIER() != nil {
-			schema = n.Any_name().IDENTIFIER().GetText()
-			if unescape {
-				schema = trimIdentQuotes(schema)
-			}
+			ident.RawSchema = tokx.Extract(n)
+			ident.Schema = trimIdentQuotes(ident.RawSchema)
+			ident.SchemaOffset, _ = tokx.Offset(n)
 		}
 	}
 
 	if x, ok := stmtCtx.Table_name().(*sqlite.Table_nameContext); ok {
 		if x.Any_name() != nil && !x.Any_name().IsEmpty() && x.Any_name().IDENTIFIER() != nil {
-			table = x.Any_name().IDENTIFIER().GetText()
-			if unescape {
-				table = trimIdentQuotes(table)
-			}
+			ident.RawTable = tokx.Extract(x)
+			ident.Table = trimIdentQuotes(ident.RawTable)
+			ident.TableOffset, _ = tokx.Offset(x)
 		}
 	}
 
-	if table == "" {
-		return "", "", errz.Errorf("failed to extract table name from CREATE TABLE statement")
+	if ident.Table == "" {
+		return nil, errz.Errorf("failed to extract table name from CREATE TABLE statement")
 	}
 
-	return schema, table, nil
+	return ident, nil
 }
 
 // ExtractCreateTableStmtColDefs extracts the column definitions from a CREATE
@@ -102,6 +138,8 @@ func ExtractCreateTableStmtColDefs(stmt string) ([]*ColDef, error) {
 			}
 
 			colDef.InputOffset, _ = tokx.Offset(defCtx)
+			colDef.RawNameOffset, _ = tokx.Offset(defCtx.Column_name())
+			colDef.RawTypeOffset, _ = tokx.Offset(defCtx.Type_name())
 
 			colDefs = append(colDefs, colDef)
 		}
@@ -134,12 +172,70 @@ type ColDef struct {
 	// Type is the canonicalized column type.
 	Type string
 
-	// InputOffset is the character start index of the column definition in the
+	// InputOffset is the byte offset of the column definition (Raw) in the
 	// input. The def ends at InputOffset+len(Raw).
 	InputOffset int
+
+	// RawNameOffset is the byte offset of RawName in the input. The name
+	// token ends at RawNameOffset+len(RawName). Used by drivers to splice
+	// rewrites at exact positions without relying on substring matching.
+	RawNameOffset int
+
+	// RawTypeOffset is the byte offset of RawType in the input. The type
+	// token ends at RawTypeOffset+len(RawType). Used by drivers to splice
+	// rewrites at exact positions without relying on substring matching.
+	RawTypeOffset int
 }
 
 // String returns the raw text of the column definition.
 func (cd *ColDef) String() string {
 	return cd.Raw
+}
+
+// Edit describes a single non-overlapping byte-range replacement within an
+// input string. Used by ApplyEdits to splice multiple parser-derived
+// rewrites into a CREATE TABLE statement.
+type Edit struct {
+	// Replacement is the text to splice in place of input[Start:End].
+	Replacement string
+
+	// Start is the byte offset where the replacement begins (inclusive).
+	Start int
+
+	// End is the byte offset where the replacement ends (exclusive).
+	// End must be >= Start.
+	End int
+}
+
+// ApplyEdits returns input with each edit's [Start:End) range replaced by
+// its Replacement. Edits may be supplied in any order; they are applied in
+// reverse start order so pre-edit offsets remain valid throughout.
+//
+// Returns an error if any edit has End < Start, ranges overlap, or any
+// range falls outside [0, len(input)].
+func ApplyEdits(input string, edits []Edit) (string, error) {
+	if len(edits) == 0 {
+		return input, nil
+	}
+
+	sorted := make([]Edit, len(edits))
+	copy(sorted, edits)
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i].Start < sorted[j].Start })
+
+	for i, e := range sorted {
+		if e.Start < 0 || e.End > len(input) || e.End < e.Start {
+			return "", errz.Errorf("sqlparser: ApplyEdits: edit %d out of range [%d:%d) for input length %d",
+				i, e.Start, e.End, len(input))
+		}
+		if i > 0 && e.Start < sorted[i-1].End {
+			return "", errz.Errorf("sqlparser: ApplyEdits: edits %d and %d overlap", i-1, i)
+		}
+	}
+
+	out := input
+	for i := len(sorted) - 1; i >= 0; i-- {
+		e := sorted[i]
+		out = out[:e.Start] + e.Replacement + out[e.End:]
+	}
+	return out, nil
 }

--- a/drivers/sqlite3/sqlparser/sqlparser_test.go
+++ b/drivers/sqlite3/sqlparser/sqlparser_test.go
@@ -316,6 +316,28 @@ func TestApplyEdits(t *testing.T) {
 			edits:   []sqlparser.Edit{{Start: 0, End: 10, Replacement: "X"}},
 			wantErr: true,
 		},
+		{
+			// Insertion at Start=5 plus replacement at Start=5: the relative
+			// apply order would depend on sort.Slice stability and the result
+			// would be non-deterministic. Must be rejected.
+			name:  "shared_start_insertion_plus_replacement_error",
+			input: "abcdefg",
+			edits: []sqlparser.Edit{
+				{Start: 5, End: 5, Replacement: "X"},
+				{Start: 5, End: 7, Replacement: "Y"},
+			},
+			wantErr: true,
+		},
+		{
+			// Two insertions at the same Start are also ambiguous.
+			name:  "shared_start_two_insertions_error",
+			input: "abcdef",
+			edits: []sqlparser.Edit{
+				{Start: 3, End: 3, Replacement: "X"},
+				{Start: 3, End: 3, Replacement: "Y"},
+			},
+			wantErr: true,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/drivers/sqlite3/sqlparser/sqlparser_test.go
+++ b/drivers/sqlite3/sqlparser/sqlparser_test.go
@@ -1,6 +1,7 @@
 package sqlparser_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -9,60 +10,73 @@ import (
 	"github.com/neilotoole/sq/testh/tu"
 )
 
-func TestExtractTableNameFromCreateTableStmt(t *testing.T) {
+func TestExtractTableIdentFromCreateTableStmt(t *testing.T) {
 	testCases := []struct {
-		in         string
-		unescape   bool
-		wantSchema string
-		wantTable  string
-		wantErr    bool
+		in            string
+		wantSchema    string
+		wantTable     string
+		wantRawSchema string
+		wantRawTable  string
+		wantErr       bool
 	}{
 		{
-			in:        `CREATE TABLE actor ( actor_id INTEGER NOT NULL)`,
-			unescape:  true,
-			wantTable: "actor",
+			in:           `CREATE TABLE actor ( actor_id INTEGER NOT NULL)`,
+			wantTable:    "actor",
+			wantRawTable: "actor",
 		},
 		{
-			in:         `CREATE TABLE "sakila"."actor" ( actor_id INTEGER NOT NULL)`,
-			unescape:   true,
-			wantSchema: "sakila",
-			wantTable:  "actor",
+			in:            `CREATE TABLE "sakila"."actor" ( actor_id INTEGER NOT NULL)`,
+			wantSchema:    "sakila",
+			wantTable:     "actor",
+			wantRawSchema: `"sakila"`,
+			wantRawTable:  `"actor"`,
 		},
 		{
-			in:       `CREATE TABLE "sakila"."actor"."not_legal" ( actor_id INTEGER NOT NULL)`,
-			unescape: true,
-			wantErr:  true,
+			in:      `CREATE TABLE "sakila"."actor"."not_legal" ( actor_id INTEGER NOT NULL)`,
+			wantErr: true,
 		},
 		{
-			in:         `CREATE TABLE [sakila]."actor" ( actor_id INTEGER NOT NULL)`,
-			unescape:   true,
-			wantSchema: "sakila",
-			wantTable:  "actor",
+			in:            `CREATE TABLE [sakila]."actor" ( actor_id INTEGER NOT NULL)`,
+			wantSchema:    "sakila",
+			wantTable:     "actor",
+			wantRawSchema: "[sakila]",
+			wantRawTable:  `"actor"`,
 		},
 		{
-			in:         `CREATE TABLE [sakila]."actor" ( actor_id INTEGER NOT NULL)`,
-			unescape:   false,
-			wantSchema: "[sakila]",
-			wantTable:  `"actor"`,
-		},
-		{
-			in:         `CREATE TABLE "sak ila"."actor" ( actor_id INTEGER NOT NULL)`,
-			unescape:   true,
-			wantSchema: "sak ila",
-			wantTable:  "actor",
+			in:            `CREATE TABLE "sak ila"."actor" ( actor_id INTEGER NOT NULL)`,
+			wantSchema:    "sak ila",
+			wantTable:     "actor",
+			wantRawSchema: `"sak ila"`,
+			wantRawTable:  `"actor"`,
 		},
 	}
 
 	for i, tc := range testCases {
 		t.Run(tu.Name(i, tc.in), func(t *testing.T) {
-			schema, table, err := sqlparser.ExtractTableIdentFromCreateTableStmt(tc.in, tc.unescape)
+			ident, err := sqlparser.ExtractTableIdentFromCreateTableStmt(tc.in)
 			if tc.wantErr {
 				require.Error(t, err)
 				return
 			}
 			require.NoError(t, err)
-			require.Equal(t, tc.wantSchema, schema)
-			require.Equal(t, tc.wantTable, table)
+			require.NotNil(t, ident)
+			require.Equal(t, tc.wantSchema, ident.Schema)
+			require.Equal(t, tc.wantTable, ident.Table)
+			require.Equal(t, tc.wantRawSchema, ident.RawSchema)
+			require.Equal(t, tc.wantRawTable, ident.RawTable)
+
+			// Offsets must round-trip: input[offset:offset+len(raw)] == raw.
+			require.Equal(t, ident.RawTable,
+				tc.in[ident.TableOffset:ident.TableOffset+len(ident.RawTable)],
+				"TableOffset must point at RawTable in the input")
+			if ident.RawSchema == "" {
+				require.Equal(t, -1, ident.SchemaOffset,
+					"SchemaOffset must be -1 when no schema is present")
+			} else {
+				require.Equal(t, ident.RawSchema,
+					tc.in[ident.SchemaOffset:ident.SchemaOffset+len(ident.RawSchema)],
+					"SchemaOffset must point at RawSchema in the input")
+			}
 		})
 	}
 }
@@ -84,6 +98,10 @@ weight INTEGER NOT NULL
 	require.Equal(t, "TEXT", colDefs[0].RawType)
 	snippet := input[colDefs[0].InputOffset : colDefs[0].InputOffset+len(colDefs[0].Raw)]
 	require.Equal(t, colDefs[0].Raw, snippet)
+	require.Equal(t, colDefs[0].RawName,
+		input[colDefs[0].RawNameOffset:colDefs[0].RawNameOffset+len(colDefs[0].RawName)])
+	require.Equal(t, colDefs[0].RawType,
+		input[colDefs[0].RawTypeOffset:colDefs[0].RawTypeOffset+len(colDefs[0].RawType)])
 
 	require.Equal(t, `"age" INTEGER( 10 ) NOT NULL`, colDefs[1].Raw)
 	require.Equal(t, `"age"`, colDefs[1].RawName)
@@ -92,6 +110,10 @@ weight INTEGER NOT NULL
 	require.Equal(t, "INTEGER( 10 )", colDefs[1].RawType)
 	snippet = input[colDefs[1].InputOffset : colDefs[1].InputOffset+len(colDefs[1].Raw)]
 	require.Equal(t, colDefs[1].Raw, snippet)
+	require.Equal(t, colDefs[1].RawName,
+		input[colDefs[1].RawNameOffset:colDefs[1].RawNameOffset+len(colDefs[1].RawName)])
+	require.Equal(t, colDefs[1].RawType,
+		input[colDefs[1].RawTypeOffset:colDefs[1].RawTypeOffset+len(colDefs[1].RawType)])
 
 	require.Equal(t, `weight INTEGER NOT NULL`, colDefs[2].Raw)
 	require.Equal(t, `weight`, colDefs[2].RawName)
@@ -100,6 +122,10 @@ weight INTEGER NOT NULL
 	require.Equal(t, "INTEGER", colDefs[2].RawType)
 	snippet = input[colDefs[2].InputOffset : colDefs[2].InputOffset+len(colDefs[2].Raw)]
 	require.Equal(t, colDefs[2].Raw, snippet)
+	require.Equal(t, colDefs[2].RawName,
+		input[colDefs[2].RawNameOffset:colDefs[2].RawNameOffset+len(colDefs[2].RawName)])
+	require.Equal(t, colDefs[2].RawType,
+		input[colDefs[2].RawTypeOffset:colDefs[2].RawTypeOffset+len(colDefs[2].RawType)])
 }
 
 // TestExtractCreateTableStmtColDefs_QuotedIdentifiers verifies that ColDef.Name
@@ -147,4 +173,180 @@ func TestExtractCreateTableStmtColDefs_QuotedIdentifiers(t *testing.T) {
 			require.Equal(t, "age", colDefs[0].Name)
 		})
 	}
+}
+
+// TestExtractCreateTableStmtColDefs_Offsets_NameVsType is the offset
+// counterpart to gh750: when a column name shares a prefix with its type
+// token (or equals it outright), substring-based rewrites can clobber the
+// name. RawTypeOffset must point past the name to the actual type token.
+func TestExtractCreateTableStmtColDefs_Offsets_NameVsType(t *testing.T) {
+	testCases := []struct {
+		name string
+		stmt string
+		col  string
+		typ  string
+	}{
+		{
+			name: "name_prefixes_type",
+			stmt: `CREATE TABLE t (text_payload TEXT NOT NULL)`,
+			col:  "text_payload",
+			typ:  "TEXT",
+		},
+		{
+			name: "name_equals_type",
+			stmt: `CREATE TABLE t (INTEGER INTEGER NOT NULL)`,
+			col:  "INTEGER",
+			typ:  "INTEGER",
+		},
+		{
+			name: "name_contains_type",
+			stmt: `CREATE TABLE t (my_text_col TEXT NOT NULL)`,
+			col:  "my_text_col",
+			typ:  "TEXT",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			colDefs, err := sqlparser.ExtractCreateTableStmtColDefs(tc.stmt)
+			require.NoError(t, err)
+			require.Len(t, colDefs, 1)
+			cd := colDefs[0]
+			require.Equal(t, tc.col, cd.Name)
+			require.Equal(t, tc.typ, cd.RawType)
+
+			// Offsets must round-trip: input[offset:offset+len(raw)] == raw.
+			require.Equal(t, cd.RawName,
+				tc.stmt[cd.RawNameOffset:cd.RawNameOffset+len(cd.RawName)],
+				"RawNameOffset must point at the name token, not a substring match in the type")
+			require.Equal(t, cd.RawType,
+				tc.stmt[cd.RawTypeOffset:cd.RawTypeOffset+len(cd.RawType)],
+				"RawTypeOffset must point at the type token, not the name's prefix")
+
+			// And specifically: the type offset must come AFTER the name offset.
+			require.Greater(t, cd.RawTypeOffset, cd.RawNameOffset,
+				"RawTypeOffset must come after RawNameOffset, otherwise the type-replace would clobber the name")
+		})
+	}
+}
+
+func TestApplyEdits(t *testing.T) {
+	testCases := []struct {
+		name    string
+		input   string
+		edits   []sqlparser.Edit
+		want    string
+		wantErr bool
+	}{
+		{
+			name:  "empty",
+			input: "hello world",
+			edits: nil,
+			want:  "hello world",
+		},
+		{
+			name:  "single_middle",
+			input: "hello world",
+			edits: []sqlparser.Edit{{Start: 6, End: 11, Replacement: "there"}},
+			want:  "hello there",
+		},
+		{
+			name:  "two_in_order",
+			input: "abcdef",
+			edits: []sqlparser.Edit{
+				{Start: 0, End: 1, Replacement: "X"},
+				{Start: 4, End: 5, Replacement: "Y"},
+			},
+			want: "XbcdYf",
+		},
+		{
+			name:  "two_out_of_order_input",
+			input: "abcdef",
+			edits: []sqlparser.Edit{
+				{Start: 4, End: 5, Replacement: "Y"},
+				{Start: 0, End: 1, Replacement: "X"},
+			},
+			want: "XbcdYf",
+		},
+		{
+			name:  "adjacent_edits",
+			input: "abcdef",
+			edits: []sqlparser.Edit{
+				{Start: 1, End: 3, Replacement: "XX"},
+				{Start: 3, End: 5, Replacement: "YY"},
+			},
+			want: "aXXYYf",
+		},
+		{
+			name:  "insertion",
+			input: "abcdef",
+			edits: []sqlparser.Edit{{Start: 3, End: 3, Replacement: "_INS_"}},
+			want:  "abc_INS_def",
+		},
+		{
+			name:  "deletion",
+			input: "abcdef",
+			edits: []sqlparser.Edit{{Start: 2, End: 4, Replacement: ""}},
+			want:  "abef",
+		},
+		{
+			name:  "longer_replacement",
+			input: "name TYPE x",
+			edits: []sqlparser.Edit{{Start: 5, End: 9, Replacement: "VERYLONGTYPE"}},
+			want:  "name VERYLONGTYPE x",
+		},
+		{
+			name:  "overlapping_error",
+			input: "abcdef",
+			edits: []sqlparser.Edit{
+				{Start: 0, End: 3, Replacement: "X"},
+				{Start: 2, End: 4, Replacement: "Y"},
+			},
+			wantErr: true,
+		},
+		{
+			name:    "end_before_start_error",
+			input:   "abcdef",
+			edits:   []sqlparser.Edit{{Start: 4, End: 2, Replacement: "X"}},
+			wantErr: true,
+		},
+		{
+			name:    "out_of_range_error",
+			input:   "abc",
+			edits:   []sqlparser.Edit{{Start: 0, End: 10, Replacement: "X"}},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := sqlparser.ApplyEdits(tc.input, tc.edits)
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// TestApplyEdits_DDLRewriteIntegration sanity-checks the end-to-end story
+// that motivates gh750: parser offsets feed ApplyEdits, and the resulting
+// DDL is correct even when the column name shares a prefix with its type
+// (the classic substring-collision failure mode).
+func TestApplyEdits_DDLRewriteIntegration(t *testing.T) {
+	const input = `CREATE TABLE t (text_payload TEXT NOT NULL)`
+	colDefs, err := sqlparser.ExtractCreateTableStmtColDefs(input)
+	require.NoError(t, err)
+	require.Len(t, colDefs, 1)
+	cd := colDefs[0]
+
+	got, err := sqlparser.ApplyEdits(input, []sqlparser.Edit{
+		{Start: cd.RawTypeOffset, End: cd.RawTypeOffset + len(cd.RawType), Replacement: "INTEGER"},
+	})
+	require.NoError(t, err)
+	require.Equal(t, `CREATE TABLE t (text_payload INTEGER NOT NULL)`, got)
+	require.True(t, strings.Contains(got, "text_payload"),
+		"naive strings.Replace(input, RawType, ...) would have produced 'INTEGER_payload INTEGER'; offsets prevent that")
 }

--- a/libsq/ast/antlrz/antlrz.go
+++ b/libsq/ast/antlrz/antlrz.go
@@ -4,6 +4,7 @@ package antlrz
 import (
 	"strings"
 	"sync"
+	"unicode/utf8"
 
 	antlr "github.com/antlr4-go/antlr/v4"
 )
@@ -20,8 +21,9 @@ func NewTokenExtractor(input string) *TokenExtractor {
 	return &TokenExtractor{input: input}
 }
 
-// Offset returns the start and stop (inclusive) offsets of the parser rule in
-// the input.
+// Offset returns the start and stop byte offsets of the parser rule in the
+// input. start is inclusive; stop is exclusive (input[start:stop] yields the
+// rule's raw text).
 func (l *TokenExtractor) Offset(prc antlr.ParserRuleContext) (start, stop int) {
 	l.once.Do(func() {
 		l.lines = strings.Split(l.input, "\n")
@@ -29,11 +31,11 @@ func (l *TokenExtractor) Offset(prc antlr.ParserRuleContext) (start, stop int) {
 
 	startToken := prc.GetStart()
 	startLine := startToken.GetLine() - 1
-	startCol := startToken.GetColumn()
+	startCol := runeColToByteCol(l.lines[startLine], startToken.GetColumn())
 
 	stopToken := prc.GetStop()
 	stopLine := stopToken.GetLine() - 1
-	stopCol := stopToken.GetColumn() + len(stopToken.GetText())
+	stopCol := runeColToByteCol(l.lines[stopLine], stopToken.GetColumn()) + len(stopToken.GetText())
 
 	for i := range startLine {
 		startCol += len(l.lines[i]) + 1
@@ -55,11 +57,11 @@ func (l *TokenExtractor) Extract(prc antlr.ParserRuleContext) string {
 
 	startToken := prc.GetStart()
 	startLine := startToken.GetLine() - 1
-	startCol := startToken.GetColumn()
+	startCol := runeColToByteCol(l.lines[startLine], startToken.GetColumn())
 
 	stopToken := prc.GetStop()
 	stopLine := stopToken.GetLine() - 1
-	stopCol := stopToken.GetColumn() + len(stopToken.GetText())
+	stopCol := runeColToByteCol(l.lines[stopLine], stopToken.GetColumn()) + len(stopToken.GetText())
 
 	if startLine == stopLine {
 		return l.lines[startLine][startCol:stopCol]
@@ -76,4 +78,21 @@ func (l *TokenExtractor) Extract(prc antlr.ParserRuleContext) string {
 	sb.WriteString(l.lines[stopLine][:stopCol])
 
 	return sb.String()
+}
+
+// runeColToByteCol converts an ANTLR-reported rune-based column position on a
+// line to a Go byte offset into that line's underlying string. ANTLR's
+// Token.GetColumn returns the count of runes preceding the token on its line;
+// directly using that count as a byte index breaks whenever multi-byte UTF-8
+// characters appear earlier on the same line.
+func runeColToByteCol(line string, runeCol int) int {
+	byteCol := 0
+	for range runeCol {
+		if byteCol >= len(line) {
+			return byteCol
+		}
+		_, size := utf8.DecodeRuneInString(line[byteCol:])
+		byteCol += size
+	}
+	return byteCol
 }

--- a/libsq/ast/antlrz/antlrz_test.go
+++ b/libsq/ast/antlrz/antlrz_test.go
@@ -1,0 +1,74 @@
+package antlrz_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/neilotoole/sq/drivers/sqlite3/sqlparser"
+)
+
+// TestTokenExtractor_Offset_UTF8 guards against an off-by-N byte error in
+// TokenExtractor.Offset: ANTLR's Token.GetColumn reports a rune-based column
+// position, but the returned offset must be a Go byte index so callers can
+// safely slice the input string. When a multi-byte UTF-8 identifier appears
+// earlier on the same line, the rune count diverges from the byte count.
+//
+// This test exercises the path through the sqlite3 sqlparser, since that is
+// the closest public surface that uses TokenExtractor.Offset for downstream
+// string slicing.
+func TestTokenExtractor_Offset_UTF8(t *testing.T) {
+	testCases := []struct {
+		name string
+		stmt string
+		col  string
+	}{
+		{
+			name: "ascii_only",
+			stmt: `CREATE TABLE actor (actor_id INTEGER NOT NULL)`,
+			col:  "actor_id",
+		},
+		{
+			name: "non_ascii_table_name",
+			stmt: `CREATE TABLE "名前" (actor_id INTEGER NOT NULL)`,
+			col:  "actor_id",
+		},
+		{
+			name: "non_ascii_schema_and_table",
+			stmt: `CREATE TABLE "名前"."actor" (actor_id INTEGER NOT NULL)`,
+			col:  "actor_id",
+		},
+		{
+			name: "non_ascii_column_name",
+			stmt: `CREATE TABLE t ("名前" TEXT NOT NULL, actor_id INTEGER)`,
+			col:  "actor_id",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ident, err := sqlparser.ExtractTableIdentFromCreateTableStmt(tc.stmt)
+			require.NoError(t, err)
+			require.Equal(t, ident.RawTable,
+				tc.stmt[ident.TableOffset:ident.TableOffset+len(ident.RawTable)],
+				"TableOffset must be a byte offset; round-trip into input must yield RawTable")
+			if ident.SchemaOffset >= 0 {
+				require.Equal(t, ident.RawSchema,
+					tc.stmt[ident.SchemaOffset:ident.SchemaOffset+len(ident.RawSchema)],
+					"SchemaOffset must be a byte offset")
+			}
+
+			colDefs, err := sqlparser.ExtractCreateTableStmtColDefs(tc.stmt)
+			require.NoError(t, err)
+			require.NotEmpty(t, colDefs)
+			for _, cd := range colDefs {
+				require.Equal(t, cd.RawName,
+					tc.stmt[cd.RawNameOffset:cd.RawNameOffset+len(cd.RawName)],
+					"RawNameOffset must be a byte offset; round-trip into input must yield RawName")
+				require.Equal(t, cd.RawType,
+					tc.stmt[cd.RawTypeOffset:cd.RawTypeOffset+len(cd.RawType)],
+					"RawTypeOffset must be a byte offset; round-trip into input must yield RawType")
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Replace unanchored `strings.Replace` in the sqlite3 and rqlite DDL rewrites with byte-offset-based splicing driven by the shared `sqlparser`. The old approach could clobber the wrong token when a column name shared a prefix with its type (e.g. `TEXT_DATA TEXT`), or when the table identifier recurred in CHECK exprs / DEFAULT literals / comments.
- `sqlparser` gains:
  - `ColDef.RawNameOffset` + `ColDef.RawTypeOffset`.
  - A new `TableIdent` struct that carries raw-with-quotes, unescaped, and byte offsets, replacing the old `(stmt, unescape) -> (schema, table, err)` signature on `ExtractTableIdentFromCreateTableStmt`.
  - A new `ApplyEdits(input, edits)` helper that splices multiple non-overlapping byte-range edits in reverse so pre-edit offsets remain valid throughout. `ApplyEdits` validates that no two edits overlap and no two share the same `Start` (the latter would be ambiguous when one is an insertion, since `sort.Slice` is not stable on equal keys).
- Both drivers' `AlterTableColumnKinds` build a single `[]Edit` covering every column-type swap and the tmp-table rename, then call `ApplyEdits` once. Both `CopyTable` paths use `TableIdent`'s offsets to slice the destination identifier in directly. Stays lockstep per the gh737 design spec.
- Fix `libsq/ast/antlrz/antlrz.go`: `TokenExtractor.Offset` and `Extract` were mixing ANTLR's rune-based `Token.GetColumn()` with byte-based `len(line)` accumulation, producing wrong offsets whenever non-ASCII identifiers appeared earlier on the same line (e.g. `CREATE TABLE "名前"."actor" (...)`). Convert the rune column to a byte column once per call via `utf8.DecodeRuneInString` so the returned offsets are true byte indices, matching their godoc claim.
- Tidy three `errz.Wrapf` calls in the sqlite3 driver that had no format verbs; align with `errz.Wrap` per CLAUDE.md's error-handling table.

## Tests

Parser layer:
- `TestExtractCreateTableStmtColDefs` / `TestExtractTableIdentFromCreateTableStmt` updated for the new shapes and assert offset round-trip.
- New `TestExtractCreateTableStmtColDefs_Offsets_NameVsType` covers the adversarial `text_payload TEXT`, `INTEGER INTEGER`, `my_text_col TEXT` cases.
- New `TestApplyEdits` (13 subtests) covers ordering, adjacency, insertion, deletion, longer-replacement, plus the four rejection paths: overlap, end < start, out-of-range, and the two same-`Start` ambiguity shapes.
- New `TestApplyEdits_DDLRewriteIntegration` is an end-to-end sanity check on the `text_payload TEXT` case via the parser surface.
- New `libsq/ast/antlrz/antlrz_test.go::TestTokenExtractor_Offset_UTF8` covers ascii_only, non_ascii_table_name, non_ascii_schema_and_table, non_ascii_column_name.

Driver layer (mirrored across sqlite3 and rqlite):
- `{TestDriveri_,Test}AlterTableColumnKinds_ColumnNamePrefixesType` with lowercase, uppercase, and bracket-quoted subtests.
- `{TestDriveri_,Test}CopyTable_TableIdentInDefaultLiteral` as a regression safeguard for the identifier rewrite leaving DEFAULT literals untouched.

Closes #750.

## Test plan

- [x] `go test ./drivers/sqlite3/sqlparser/... ./libsq/ast/antlrz/...` (all subtests pass)
- [x] `go test -short ./drivers/sqlite3/... ./drivers/rqlite/...` (clean)
- [x] `make lint` (0 issues)
- [x] `make lint-markdown` (0 errors)
- [x] CI runs the rqlite adversarial driver tests against the sakiladb/rqlite container