### PR TITLE
gh699: stop getDBProperties executing side-effecting sqlite pragmas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -143,6 +143,15 @@ keyring support) and support for [rqlite](https://sq.io/docs/drivers/rqlite).
 
 ### Fixed
 
+- [#699]: The [SQLite driver](https://sq.io/docs/drivers/sqlite) no longer executes
+  side-effecting or whole-database-scanning pragmas when reading source metadata
+  (e.g. [`sq inspect`](https://sq.io/docs/inspect)). Reading DB properties via SQLite's
+  pragma table-valued functions actually executes each pragma, so `pragma_optimize`
+  could run `ANALYZE`, silently writing `sqlite_stat1` to the database. That made the
+  nominally read-only metadata path take the file write lock (concurrent metadata reads
+  could then fail with `database is locked`), and `integrity_check` / `quick_check` /
+  `foreign_key_check` scanned the entire database on every inspect. These pragmas are
+  now skipped, and those keys no longer appear in the inspect output's DB properties.
 - [#743]: [`sq add`](https://sq.io/docs/cmd/add) shell completion: `<scheme>://host:port?<TAB>`
   now offers connection parameters instead of credential placeholders.
   Bare-host (no `user@`) URLs are recognized correctly for postgres,
@@ -1754,6 +1763,7 @@ make working with lots of sources much easier.
 [#444]: https://github.com/neilotoole/sq/issues/444
 [#660]: https://github.com/neilotoole/sq/issues/660
 [#692]: https://github.com/neilotoole/sq/issues/692
+[#699]: https://github.com/neilotoole/sq/issues/699
 [#716]: https://github.com/neilotoole/sq/issues/716
 [#717]: https://github.com/neilotoole/sq/issues/717
 [#714]: https://github.com/neilotoole/sq/issues/714

--- a/drivers/sqlite3/internal_test.go
+++ b/drivers/sqlite3/internal_test.go
@@ -1,6 +1,9 @@
 package sqlite3
 
 import (
+	"context"
+	"database/sql"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -58,6 +61,61 @@ func TestDsnFromLocation(t *testing.T) {
 			require.Equal(t, tc.want, got)
 		})
 	}
+}
+
+// TestGetDBPropertiesNoSideEffects verifies gh699: getDBProperties must
+// not execute pragmas that mutate the database or scan it end-to-end.
+// The pragma table-valued function mechanism ("SELECT * FROM pragma_x")
+// executes the pragma to produce its rows: notably "SELECT * FROM
+// pragma_optimize" runs ANALYZE, writing sqlite_stat1 to the db file.
+// That made the read-only metadata path a writer, so concurrent
+// SourceMetadata calls contended for the file write lock and flaked
+// with "database is locked" (SQLITE_BUSY) on loaded CI runners.
+func TestGetDBPropertiesNoSideEffects(t *testing.T) {
+	ctx := context.Background()
+	dbFile := filepath.Join(t.TempDir(), "gh699.db")
+
+	db, err := sql.Open(dbDrvr, dbFile)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, db.Close()) }()
+
+	// Single conn, so the priming query below and the pragma reads share
+	// a connection: "PRAGMA optimize" only considers tables that the
+	// current connection has queried.
+	db.SetMaxOpenConns(1)
+
+	_, err = db.ExecContext(ctx, `CREATE TABLE t (a INTEGER);
+WITH RECURSIVE c(x) AS (SELECT 1 UNION ALL SELECT x+1 FROM c WHERE x<5000)
+INSERT INTO t SELECT x FROM c;
+CREATE INDEX idx_t_a ON t(a);`)
+	require.NoError(t, err)
+
+	// Prime the connection's query history so that, were getDBProperties
+	// to execute pragma_optimize, the ANALYZE would actually fire.
+	var n int
+	require.NoError(t, db.QueryRowContext(ctx, `SELECT count(*) FROM t WHERE a = 42`).Scan(&n))
+	require.Equal(t, 1, n)
+
+	props, err := getDBProperties(ctx, db)
+	require.NoError(t, err)
+	require.NotEmpty(t, props)
+	require.Contains(t, props, "journal_mode")
+
+	// Side-effecting and whole-db-scanning pragmas must not be executed,
+	// and thus must not appear as properties.
+	for _, banned := range []string{
+		"foreign_key_check", "incremental_vacuum", "integrity_check",
+		"optimize", "quick_check", "wal_checkpoint",
+	} {
+		require.NotContains(t, props, banned)
+	}
+
+	// The acid test: the db must not have been modified. If
+	// pragma_optimize executed, ANALYZE would have created sqlite_stat1.
+	var statCount int
+	require.NoError(t, db.QueryRowContext(ctx,
+		`SELECT count(*) FROM sqlite_master WHERE name LIKE 'sqlite_stat%'`).Scan(&statCount))
+	require.Equal(t, 0, statCount, "getDBProperties must not write to the db (ANALYZE via pragma_optimize)")
 }
 
 func TestFilePathFromLocation(t *testing.T) {

--- a/drivers/sqlite3/internal_test.go
+++ b/drivers/sqlite3/internal_test.go
@@ -3,6 +3,7 @@ package sqlite3
 import (
 	"context"
 	"database/sql"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -84,10 +85,18 @@ func TestGetDBPropertiesNoSideEffects(t *testing.T) {
 	// current connection has queried.
 	db.SetMaxOpenConns(1)
 
+	// The dangling FK row (no parent table row, foreign_keys enforcement
+	// is off by default) means pragma_foreign_key_check would return a
+	// row if executed, making the foreign_key_check assertion below
+	// load-bearing: on a violation-free db that pragma returns zero rows
+	// and its key would be absent from props regardless.
 	_, err = db.ExecContext(ctx, `CREATE TABLE t (a INTEGER);
 WITH RECURSIVE c(x) AS (SELECT 1 UNION ALL SELECT x+1 FROM c WHERE x<5000)
 INSERT INTO t SELECT x FROM c;
-CREATE INDEX idx_t_a ON t(a);`)
+CREATE INDEX idx_t_a ON t(a);
+CREATE TABLE parent (id INTEGER PRIMARY KEY);
+CREATE TABLE child (pid INTEGER REFERENCES parent(id));
+INSERT INTO child VALUES (999);`)
 	require.NoError(t, err)
 
 	// Prime the connection's query history so that, were getDBProperties
@@ -95,6 +104,12 @@ CREATE INDEX idx_t_a ON t(a);`)
 	var n int
 	require.NoError(t, db.QueryRowContext(ctx, `SELECT count(*) FROM t WHERE a = 42`).Scan(&n))
 	require.Equal(t, 1, n)
+
+	// Snapshot the db file: getDBProperties must not modify it. The
+	// setup writes above are committed (delete journal mode, no other
+	// connections), so the on-disk bytes are stable here.
+	fileBytesBefore, err := os.ReadFile(dbFile)
+	require.NoError(t, err)
 
 	props, err := getDBProperties(ctx, db)
 	require.NoError(t, err)
@@ -116,6 +131,13 @@ CREATE INDEX idx_t_a ON t(a);`)
 	require.NoError(t, db.QueryRowContext(ctx,
 		`SELECT count(*) FROM sqlite_master WHERE name LIKE 'sqlite_stat%'`).Scan(&statCount))
 	require.Equal(t, 0, statCount, "getDBProperties must not write to the db (ANALYZE via pragma_optimize)")
+
+	// Stronger still: the file bytes must be untouched. Unlike the
+	// sqlite_stat1 check, this catches ANY write, independent of the
+	// bundled SQLite's PRAGMA optimize heuristics.
+	fileBytesAfter, err := os.ReadFile(dbFile)
+	require.NoError(t, err)
+	require.Equal(t, fileBytesBefore, fileBytesAfter, "getDBProperties must not modify the db file")
 }
 
 func TestFilePathFromLocation(t *testing.T) {

--- a/drivers/sqlite3/pragma.go
+++ b/drivers/sqlite3/pragma.go
@@ -13,6 +13,29 @@ import (
 	"github.com/neilotoole/sq/libsq/core/sqlz"
 )
 
+// pragmaSkip enumerates pragmas that getDBProperties must not read.
+// The pragma table-valued function mechanism ("SELECT * FROM pragma_x")
+// executes the pragma to produce its rows, so these aren't passive
+// properties: reading them would mutate the database or scan it
+// end-to-end. Notably, "SELECT * FROM pragma_optimize" can run ANALYZE,
+// which writes sqlite_stat1: that made the nominally read-only metadata
+// path take SQLite's file write lock, so concurrent SourceMetadata
+// calls flaked with "database is locked" (SQLITE_BUSY) on loaded CI
+// runners (gh699). It would also fail outright on a read-only source
+// (e.g. ?mode=ro).
+//
+// As of SQLite 3.51, incremental_vacuum and wal_checkpoint have no
+// pragma function (the "no such table" branch in readPragma skips
+// them), but they're listed defensively in case that changes.
+var pragmaSkip = map[string]bool{
+	"foreign_key_check":  true, // full-db scan
+	"incremental_vacuum": true, // mutates: frees pages from the freelist
+	"integrity_check":    true, // full-db scan
+	"optimize":           true, // mutates: may run ANALYZE, writing sqlite_stat1
+	"quick_check":        true, // full-db scan
+	"wal_checkpoint":     true, // mutates: forces a WAL checkpoint
+}
+
 // getDBProperties returns a map of the DB's settings, as exposed
 // via SQLite's pragma mechanism. The supplied incr func should
 // be invoked for each row read from the DB.
@@ -26,6 +49,10 @@ func getDBProperties(ctx context.Context, db sqlz.DB) (map[string]any, error) {
 
 	m := make(map[string]any, len(pragmas))
 	for _, pragma := range pragmas {
+		if pragmaSkip[pragma] {
+			continue
+		}
+
 		var val any
 		val, err = readPragma(ctx, db, pragma)
 		if err != nil {

--- a/drivers/sqlite3/pragma.go
+++ b/drivers/sqlite3/pragma.go
@@ -37,8 +37,7 @@ var pragmaSkip = map[string]bool{
 }
 
 // getDBProperties returns a map of the DB's settings, as exposed
-// via SQLite's pragma mechanism. The supplied incr func should
-// be invoked for each row read from the DB.
+// via SQLite's pragma mechanism.
 //
 // See: https://www.sqlite.org/pragma.html
 func getDBProperties(ctx context.Context, db sqlz.DB) (map[string]any, error) {
@@ -70,7 +69,7 @@ func getDBProperties(ctx context.Context, db sqlz.DB) (map[string]any, error) {
 	return m, nil
 }
 
-// readPragma reads the values of pragma from the DB,and returns its value,
+// readPragma reads the values of pragma from the DB, and returns its value,
 // which is either a scalar value such as a string, or a map[string]any.
 func readPragma(ctx context.Context, db sqlz.DB, pragma string) (any, error) {
 	var (

--- a/drivers/sqlite3/sqlite3_test.go
+++ b/drivers/sqlite3/sqlite3_test.go
@@ -878,9 +878,6 @@ func TestDriveri_CopyTable_PreservesOnDeleteCascade(t *testing.T) {
 func TestBusyTimeoutDefault(t *testing.T) {
 	t.Parallel()
 
-	th := testh.New(t)
-	dbPath := tu.TempFile(t, "gh699.db")
-
 	testCases := []struct {
 		name    string
 		connStr string
@@ -893,6 +890,9 @@ func TestBusyTimeoutDefault(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
+
+			th := testh.New(t)
+			dbPath := tu.TempFile(t, "gh699.db")
 
 			loc, err := sqlite3.MungeLocation("sqlite3://" + filepath.ToSlash(dbPath) + tc.connStr)
 			require.NoError(t, err)

--- a/drivers/sqlite3/sqlite3_test.go
+++ b/drivers/sqlite3/sqlite3_test.go
@@ -871,6 +871,49 @@ func TestDriveri_CopyTable_PreservesOnDeleteCascade(t *testing.T) {
 		"ON DELETE CASCADE must fire on the destination: deleting id=1 should cascade to id=2 and id=3")
 }
 
+// TestBusyTimeoutDefault verifies gh699: every sqlite3 connection gets a
+// default busy_timeout so that concurrent access waits for locks instead
+// of immediately failing with SQLITE_BUSY ("database is locked"). A
+// user-supplied _busy_timeout conn param must still win.
+func TestBusyTimeoutDefault(t *testing.T) {
+	t.Parallel()
+
+	th := testh.New(t)
+	dbPath := tu.TempFile(t, "gh699.db")
+
+	testCases := []struct {
+		name    string
+		connStr string
+		want    int
+	}{
+		{name: "default", connStr: "", want: 5000},
+		{name: "user_override", connStr: "?_busy_timeout=1234", want: 1234},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			loc, err := sqlite3.MungeLocation("sqlite3://" + filepath.ToSlash(dbPath) + tc.connStr)
+			require.NoError(t, err)
+
+			src := &source.Source{
+				Handle:   "@gh699_" + tc.name,
+				Type:     drivertype.SQLite,
+				Location: loc,
+			}
+
+			grip := th.Open(src)
+			db, err := grip.DB(th.Context)
+			require.NoError(t, err)
+
+			var got int
+			require.NoError(t, db.QueryRowContext(th.Context, "PRAGMA busy_timeout").Scan(&got))
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
 // TestSourceMetadata_LocationWithConnParams reproduces gh720: a
 // source-level metadata read must succeed when the source location
 // carries a connection-string suffix (e.g. ?mode=ro). The previous


### PR DESCRIPTION
Fixes #699.

## Root cause

The flake diagnosis in #699 pointed at a missing `busy_timeout`, but that premise turned out to be wrong: mattn/go-sqlite3 already defaults `busy_timeout` to 5000ms (which matches the ~5.95s elapsed time of the observed CI failure: the test *waited* the full timeout and still failed).

The real problem: the metadata path is not read-only. `getDBProperties` reads every pragma in `pragma_pragma_list` via SQLite's pragma table-valued functions (`SELECT * FROM pragma_x`), and that mechanism *executes* each pragma to produce its rows. In particular, `pragma_optimize` can run `ANALYZE`, writing `sqlite_stat1` to the database. Empirically confirmed: after `SourceMetadata` on a fresh db, `sqlite_stat1` exists.

So `TestGrip_SourceMetadata_concurrent` ran 5 goroutines that each took SQLite's file write lock. In rollback-journal mode a pending writer also blocks *new readers*, which is exactly why a pure read (`getTypeOfColumn`) timed out with `database is locked` on a loaded CI runner.

Beyond the flake, this was a real production bug: `sq inspect` silently wrote to the inspected SQLite database (and would error on read-only sources, e.g. `?mode=ro`), and `integrity_check` / `quick_check` / `foreign_key_check` scanned the entire database on every inspect.

## Fix

`getDBProperties` now skips a small denylist of pragmas that are actions rather than properties:

- `optimize` (mutates: may run `ANALYZE`)
- `integrity_check`, `quick_check`, `foreign_key_check` (full-db scans)
- `incremental_vacuum`, `wal_checkpoint` (mutating; currently have no pragma function, listed defensively)

Those keys consequently no longer appear in `sq inspect` DB properties output.

## Testing

- New `TestGetDBPropertiesNoSideEffects` reproduces the write (fails before the fix: `sqlite_stat1` created) and pins the no-side-effects behavior.
- New `TestBusyTimeoutDefault` pins the 5000ms driver default and the `?_busy_timeout` user-override path that concurrency safety relies on.
- `go test -count=20 -run TestGrip_SourceMetadata_concurrent ./libsq/driver/...` passes.
- `make lint` and `make lint-markdown` clean; `go test -short` green for `drivers/sqlite3`, `libsq/driver`, and `cli`.