### PR TITLE
gh759: CopyTable rewrites self-referential FKs (sqlite3 + rqlite)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -174,6 +174,13 @@ keyring support) and support for [rqlite](https://sq.io/docs/drivers/rqlite).
   `sqlparser` package now exposes `ColDef.RawNameOffset` / `ColDef.RawTypeOffset`,
   a `TableIdent` struct with token offsets, and an `ApplyEdits` helper for
   non-overlapping byte-range splicing.
+- [#759]: `CopyTable` on the [sqlite3](https://sq.io/docs/drivers/sqlite) and
+  [rqlite](https://sq.io/docs/drivers/rqlite) drivers now rewrites
+  self-referential foreign keys to point at the destination table. Previously
+  the destination's `REFERENCES <src>(...)` clause was left untouched, so its
+  FKs resolved against the source table instead of itself. The shared
+  `sqlparser` package gains `ExtractForeignTableRefsFromCreateTableStmt` for
+  this rewrite; cross-table FKs are left alone.
 
 ## [v0.53.0] - 2026-05-25
 
@@ -1757,6 +1764,7 @@ make working with lots of sources much easier.
 [#744]: https://github.com/neilotoole/sq/issues/744
 [#750]: https://github.com/neilotoole/sq/issues/750
 [#752]: https://github.com/neilotoole/sq/issues/752
+[#759]: https://github.com/neilotoole/sq/issues/759
 
 [v0.15.2]: https://github.com/neilotoole/sq/releases/tag/v0.15.2
 [v0.15.3]: https://github.com/neilotoole/sq/compare/v0.15.2...v0.15.3

--- a/drivers/rqlite/rqlite.go
+++ b/drivers/rqlite/rqlite.go
@@ -431,6 +431,11 @@ func (d *driveri) CopyTable(ctx context.Context, db sqlz.DB,
 
 	// Rewrite self-FKs so the destination's REFERENCES point at itself
 	// rather than the source (gh759). Cross-table FKs are left alone.
+	// SQLite's foreign_table grammar rule is a single any_name (no
+	// schema qualification permitted), so the replacement here is the
+	// destination's bare table token even when destQuoted carries a
+	// "schema"."table" prefix for the CREATE TABLE identifier edit.
+	destTableQuoted := stringz.DoubleQuote(toTbl.Table)
 	fkRefs, err := sqlparser.ExtractForeignTableRefsFromCreateTableStmt(ogDDL)
 	if err != nil {
 		return 0, errz.Wrap(err, "rqlite: copy table")
@@ -442,7 +447,7 @@ func (d *driveri) CopyTable(ctx context.Context, db sqlz.DB,
 		edits = append(edits, sqlparser.Edit{
 			Start:       r.TableOffset,
 			End:         r.TableOffset + len(r.RawTable),
-			Replacement: destQuoted,
+			Replacement: destTableQuoted,
 		})
 	}
 

--- a/drivers/rqlite/rqlite.go
+++ b/drivers/rqlite/rqlite.go
@@ -384,18 +384,18 @@ func dsnFromLocation(loc string) (string, error) {
 // batch.
 //
 // The rewrite preserves the original CREATE TABLE text modulo the
-// table identifier substitution. Constraints carried across: UNIQUE,
-// FOREIGN KEY, AUTOINCREMENT, CHECK, composite PRIMARY KEY, exact
-// DEFAULT expressions, WITHOUT ROWID, and column comments.
+// table identifier substitution and any self-referential FK rewrites.
+// Constraints carried across: UNIQUE, FOREIGN KEY, AUTOINCREMENT,
+// CHECK, composite PRIMARY KEY, exact DEFAULT expressions, WITHOUT
+// ROWID, and column comments. Self-referential foreign keys
+// (REFERENCES <src>(...) inside the same CREATE TABLE) are rewritten
+// to point at the destination so the destination's FKs resolve
+// against itself rather than the source (gh759). Cross-table FKs are
+// left untouched.
 //
 // Not preserved: indexes and triggers. These live as separate
 // sqlite_master rows and are out of scope for CopyTable. Matches the
 // sqlite3 driver's behavior.
-//
-// Known limitation (inherited from sqlite3): self-referential FKs
-// are not rewritten. If the source has REFERENCES "actor"(id) and
-// the user copies to "actor_bak", the destination FK still points
-// at "actor" (the source).
 func (d *driveri) CopyTable(ctx context.Context, db sqlz.DB,
 	fromTbl, toTbl tablefq.T, copyData bool,
 ) (int64, error) {
@@ -421,12 +421,32 @@ func (d *driveri) CopyTable(ctx context.Context, db sqlz.DB,
 		identStart = ogIdent.SchemaOffset
 	}
 	identEnd := ogIdent.TableOffset + len(ogIdent.RawTable)
+	destQuoted := toTbl.Render(stringz.DoubleQuote)
 
-	destDDL, err := sqlparser.ApplyEdits(ogDDL, []sqlparser.Edit{{
+	edits := []sqlparser.Edit{{
 		Start:       identStart,
 		End:         identEnd,
-		Replacement: toTbl.Render(stringz.DoubleQuote),
-	}})
+		Replacement: destQuoted,
+	}}
+
+	// Rewrite self-FKs so the destination's REFERENCES point at itself
+	// rather than the source (gh759). Cross-table FKs are left alone.
+	fkRefs, err := sqlparser.ExtractForeignTableRefsFromCreateTableStmt(ogDDL)
+	if err != nil {
+		return 0, errz.Wrap(err, "rqlite: copy table")
+	}
+	for _, r := range fkRefs {
+		if !strings.EqualFold(r.Table, ogIdent.Table) {
+			continue
+		}
+		edits = append(edits, sqlparser.Edit{
+			Start:       r.TableOffset,
+			End:         r.TableOffset + len(r.RawTable),
+			Replacement: destQuoted,
+		})
+	}
+
+	destDDL, err := sqlparser.ApplyEdits(ogDDL, edits)
 	if err != nil {
 		return 0, errz.Wrap(err, "rqlite: copy table: failed to apply DDL rewrites")
 	}

--- a/drivers/rqlite/rqlite_test.go
+++ b/drivers/rqlite/rqlite_test.go
@@ -1049,6 +1049,67 @@ func TestCopyTable_PreservesFKs(t *testing.T) {
 	}
 }
 
+// TestCopyTable_RewritesSelfFK is the rqlite half of gh759: when a
+// source table carries a self-referential FOREIGN KEY (REFERENCES
+// <src>(...)), the destination's REFERENCES must name the destination,
+// not the source. Otherwise the destination's FKs resolve against the
+// source row set, which is the bug.
+//
+// The structural assertion (TableMetadata.FK.Outgoing[0].RefTable ==
+// dstName) is the load-bearing check. The DDL string check is a belt
+// next to that suspenders. FK runtime enforcement isn't exercised here
+// because rqlite's stateless HTTP transport doesn't reliably carry
+// per-connection PRAGMA foreign_keys across separate requests; the
+// sqlite3 sibling test covers that runtime axis.
+func TestCopyTable_RewritesSelfFK(t *testing.T) {
+	tu.SkipShort(t, true)
+	t.Parallel()
+
+	th := testh.New(t)
+	src := th.Source(sakila.Rq)
+	grip := th.Open(src)
+	drvr := grip.SQLDriver()
+	db, err := grip.DB(th.Context)
+	require.NoError(t, err)
+
+	uniq := stringz.Uniq8()
+	srcName := "actor_self_fk_" + uniq
+	dstName := "actor_self_fk_bak_" + uniq
+	t.Cleanup(func() {
+		_ = drvr.DropTable(th.Context, db, tablefq.T{Table: dstName}, true)
+		_ = drvr.DropTable(th.Context, db, tablefq.T{Table: srcName}, true)
+	})
+
+	_, err = db.ExecContext(th.Context, fmt.Sprintf(
+		`CREATE TABLE %q (id INTEGER PRIMARY KEY, parent_id INTEGER, `+
+			`FOREIGN KEY (parent_id) REFERENCES %q(id))`,
+		srcName, srcName))
+	require.NoError(t, err)
+
+	_, err = drvr.CopyTable(th.Context, db,
+		tablefq.T{Table: srcName}, tablefq.T{Table: dstName}, false)
+	require.NoError(t, err)
+
+	md, err := grip.TableMetadata(th.Context, dstName)
+	require.NoError(t, err)
+	require.NotNil(t, md.FK, "destination should carry an FK after CopyTable")
+	require.Len(t, md.FK.Outgoing, 1, "destination should have exactly one outgoing FK")
+	require.Equal(t, dstName, md.FK.Outgoing[0].RefTable,
+		"FK target must be rewritten to the destination, not left pointing at the source")
+
+	var destDDL string
+	require.NoError(t, db.QueryRowContext(th.Context,
+		`SELECT sql FROM sqlite_master WHERE type='table' AND name=?`, dstName).Scan(&destDDL))
+	require.True(t,
+		strings.Contains(destDDL, fmt.Sprintf(`REFERENCES %q(`, dstName)) ||
+			strings.Contains(destDDL, fmt.Sprintf(`REFERENCES %s(`, dstName)),
+		"destination DDL REFERENCES clause must name the destination, got: %s", destDDL)
+	require.False(t,
+		strings.Contains(destDDL, fmt.Sprintf(`REFERENCES %q(`, srcName)) ||
+			strings.Contains(destDDL, fmt.Sprintf(`REFERENCES %s(`, srcName)),
+		"destination DDL REFERENCES clause must not still name the source, got: %s", destDDL)
+}
+
 // TestAlterTableColumnKinds_PreservesFKs verifies that the
 // alter-rebuild dance carries the source table's FOREIGN KEY
 // constraints across. Uses an ad-hoc parent/child fixture because

--- a/drivers/rqlite/rqlite_test.go
+++ b/drivers/rqlite/rqlite_test.go
@@ -1326,6 +1326,55 @@ func TestCopyTable_CaseMismatchSelfFK(t *testing.T) {
 		md.FK.Outgoing[0].RefTable)
 }
 
+// TestCopyTable_SchemaQualifiedDest is the rqlite parity for the
+// sqlite3 sibling: a destination with an explicit schema must rewrite
+// the CREATE TABLE identifier with the dotted "schema"."table" form
+// but the FK REFERENCES target as a bare table token. SQLite's
+// foreign_table grammar rule is a single any_name; the runtime
+// rejects "schema"."tbl" as a REFERENCES target with a syntax error,
+// so a regression would surface at CopyTable's exec rather than via
+// the structural metadata assertion.
+func TestCopyTable_SchemaQualifiedDest(t *testing.T) {
+	tu.SkipShort(t, true)
+	t.Parallel()
+
+	th := testh.New(t)
+	src := th.Source(sakila.Rq)
+	grip := th.Open(src)
+	drvr := grip.SQLDriver()
+	db, err := grip.DB(th.Context)
+	require.NoError(t, err)
+
+	uniq := stringz.Uniq8()
+	srcName := "actor_schema_" + uniq
+	dstName := "actor_schema_bak_" + uniq
+	t.Cleanup(func() {
+		_ = drvr.DropTable(th.Context, db, tablefq.T{Table: dstName}, true)
+		_ = drvr.DropTable(th.Context, db, tablefq.T{Table: srcName}, true)
+	})
+
+	_, err = db.ExecContext(th.Context, fmt.Sprintf(
+		`CREATE TABLE %q (id INTEGER PRIMARY KEY, parent_id INTEGER REFERENCES %q(id))`,
+		srcName, srcName))
+	require.NoError(t, err)
+
+	_, err = drvr.CopyTable(th.Context, db,
+		tablefq.T{Table: srcName},
+		tablefq.T{Schema: "main", Table: dstName},
+		false)
+	require.NoError(t, err,
+		"CopyTable to a schema-qualified destination must succeed; "+
+			"the runtime rejects \"main\".\"%s\" as a REFERENCES target",
+		dstName)
+
+	md, err := grip.TableMetadata(th.Context, dstName)
+	require.NoError(t, err)
+	require.NotNil(t, md.FK)
+	require.Len(t, md.FK.Outgoing, 1)
+	require.Equal(t, dstName, md.FK.Outgoing[0].RefTable,
+		"FK target must be the bare destination table, not a schema-qualified form")
+}
+
 // TestAlterTableColumnKinds_PreservesFKs verifies that the
 // alter-rebuild dance carries the source table's FOREIGN KEY
 // constraints across. Uses an ad-hoc parent/child fixture because

--- a/drivers/rqlite/rqlite_test.go
+++ b/drivers/rqlite/rqlite_test.go
@@ -1136,8 +1136,10 @@ func TestCopyTable_RewritesSelfFK(t *testing.T) {
 // TestCopyTable_LeavesCrossFKsAlone is the rqlite half of the cross-FK
 // preservation invariant: REFERENCES whose target is not the source
 // table must survive the copy untouched, even when the same table also
-// carries a self-FK that does get rewritten. Predicate-inversion
-// regression class introduced by gh759; mirrored on both drivers.
+// carries a self-FK that does get rewritten. A regression that
+// inverted the predicate would silently re-point cross-table FKs at
+// the destination, a worse bug than the original gh759. Mirrored on
+// both drivers.
 func TestCopyTable_LeavesCrossFKsAlone(t *testing.T) {
 	tu.SkipShort(t, true)
 	t.Parallel()

--- a/drivers/rqlite/rqlite_test.go
+++ b/drivers/rqlite/rqlite_test.go
@@ -1055,13 +1055,88 @@ func TestCopyTable_PreservesFKs(t *testing.T) {
 // not the source. Otherwise the destination's FKs resolve against the
 // source row set, which is the bug.
 //
-// The structural assertion (TableMetadata.FK.Outgoing[0].RefTable ==
-// dstName) is the load-bearing check. The DDL string check is a belt
-// next to that suspenders. FK runtime enforcement isn't exercised here
+// The structural assertion (TableMetadata.FK.Outgoing[].RefTable ==
+// dstName) is the load-bearing check. The DDL string check is a
+// redundant cross-check. FK runtime enforcement isn't exercised here
 // because rqlite's stateless HTTP transport doesn't reliably carry
 // per-connection PRAGMA foreign_keys across separate requests; the
 // sqlite3 sibling test covers that runtime axis.
+//
+// Table-driven across the same shapes as the sqlite3 sibling for the
+// step-for-step parity gh737 mandates.
 func TestCopyTable_RewritesSelfFK(t *testing.T) {
+	tu.SkipShort(t, true)
+	t.Parallel()
+
+	testCases := []struct {
+		name string
+		// ddl is the source CREATE TABLE. %[1]s is the source table name.
+		ddl string
+	}{
+		{
+			name: "column_constraint",
+			ddl:  `CREATE TABLE %[1]q (id INTEGER PRIMARY KEY, parent_id INTEGER REFERENCES %[1]q(id))`,
+		},
+		{
+			name: "table_constraint",
+			ddl: `CREATE TABLE %[1]q (id INTEGER PRIMARY KEY, parent_id INTEGER, ` +
+				`FOREIGN KEY (parent_id) REFERENCES %[1]q(id))`,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			th := testh.New(t)
+			src := th.Source(sakila.Rq)
+			grip := th.Open(src)
+			drvr := grip.SQLDriver()
+			db, err := grip.DB(th.Context)
+			require.NoError(t, err)
+
+			uniq := stringz.Uniq8()
+			srcName := "actor_self_fk_" + uniq
+			dstName := "actor_self_fk_bak_" + uniq
+			t.Cleanup(func() {
+				_ = drvr.DropTable(th.Context, db, tablefq.T{Table: dstName}, true)
+				_ = drvr.DropTable(th.Context, db, tablefq.T{Table: srcName}, true)
+			})
+
+			_, err = db.ExecContext(th.Context, fmt.Sprintf(tc.ddl, srcName))
+			require.NoError(t, err)
+
+			_, err = drvr.CopyTable(th.Context, db,
+				tablefq.T{Table: srcName}, tablefq.T{Table: dstName}, false)
+			require.NoError(t, err)
+
+			md, err := grip.TableMetadata(th.Context, dstName)
+			require.NoError(t, err)
+			require.NotNil(t, md.FK, "destination should carry an FK after CopyTable")
+			require.Len(t, md.FK.Outgoing, 1, "destination should have exactly one outgoing FK")
+			require.Equal(t, dstName, md.FK.Outgoing[0].RefTable,
+				"FK target must be rewritten to the destination, not left pointing at the source")
+
+			var destDDL string
+			require.NoError(t, db.QueryRowContext(th.Context,
+				`SELECT sql FROM sqlite_master WHERE type='table' AND name=?`, dstName).Scan(&destDDL))
+			require.True(t,
+				strings.Contains(destDDL, fmt.Sprintf(`REFERENCES %q(`, dstName)) ||
+					strings.Contains(destDDL, fmt.Sprintf(`REFERENCES %s(`, dstName)),
+				"destination DDL REFERENCES clause must name the destination, got: %s", destDDL)
+			require.False(t,
+				strings.Contains(destDDL, fmt.Sprintf(`REFERENCES %q(`, srcName)) ||
+					strings.Contains(destDDL, fmt.Sprintf(`REFERENCES %s(`, srcName)),
+				"destination DDL REFERENCES clause must not still name the source, got: %s", destDDL)
+		})
+	}
+}
+
+// TestCopyTable_LeavesCrossFKsAlone is the rqlite half of the cross-FK
+// preservation invariant: REFERENCES whose target is not the source
+// table must survive the copy untouched, even when the same table also
+// carries a self-FK that does get rewritten. Mirrors the sqlite3
+// sibling for gh737 driver parity.
+func TestCopyTable_LeavesCrossFKsAlone(t *testing.T) {
 	tu.SkipShort(t, true)
 	t.Parallel()
 
@@ -1073,17 +1148,24 @@ func TestCopyTable_RewritesSelfFK(t *testing.T) {
 	require.NoError(t, err)
 
 	uniq := stringz.Uniq8()
-	srcName := "actor_self_fk_" + uniq
-	dstName := "actor_self_fk_bak_" + uniq
+	parentName := "parent_xfk_" + uniq
+	srcName := "actor_xfk_" + uniq
+	dstName := "actor_xfk_bak_" + uniq
 	t.Cleanup(func() {
 		_ = drvr.DropTable(th.Context, db, tablefq.T{Table: dstName}, true)
 		_ = drvr.DropTable(th.Context, db, tablefq.T{Table: srcName}, true)
+		_ = drvr.DropTable(th.Context, db, tablefq.T{Table: parentName}, true)
 	})
 
 	_, err = db.ExecContext(th.Context, fmt.Sprintf(
-		`CREATE TABLE %q (id INTEGER PRIMARY KEY, parent_id INTEGER, `+
-			`FOREIGN KEY (parent_id) REFERENCES %q(id))`,
-		srcName, srcName))
+		`CREATE TABLE %q (id INTEGER PRIMARY KEY)`, parentName))
+	require.NoError(t, err)
+	_, err = db.ExecContext(th.Context, fmt.Sprintf(
+		`CREATE TABLE %q (`+
+			`id INTEGER PRIMARY KEY, `+
+			`parent_id INTEGER REFERENCES %q(id), `+
+			`other_id INTEGER REFERENCES %q(id))`,
+		srcName, srcName, parentName))
 	require.NoError(t, err)
 
 	_, err = drvr.CopyTable(th.Context, db,
@@ -1092,22 +1174,63 @@ func TestCopyTable_RewritesSelfFK(t *testing.T) {
 
 	md, err := grip.TableMetadata(th.Context, dstName)
 	require.NoError(t, err)
-	require.NotNil(t, md.FK, "destination should carry an FK after CopyTable")
-	require.Len(t, md.FK.Outgoing, 1, "destination should have exactly one outgoing FK")
-	require.Equal(t, dstName, md.FK.Outgoing[0].RefTable,
-		"FK target must be rewritten to the destination, not left pointing at the source")
+	require.NotNil(t, md.FK)
+	require.Len(t, md.FK.Outgoing, 2, "destination should have two outgoing FKs")
 
-	var destDDL string
-	require.NoError(t, db.QueryRowContext(th.Context,
-		`SELECT sql FROM sqlite_master WHERE type='table' AND name=?`, dstName).Scan(&destDDL))
-	require.True(t,
-		strings.Contains(destDDL, fmt.Sprintf(`REFERENCES %q(`, dstName)) ||
-			strings.Contains(destDDL, fmt.Sprintf(`REFERENCES %s(`, dstName)),
-		"destination DDL REFERENCES clause must name the destination, got: %s", destDDL)
-	require.False(t,
-		strings.Contains(destDDL, fmt.Sprintf(`REFERENCES %q(`, srcName)) ||
-			strings.Contains(destDDL, fmt.Sprintf(`REFERENCES %s(`, srcName)),
-		"destination DDL REFERENCES clause must not still name the source, got: %s", destDDL)
+	refTables := map[string]bool{}
+	for _, fk := range md.FK.Outgoing {
+		refTables[fk.RefTable] = true
+	}
+	require.True(t, refTables[dstName],
+		"self-FK must be rewritten to the destination, got refs %v", refTables)
+	require.True(t, refTables[parentName],
+		"cross-table FK to %q must be preserved, got refs %v", parentName, refTables)
+	require.False(t, refTables[srcName],
+		"no FK should still name the source after copy, got refs %v", refTables)
+}
+
+// TestCopyTable_MultipleSelfFKs verifies every self-FK in a source
+// table is rewritten, not just the first — guards against a regression
+// that returned after the first match.
+func TestCopyTable_MultipleSelfFKs(t *testing.T) {
+	tu.SkipShort(t, true)
+	t.Parallel()
+
+	th := testh.New(t)
+	src := th.Source(sakila.Rq)
+	grip := th.Open(src)
+	drvr := grip.SQLDriver()
+	db, err := grip.DB(th.Context)
+	require.NoError(t, err)
+
+	uniq := stringz.Uniq8()
+	srcName := "actor_multi_fk_" + uniq
+	dstName := "actor_multi_fk_bak_" + uniq
+	t.Cleanup(func() {
+		_ = drvr.DropTable(th.Context, db, tablefq.T{Table: dstName}, true)
+		_ = drvr.DropTable(th.Context, db, tablefq.T{Table: srcName}, true)
+	})
+
+	_, err = db.ExecContext(th.Context, fmt.Sprintf(
+		`CREATE TABLE %q (`+
+			`id INTEGER PRIMARY KEY, `+
+			`parent_id INTEGER REFERENCES %q(id), `+
+			`buddy_id INTEGER REFERENCES %q(id))`,
+		srcName, srcName, srcName))
+	require.NoError(t, err)
+
+	_, err = drvr.CopyTable(th.Context, db,
+		tablefq.T{Table: srcName}, tablefq.T{Table: dstName}, false)
+	require.NoError(t, err)
+
+	md, err := grip.TableMetadata(th.Context, dstName)
+	require.NoError(t, err)
+	require.NotNil(t, md.FK)
+	require.Len(t, md.FK.Outgoing, 2, "destination should have two outgoing FKs")
+	for _, fk := range md.FK.Outgoing {
+		require.Equal(t, dstName, fk.RefTable,
+			"every self-FK must be rewritten to the destination, got %v", fk)
+	}
 }
 
 // TestAlterTableColumnKinds_PreservesFKs verifies that the

--- a/drivers/rqlite/rqlite_test.go
+++ b/drivers/rqlite/rqlite_test.go
@@ -1055,22 +1055,24 @@ func TestCopyTable_PreservesFKs(t *testing.T) {
 // not the source. Otherwise the destination's FKs resolve against the
 // source row set, which is the bug.
 //
-// The structural assertion (TableMetadata.FK.Outgoing[].RefTable ==
+// The structural assertion (TableMetadata.FK.Outgoing[0].RefTable ==
 // dstName) is the load-bearing check. The DDL string check is a
 // redundant cross-check. FK runtime enforcement isn't exercised here
 // because rqlite's stateless HTTP transport doesn't reliably carry
 // per-connection PRAGMA foreign_keys across separate requests; the
 // sqlite3 sibling test covers that runtime axis.
 //
-// Table-driven across the same shapes as the sqlite3 sibling for the
-// step-for-step parity gh737 mandates.
+// Table-driven across the cardinal self-FK shapes so the two drivers
+// stay in step (gh737 established the rqlite faithful-DDL baseline
+// this builds on).
 func TestCopyTable_RewritesSelfFK(t *testing.T) {
 	tu.SkipShort(t, true)
 	t.Parallel()
 
 	testCases := []struct {
 		name string
-		// ddl is the source CREATE TABLE. %[1]s is the source table name.
+		// ddl is the source CREATE TABLE; %[1]q is the source table
+		// name, double-quoted via the %q verb.
 		ddl string
 	}{
 		{
@@ -1134,8 +1136,8 @@ func TestCopyTable_RewritesSelfFK(t *testing.T) {
 // TestCopyTable_LeavesCrossFKsAlone is the rqlite half of the cross-FK
 // preservation invariant: REFERENCES whose target is not the source
 // table must survive the copy untouched, even when the same table also
-// carries a self-FK that does get rewritten. Mirrors the sqlite3
-// sibling for gh737 driver parity.
+// carries a self-FK that does get rewritten. Predicate-inversion
+// regression class introduced by gh759; mirrored on both drivers.
 func TestCopyTable_LeavesCrossFKsAlone(t *testing.T) {
 	tu.SkipShort(t, true)
 	t.Parallel()
@@ -1190,7 +1192,7 @@ func TestCopyTable_LeavesCrossFKsAlone(t *testing.T) {
 }
 
 // TestCopyTable_MultipleSelfFKs verifies every self-FK in a source
-// table is rewritten, not just the first — guards against a regression
+// table is rewritten, not just the first; guards against a regression
 // that returned after the first match.
 func TestCopyTable_MultipleSelfFKs(t *testing.T) {
 	tu.SkipShort(t, true)
@@ -1231,6 +1233,95 @@ func TestCopyTable_MultipleSelfFKs(t *testing.T) {
 		require.Equal(t, dstName, fk.RefTable,
 			"every self-FK must be rewritten to the destination, got %v", fk)
 	}
+}
+
+// TestCopyTable_CompositeSelfFK verifies composite-column
+// FOREIGN KEY(a, b) REFERENCES self(x, y) is rewritten to point at the
+// destination. Mirrors the sqlite3 sibling.
+func TestCopyTable_CompositeSelfFK(t *testing.T) {
+	tu.SkipShort(t, true)
+	t.Parallel()
+
+	th := testh.New(t)
+	src := th.Source(sakila.Rq)
+	grip := th.Open(src)
+	drvr := grip.SQLDriver()
+	db, err := grip.DB(th.Context)
+	require.NoError(t, err)
+
+	uniq := stringz.Uniq8()
+	srcName := "link_composite_" + uniq
+	dstName := "link_composite_bak_" + uniq
+	t.Cleanup(func() {
+		_ = drvr.DropTable(th.Context, db, tablefq.T{Table: dstName}, true)
+		_ = drvr.DropTable(th.Context, db, tablefq.T{Table: srcName}, true)
+	})
+
+	_, err = db.ExecContext(th.Context, fmt.Sprintf(
+		`CREATE TABLE %q (`+
+			`a INTEGER, b INTEGER, x INTEGER, y INTEGER, `+
+			`PRIMARY KEY (x, y), `+
+			`FOREIGN KEY(a, b) REFERENCES %q(x, y))`,
+		srcName, srcName))
+	require.NoError(t, err)
+
+	_, err = drvr.CopyTable(th.Context, db,
+		tablefq.T{Table: srcName}, tablefq.T{Table: dstName}, false)
+	require.NoError(t, err)
+
+	md, err := grip.TableMetadata(th.Context, dstName)
+	require.NoError(t, err)
+	require.NotNil(t, md.FK)
+	require.Len(t, md.FK.Outgoing, 1)
+	require.Equal(t, dstName, md.FK.Outgoing[0].RefTable,
+		"composite self-FK must be rewritten to the destination")
+}
+
+// TestCopyTable_CaseMismatchSelfFK verifies the driver's case-insensitive
+// match predicate: a source table named `actor_...` whose REFERENCES
+// target is written as `Actor_...` is still rewritten. SQLite identifier
+// comparison is ASCII case-insensitive for unquoted refs; the driver
+// uses strings.EqualFold. A regression to case-sensitive matching would
+// leave the destination FK pointing at the source.
+func TestCopyTable_CaseMismatchSelfFK(t *testing.T) {
+	tu.SkipShort(t, true)
+	t.Parallel()
+
+	th := testh.New(t)
+	src := th.Source(sakila.Rq)
+	grip := th.Open(src)
+	drvr := grip.SQLDriver()
+	db, err := grip.DB(th.Context)
+	require.NoError(t, err)
+
+	uniq := stringz.Uniq8()
+	srcName := "actor_case_" + uniq
+	upperFKTarget := strings.ToUpper(srcName[:1]) + srcName[1:]
+	dstName := "actor_case_bak_" + uniq
+	t.Cleanup(func() {
+		_ = drvr.DropTable(th.Context, db, tablefq.T{Table: dstName}, true)
+		_ = drvr.DropTable(th.Context, db, tablefq.T{Table: srcName}, true)
+	})
+
+	_, err = db.ExecContext(th.Context, fmt.Sprintf(
+		`CREATE TABLE %s (id INTEGER PRIMARY KEY, parent_id INTEGER REFERENCES %s(id))`,
+		srcName, upperFKTarget))
+	require.NoError(t, err)
+
+	_, err = drvr.CopyTable(th.Context, db,
+		tablefq.T{Table: srcName}, tablefq.T{Table: dstName}, false)
+	require.NoError(t, err)
+
+	md, err := grip.TableMetadata(th.Context, dstName)
+	require.NoError(t, err)
+	require.NotNil(t, md.FK)
+	require.Len(t, md.FK.Outgoing, 1)
+	require.True(t, strings.EqualFold(md.FK.Outgoing[0].RefTable, dstName),
+		"FK target must be rewritten to the destination despite case mismatch, got %q",
+		md.FK.Outgoing[0].RefTable)
+	require.False(t, strings.EqualFold(md.FK.Outgoing[0].RefTable, srcName),
+		"FK target must not still name the source after rewrite, got %q",
+		md.FK.Outgoing[0].RefTable)
 }
 
 // TestAlterTableColumnKinds_PreservesFKs verifies that the

--- a/drivers/sqlite3/sqlite3.go
+++ b/drivers/sqlite3/sqlite3.go
@@ -321,7 +321,7 @@ func (d *driveri) CopyTable(ctx context.Context, db sqlz.DB,
 	// recurs elsewhere in the DDL (CHECK exprs, default literals, etc.).
 	ogIdent, err := sqlparser.ExtractTableIdentFromCreateTableStmt(ogTblCreateStmt)
 	if err != nil {
-		return 0, errw(err)
+		return 0, errz.Wrap(err, "sqlite3: copy table")
 	}
 
 	identStart := ogIdent.TableOffset
@@ -337,8 +337,8 @@ func (d *driveri) CopyTable(ctx context.Context, db sqlz.DB,
 		Replacement: destQuoted,
 	}}
 
-	// Without this, the destination's self-referential FKs would resolve back
-	// to the source table, not itself (gh759). Cross-table FKs are left alone.
+	// Rewrite self-FKs so the destination's REFERENCES point at itself
+	// rather than the source (gh759). Cross-table FKs are left alone.
 	fkRefs, err := sqlparser.ExtractForeignTableRefsFromCreateTableStmt(ogTblCreateStmt)
 	if err != nil {
 		return 0, errz.Wrap(err, "sqlite3: copy table")

--- a/drivers/sqlite3/sqlite3.go
+++ b/drivers/sqlite3/sqlite3.go
@@ -286,6 +286,15 @@ func (d *driveri) Renderer() *render.Renderer {
 }
 
 // CopyTable implements driver.SQLDriver.
+//
+// The implementation reads the source table's CREATE statement from
+// sqlite_master, extracts the table identifier (with byte offsets) via
+// the shared sqlparser package, and substitutes the destination name in
+// place. Self-referential foreign keys (REFERENCES <src>(...) inside
+// the same CREATE TABLE) are also rewritten to point at the destination
+// so the destination's FKs resolve against itself rather than the
+// source. Cross-table FKs (REFERENCES other(...) where other != src)
+// are left untouched.
 func (d *driveri) CopyTable(ctx context.Context, db sqlz.DB,
 	fromTbl, toTbl tablefq.T, copyData bool,
 ) (int64, error) {
@@ -320,12 +329,33 @@ func (d *driveri) CopyTable(ctx context.Context, db sqlz.DB,
 		identStart = ogIdent.SchemaOffset
 	}
 	identEnd := ogIdent.TableOffset + len(ogIdent.RawTable)
+	destQuoted := toTbl.Render(stringz.DoubleQuote)
 
-	destTblCreateStmt, err := sqlparser.ApplyEdits(ogTblCreateStmt, []sqlparser.Edit{{
+	edits := []sqlparser.Edit{{
 		Start:       identStart,
 		End:         identEnd,
-		Replacement: toTbl.Render(stringz.DoubleQuote),
-	}})
+		Replacement: destQuoted,
+	}}
+
+	// Rewrite self-FKs so REFERENCES <src>(...) becomes REFERENCES <dest>(...).
+	// Otherwise the destination's FKs would resolve against the source table,
+	// not itself (gh759). Cross-table FKs are left alone.
+	fkRefs, err := sqlparser.ExtractForeignTableRefsFromCreateTableStmt(ogTblCreateStmt)
+	if err != nil {
+		return 0, errw(err)
+	}
+	for _, r := range fkRefs {
+		if !strings.EqualFold(r.Table, ogIdent.Table) {
+			continue
+		}
+		edits = append(edits, sqlparser.Edit{
+			Start:       r.TableOffset,
+			End:         r.TableOffset + len(r.RawTable),
+			Replacement: destQuoted,
+		})
+	}
+
+	destTblCreateStmt, err := sqlparser.ApplyEdits(ogTblCreateStmt, edits)
 	if err != nil {
 		return 0, errz.Wrap(err, "sqlite3: copy table: failed to apply DDL rewrites")
 	}

--- a/drivers/sqlite3/sqlite3.go
+++ b/drivers/sqlite3/sqlite3.go
@@ -339,6 +339,11 @@ func (d *driveri) CopyTable(ctx context.Context, db sqlz.DB,
 
 	// Rewrite self-FKs so the destination's REFERENCES point at itself
 	// rather than the source (gh759). Cross-table FKs are left alone.
+	// SQLite's foreign_table grammar rule is a single any_name (no
+	// schema qualification permitted), so the replacement here is the
+	// destination's bare table token even when destQuoted carries a
+	// "schema"."table" prefix for the CREATE TABLE identifier edit.
+	destTableQuoted := stringz.DoubleQuote(toTbl.Table)
 	fkRefs, err := sqlparser.ExtractForeignTableRefsFromCreateTableStmt(ogTblCreateStmt)
 	if err != nil {
 		return 0, errz.Wrap(err, "sqlite3: copy table")
@@ -350,7 +355,7 @@ func (d *driveri) CopyTable(ctx context.Context, db sqlz.DB,
 		edits = append(edits, sqlparser.Edit{
 			Start:       r.TableOffset,
 			End:         r.TableOffset + len(r.RawTable),
-			Replacement: destQuoted,
+			Replacement: destTableQuoted,
 		})
 	}
 

--- a/drivers/sqlite3/sqlite3.go
+++ b/drivers/sqlite3/sqlite3.go
@@ -337,12 +337,11 @@ func (d *driveri) CopyTable(ctx context.Context, db sqlz.DB,
 		Replacement: destQuoted,
 	}}
 
-	// Rewrite self-FKs so REFERENCES <src>(...) becomes REFERENCES <dest>(...).
-	// Otherwise the destination's FKs would resolve against the source table,
-	// not itself (gh759). Cross-table FKs are left alone.
+	// Without this, the destination's self-referential FKs would resolve back
+	// to the source table, not itself (gh759). Cross-table FKs are left alone.
 	fkRefs, err := sqlparser.ExtractForeignTableRefsFromCreateTableStmt(ogTblCreateStmt)
 	if err != nil {
-		return 0, errw(err)
+		return 0, errz.Wrap(err, "sqlite3: copy table")
 	}
 	for _, r := range fkRefs {
 		if !strings.EqualFold(r.Table, ogIdent.Table) {

--- a/drivers/sqlite3/sqlite3_test.go
+++ b/drivers/sqlite3/sqlite3_test.go
@@ -796,7 +796,15 @@ func TestDriveri_CopyTable_CompositeSelfFK(t *testing.T) {
 // TABLE identifier with the dotted form but the self-FK REFERENCES
 // target as a bare table token. SQLite's foreign_table grammar rule is
 // a single any_name; emitting "schema"."tbl" as a REFERENCES target
-// produces invalid DDL.
+// produces a syntax error from the runtime.
+//
+// The load-bearing catch is the first require.NoError on CopyTable: a
+// regression that reused the schema-qualified destQuoted on the FK
+// edits would surface as a CREATE TABLE syntax error before any of the
+// downstream assertions run. The structural assertSelfFKRewritten and
+// the NotContains "main"."actor_bak" assertion lock the post-fix form;
+// the runtime FK enforcement at the end confirms the rewritten FK
+// still binds.
 func TestDriveri_CopyTable_SchemaQualifiedDest(t *testing.T) {
 	th, db, drvr := openSqliteForFKTest(t)
 

--- a/drivers/sqlite3/sqlite3_test.go
+++ b/drivers/sqlite3/sqlite3_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/neilotoole/sq/drivers/sqlite3"
+	"github.com/neilotoole/sq/drivers/sqlite3/sqlparser"
 	"github.com/neilotoole/sq/libsq/core/kind"
 	"github.com/neilotoole/sq/libsq/core/schema"
 	"github.com/neilotoole/sq/libsq/core/sqlz"
@@ -586,21 +587,29 @@ func openSqliteForFKTest(t *testing.T) (*testh.Helper, *sql.DB, driver.SQLDriver
 	return th, db, grip.SQLDriver()
 }
 
-// assertSelfFKRewritten asserts that destDDL's REFERENCES clause names
-// dstName and does not still name srcName. Tolerates either quoted or
-// unquoted identifier styles that sqlite_master may carry.
+// assertSelfFKRewritten parses destDDL via the sqlparser and asserts
+// every REFERENCES target's dequoted name equals dstName (and not
+// srcName), regardless of which of SQLite's four identifier-quote styles
+// (double-quote, single-quote, backtick, square brackets) the source
+// DDL carried. A naive substring check would silently miss a leftover
+// source ref written in a quote style not covered by the check.
+//
+// Only valid for tests whose source DDL contains self-FKs and no
+// cross-table FKs.
 func assertSelfFKRewritten(t *testing.T, destDDL, srcName, dstName string) {
 	t.Helper()
-	require.Contains(t, destDDL, `REFERENCES`,
-		"destination DDL should still carry a REFERENCES clause")
-	require.True(t,
-		strings.Contains(destDDL, fmt.Sprintf(`REFERENCES %s(`, dstName)) ||
-			strings.Contains(destDDL, fmt.Sprintf(`REFERENCES "%s"(`, dstName)),
-		"REFERENCES must name the destination %q, got: %s", dstName, destDDL)
-	require.False(t,
-		strings.Contains(destDDL, fmt.Sprintf(`REFERENCES %s(`, srcName)) ||
-			strings.Contains(destDDL, fmt.Sprintf(`REFERENCES "%s"(`, srcName)),
-		"REFERENCES must no longer name the source %q, got: %s", srcName, destDDL)
+	refs, err := sqlparser.ExtractForeignTableRefsFromCreateTableStmt(destDDL)
+	require.NoError(t, err, "destination DDL must parse: %s", destDDL)
+	require.NotEmpty(t, refs,
+		"destination DDL should still carry at least one REFERENCES clause: %s", destDDL)
+	for _, r := range refs {
+		require.False(t, strings.EqualFold(r.Table, srcName),
+			"REFERENCES must no longer name the source %q (got %q in %s)",
+			srcName, r.RawTable, destDDL)
+		require.True(t, strings.EqualFold(r.Table, dstName),
+			"REFERENCES must name the destination %q (got %q in %s)",
+			dstName, r.RawTable, destDDL)
+	}
 }
 
 // TestDriveri_CopyTable_RewritesSelfFK verifies gh759: a CREATE TABLE
@@ -614,7 +623,7 @@ func TestDriveri_CopyTable_RewritesSelfFK(t *testing.T) {
 		// %[2]s is the FK-target identifier form (so the case_mismatch case
 		// can declare the source as `actor` but REFERENCE `Actor`).
 		ddl        string
-		fkTargetFn func(srcName string) string // produces the REFERENCES target as it appears in ddl
+		fkTargetFn func(srcName string) string // produces the REFERENCES target as it appears in ddl.
 	}{
 		{
 			name:       "column_constraint_unquoted",
@@ -722,7 +731,7 @@ func TestDriveri_CopyTable_LeavesCrossFKsAlone(t *testing.T) {
 }
 
 // TestDriveri_CopyTable_MultipleSelfFKs verifies every self-FK in a
-// table with more than one REFERENCES <src>(...) is rewritten — guards
+// table with more than one REFERENCES <src>(...) is rewritten; guards
 // against a regression that returned after the first match.
 func TestDriveri_CopyTable_MultipleSelfFKs(t *testing.T) {
 	th, db, drvr := openSqliteForFKTest(t)
@@ -780,6 +789,44 @@ func TestDriveri_CopyTable_CompositeSelfFK(t *testing.T) {
 		destDDL)
 	require.False(t, strings.Contains(destDDL, `REFERENCES link(`),
 		"composite FK must no longer point at link, got: %s", destDDL)
+}
+
+// TestDriveri_CopyTable_PreservesOnDeleteCascade is the runtime sibling
+// of the sqlparser-level PreservesActionClauses test: prove that a self
+// FK with ON DELETE CASCADE not only round-trips textually through the
+// rewrite, but still fires against the destination table at runtime.
+// Catches a regression class where the rewrite mangles the action clause
+// in some way that survives the parser's eyes but breaks SQLite's.
+func TestDriveri_CopyTable_PreservesOnDeleteCascade(t *testing.T) {
+	th, db, drvr := openSqliteForFKTest(t)
+
+	_, err := db.ExecContext(th.Context,
+		`CREATE TABLE actor (`+
+			`id INTEGER PRIMARY KEY, `+
+			`parent_id INTEGER REFERENCES actor(id) ON DELETE CASCADE)`)
+	require.NoError(t, err)
+
+	_, err = drvr.CopyTable(th.Context, db,
+		tablefq.T{Table: "actor"}, tablefq.T{Table: "actor_bak"}, false)
+	require.NoError(t, err)
+
+	_, err = db.ExecContext(th.Context, `INSERT INTO actor_bak (id) VALUES (1)`)
+	require.NoError(t, err)
+	_, err = db.ExecContext(th.Context,
+		`INSERT INTO actor_bak (id, parent_id) VALUES (2, 1)`)
+	require.NoError(t, err)
+	_, err = db.ExecContext(th.Context,
+		`INSERT INTO actor_bak (id, parent_id) VALUES (3, 2)`)
+	require.NoError(t, err)
+
+	_, err = db.ExecContext(th.Context, `DELETE FROM actor_bak WHERE id=1`)
+	require.NoError(t, err)
+
+	var count int
+	require.NoError(t, db.QueryRowContext(th.Context,
+		`SELECT COUNT(*) FROM actor_bak`).Scan(&count))
+	require.Equal(t, 0, count,
+		"ON DELETE CASCADE must fire on the destination: deleting id=1 should cascade to id=2 and id=3")
 }
 
 // TestSourceMetadata_LocationWithConnParams reproduces gh720: a

--- a/drivers/sqlite3/sqlite3_test.go
+++ b/drivers/sqlite3/sqlite3_test.go
@@ -1,6 +1,7 @@
 package sqlite3_test
 
 import (
+	"database/sql"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -17,6 +18,7 @@ import (
 	"github.com/neilotoole/sq/libsq/core/sqlz"
 	"github.com/neilotoole/sq/libsq/core/stringz"
 	"github.com/neilotoole/sq/libsq/core/tablefq"
+	"github.com/neilotoole/sq/libsq/driver"
 	"github.com/neilotoole/sq/libsq/source"
 	"github.com/neilotoole/sq/libsq/source/drivertype"
 	"github.com/neilotoole/sq/testh"
@@ -560,6 +562,47 @@ func TestDriveri_CopyTable_TableIdentInDefaultLiteral(t *testing.T) {
 		"the DEFAULT literal must not be rewritten by the table-identifier substitution")
 }
 
+// openSqliteForFKTest opens a fresh sqlite3 source with a connection
+// pinned to a single underlying connection. Pinning is load-bearing for
+// FK enforcement assertions: PRAGMA foreign_keys is per-connection in
+// SQLite, and without SetMaxOpenConns(1) subsequent ExecContext calls
+// might land on a different pool connection where the PRAGMA was never
+// set.
+func openSqliteForFKTest(t *testing.T) (*testh.Helper, *sql.DB, driver.SQLDriver) {
+	t.Helper()
+	th := testh.New(t)
+	src := &source.Source{
+		Handle:   "@test",
+		Type:     drivertype.SQLite,
+		Location: "sqlite3://" + tu.TempFile(t, "test.db"),
+	}
+	grip := th.Open(src)
+	db, err := grip.DB(th.Context)
+	require.NoError(t, err)
+	db.SetMaxOpenConns(1)
+
+	_, err = db.ExecContext(th.Context, `PRAGMA foreign_keys = ON`)
+	require.NoError(t, err)
+	return th, db, grip.SQLDriver()
+}
+
+// assertSelfFKRewritten asserts that destDDL's REFERENCES clause names
+// dstName and does not still name srcName. Tolerates either quoted or
+// unquoted identifier styles that sqlite_master may carry.
+func assertSelfFKRewritten(t *testing.T, destDDL, srcName, dstName string) {
+	t.Helper()
+	require.Contains(t, destDDL, `REFERENCES`,
+		"destination DDL should still carry a REFERENCES clause")
+	require.True(t,
+		strings.Contains(destDDL, fmt.Sprintf(`REFERENCES %s(`, dstName)) ||
+			strings.Contains(destDDL, fmt.Sprintf(`REFERENCES "%s"(`, dstName)),
+		"REFERENCES must name the destination %q, got: %s", dstName, destDDL)
+	require.False(t,
+		strings.Contains(destDDL, fmt.Sprintf(`REFERENCES %s(`, srcName)) ||
+			strings.Contains(destDDL, fmt.Sprintf(`REFERENCES "%s"(`, srcName)),
+		"REFERENCES must no longer name the source %q, got: %s", srcName, destDDL)
+}
+
 // TestDriveri_CopyTable_RewritesSelfFK verifies gh759: a CREATE TABLE
 // with a self-referential FOREIGN KEY (REFERENCES <src>(...)) must have
 // the FK target rewritten to the destination, so the destination's FKs
@@ -567,42 +610,44 @@ func TestDriveri_CopyTable_TableIdentInDefaultLiteral(t *testing.T) {
 func TestDriveri_CopyTable_RewritesSelfFK(t *testing.T) {
 	testCases := []struct {
 		name string
-		ddl  string // %[1]s is the source table name (parameterized so we
-		// exercise both quoted and unquoted FK target forms).
+		// ddl is the source CREATE TABLE; %[1]s is the source table name,
+		// %[2]s is the FK-target identifier form (so the case_mismatch case
+		// can declare the source as `actor` but REFERENCE `Actor`).
+		ddl        string
+		fkTargetFn func(srcName string) string // produces the REFERENCES target as it appears in ddl
 	}{
 		{
-			name: "column_constraint_unquoted",
-			ddl:  `CREATE TABLE %[1]s (id INTEGER PRIMARY KEY, parent_id INTEGER REFERENCES %[1]s(id))`,
+			name:       "column_constraint_unquoted",
+			ddl:        `CREATE TABLE %[1]s (id INTEGER PRIMARY KEY, parent_id INTEGER REFERENCES %[2]s(id))`,
+			fkTargetFn: func(s string) string { return s },
 		},
 		{
-			name: "column_constraint_quoted",
-			ddl:  `CREATE TABLE "%[1]s" (id INTEGER PRIMARY KEY, parent_id INTEGER REFERENCES "%[1]s"(id))`,
+			name:       "column_constraint_quoted",
+			ddl:        `CREATE TABLE "%[1]s" (id INTEGER PRIMARY KEY, parent_id INTEGER REFERENCES "%[2]s"(id))`,
+			fkTargetFn: func(s string) string { return s },
 		},
 		{
 			name: "table_constraint",
-			ddl:  `CREATE TABLE %[1]s (id INTEGER PRIMARY KEY, parent_id INTEGER, FOREIGN KEY(parent_id) REFERENCES %[1]s(id))`,
+			ddl: `CREATE TABLE %[1]s (id INTEGER PRIMARY KEY, parent_id INTEGER, ` +
+				`FOREIGN KEY(parent_id) REFERENCES %[2]s(id))`,
+			fkTargetFn: func(s string) string { return s },
+		},
+		{
+			// Source is `actor`, FK target is `Actor`; the driver predicate
+			// matches them case-insensitively per SQLite's identifier rules.
+			name:       "case_mismatch_fk_target",
+			ddl:        `CREATE TABLE %[1]s (id INTEGER PRIMARY KEY, parent_id INTEGER REFERENCES %[2]s(id))`,
+			fkTargetFn: func(s string) string { return strings.ToUpper(s[:1]) + s[1:] },
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			th := testh.New(t)
-			src := &source.Source{
-				Handle:   "@test",
-				Type:     drivertype.SQLite,
-				Location: "sqlite3://" + tu.TempFile(t, "test.db"),
-			}
-			grip := th.Open(src)
-			db, err := grip.DB(th.Context)
-			require.NoError(t, err)
-			drvr := grip.SQLDriver()
-
-			// FK enforcement is required for the runtime-behavior assertion.
-			_, err = db.ExecContext(th.Context, `PRAGMA foreign_keys = ON`)
-			require.NoError(t, err)
+			th, db, drvr := openSqliteForFKTest(t)
 
 			const srcName, dstName = "actor", "actor_bak"
-			_, err = db.ExecContext(th.Context, fmt.Sprintf(tc.ddl, srcName))
+			_, err := db.ExecContext(th.Context,
+				fmt.Sprintf(tc.ddl, srcName, tc.fkTargetFn(srcName)))
 			require.NoError(t, err)
 			// Seed the source with id=1 so we can verify the destination FK
 			// does NOT resolve to it after the copy.
@@ -614,20 +659,10 @@ func TestDriveri_CopyTable_RewritesSelfFK(t *testing.T) {
 				tablefq.T{Table: srcName}, tablefq.T{Table: dstName}, false)
 			require.NoError(t, err)
 
-			// Destination DDL must name the destination in its REFERENCES clause.
 			var destDDL string
 			require.NoError(t, db.QueryRowContext(th.Context,
 				`SELECT sql FROM sqlite_master WHERE type='table' AND name=?`, dstName).Scan(&destDDL))
-			require.Contains(t, destDDL, `REFERENCES`,
-				"destination DDL should still carry a REFERENCES clause")
-			require.True(t,
-				strings.Contains(destDDL, fmt.Sprintf(`REFERENCES %s(`, dstName)) ||
-					strings.Contains(destDDL, fmt.Sprintf(`REFERENCES "%s"(`, dstName)),
-				"REFERENCES must name the destination, got: %s", destDDL)
-			require.False(t,
-				strings.Contains(destDDL, fmt.Sprintf(`REFERENCES %s(`, srcName)) ||
-					strings.Contains(destDDL, fmt.Sprintf(`REFERENCES "%s"(`, srcName)),
-				"REFERENCES must no longer name the source, got: %s", destDDL)
+			assertSelfFKRewritten(t, destDDL, srcName, dstName)
 
 			// Runtime check: inserting a row whose parent_id points at id=1
 			// must fail, because id=1 lives only in the source. If the FK
@@ -648,6 +683,103 @@ func TestDriveri_CopyTable_RewritesSelfFK(t *testing.T) {
 			require.NoError(t, err)
 		})
 	}
+}
+
+// TestDriveri_CopyTable_LeavesCrossFKsAlone verifies the load-bearing
+// invariant of gh759: REFERENCES whose target is NOT the source table
+// must be left untouched. A regression that inverted the predicate
+// would silently re-point cross-table FKs at the destination, a worse
+// bug than the original.
+func TestDriveri_CopyTable_LeavesCrossFKsAlone(t *testing.T) {
+	th, db, drvr := openSqliteForFKTest(t)
+
+	_, err := db.ExecContext(th.Context,
+		`CREATE TABLE parent (id INTEGER PRIMARY KEY)`)
+	require.NoError(t, err)
+	_, err = db.ExecContext(th.Context,
+		`CREATE TABLE actor (`+
+			`id INTEGER PRIMARY KEY, `+
+			`parent_id INTEGER REFERENCES actor(id), `+
+			`other_id INTEGER REFERENCES parent(id))`)
+	require.NoError(t, err)
+
+	_, err = drvr.CopyTable(th.Context, db,
+		tablefq.T{Table: "actor"}, tablefq.T{Table: "actor_bak"}, false)
+	require.NoError(t, err)
+
+	var destDDL string
+	require.NoError(t, db.QueryRowContext(th.Context,
+		`SELECT sql FROM sqlite_master WHERE type='table' AND name=?`, "actor_bak").Scan(&destDDL))
+
+	require.True(t,
+		strings.Contains(destDDL, `REFERENCES actor_bak(`) ||
+			strings.Contains(destDDL, `REFERENCES "actor_bak"(`),
+		"self-FK must be rewritten to actor_bak, got: %s", destDDL)
+	require.True(t,
+		strings.Contains(destDDL, `REFERENCES parent(`) ||
+			strings.Contains(destDDL, `REFERENCES "parent"(`),
+		"cross-table FK to parent must be preserved, got: %s", destDDL)
+}
+
+// TestDriveri_CopyTable_MultipleSelfFKs verifies every self-FK in a
+// table with more than one REFERENCES <src>(...) is rewritten — guards
+// against a regression that returned after the first match.
+func TestDriveri_CopyTable_MultipleSelfFKs(t *testing.T) {
+	th, db, drvr := openSqliteForFKTest(t)
+
+	_, err := db.ExecContext(th.Context,
+		`CREATE TABLE actor (`+
+			`id INTEGER PRIMARY KEY, `+
+			`parent_id INTEGER REFERENCES actor(id), `+
+			`buddy_id INTEGER REFERENCES actor(id))`)
+	require.NoError(t, err)
+
+	_, err = drvr.CopyTable(th.Context, db,
+		tablefq.T{Table: "actor"}, tablefq.T{Table: "actor_bak"}, false)
+	require.NoError(t, err)
+
+	var destDDL string
+	require.NoError(t, db.QueryRowContext(th.Context,
+		`SELECT sql FROM sqlite_master WHERE type='table' AND name=?`, "actor_bak").Scan(&destDDL))
+
+	require.Equal(t, 2,
+		strings.Count(destDDL, `REFERENCES actor_bak(`)+
+			strings.Count(destDDL, `REFERENCES "actor_bak"(`),
+		"both self-FKs must point at actor_bak, got: %s", destDDL)
+	require.False(t,
+		strings.Contains(destDDL, `REFERENCES actor(`) ||
+			strings.Contains(destDDL, `REFERENCES "actor"(`),
+		"no self-FK may still point at the source, got: %s", destDDL)
+}
+
+// TestDriveri_CopyTable_CompositeSelfFK verifies composite-column
+// FOREIGN KEY(a, b) REFERENCES self(x, y) is rewritten to point at the
+// destination, with the column lists left intact.
+func TestDriveri_CopyTable_CompositeSelfFK(t *testing.T) {
+	th, db, drvr := openSqliteForFKTest(t)
+
+	_, err := db.ExecContext(th.Context,
+		`CREATE TABLE link (`+
+			`a INTEGER, b INTEGER, x INTEGER, y INTEGER, `+
+			`PRIMARY KEY (x, y), `+
+			`FOREIGN KEY(a, b) REFERENCES link(x, y))`)
+	require.NoError(t, err)
+
+	_, err = drvr.CopyTable(th.Context, db,
+		tablefq.T{Table: "link"}, tablefq.T{Table: "link_bak"}, false)
+	require.NoError(t, err)
+
+	var destDDL string
+	require.NoError(t, db.QueryRowContext(th.Context,
+		`SELECT sql FROM sqlite_master WHERE type='table' AND name=?`, "link_bak").Scan(&destDDL))
+
+	require.True(t,
+		strings.Contains(destDDL, `REFERENCES link_bak(x, y)`) ||
+			strings.Contains(destDDL, `REFERENCES "link_bak"(x, y)`),
+		"composite FK must be rewritten to link_bak with parent columns preserved, got: %s",
+		destDDL)
+	require.False(t, strings.Contains(destDDL, `REFERENCES link(`),
+		"composite FK must no longer point at link, got: %s", destDDL)
 }
 
 // TestSourceMetadata_LocationWithConnParams reproduces gh720: a

--- a/drivers/sqlite3/sqlite3_test.go
+++ b/drivers/sqlite3/sqlite3_test.go
@@ -1,9 +1,11 @@
 package sqlite3_test
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 
 	_ "github.com/mattn/go-sqlite3"
@@ -556,6 +558,96 @@ func TestDriveri_CopyTable_TableIdentInDefaultLiteral(t *testing.T) {
 		`SELECT tag FROM actor_bak WHERE id=2`).Scan(&tag))
 	require.Equal(t, "actor_tag", tag,
 		"the DEFAULT literal must not be rewritten by the table-identifier substitution")
+}
+
+// TestDriveri_CopyTable_RewritesSelfFK verifies gh759: a CREATE TABLE
+// with a self-referential FOREIGN KEY (REFERENCES <src>(...)) must have
+// the FK target rewritten to the destination, so the destination's FKs
+// resolve against itself rather than the source.
+func TestDriveri_CopyTable_RewritesSelfFK(t *testing.T) {
+	testCases := []struct {
+		name string
+		ddl  string // %[1]s is the source table name (parameterized so we
+		// exercise both quoted and unquoted FK target forms).
+	}{
+		{
+			name: "column_constraint_unquoted",
+			ddl:  `CREATE TABLE %[1]s (id INTEGER PRIMARY KEY, parent_id INTEGER REFERENCES %[1]s(id))`,
+		},
+		{
+			name: "column_constraint_quoted",
+			ddl:  `CREATE TABLE "%[1]s" (id INTEGER PRIMARY KEY, parent_id INTEGER REFERENCES "%[1]s"(id))`,
+		},
+		{
+			name: "table_constraint",
+			ddl:  `CREATE TABLE %[1]s (id INTEGER PRIMARY KEY, parent_id INTEGER, FOREIGN KEY(parent_id) REFERENCES %[1]s(id))`,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			th := testh.New(t)
+			src := &source.Source{
+				Handle:   "@test",
+				Type:     drivertype.SQLite,
+				Location: "sqlite3://" + tu.TempFile(t, "test.db"),
+			}
+			grip := th.Open(src)
+			db, err := grip.DB(th.Context)
+			require.NoError(t, err)
+			drvr := grip.SQLDriver()
+
+			// FK enforcement is required for the runtime-behavior assertion.
+			_, err = db.ExecContext(th.Context, `PRAGMA foreign_keys = ON`)
+			require.NoError(t, err)
+
+			const srcName, dstName = "actor", "actor_bak"
+			_, err = db.ExecContext(th.Context, fmt.Sprintf(tc.ddl, srcName))
+			require.NoError(t, err)
+			// Seed the source with id=1 so we can verify the destination FK
+			// does NOT resolve to it after the copy.
+			_, err = db.ExecContext(th.Context,
+				fmt.Sprintf(`INSERT INTO %q (id) VALUES (1)`, srcName))
+			require.NoError(t, err)
+
+			_, err = drvr.CopyTable(th.Context, db,
+				tablefq.T{Table: srcName}, tablefq.T{Table: dstName}, false)
+			require.NoError(t, err)
+
+			// Destination DDL must name the destination in its REFERENCES clause.
+			var destDDL string
+			require.NoError(t, db.QueryRowContext(th.Context,
+				`SELECT sql FROM sqlite_master WHERE type='table' AND name=?`, dstName).Scan(&destDDL))
+			require.Contains(t, destDDL, `REFERENCES`,
+				"destination DDL should still carry a REFERENCES clause")
+			require.True(t,
+				strings.Contains(destDDL, fmt.Sprintf(`REFERENCES %s(`, dstName)) ||
+					strings.Contains(destDDL, fmt.Sprintf(`REFERENCES "%s"(`, dstName)),
+				"REFERENCES must name the destination, got: %s", destDDL)
+			require.False(t,
+				strings.Contains(destDDL, fmt.Sprintf(`REFERENCES %s(`, srcName)) ||
+					strings.Contains(destDDL, fmt.Sprintf(`REFERENCES "%s"(`, srcName)),
+				"REFERENCES must no longer name the source, got: %s", destDDL)
+
+			// Runtime check: inserting a row whose parent_id points at id=1
+			// must fail, because id=1 lives only in the source. If the FK
+			// still pointed at the source (the gh759 bug), the insert would
+			// succeed.
+			_, err = db.ExecContext(th.Context,
+				fmt.Sprintf(`INSERT INTO %q (id, parent_id) VALUES (10, 1)`, dstName))
+			require.Error(t, err,
+				"FK must resolve to the destination; an id present only in the source must not satisfy it")
+
+			// Sanity: a self-referential insert against the destination's own
+			// row resolves cleanly.
+			_, err = db.ExecContext(th.Context,
+				fmt.Sprintf(`INSERT INTO %q (id) VALUES (2)`, dstName))
+			require.NoError(t, err)
+			_, err = db.ExecContext(th.Context,
+				fmt.Sprintf(`INSERT INTO %q (id, parent_id) VALUES (3, 2)`, dstName))
+			require.NoError(t, err)
+		})
+	}
 }
 
 // TestSourceMetadata_LocationWithConnParams reproduces gh720: a

--- a/drivers/sqlite3/sqlite3_test.go
+++ b/drivers/sqlite3/sqlite3_test.go
@@ -792,9 +792,9 @@ func TestDriveri_CopyTable_CompositeSelfFK(t *testing.T) {
 }
 
 // TestDriveri_CopyTable_PreservesOnDeleteCascade is the runtime sibling
-// of the sqlparser-level PreservesActionClauses test: prove that a self
-// FK with ON DELETE CASCADE not only round-trips textually through the
-// rewrite, but still fires against the destination table at runtime.
+// of the sqlparser-level PreservesActionClauses test: verifies that a
+// self FK with ON DELETE CASCADE round-trips textually through the
+// rewrite and still fires against the destination table at runtime.
 // Catches a regression class where the rewrite mangles the action clause
 // in some way that survives the parser's eyes but breaks SQLite's.
 func TestDriveri_CopyTable_PreservesOnDeleteCascade(t *testing.T) {

--- a/drivers/sqlite3/sqlite3_test.go
+++ b/drivers/sqlite3/sqlite3_test.go
@@ -791,6 +791,40 @@ func TestDriveri_CopyTable_CompositeSelfFK(t *testing.T) {
 		"composite FK must no longer point at link, got: %s", destDDL)
 }
 
+// TestDriveri_CopyTable_SchemaQualifiedDest verifies that a destination
+// with an explicit schema (e.g. "main"."actor_bak") rewrites the CREATE
+// TABLE identifier with the dotted form but the self-FK REFERENCES
+// target as a bare table token. SQLite's foreign_table grammar rule is
+// a single any_name; emitting "schema"."tbl" as a REFERENCES target
+// produces invalid DDL.
+func TestDriveri_CopyTable_SchemaQualifiedDest(t *testing.T) {
+	th, db, drvr := openSqliteForFKTest(t)
+
+	_, err := db.ExecContext(th.Context,
+		`CREATE TABLE actor (id INTEGER PRIMARY KEY, parent_id INTEGER REFERENCES actor(id))`)
+	require.NoError(t, err)
+	_, err = db.ExecContext(th.Context, `INSERT INTO actor (id) VALUES (1)`)
+	require.NoError(t, err)
+
+	_, err = drvr.CopyTable(th.Context, db,
+		tablefq.T{Table: "actor"},
+		tablefq.T{Schema: "main", Table: "actor_bak"},
+		false)
+	require.NoError(t, err, "CopyTable to a schema-qualified destination must succeed")
+
+	var destDDL string
+	require.NoError(t, db.QueryRowContext(th.Context,
+		`SELECT sql FROM sqlite_master WHERE type='table' AND name=?`, "actor_bak").Scan(&destDDL))
+	assertSelfFKRewritten(t, destDDL, "actor", "actor_bak")
+	require.NotContains(t, destDDL, `REFERENCES "main"."actor_bak"`,
+		"REFERENCES target must be unqualified per the SQLite grammar, got: %s", destDDL)
+
+	// Runtime: FK still enforces against the destination.
+	_, err = db.ExecContext(th.Context,
+		`INSERT INTO actor_bak (id, parent_id) VALUES (10, 1)`)
+	require.Error(t, err, "FK must enforce against the destination row set")
+}
+
 // TestDriveri_CopyTable_PreservesOnDeleteCascade is the runtime sibling
 // of the sqlparser-level PreservesActionClauses test: verifies that a
 // self FK with ON DELETE CASCADE round-trips textually through the

--- a/drivers/sqlite3/sqlparser/create_table.go
+++ b/drivers/sqlite3/sqlparser/create_table.go
@@ -111,6 +111,9 @@ func ExtractTableIdentFromCreateTableStmt(stmt string) (*TableIdent, error) {
 // (`col INTEGER REFERENCES other(id)`) and the table-constraint form
 // (`FOREIGN KEY(col) REFERENCES other(id)`) funnel through the same
 // foreign_table grammar rule, so both produce ForeignTableRef entries.
+//
+// Returned by value (not pointer) because the struct is small, logically
+// immutable after extraction, and used read-only by callers.
 type ForeignTableRef struct {
 	// RawTable is the raw text of the referenced table token as it appeared
 	// in the input, preserving any of SQLite's four legal identifier-quote
@@ -126,9 +129,14 @@ type ForeignTableRef struct {
 	TableOffset int
 }
 
+// String returns the raw text of the foreign-table reference.
+func (r ForeignTableRef) String() string {
+	return r.RawTable
+}
+
 // ExtractForeignTableRefsFromCreateTableStmt returns one ForeignTableRef per
 // REFERENCES <table> occurrence in a CREATE TABLE statement. Refs are
-// returned in source order. An empty slice (not an error) is returned when
+// returned in source order. A nil slice (and nil error) is returned when
 // the statement has no foreign-key clauses.
 func ExtractForeignTableRefsFromCreateTableStmt(stmt string) ([]ForeignTableRef, error) {
 	stmtCtx, err := parseCreateTableStmt(stmt)
@@ -143,19 +151,22 @@ func ExtractForeignTableRefsFromCreateTableStmt(stmt string) ([]ForeignTableRef,
 }
 
 // collectForeignTables descends node depth-first, appending one
-// ForeignTableRef per Foreign_tableContext encountered. The walk stops
-// descending into a foreign_table once found, since its only child is the
-// table-name any_name (a leaf for our purposes).
+// ForeignTableRef per Foreign_tableContext encountered. After recording
+// a match, the walk skips descending into the foreign_table: its only
+// child is the table-name any_name, and re-entering would risk a
+// double-record if the grammar ever grows another Foreign_tableContext
+// descendant.
 func collectForeignTables(node antlr.Tree, tokx *antlrz.TokenExtractor, out *[]ForeignTableRef) {
 	if ft, ok := node.(*sqlite.Foreign_tableContext); ok {
 		raw := tokx.Extract(ft)
-		if raw == "" {
+		table := trimIdentQuotes(raw)
+		if table == "" {
 			return
 		}
 		offset, _ := tokx.Offset(ft)
 		*out = append(*out, ForeignTableRef{
 			RawTable:    raw,
-			Table:       trimIdentQuotes(raw),
+			Table:       table,
 			TableOffset: offset,
 		})
 		return

--- a/drivers/sqlite3/sqlparser/create_table.go
+++ b/drivers/sqlite3/sqlparser/create_table.go
@@ -105,6 +105,66 @@ func ExtractTableIdentFromCreateTableStmt(stmt string) (*TableIdent, error) {
 	return ident, nil
 }
 
+// ForeignTableRef describes a single REFERENCES <table> occurrence inside a
+// CREATE TABLE statement's foreign-key clauses, with the byte offset of the
+// table token in the original input. Both the column-constraint form
+// (`col INTEGER REFERENCES other(id)`) and the table-constraint form
+// (`FOREIGN KEY(col) REFERENCES other(id)`) funnel through the same
+// foreign_table grammar rule, so both produce ForeignTableRef entries.
+type ForeignTableRef struct {
+	// RawTable is the raw text of the referenced table token as it appeared
+	// in the input, preserving any of SQLite's four legal identifier-quote
+	// styles (double-quote, single-quote, backtick, square brackets).
+	RawTable string
+
+	// Table is the referenced table name with quotes stripped. Always
+	// non-empty.
+	Table string
+
+	// TableOffset is the byte offset of RawTable in the input. The token
+	// ends at TableOffset+len(RawTable).
+	TableOffset int
+}
+
+// ExtractForeignTableRefsFromCreateTableStmt returns one ForeignTableRef per
+// REFERENCES <table> occurrence in a CREATE TABLE statement. Refs are
+// returned in source order. An empty slice (not an error) is returned when
+// the statement has no foreign-key clauses.
+func ExtractForeignTableRefsFromCreateTableStmt(stmt string) ([]ForeignTableRef, error) {
+	stmtCtx, err := parseCreateTableStmt(stmt)
+	if err != nil {
+		return nil, err
+	}
+
+	tokx := antlrz.NewTokenExtractor(stmt)
+	var refs []ForeignTableRef
+	collectForeignTables(stmtCtx, tokx, &refs)
+	return refs, nil
+}
+
+// collectForeignTables descends node depth-first, appending one
+// ForeignTableRef per Foreign_tableContext encountered. The walk stops
+// descending into a foreign_table once found, since its only child is the
+// table-name any_name (a leaf for our purposes).
+func collectForeignTables(node antlr.Tree, tokx *antlrz.TokenExtractor, out *[]ForeignTableRef) {
+	if ft, ok := node.(*sqlite.Foreign_tableContext); ok {
+		raw := tokx.Extract(ft)
+		if raw == "" {
+			return
+		}
+		offset, _ := tokx.Offset(ft)
+		*out = append(*out, ForeignTableRef{
+			RawTable:    raw,
+			Table:       trimIdentQuotes(raw),
+			TableOffset: offset,
+		})
+		return
+	}
+	for _, child := range node.GetChildren() {
+		collectForeignTables(child, tokx, out)
+	}
+}
+
 // ExtractCreateTableStmtColDefs extracts the column definitions from a CREATE
 // TABLE statement.
 func ExtractCreateTableStmtColDefs(stmt string) ([]*ColDef, error) {

--- a/drivers/sqlite3/sqlparser/sqlparser_test.go
+++ b/drivers/sqlite3/sqlparser/sqlparser_test.go
@@ -527,8 +527,8 @@ func TestExtractForeignTableRefsFromCreateTableStmt_EditIntegration(t *testing.T
 }
 
 // TestExtractForeignTableRefsFromCreateTableStmt_PreservesActionClauses
-// proves that ON DELETE / ON UPDATE / DEFERRABLE clauses after the rewritten
-// table token survive the splice — i.e. the offset/length span the table
+// verifies that ON DELETE / ON UPDATE / DEFERRABLE clauses after the rewritten
+// table token survive the splice: the offset/length span the table
 // token alone, not the surrounding clause.
 func TestExtractForeignTableRefsFromCreateTableStmt_PreservesActionClauses(t *testing.T) {
 	const input = `CREATE TABLE actor (id INTEGER PRIMARY KEY, ` +

--- a/drivers/sqlite3/sqlparser/sqlparser_test.go
+++ b/drivers/sqlite3/sqlparser/sqlparser_test.go
@@ -451,6 +451,17 @@ func TestExtractForeignTableRefsFromCreateTableStmt(t *testing.T) {
 			in:    `NOT A CREATE STATEMENT`,
 			isErr: true,
 		},
+		{
+			// Pins the grammar contract the gh759 fix relies on: SQLite's
+			// foreign_table rule is a single any_name, so a schema-qualified
+			// REFERENCES target must be rejected by the parser. Without this
+			// case, a future grammar relaxation could let the runtime fix
+			// (drivers/*/CopyTable using bare-table-only for FK targets)
+			// silently round-trip an invalid form.
+			name:  "fk_target_with_schema_qualifier_rejected",
+			in:    `CREATE TABLE actor (id INTEGER, parent_id INTEGER REFERENCES "main"."actor"(id))`,
+			isErr: true,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/drivers/sqlite3/sqlparser/sqlparser_test.go
+++ b/drivers/sqlite3/sqlparser/sqlparser_test.go
@@ -403,9 +403,48 @@ func TestExtractForeignTableRefsFromCreateTableStmt(t *testing.T) {
 			want: []sqlparser.ForeignTableRef{{RawTable: "[actor]", Table: "actor"}},
 		},
 		{
+			name: "fk_target_with_backtick_quotes",
+			in:   "CREATE TABLE actor (id INTEGER, parent_id INTEGER REFERENCES `actor`(id))",
+			want: []sqlparser.ForeignTableRef{{RawTable: "`actor`", Table: "actor"}},
+		},
+		{
+			name: "fk_target_with_single_quote_quotes",
+			in:   `CREATE TABLE actor (id INTEGER, parent_id INTEGER REFERENCES 'actor'(id))`,
+			want: []sqlparser.ForeignTableRef{{RawTable: `'actor'`, Table: "actor"}},
+		},
+		{
 			name: "fk_target_case_preserved",
 			in:   `CREATE TABLE actor (id INTEGER, parent_id INTEGER REFERENCES Actor(id))`,
 			want: []sqlparser.ForeignTableRef{{RawTable: "Actor", Table: "Actor"}},
+		},
+		{
+			name: "column_constraint_self_fk_with_on_delete_cascade",
+			in:   `CREATE TABLE actor (id INTEGER, parent_id INTEGER REFERENCES actor(id) ON DELETE CASCADE)`,
+			want: []sqlparser.ForeignTableRef{{RawTable: "actor", Table: "actor"}},
+		},
+		{
+			name: "table_constraint_with_on_delete_set_null_on_update_cascade",
+			in: `CREATE TABLE actor (id INTEGER, parent_id INTEGER, ` +
+				`FOREIGN KEY(parent_id) REFERENCES actor(id) ON DELETE SET NULL ON UPDATE CASCADE)`,
+			want: []sqlparser.ForeignTableRef{{RawTable: "actor", Table: "actor"}},
+		},
+		{
+			name: "column_constraint_deferrable",
+			in: `CREATE TABLE actor (id INTEGER, parent_id INTEGER ` +
+				`REFERENCES actor(id) DEFERRABLE INITIALLY DEFERRED)`,
+			want: []sqlparser.ForeignTableRef{{RawTable: "actor", Table: "actor"}},
+		},
+		{
+			name: "composite_self_fk",
+			in: `CREATE TABLE link (a INTEGER, b INTEGER, x INTEGER, y INTEGER, ` +
+				`FOREIGN KEY(a, b) REFERENCES link(x, y))`,
+			want: []sqlparser.ForeignTableRef{{RawTable: "link", Table: "link"}},
+		},
+		{
+			name: "fk_target_multi_column_parent_list",
+			in: `CREATE TABLE child (a INTEGER, b INTEGER, ` +
+				`FOREIGN KEY(a, b) REFERENCES parent(x, y))`,
+			want: []sqlparser.ForeignTableRef{{RawTable: "parent", Table: "parent"}},
 		},
 		{
 			name:  "invalid_stmt",
@@ -433,6 +472,16 @@ func TestExtractForeignTableRefsFromCreateTableStmt(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestForeignTableRef_String verifies the String() method returns the raw
+// text of the reference, for log/debug ergonomics on par with ColDef.
+func TestForeignTableRef_String(t *testing.T) {
+	const input = `CREATE TABLE actor (id INTEGER, parent_id INTEGER REFERENCES "actor"(id))`
+	refs, err := sqlparser.ExtractForeignTableRefsFromCreateTableStmt(input)
+	require.NoError(t, err)
+	require.Len(t, refs, 1)
+	require.Equal(t, `"actor"`, refs[0].String())
 }
 
 // TestExtractForeignTableRefsFromCreateTableStmt_EditIntegration is the
@@ -475,6 +524,31 @@ func TestExtractForeignTableRefsFromCreateTableStmt_EditIntegration(t *testing.T
 	require.Equal(t, want, got)
 	require.False(t, strings.Contains(got, `"actor"`),
 		"every self-FK occurrence must be rewritten")
+}
+
+// TestExtractForeignTableRefsFromCreateTableStmt_PreservesActionClauses
+// proves that ON DELETE / ON UPDATE / DEFERRABLE clauses after the rewritten
+// table token survive the splice — i.e. the offset/length span the table
+// token alone, not the surrounding clause.
+func TestExtractForeignTableRefsFromCreateTableStmt_PreservesActionClauses(t *testing.T) {
+	const input = `CREATE TABLE actor (id INTEGER PRIMARY KEY, ` +
+		`parent_id INTEGER REFERENCES actor(id) ON DELETE CASCADE ON UPDATE RESTRICT ` +
+		`DEFERRABLE INITIALLY DEFERRED)`
+
+	refs, err := sqlparser.ExtractForeignTableRefsFromCreateTableStmt(input)
+	require.NoError(t, err)
+	require.Len(t, refs, 1)
+	r := refs[0]
+	got, err := sqlparser.ApplyEdits(input, []sqlparser.Edit{{
+		Start:       r.TableOffset,
+		End:         r.TableOffset + len(r.RawTable),
+		Replacement: "actor_bak",
+	}})
+	require.NoError(t, err)
+	const want = `CREATE TABLE actor (id INTEGER PRIMARY KEY, ` +
+		`parent_id INTEGER REFERENCES actor_bak(id) ON DELETE CASCADE ON UPDATE RESTRICT ` +
+		`DEFERRABLE INITIALLY DEFERRED)`
+	require.Equal(t, want, got)
 }
 
 // TestApplyEdits_DDLRewriteIntegration sanity-checks the end-to-end story

--- a/drivers/sqlite3/sqlparser/sqlparser_test.go
+++ b/drivers/sqlite3/sqlparser/sqlparser_test.go
@@ -353,6 +353,130 @@ func TestApplyEdits(t *testing.T) {
 	}
 }
 
+// TestExtractForeignTableRefsFromCreateTableStmt covers the helper that
+// powers gh759's self-FK rewrite in CopyTable: every REFERENCES <table>
+// occurrence inside a CREATE TABLE stmt must come back with a byte offset
+// that round-trips against the input.
+func TestExtractForeignTableRefsFromCreateTableStmt(t *testing.T) {
+	testCases := []struct {
+		name  string
+		in    string
+		want  []sqlparser.ForeignTableRef
+		isErr bool
+	}{
+		{
+			name: "no_fks",
+			in:   `CREATE TABLE actor (id INTEGER PRIMARY KEY, name TEXT)`,
+			want: nil,
+		},
+		{
+			name: "column_constraint_self_fk_unquoted",
+			in:   `CREATE TABLE actor (id INTEGER PRIMARY KEY, parent_id INTEGER REFERENCES actor(id))`,
+			want: []sqlparser.ForeignTableRef{{RawTable: "actor", Table: "actor"}},
+		},
+		{
+			name: "column_constraint_self_fk_quoted",
+			in:   `CREATE TABLE "actor" (id INTEGER, parent_id INTEGER REFERENCES "actor"(id))`,
+			want: []sqlparser.ForeignTableRef{{RawTable: `"actor"`, Table: "actor"}},
+		},
+		{
+			name: "table_constraint_self_fk",
+			in:   `CREATE TABLE actor (id INTEGER, parent_id INTEGER, FOREIGN KEY (parent_id) REFERENCES actor(id))`,
+			want: []sqlparser.ForeignTableRef{{RawTable: "actor", Table: "actor"}},
+		},
+		{
+			name: "cross_table_fk_only",
+			in:   `CREATE TABLE address (id INTEGER, city_id INTEGER REFERENCES city(id))`,
+			want: []sqlparser.ForeignTableRef{{RawTable: "city", Table: "city"}},
+		},
+		{
+			name: "mixed_fks_in_source_order",
+			in:   `CREATE TABLE film (id INTEGER, lang INTEGER REFERENCES language(id), parent INTEGER REFERENCES film(id))`,
+			want: []sqlparser.ForeignTableRef{
+				{RawTable: "language", Table: "language"},
+				{RawTable: "film", Table: "film"},
+			},
+		},
+		{
+			name: "fk_target_with_square_bracket_quotes",
+			in:   `CREATE TABLE actor (id INTEGER, parent_id INTEGER REFERENCES [actor](id))`,
+			want: []sqlparser.ForeignTableRef{{RawTable: "[actor]", Table: "actor"}},
+		},
+		{
+			name: "fk_target_case_preserved",
+			in:   `CREATE TABLE actor (id INTEGER, parent_id INTEGER REFERENCES Actor(id))`,
+			want: []sqlparser.ForeignTableRef{{RawTable: "Actor", Table: "Actor"}},
+		},
+		{
+			name:  "invalid_stmt",
+			in:    `NOT A CREATE STATEMENT`,
+			isErr: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := sqlparser.ExtractForeignTableRefsFromCreateTableStmt(tc.in)
+			if tc.isErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Len(t, got, len(tc.want))
+			for i, w := range tc.want {
+				require.Equal(t, w.RawTable, got[i].RawTable, "RawTable mismatch at index %d", i)
+				require.Equal(t, w.Table, got[i].Table, "Table mismatch at index %d", i)
+				// Offsets must round-trip against the input.
+				require.Equal(t, got[i].RawTable,
+					tc.in[got[i].TableOffset:got[i].TableOffset+len(got[i].RawTable)],
+					"TableOffset must point at RawTable in the input at index %d", i)
+			}
+		})
+	}
+}
+
+// TestExtractForeignTableRefsFromCreateTableStmt_EditIntegration is the
+// end-to-end story for gh759: every self-FK offset becomes an
+// ApplyEdits Edit alongside the table-identifier edit, and the rewritten
+// DDL points all self-FKs at the destination.
+func TestExtractForeignTableRefsFromCreateTableStmt_EditIntegration(t *testing.T) {
+	const input = `CREATE TABLE "actor" (id INTEGER PRIMARY KEY, ` +
+		`parent_id INTEGER REFERENCES "actor"(id), ` +
+		`buddy INTEGER REFERENCES "actor"(id))`
+
+	ident, err := sqlparser.ExtractTableIdentFromCreateTableStmt(input)
+	require.NoError(t, err)
+	refs, err := sqlparser.ExtractForeignTableRefsFromCreateTableStmt(input)
+	require.NoError(t, err)
+	require.Len(t, refs, 2)
+
+	const destQuoted = `"actor_bak"`
+	edits := []sqlparser.Edit{{
+		Start:       ident.TableOffset,
+		End:         ident.TableOffset + len(ident.RawTable),
+		Replacement: destQuoted,
+	}}
+	for _, r := range refs {
+		if !strings.EqualFold(r.Table, ident.Table) {
+			continue
+		}
+		edits = append(edits, sqlparser.Edit{
+			Start:       r.TableOffset,
+			End:         r.TableOffset + len(r.RawTable),
+			Replacement: destQuoted,
+		})
+	}
+
+	got, err := sqlparser.ApplyEdits(input, edits)
+	require.NoError(t, err)
+	const want = `CREATE TABLE "actor_bak" (id INTEGER PRIMARY KEY, ` +
+		`parent_id INTEGER REFERENCES "actor_bak"(id), ` +
+		`buddy INTEGER REFERENCES "actor_bak"(id))`
+	require.Equal(t, want, got)
+	require.False(t, strings.Contains(got, `"actor"`),
+		"every self-FK occurrence must be rewritten")
+}
+
 // TestApplyEdits_DDLRewriteIntegration sanity-checks the end-to-end story
 // that motivates gh750: parser offsets feed ApplyEdits, and the resulting
 // DDL is correct even when the column name shares a prefix with its type


### PR DESCRIPTION
Fixes #759.

## Summary

- New shared helper `ExtractForeignTableRefsFromCreateTableStmt` in the SQLite `sqlparser` package: walks the parsed CREATE TABLE AST for every `foreign_table` node and returns its raw text, dequoted name, and byte offset.
- Both `CopyTable` impls (sqlite3, rqlite) now emit one `sqlparser.Edit` per FK ref whose dequoted name case-insensitively matches the source table, alongside the existing table-identifier edit. Cross-table FKs are left untouched. Slot into the same `ApplyEdits` path that landed in #763.
- rqlite godoc drops its "Known limitation" note; sqlite3 godoc gains a matching FK-rewrite paragraph.

## Why

PR #748 (gh737) landed the faithful-DDL-rewrite shape but `strings.Replace(..., 1)` only touched the `CREATE TABLE <ident>` token. A self-FK `REFERENCES "actor"(id)` survived the copy verbatim, so `actor_bak`'s FKs resolved against `actor`'s row set, not its own. The cheap regex-replace approximation discussed in the issue would have inherited the substring-collision class tracked by #750; the parser-based offset rewrite is the proper fix.

## Test plan

- [x] `make lint` clean.
- [x] `go test -short ./drivers/sqlite3/...` (sqlparser + sqlite3 driver). New `TestExtractForeignTableRefsFromCreateTableStmt` covers no-FK, column-constraint, table-constraint, cross-table-only, mixed-source-order, square-bracket quoting, case-preserved quoting, and parse-error inputs. New `TestExtractForeignTableRefsFromCreateTableStmt_EditIntegration` proves the offsets compose with `ApplyEdits` end-to-end.
- [x] `go test ./drivers/sqlite3/ -run TestDriveri_CopyTable_RewritesSelfFK` — table-driven across all three FK forms; with `PRAGMA foreign_keys = ON`, asserts the destination DDL `REFERENCES` names the destination AND that an insert pointing at a source-only id is refused.
- [x] `SQ_TEST_SRC__SAKILA_RQ=localhost:4001 go test ./drivers/rqlite/ -run TestCopyTable` — all 10 CopyTable tests pass, including the new `TestCopyTable_RewritesSelfFK`. The rqlite test uses `TableMetadata.FK.Outgoing[0].RefTable` for the structural check; the runtime FK enforcement axis is covered by the sqlite3 sibling (rqlite's stateless HTTP transport makes per-connection PRAGMA unreliable).