### PR TITLE
gh757: AlterTableColumnKinds preserves AUTOINCREMENT sequence (sqlite3 + rqlite)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -181,6 +181,13 @@ keyring support) and support for [rqlite](https://sq.io/docs/drivers/rqlite).
   FKs resolved against the source table instead of itself. The shared
   `sqlparser` package gains `ExtractForeignTableRefsFromCreateTableStmt` for
   this rewrite; cross-table FKs are left alone.
+- [#757]: `AlterTableColumnKinds` on the [sqlite3](https://sq.io/docs/drivers/sqlite)
+  and [rqlite](https://sq.io/docs/drivers/rqlite) drivers now preserves
+  AUTOINCREMENT sequence continuity across the table rebuild. Previously the
+  rebuild's `DROP TABLE` removed the table's `sqlite_sequence` row, so the next
+  insert picked `MAX(rowid)+1` rather than `seq+1`, silently reusing rowids of
+  previously deleted rows. The original `seq` is now captured before the
+  rebuild and restored afterward.
 
 ## [v0.53.0] - 2026-05-25
 
@@ -1764,6 +1771,7 @@ make working with lots of sources much easier.
 [#744]: https://github.com/neilotoole/sq/issues/744
 [#750]: https://github.com/neilotoole/sq/issues/750
 [#752]: https://github.com/neilotoole/sq/issues/752
+[#757]: https://github.com/neilotoole/sq/issues/757
 [#759]: https://github.com/neilotoole/sq/issues/759
 
 [v0.15.2]: https://github.com/neilotoole/sq/releases/tag/v0.15.2

--- a/drivers/rqlite/rqlite.go
+++ b/drivers/rqlite/rqlite.go
@@ -841,8 +841,9 @@ func (d *driveri) AlterTableRenameColumn(ctx context.Context, db sqlz.DB, tbl, c
 // removes the original table's sqlite_sequence row, so the row is
 // captured outside the batch and restored as part of the batch after
 // the rename, matching the sqlite3 driver. The restore takes
-// max(seq, captured), so a sequence advanced by writes between the
-// capture read and the batch is never moved backward.
+// max(seq, captured), so it never lowers the value the rebuilt table
+// already holds; like the rebuild as a whole, it makes no guarantee
+// against writes that race the batch.
 func (d *driveri) AlterTableColumnKinds(ctx context.Context, db sqlz.DB,
 	tbl string, colNames []string, kinds []kind.Kind,
 ) error {
@@ -942,11 +943,12 @@ func (d *driveri) AlterTableColumnKinds(ctx context.Context, db sqlz.DB,
 		// rebuilt table's sqlite_sequence row, created by the copy and
 		// renamed along with the table, holds MAX(rowid) of the copied
 		// rows (0 if the copy moved no rows) rather than the original
-		// seq. The UPDATE takes max(seq, captured) so the sequence never
-		// moves backward, even if the capture read (outside the batch)
-		// was stale; the conditional INSERT covers the case of no row
-		// existing. sqlite_sequence has no unique constraint on name,
-		// which rules out INSERT OR REPLACE.
+		// seq. The UPDATE takes max(seq, captured) so the restore never
+		// lowers the value already in place, even if the capture read
+		// (outside the batch) returned a stale low value; the conditional
+		// INSERT covers the case of no row existing. sqlite_sequence has
+		// no unique constraint on name, which rules out INSERT OR
+		// REPLACE.
 		stmts = append(stmts,
 			gorqlite.ParameterizedStatement{
 				Query:     "UPDATE sqlite_sequence SET seq = max(seq, ?) WHERE name = ?",

--- a/drivers/rqlite/rqlite.go
+++ b/drivers/rqlite/rqlite.go
@@ -834,12 +834,15 @@ func (d *driveri) AlterTableRenameColumn(ctx context.Context, db sqlz.DB, tbl, c
 // exact DEFAULT expressions, WITHOUT ROWID, and column comments.
 // Self-referential FKs resolve correctly because the DROP-and-
 // RENAME-back restores the original table name (the inner REFERENCES
-// clause is untouched by the count=1 substring replace).
+// clause is untouched because the rewrite is anchored to the table
+// identifier's byte offset).
 //
 // AUTOINCREMENT sequence continuity is preserved (gh757): the DROP
 // removes the original table's sqlite_sequence row, so the row is
 // captured outside the batch and restored as part of the batch after
-// the rename, matching the sqlite3 driver.
+// the rename, matching the sqlite3 driver. The restore takes
+// max(seq, captured), so a sequence advanced by writes between the
+// capture read and the batch is never moved backward.
 func (d *driveri) AlterTableColumnKinds(ctx context.Context, db sqlz.DB,
 	tbl string, colNames []string, kinds []kind.Kind,
 ) error {
@@ -937,18 +940,22 @@ func (d *driveri) AlterTableColumnKinds(ctx context.Context, db sqlz.DB,
 	if srcSeq.Valid {
 		// Restore AUTOINCREMENT continuity (gh757). After the rename, the
 		// rebuilt table's sqlite_sequence row, created by the copy and
-		// renamed along with the table, holds MAX(rowid) rather than the
-		// original seq; if the source table was empty, no row exists at
-		// all. sqlite_sequence has no unique constraint on name, so
-		// DELETE-then-INSERT rather than INSERT OR REPLACE.
+		// renamed along with the table, holds MAX(rowid) of the copied
+		// rows (0 if the copy moved no rows) rather than the original
+		// seq. The UPDATE takes max(seq, captured) so the sequence never
+		// moves backward, even if the capture read (outside the batch)
+		// was stale; the conditional INSERT covers the case of no row
+		// existing. sqlite_sequence has no unique constraint on name,
+		// which rules out INSERT OR REPLACE.
 		stmts = append(stmts,
 			gorqlite.ParameterizedStatement{
-				Query:     "DELETE FROM sqlite_sequence WHERE name=?",
-				Arguments: []any{tbl},
+				Query:     "UPDATE sqlite_sequence SET seq = max(seq, ?) WHERE name = ?",
+				Arguments: []any{srcSeq.Int64, tbl},
 			},
 			gorqlite.ParameterizedStatement{
-				Query:     "INSERT INTO sqlite_sequence (name, seq) VALUES (?, ?)",
-				Arguments: []any{tbl, srcSeq.Int64},
+				Query: "INSERT INTO sqlite_sequence (name, seq) SELECT ?, ? " +
+					"WHERE NOT EXISTS (SELECT 1 FROM sqlite_sequence WHERE name = ?)",
+				Arguments: []any{tbl, srcSeq.Int64, tbl},
 			},
 		)
 	}

--- a/drivers/rqlite/rqlite.go
+++ b/drivers/rqlite/rqlite.go
@@ -28,6 +28,7 @@ package rqlite
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/url"
@@ -815,9 +816,10 @@ func (d *driveri) AlterTableRenameColumn(ctx context.Context, db sqlz.DB, tbl, c
 //	INSERT INTO <tmp> SELECT * FROM <original>
 //	DROP TABLE <original>
 //	ALTER TABLE <tmp> RENAME TO <original>
+//	(restore sqlite_sequence row, if the original table had one)
 //	PRAGMA foreign_keys=<prev>
 //
-// All six statements ride one /db/execute HTTP call and are atomic
+// All statements ride one /db/execute HTTP call and are atomic
 // at rqlite. The prior foreign_keys value is read outside the batch
 // (rqlite has no interactive transactions) and inlined as the final
 // statement, restoring the session state rather than blindly forcing
@@ -834,10 +836,10 @@ func (d *driveri) AlterTableRenameColumn(ctx context.Context, db sqlz.DB, tbl, c
 // RENAME-back restores the original table name (the inner REFERENCES
 // clause is untouched by the count=1 substring replace).
 //
-// Inherited gap (matches sqlite3 driver): AUTOINCREMENT sequence
-// continuity is not preserved. The sqlite_sequence row for the
-// original table is removed by the DROP, so after the rename
-// AUTOINCREMENT restarts from MAX(rowid)+1 rather than seq+1.
+// AUTOINCREMENT sequence continuity is preserved (gh757): the DROP
+// removes the original table's sqlite_sequence row, so the row is
+// captured outside the batch and restored as part of the batch after
+// the rename, matching the sqlite3 driver.
 func (d *driveri) AlterTableColumnKinds(ctx context.Context, db sqlz.DB,
 	tbl string, colNames []string, kinds []kind.Kind,
 ) error {
@@ -913,6 +915,15 @@ func (d *driveri) AlterTableColumnKinds(ctx context.Context, db sqlz.DB,
 		return errz.Wrapf(errw(err), "rqlite: alter table: failed to read foreign_keys pragma")
 	}
 
+	// Capture the table's sqlite_sequence row (if any) outside the batch.
+	// The DROP TABLE in the batch removes the row, so without a restore
+	// the next AUTOINCREMENT insert would pick MAX(rowid)+1 rather than
+	// seq+1, silently reusing rowids of previously deleted rows (gh757).
+	srcSeq, err := readSqliteSequence(ctx, db, tbl)
+	if err != nil {
+		return err
+	}
+
 	stmts := []gorqlite.ParameterizedStatement{
 		{Query: "PRAGMA foreign_keys=off"},
 		{Query: nuDDL},
@@ -921,9 +932,60 @@ func (d *driveri) AlterTableColumnKinds(ctx context.Context, db sqlz.DB,
 		{Query: "DROP TABLE " + stringz.DoubleQuote(tbl)},
 		{Query: fmt.Sprintf(`ALTER TABLE %s RENAME TO %s`,
 			stringz.DoubleQuote(tmpName), stringz.DoubleQuote(tbl))},
-		{Query: fmt.Sprintf("PRAGMA foreign_keys=%d", fkPrev)},
 	}
+
+	if srcSeq.Valid {
+		// Restore AUTOINCREMENT continuity (gh757). After the rename, the
+		// rebuilt table's sqlite_sequence row, created by the copy and
+		// renamed along with the table, holds MAX(rowid) rather than the
+		// original seq; if the source table was empty, no row exists at
+		// all. sqlite_sequence has no unique constraint on name, so
+		// DELETE-then-INSERT rather than INSERT OR REPLACE.
+		stmts = append(stmts,
+			gorqlite.ParameterizedStatement{
+				Query:     "DELETE FROM sqlite_sequence WHERE name=?",
+				Arguments: []any{tbl},
+			},
+			gorqlite.ParameterizedStatement{
+				Query:     "INSERT INTO sqlite_sequence (name, seq) VALUES (?, ?)",
+				Arguments: []any{tbl, srcSeq.Int64},
+			},
+		)
+	}
+
+	stmts = append(stmts, gorqlite.ParameterizedStatement{
+		Query: fmt.Sprintf("PRAGMA foreign_keys=%d", fkPrev),
+	})
 
 	_, err = writeAtomic(ctx, db, stmts...)
 	return err
+}
+
+// readSqliteSequence returns the sqlite_sequence row for tbl. The result is
+// invalid (and err nil) if the sqlite_sequence table doesn't exist, or has
+// no row for tbl. Mirrors the sqlite3 driver's helper of the same name.
+func readSqliteSequence(ctx context.Context, db sqlz.DB, tbl string) (sql.NullInt64, error) {
+	var seq sql.NullInt64
+
+	// sqlite_sequence only exists once an AUTOINCREMENT table has been
+	// created in the DB; querying it blindly would error.
+	var n int
+	if err := db.QueryRowContext(ctx,
+		"SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='sqlite_sequence'",
+	).Scan(&n); err != nil {
+		return seq, errz.Wrap(errw(err),
+			"rqlite: alter table: failed to check for sqlite_sequence table")
+	}
+	if n == 0 {
+		return seq, nil
+	}
+
+	if err := db.QueryRowContext(ctx,
+		"SELECT seq FROM sqlite_sequence WHERE name=?", tbl,
+	).Scan(&seq); err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return seq, errz.Wrapf(errw(err),
+			"rqlite: alter table: failed to read sqlite_sequence for {%s}", tbl)
+	}
+
+	return seq, nil
 }

--- a/drivers/rqlite/rqlite_test.go
+++ b/drivers/rqlite/rqlite_test.go
@@ -397,6 +397,63 @@ func TestAlterTableColumnKinds(t *testing.T) {
 	require.Equal(t, "hello", gotB)
 }
 
+// TestAlterTableColumnKinds_PreservesAutoincrementSeq reproduces gh757: the
+// table-rebuild dance in AlterTableColumnKinds dropped the original table,
+// which removed its sqlite_sequence row, so AUTOINCREMENT restarted from
+// MAX(rowid)+1 instead of seq+1. With rows previously deleted from the high
+// end, the next insert silently reused their ids. Mirrors the sqlite3
+// driver test.
+func TestAlterTableColumnKinds_PreservesAutoincrementSeq(t *testing.T) {
+	tu.SkipShort(t, true)
+	t.Parallel()
+
+	th := testh.New(t)
+	src := th.Source(sakila.Rq)
+	grip := th.Open(src)
+	drvr := grip.SQLDriver()
+	db, err := grip.DB(th.Context)
+	require.NoError(t, err)
+
+	tblName := "seqtbl_" + stringz.Uniq8()
+	t.Cleanup(func() {
+		_ = drvr.DropTable(th.Context, db, tablefq.T{Table: tblName}, true)
+	})
+
+	_, err = db.ExecContext(th.Context, fmt.Sprintf(
+		`CREATE TABLE %q (id INTEGER PRIMARY KEY AUTOINCREMENT, val INTEGER NOT NULL)`, tblName))
+	require.NoError(t, err)
+
+	for i := 1; i <= 10; i++ {
+		_, err = db.ExecContext(th.Context,
+			fmt.Sprintf(`INSERT INTO %q (val) VALUES (?)`, tblName), i)
+		require.NoError(t, err)
+	}
+	_, err = db.ExecContext(th.Context,
+		fmt.Sprintf(`DELETE FROM %q WHERE id > 5`, tblName))
+	require.NoError(t, err)
+
+	var seq, maxID int64
+	require.NoError(t, db.QueryRowContext(th.Context,
+		`SELECT seq FROM sqlite_sequence WHERE name=?`, tblName).Scan(&seq))
+	require.Equal(t, int64(10), seq)
+	require.NoError(t, db.QueryRowContext(th.Context,
+		fmt.Sprintf(`SELECT MAX(id) FROM %q`, tblName)).Scan(&maxID))
+	require.Equal(t, int64(5), maxID)
+
+	require.NoError(t, drvr.AlterTableColumnKinds(th.Context, db, tblName,
+		[]string{"val"}, []kind.Kind{kind.Text}))
+
+	_, err = db.ExecContext(th.Context,
+		fmt.Sprintf(`INSERT INTO %q (val) VALUES ('post-alter')`, tblName))
+	require.NoError(t, err)
+
+	var newID int64
+	require.NoError(t, db.QueryRowContext(th.Context,
+		fmt.Sprintf(`SELECT id FROM %q WHERE val = 'post-alter'`, tblName)).Scan(&newID))
+	require.Equal(t, int64(11), newID,
+		"AUTOINCREMENT must continue from the preserved sequence (seq+1), not MAX(rowid)+1")
+}
+
 // TestAlterTableColumnKinds_QuotedIdentifier reproduces gh752: a column
 // declared with any of SQLite's four legal identifier-quoting styles
 // (double-quote, single-quote, backtick, square brackets) used to fail the

--- a/drivers/sqlite3/alter.go
+++ b/drivers/sqlite3/alter.go
@@ -49,6 +49,10 @@ func (d *driveri) AlterTableAddColumn(ctx context.Context, db sqlz.DB, tbl, col 
 //   - https://www.sqlite.org/faq.html#q11
 //   - https://www.sqlitetutorial.net/sqlite-alter-table/
 //
+// AUTOINCREMENT sequence continuity is preserved across the rebuild (gh757):
+// the table's sqlite_sequence row is captured before the rebuild and restored
+// afterward, so the next insert picks seq+1 rather than MAX(rowid)+1.
+//
 // Note that colNames and kinds must be the same length.
 func (d *driveri) AlterTableColumnKinds(ctx context.Context, db sqlz.DB,
 	tblName string, colNames []string, kinds []kind.Kind,
@@ -156,20 +160,27 @@ func (d *driveri) AlterTableColumnKinds(ctx context.Context, db sqlz.DB,
 	if srcSeq.Valid {
 		// Restore AUTOINCREMENT continuity (gh757). At this point the
 		// rebuilt table's sqlite_sequence row, created by the copy and
-		// renamed along with the table, holds MAX(rowid) rather than the
-		// original seq; if the source table was empty, no row exists at
-		// all. sqlite_sequence has no unique constraint on name, so
-		// DELETE-then-INSERT rather than INSERT OR REPLACE.
+		// renamed along with the table, holds MAX(rowid) of the copied
+		// rows (0 if the copy moved no rows) rather than the original
+		// seq. The UPDATE takes max(seq, captured) so the sequence never
+		// moves backward, and the conditional INSERT covers the case of
+		// no row existing. Neither statement destroys state, so a failure
+		// here can't lose the live sequence value. sqlite_sequence has no
+		// unique constraint on name, which rules out INSERT OR REPLACE.
 		if _, err = db.ExecContext(ctx,
-			"DELETE FROM sqlite_sequence WHERE name=?", tblName); err != nil {
+			"UPDATE sqlite_sequence SET seq = max(seq, ?) WHERE name = ?",
+			srcSeq.Int64, tblName); err != nil {
 			return errz.Wrapf(errw(err),
-				"sqlite3: alter table: failed to clear sqlite_sequence for {%s}", tblName)
+				"sqlite3: alter table: table {%s} was rebuilt, but updating sqlite_sequence to %d failed",
+				tblName, srcSeq.Int64)
 		}
 		if _, err = db.ExecContext(ctx,
-			"INSERT INTO sqlite_sequence (name, seq) VALUES (?, ?)",
-			tblName, srcSeq.Int64); err != nil {
+			"INSERT INTO sqlite_sequence (name, seq) SELECT ?, ? "+
+				"WHERE NOT EXISTS (SELECT 1 FROM sqlite_sequence WHERE name = ?)",
+			tblName, srcSeq.Int64, tblName); err != nil {
 			return errz.Wrapf(errw(err),
-				"sqlite3: alter table: failed to restore sqlite_sequence for {%s}", tblName)
+				"sqlite3: alter table: table {%s} was rebuilt, but restoring sqlite_sequence to %d failed",
+				tblName, srcSeq.Int64)
 		}
 	}
 

--- a/drivers/sqlite3/alter.go
+++ b/drivers/sqlite3/alter.go
@@ -2,6 +2,8 @@ package sqlite3
 
 import (
 	"context"
+	"database/sql"
+	"errors"
 	"fmt"
 
 	"github.com/neilotoole/sq/drivers/sqlite3/sqlparser"
@@ -66,6 +68,15 @@ func (d *driveri) AlterTableColumnKinds(ctx context.Context, db sqlz.DB,
 	var ogDDL string
 	if err = db.QueryRowContext(ctx, q, tblName).Scan(&ogDDL); err != nil {
 		return errz.Wrapf(err, "sqlite3: alter table: failed to read original DDL")
+	}
+
+	// Capture the table's sqlite_sequence row (if any) before the rebuild.
+	// The DROP TABLE below removes the row, so without a restore the next
+	// AUTOINCREMENT insert would pick MAX(rowid)+1 rather than seq+1,
+	// silently reusing rowids of previously deleted rows (gh757).
+	srcSeq, err := readSqliteSequence(ctx, db, tblName)
+	if err != nil {
+		return err
 	}
 
 	allColDefs, err := sqlparser.ExtractCreateTableStmtColDefs(ogDDL)
@@ -142,7 +153,56 @@ func (d *driveri) AlterTableColumnKinds(ctx context.Context, db sqlz.DB,
 		return errz.Wrapf(err, "sqlite3: alter table: failed to rename temporary table")
 	}
 
+	if srcSeq.Valid {
+		// Restore AUTOINCREMENT continuity (gh757). At this point the
+		// rebuilt table's sqlite_sequence row, created by the copy and
+		// renamed along with the table, holds MAX(rowid) rather than the
+		// original seq; if the source table was empty, no row exists at
+		// all. sqlite_sequence has no unique constraint on name, so
+		// DELETE-then-INSERT rather than INSERT OR REPLACE.
+		if _, err = db.ExecContext(ctx,
+			"DELETE FROM sqlite_sequence WHERE name=?", tblName); err != nil {
+			return errz.Wrapf(errw(err),
+				"sqlite3: alter table: failed to clear sqlite_sequence for {%s}", tblName)
+		}
+		if _, err = db.ExecContext(ctx,
+			"INSERT INTO sqlite_sequence (name, seq) VALUES (?, ?)",
+			tblName, srcSeq.Int64); err != nil {
+			return errz.Wrapf(errw(err),
+				"sqlite3: alter table: failed to restore sqlite_sequence for {%s}", tblName)
+		}
+	}
+
 	return nil
+}
+
+// readSqliteSequence returns the sqlite_sequence row for tbl. The result is
+// invalid (and err nil) if the sqlite_sequence table doesn't exist, or has
+// no row for tbl.
+func readSqliteSequence(ctx context.Context, db sqlz.DB, tbl string) (sql.NullInt64, error) {
+	var seq sql.NullInt64
+
+	// sqlite_sequence only exists once an AUTOINCREMENT table has been
+	// created in the DB; querying it blindly would error.
+	var n int
+	if err := db.QueryRowContext(ctx,
+		"SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='sqlite_sequence'",
+	).Scan(&n); err != nil {
+		return seq, errz.Wrap(errw(err),
+			"sqlite3: alter table: failed to check for sqlite_sequence table")
+	}
+	if n == 0 {
+		return seq, nil
+	}
+
+	if err := db.QueryRowContext(ctx,
+		"SELECT seq FROM sqlite_sequence WHERE name=?", tbl,
+	).Scan(&seq); err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return seq, errz.Wrapf(errw(err),
+			"sqlite3: alter table: failed to read sqlite_sequence for {%s}", tbl)
+	}
+
+	return seq, nil
 }
 
 // pragmaDisableForeignKeys disables foreign keys, returning a function that

--- a/drivers/sqlite3/alter.go
+++ b/drivers/sqlite3/alter.go
@@ -162,11 +162,12 @@ func (d *driveri) AlterTableColumnKinds(ctx context.Context, db sqlz.DB,
 		// rebuilt table's sqlite_sequence row, created by the copy and
 		// renamed along with the table, holds MAX(rowid) of the copied
 		// rows (0 if the copy moved no rows) rather than the original
-		// seq. The UPDATE takes max(seq, captured) so the sequence never
-		// moves backward, and the conditional INSERT covers the case of
-		// no row existing. Neither statement destroys state, so a failure
-		// here can't lose the live sequence value. sqlite_sequence has no
-		// unique constraint on name, which rules out INSERT OR REPLACE.
+		// seq. The UPDATE takes max(seq, captured) so the restore never
+		// lowers the value already in place, and the conditional INSERT
+		// covers the case of no row existing. Neither statement destroys
+		// state, so a failure here can't lose the live sequence value.
+		// sqlite_sequence has no unique constraint on name, which rules
+		// out INSERT OR REPLACE.
 		if _, err = db.ExecContext(ctx,
 			"UPDATE sqlite_sequence SET seq = max(seq, ?) WHERE name = ?",
 			srcSeq.Int64, tblName); err != nil {

--- a/drivers/sqlite3/sqlite3_test.go
+++ b/drivers/sqlite3/sqlite3_test.go
@@ -571,6 +571,94 @@ func TestDriveri_AlterTableColumnKinds_PreservesAutoincrementSeq(t *testing.T) {
 		"AUTOINCREMENT must continue from the preserved sequence (seq+1), not MAX(rowid)+1")
 }
 
+// TestDriveri_AlterTableColumnKinds_AutoincrementSeqEmptiedTable covers the
+// gh757 fix for a fully-emptied AUTOINCREMENT table: every row is deleted
+// before the rebuild, so the copy moves zero rows, yet the preserved
+// sequence must still dictate the next id. Guards against a restore
+// implementation that only works when the copy carries rows across.
+func TestDriveri_AlterTableColumnKinds_AutoincrementSeqEmptiedTable(t *testing.T) {
+	th := testh.New(t)
+	src := &source.Source{
+		Handle:   "@test",
+		Type:     drivertype.SQLite,
+		Location: "sqlite3://" + tu.TempFile(t, "test.db"),
+	}
+
+	grip := th.Open(src)
+	db, err := grip.DB(th.Context)
+	require.NoError(t, err)
+	drvr := grip.SQLDriver()
+
+	_, err = db.ExecContext(th.Context,
+		`CREATE TABLE seq_tbl (id INTEGER PRIMARY KEY AUTOINCREMENT, val INTEGER NOT NULL)`)
+	require.NoError(t, err)
+
+	for i := 1; i <= 10; i++ {
+		_, err = db.ExecContext(th.Context, `INSERT INTO seq_tbl (val) VALUES (?)`, i)
+		require.NoError(t, err)
+	}
+	_, err = db.ExecContext(th.Context, `DELETE FROM seq_tbl`)
+	require.NoError(t, err)
+
+	var seq int64
+	require.NoError(t, db.QueryRowContext(th.Context,
+		`SELECT seq FROM sqlite_sequence WHERE name='seq_tbl'`).Scan(&seq))
+	require.Equal(t, int64(10), seq)
+
+	require.NoError(t, drvr.AlterTableColumnKinds(th.Context, db, "seq_tbl",
+		[]string{"val"}, []kind.Kind{kind.Text}))
+
+	res, err := db.ExecContext(th.Context, `INSERT INTO seq_tbl (val) VALUES ('post-alter')`)
+	require.NoError(t, err)
+	newID, err := res.LastInsertId()
+	require.NoError(t, err)
+	require.Equal(t, int64(11), newID,
+		"AUTOINCREMENT must continue from the preserved sequence even when the table was emptied")
+}
+
+// TestDriveri_AlterTableColumnKinds_AutoincrementSeqNeighborUntouched covers
+// two gh757 hazards in one: altering a plain (non-AUTOINCREMENT) table must
+// succeed when the database's sqlite_sequence table exists but has no row
+// for the altered table, and the rebuild must not disturb the sqlite_sequence
+// rows of neighboring tables.
+func TestDriveri_AlterTableColumnKinds_AutoincrementSeqNeighborUntouched(t *testing.T) {
+	th := testh.New(t)
+	src := &source.Source{
+		Handle:   "@test",
+		Type:     drivertype.SQLite,
+		Location: "sqlite3://" + tu.TempFile(t, "test.db"),
+	}
+
+	grip := th.Open(src)
+	db, err := grip.DB(th.Context)
+	require.NoError(t, err)
+	drvr := grip.SQLDriver()
+
+	_, err = db.ExecContext(th.Context,
+		`CREATE TABLE seqful (id INTEGER PRIMARY KEY AUTOINCREMENT, val INTEGER NOT NULL)`)
+	require.NoError(t, err)
+	_, err = db.ExecContext(th.Context, `INSERT INTO seqful (val) VALUES (1), (2), (3)`)
+	require.NoError(t, err)
+
+	_, err = db.ExecContext(th.Context, `CREATE TABLE plain (val INTEGER NOT NULL)`)
+	require.NoError(t, err)
+
+	require.NoError(t, drvr.AlterTableColumnKinds(th.Context, db, "plain",
+		[]string{"val"}, []kind.Kind{kind.Text}),
+		"altering a table with no sqlite_sequence row must succeed")
+
+	var seqfulSeq int64
+	require.NoError(t, db.QueryRowContext(th.Context,
+		`SELECT seq FROM sqlite_sequence WHERE name='seqful'`).Scan(&seqfulSeq))
+	require.Equal(t, int64(3), seqfulSeq,
+		"the neighboring table's sqlite_sequence row must survive the rebuild untouched")
+
+	var n int
+	require.NoError(t, db.QueryRowContext(th.Context,
+		`SELECT COUNT(*) FROM sqlite_sequence WHERE name='plain'`).Scan(&n))
+	require.Equal(t, 0, n, "no sqlite_sequence row should be invented for a plain table")
+}
+
 // TestDriveri_CopyTable_TableIdentInDefaultLiteral verifies that CopyTable
 // rewrites only the table identifier and leaves a substring-matching
 // occurrence inside a column DEFAULT expression untouched. Regression

--- a/drivers/sqlite3/sqlite3_test.go
+++ b/drivers/sqlite3/sqlite3_test.go
@@ -523,6 +523,54 @@ func TestDriveri_AlterTableColumnKinds_ColumnNamePrefixesType(t *testing.T) {
 	}
 }
 
+// TestDriveri_AlterTableColumnKinds_PreservesAutoincrementSeq reproduces
+// gh757: the table-rebuild dance in AlterTableColumnKinds dropped the
+// original table, which removed its sqlite_sequence row, so AUTOINCREMENT
+// restarted from MAX(rowid)+1 instead of seq+1. With rows previously
+// deleted from the high end, the next insert silently reused their ids.
+func TestDriveri_AlterTableColumnKinds_PreservesAutoincrementSeq(t *testing.T) {
+	th := testh.New(t)
+	src := &source.Source{
+		Handle:   "@test",
+		Type:     drivertype.SQLite,
+		Location: "sqlite3://" + tu.TempFile(t, "test.db"),
+	}
+
+	grip := th.Open(src)
+	db, err := grip.DB(th.Context)
+	require.NoError(t, err)
+	drvr := grip.SQLDriver()
+
+	_, err = db.ExecContext(th.Context,
+		`CREATE TABLE seq_tbl (id INTEGER PRIMARY KEY AUTOINCREMENT, val INTEGER NOT NULL)`)
+	require.NoError(t, err)
+
+	for i := 1; i <= 10; i++ {
+		_, err = db.ExecContext(th.Context, `INSERT INTO seq_tbl (val) VALUES (?)`, i)
+		require.NoError(t, err)
+	}
+	_, err = db.ExecContext(th.Context, `DELETE FROM seq_tbl WHERE id > 5`)
+	require.NoError(t, err)
+
+	var seq, maxID int64
+	require.NoError(t, db.QueryRowContext(th.Context,
+		`SELECT seq FROM sqlite_sequence WHERE name='seq_tbl'`).Scan(&seq))
+	require.Equal(t, int64(10), seq)
+	require.NoError(t, db.QueryRowContext(th.Context,
+		`SELECT MAX(id) FROM seq_tbl`).Scan(&maxID))
+	require.Equal(t, int64(5), maxID)
+
+	require.NoError(t, drvr.AlterTableColumnKinds(th.Context, db, "seq_tbl",
+		[]string{"val"}, []kind.Kind{kind.Text}))
+
+	res, err := db.ExecContext(th.Context, `INSERT INTO seq_tbl (val) VALUES ('post-alter')`)
+	require.NoError(t, err)
+	newID, err := res.LastInsertId()
+	require.NoError(t, err)
+	require.Equal(t, int64(11), newID,
+		"AUTOINCREMENT must continue from the preserved sequence (seq+1), not MAX(rowid)+1")
+}
+
 // TestDriveri_CopyTable_TableIdentInDefaultLiteral verifies that CopyTable
 // rewrites only the table identifier and leaves a substring-matching
 // occurrence inside a column DEFAULT expression untouched. Regression


### PR DESCRIPTION
Fixes #757.

## Problem

The table-rebuild dance in `AlterTableColumnKinds` (both `drivers/sqlite3` and `drivers/rqlite`) drops the original table, which removes its `sqlite_sequence` row. After the temporary table is renamed back, AUTOINCREMENT restarts from `MAX(rowid)+1` rather than `seq+1`, silently reusing rowids that previously belonged to deleted rows. This was the documented gap from #748.

## Fix (capture-and-restore, per the issue's preferred approach)

- Capture the table's `sqlite_sequence` row before the rebuild. The read tolerates a database with no `sqlite_sequence` table at all (it only exists once an AUTOINCREMENT table has been created).
- Restore it after the `ALTER TABLE ... RENAME`:
  - **sqlite3**: two follow-up statements after the rename.
  - **rqlite**: the read happens outside the atomic batch (rqlite has no interactive transactions) and the restore statements are inlined into the batch before the `foreign_keys` pragma restore, the same pattern used for that pragma in #748.
- `sqlite_sequence` has no unique constraint on `name`, so the restore is DELETE-then-INSERT rather than `INSERT OR REPLACE` (which would just insert a duplicate row).
- Updated the rqlite godoc: the gap note now documents the preserved behavior.

## Tests

Per-driver regression tests following the issue's test strategy: create an `INTEGER PRIMARY KEY AUTOINCREMENT` table, insert 10 rows, delete the top 5 (so `sqlite_sequence.seq = 10`, `MAX(rowid) = 5`), run `AlterTableColumnKinds` on a non-PK column, then assert a fresh insert picks id 11, not 6.

Both tests were verified to fail (`expected: 11, actual: 6`) before the fix and pass after:

- `TestDriveri_AlterTableColumnKinds_PreservesAutoincrementSeq` (sqlite3)
- `TestAlterTableColumnKinds_PreservesAutoincrementSeq` (rqlite, against the `sakiladb/rqlite:10` container)

Full `drivers/sqlite3` and `drivers/rqlite` suites pass, repo-wide `-short` suite passes, `make lint` and `make lint-markdown` clean.