### PR TITLE
driver/rqlite: ConnParamDetector auto-detects TLS at sq add time (#764)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,8 @@ keyring support) and support for [rqlite](https://sq.io/docs/drivers/rqlite).
     for self-signed certs) when the failure looks TLS-related.
   - [#764]: `sq add` auto-detects TLS-only rqlite endpoints and stores `tls=true`
     on the source, instead of failing and asking the user to retry. Suppressed by
-    `--skip-verify` or an explicit `tls`/`insecure` param.
+    `--skip-verify`, an explicit `tls`/`insecure` param, or a `${...}` placeholder
+    location.
 - [#441]: [`sq add`](https://sq.io/docs/cmd/add) gains a `--store inline|keyring`
   flag, and a new [`secrets.store`](https://sq.io/docs/config#secretsstore) config option
   controls the default; existing behavior is preserved (`inline`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@ keyring support) and support for [rqlite](https://sq.io/docs/drivers/rqlite).
     `postgres?sslmode=...` etc.) and the companion `?insecure=true` for self-signed certs.
     Connection errors are enriched with actionable hints (add `?tls=true`, or `&insecure=true`
     for self-signed certs) when the failure looks TLS-related.
+  - [#764]: `sq add` auto-detects TLS-only rqlite endpoints and stores `tls=true`
+    on the source, instead of failing and asking the user to retry. Suppressed by
+    `--skip-verify` or an explicit `tls`/`insecure` param.
 - [#441]: [`sq add`](https://sq.io/docs/cmd/add) gains a `--store inline|keyring`
   flag, and a new [`secrets.store`](https://sq.io/docs/config#secretsstore) config option
   controls the default; existing behavior is preserved (`inline`).
@@ -1788,6 +1791,7 @@ make working with lots of sources much easier.
 [#756]: https://github.com/neilotoole/sq/issues/756
 [#757]: https://github.com/neilotoole/sq/issues/757
 [#759]: https://github.com/neilotoole/sq/issues/759
+[#764]: https://github.com/neilotoole/sq/issues/764
 
 [v0.15.2]: https://github.com/neilotoole/sq/releases/tag/v0.15.2
 [v0.15.3]: https://github.com/neilotoole/sq/compare/v0.15.2...v0.15.3

--- a/cli/cmd_add.go
+++ b/cli/cmd_add.go
@@ -714,12 +714,12 @@ func detectConnParamsForAdd(ctx context.Context, cmd *cobra.Command,
 		return nil
 	}
 
-	// v1: skip placeholder-bearing locations. Detected params would
-	// have to be merged into a stored form whose URL structure is
-	// opaque (e.g. a bare "${keyring:abc}"), which requires
-	// composition-aware rewriting. Such sources get the standard
-	// connection-error hints instead. This mirrors ValidateSource,
-	// which also skips grammar checks for placeholders.
+	// Placeholder-bearing locations are skipped: detected params
+	// would have to be merged into a stored form whose URL structure
+	// is opaque (e.g. a bare "${keyring:abc}"), which would require
+	// composition-aware rewriting of the stored value. Such sources
+	// get the standard connection-error hints instead. This mirrors
+	// ValidateSource, which also skips grammar checks for placeholders.
 	refs, err := secret.ExtractRefs(src.Location)
 	if err != nil {
 		return err

--- a/cli/cmd_add.go
+++ b/cli/cmd_add.go
@@ -766,7 +766,13 @@ func filterToAdvertisedParams(ctx context.Context, drvr driver.Driver,
 	}
 	sqlDrvr, ok := drvr.(driver.SQLDriver)
 	if !ok {
-		return params
+		// A non-SQL driver advertises no conn params, so no detected
+		// key can be validated against the subset invariant: drop
+		// them all rather than persisting unvetted params.
+		lg.FromContext(ctx).Warn(
+			"Detected conn params from non-SQL driver; dropping all",
+			lga.Src, src.Handle)
+		return url.Values{}
 	}
 	advertised := sqlDrvr.ConnParams()
 	out := url.Values{}

--- a/cli/cmd_add.go
+++ b/cli/cmd_add.go
@@ -341,6 +341,18 @@ func execSrcAdd(cmd *cobra.Command, args []string) (err error) {
 		return err
 	}
 
+	drvr, err := ru.DriverRegistry.DriverFor(src.Type)
+	if err != nil {
+		return err
+	}
+
+	// Detection may rewrite src.Location (e.g. appending ?tls=true
+	// for a TLS-only rqlite endpoint), so it runs before the source
+	// is added to the collection and before Ping verifies it.
+	if err = detectConnParamsForAdd(ctx, cmd, drvr, src); err != nil {
+		return err
+	}
+
 	if err = cfg.Collection.Add(src); err != nil {
 		return err
 	}
@@ -354,11 +366,6 @@ func execSrcAdd(cmd *cobra.Command, args []string) (err error) {
 
 		// However, we do not set the active group to be the new src's group.
 		// In UX testing, it led to confused users.
-	}
-
-	drvr, err := ru.DriverRegistry.DriverFor(src.Type)
-	if err != nil {
-		return err
 	}
 
 	if !cmdFlagIsSetTrue(cmd, flag.SkipVerify) {
@@ -686,6 +693,93 @@ func urlHasPassword(loc string) bool {
 	}
 	_, has := u.User.Password()
 	return has
+}
+
+// detectConnParamsForAdd runs the driver's ConnParamDetector (if
+// implemented) against the resolved source and merges any detected
+// params into src.Location. It is a no-op when --skip-verify is set
+// or when the location contains secret placeholders. The function
+// name carries the add-time coupling deliberately: the interface is
+// a general capability, but the location rewrite is only legitimate
+// here, while the source is being established and nothing yet
+// references it.
+func detectConnParamsForAdd(ctx context.Context, cmd *cobra.Command,
+	drvr driver.Driver, src *source.Source,
+) error {
+	if cmdFlagIsSetTrue(cmd, flag.SkipVerify) {
+		return nil
+	}
+	detector, ok := drvr.(driver.ConnParamDetector)
+	if !ok {
+		return nil
+	}
+
+	// v1: skip placeholder-bearing locations. Detected params would
+	// have to be merged into a stored form whose URL structure is
+	// opaque (e.g. a bare "${keyring:abc}"), which requires
+	// composition-aware rewriting. Such sources get the standard
+	// connection-error hints instead. This mirrors ValidateSource,
+	// which also skips grammar checks for placeholders.
+	refs, err := secret.ExtractRefs(src.Location)
+	if err != nil {
+		return err
+	}
+	if len(refs) > 0 {
+		lg.FromContext(ctx).Debug("Conn param detection skipped: placeholder location",
+			lga.Src, src.Handle)
+		return nil
+	}
+
+	probeSrc, err := driver.ResolveSourceSecrets(ctx, src)
+	if err != nil {
+		return err
+	}
+	params, err := detector.DetectConnParams(ctx, probeSrc)
+	if err != nil {
+		return err
+	}
+	params = filterToAdvertisedParams(ctx, drvr, src, params)
+	if len(params) == 0 {
+		return nil
+	}
+
+	mergedLoc, err := location.MergeQuery(src.Location, params)
+	if err != nil {
+		return err
+	}
+	src.Location = mergedLoc
+	lg.FromContext(ctx).Debug("Conn param detection rewrote location",
+		lga.Src, src.Handle, lga.Loc, src.RedactedLocation())
+	return nil
+}
+
+// filterToAdvertisedParams enforces the ConnParamDetector contract
+// clause that detected keys must be a subset of the keys advertised
+// by SQLDriver.ConnParams. A violation is a driver bug: the
+// offending keys are dropped with a warning rather than failing the
+// user's add.
+func filterToAdvertisedParams(ctx context.Context, drvr driver.Driver,
+	src *source.Source, params url.Values,
+) url.Values {
+	if len(params) == 0 {
+		return params
+	}
+	sqlDrvr, ok := drvr.(driver.SQLDriver)
+	if !ok {
+		return params
+	}
+	advertised := sqlDrvr.ConnParams()
+	out := url.Values{}
+	for k, vs := range params {
+		if _, ok := advertised[k]; !ok {
+			lg.FromContext(ctx).Warn(
+				"Detected conn param not advertised by driver; dropping",
+				lga.Src, src.Handle, lga.Key, k)
+			continue
+		}
+		out[k] = vs
+	}
+	return out
 }
 
 // readPassword reads a password from stdin pipe, or if nothing on stdin,

--- a/cli/cmd_add_test.go
+++ b/cli/cmd_add_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/neilotoole/sq/cli"
 	"github.com/neilotoole/sq/cli/testrun"
 	"github.com/neilotoole/sq/libsq/core/options"
+	"github.com/neilotoole/sq/libsq/driver"
 	"github.com/neilotoole/sq/libsq/source"
 	"github.com/neilotoole/sq/libsq/source/drivertype"
 	"github.com/neilotoole/sq/testh"
@@ -1019,4 +1020,33 @@ func TestFilterToAdvertisedParams(t *testing.T) {
 	}
 	out := cli.FilterToAdvertisedParams(context.Background(), drvr, src, in)
 	require.Equal(t, url.Values{"tls": []string{"true"}}, out)
+
+	t.Run("non-sql driver drops all params", func(t *testing.T) {
+		// A non-SQLDriver advertises no ConnParams, so nothing can be
+		// validated against the subset invariant: everything is dropped.
+		out := cli.FilterToAdvertisedParams(context.Background(), nonSQLDriverStub{}, src,
+			url.Values{"tls": {"true"}})
+		require.Empty(t, out)
+	})
+}
+
+// nonSQLDriverStub implements driver.Driver but NOT driver.SQLDriver.
+// Only the type assertion in filterToAdvertisedParams matters; the
+// methods are never called.
+type nonSQLDriverStub struct{}
+
+func (nonSQLDriverStub) Open(context.Context, *source.Source) (driver.Grip, error) {
+	panic("not implemented")
+}
+
+func (nonSQLDriverStub) Ping(context.Context, *source.Source) error {
+	panic("not implemented")
+}
+
+func (nonSQLDriverStub) DriverMetadata() driver.Metadata {
+	return driver.Metadata{}
+}
+
+func (nonSQLDriverStub) ValidateSource(*source.Source) (*source.Source, error) {
+	panic("not implemented")
 }

--- a/cli/cmd_add_test.go
+++ b/cli/cmd_add_test.go
@@ -2,14 +2,20 @@ package cli_test
 
 import (
 	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"os"
 	"path/filepath"
 	"regexp"
+	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 	gokeyring "github.com/zalando/go-keyring"
 
+	"github.com/neilotoole/sq/cli"
 	"github.com/neilotoole/sq/cli/testrun"
 	"github.com/neilotoole/sq/libsq/core/options"
 	"github.com/neilotoole/sq/libsq/source"
@@ -842,4 +848,175 @@ func TestCmdAdd_StoreKeyring_PromptsWhenNoPassword(t *testing.T) {
 	got, err := gokeyring.Get("sq", id)
 	require.NoError(t, err)
 	require.Equal(t, "postgres://alice:piped-password@localhost:5432/sakila", got)
+}
+
+// newRqliteMockHandlerForCLI returns an HTTP handler that satisfies gorqlite's
+// cluster discovery protocol, suitable for CLI-level seam tests. hostPtr is a
+// pointer to the "host:port" string of the test server resolved at request time
+// so the handler can be constructed before the server URL is known.
+//
+// The handler responds to:
+//   - GET /status  — returns a minimal JSON body with a top-level "node" key.
+//   - GET /nodes   — returns the test server as the single leader, using the
+//     scheme dictated by tlsNodes: "https" when true, "http" when false.
+//   - GET /db/query — returns a minimal single-row result (used by PingContext).
+//
+// The tlsNodes parameter controls the scheme in the /nodes response. Set it to
+// true when the test server itself is a TLS server (httptest.NewTLSServer), and
+// false for plain HTTP servers. A mismatch causes gorqlite to connect to the
+// wrong scheme during cluster discovery, and Ping will fail.
+func newRqliteMockHandlerForCLI(hostPtr *string, tlsNodes bool) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/status":
+			// Return a store.leader raft addr with no matching metadata api_addr
+			// so gorqlite falls back to /nodes to resolve the HTTP API address.
+			_, _ = w.Write([]byte(`{"node":{},"store":{"leader":"127.0.0.1:4002","metadata":{}}}`))
+		case "/nodes":
+			// Return the test server itself as the reachable leader with the
+			// appropriate scheme so gorqlite connects via the right protocol.
+			scheme := "http"
+			if tlsNodes {
+				scheme = "https"
+			}
+			body := fmt.Sprintf(
+				`{"1":{"api_addr":"%s://%s","addr":"127.0.0.1:4002","reachable":true,"leader":true}}`,
+				scheme, *hostPtr,
+			)
+			_, _ = w.Write([]byte(body))
+		case "/db/query":
+			_, _ = w.Write([]byte(`{"results":[{"columns":["1"],"types":["integer"],"values":[[1]]}]}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+}
+
+// TestCmdAdd_Rqlite_ConnParamDetection exercises the sq add detection seam
+// end-to-end against httptest servers. The TLS subtest swaps
+// http.DefaultTransport so the detector's default-verification probe trusts the
+// test server's cert; for that reason this test must not run in parallel.
+func TestCmdAdd_Rqlite_ConnParamDetection(t *testing.T) {
+	t.Run("tls_endpoint_detected_and_persisted", func(t *testing.T) {
+		var host string
+		server := httptest.NewTLSServer(newRqliteMockHandlerForCLI(&host, true))
+		t.Cleanup(server.Close)
+		host = server.Listener.Addr().String()
+
+		// The CLI-built detector uses http.DefaultTransport (nil transport).
+		// Swap in one that trusts the test cert so the HTTPS probe succeeds.
+		ogTransport := http.DefaultTransport
+		http.DefaultTransport = server.Client().Transport
+		t.Cleanup(func() { http.DefaultTransport = ogTransport })
+
+		tr := testrun.New(context.Background(), t, nil)
+		err := tr.Exec("add", "--handle", "@rq_detect", "rqlite://"+host)
+		require.NoError(t, err)
+
+		src, err := tr.Run.Config.Collection.Get("@rq_detect")
+		require.NoError(t, err)
+		require.Contains(t, src.Location, "tls=true",
+			"detection must persist tls=true for a TLS-only endpoint")
+	})
+
+	t.Run("plain_http_endpoint_not_rewritten", func(t *testing.T) {
+		var host string
+		server := httptest.NewServer(newRqliteMockHandlerForCLI(&host, false))
+		t.Cleanup(server.Close)
+		host = server.Listener.Addr().String()
+
+		tr := testrun.New(context.Background(), t, nil)
+		err := tr.Exec("add", "--handle", "@rq_plain", "rqlite://"+host)
+		require.NoError(t, err)
+
+		src, err := tr.Run.Config.Collection.Get("@rq_plain")
+		require.NoError(t, err)
+		require.NotContains(t, src.Location, "tls",
+			"plain-HTTP endpoint must not be rewritten")
+	})
+
+	t.Run("skip_verify_means_zero_probes", func(t *testing.T) {
+		var host string
+		var hits atomic.Int64
+		inner := newRqliteMockHandlerForCLI(&host, false)
+		server := httptest.NewServer(http.HandlerFunc(
+			func(w http.ResponseWriter, r *http.Request) {
+				hits.Add(1)
+				inner.ServeHTTP(w, r)
+			}))
+		t.Cleanup(server.Close)
+		host = server.Listener.Addr().String()
+
+		tr := testrun.New(context.Background(), t, nil)
+		err := tr.Exec("add", "--skip-verify", "--handle", "@rq_skip",
+			"rqlite://"+host)
+		require.NoError(t, err)
+		require.Equal(t, int64(0), hits.Load(),
+			"--skip-verify must suppress detection AND ping")
+	})
+
+	t.Run("placeholder_location_not_rewritten", func(t *testing.T) {
+		// A ${env:...} placeholder location: detection must skip, so the
+		// persisted location is byte-identical to the input.
+		t.Setenv("SQ_TEST_RQ_DSN", "rqlite://localhost:4001")
+
+		tr := testrun.New(context.Background(), t, nil)
+		err := tr.Exec("add", "--skip-verify", "--driver", "rqlite",
+			"--handle", "@rq_ph", "${env:SQ_TEST_RQ_DSN}")
+		require.NoError(t, err)
+
+		src, err := tr.Run.Config.Collection.Get("@rq_ph")
+		require.NoError(t, err)
+		require.Equal(t, "${env:SQ_TEST_RQ_DSN}", src.Location,
+			"placeholder location must be persisted untouched")
+	})
+
+	t.Run("placeholder_gate_skips_detection", func(t *testing.T) {
+		// Pins the placeholder gate in detectConnParamsForAdd
+		// specifically (the prior subtest exits via the --skip-verify
+		// gate and never reaches it). A TLS endpoint behind a
+		// placeholder, WITHOUT --skip-verify and WITHOUT a transport
+		// swap: the add must fail, and the failure mode reveals which
+		// code ran. With the gate, detection is skipped and Ping fails
+		// with the TLS-signal hint. Without the gate, detection would
+		// run against the resolved location, hit the untrusted test
+		// cert, and fail with the cert-verification error instead.
+		var host string
+		server := httptest.NewTLSServer(newRqliteMockHandlerForCLI(&host, true))
+		t.Cleanup(server.Close)
+		host = server.Listener.Addr().String()
+
+		t.Setenv("SQ_TEST_RQ_TLS_DSN", "rqlite://"+host)
+
+		tr := testrun.New(context.Background(), t, nil)
+		err := tr.Exec("add", "--driver", "rqlite",
+			"--handle", "@rq_ph_tls", "${env:SQ_TEST_RQ_TLS_DSN}")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "appears to require TLS",
+			"failure must come from Ping enrichment, proving detection was skipped")
+		require.NotContains(t, err.Error(), "certificate could not be verified",
+			"detection's cert error would mean the placeholder gate did not fire")
+	})
+}
+
+// TestFilterToAdvertisedParams pins the subset-invariant contract clause:
+// detected keys not advertised by the driver's ConnParams are dropped (a driver
+// bug must not fail the user's add).
+func TestFilterToAdvertisedParams(t *testing.T) {
+	tr := testrun.New(context.Background(), t, nil)
+	drvr, err := tr.Run.DriverRegistry.DriverFor(drivertype.Rqlite)
+	require.NoError(t, err)
+
+	src := &source.Source{
+		Handle:   "@rq",
+		Type:     drivertype.Rqlite,
+		Location: "rqlite://host:4001",
+	}
+	in := url.Values{
+		"tls":           {"true"}, // advertised by rqlite ConnParams
+		"bogusDetected": {"x"},    // NOT advertised: must be dropped
+	}
+	out := cli.FilterToAdvertisedParams(context.Background(), drvr, src, in)
+	require.Equal(t, url.Values{"tls": []string{"true"}}, out)
 }

--- a/cli/internal_test.go
+++ b/cli/internal_test.go
@@ -11,6 +11,7 @@ var (
 	FetchBrewVersion          = fetchBrewVersion
 	RenderSQLSupportsFormat   = renderSQLSupportsFormat
 	ErrBinaryFormatToTerminal = errBinaryFormatToTerminal
+	FilterToAdvertisedParams  = filterToAdvertisedParams
 )
 
 // The legacy parsedLoc/plocStage parser was removed when

--- a/drivers/rqlite/connector_test.go
+++ b/drivers/rqlite/connector_test.go
@@ -33,7 +33,7 @@ func newRqliteMockHandler(hostPtr *string) http.Handler {
 			// Return a store.leader raft addr with no matching metadata api_addr
 			// so gorqlite successfully parses the leader but then falls back to
 			// /nodes to resolve the HTTP API address.
-			_, _ = w.Write([]byte(`{"store":{"leader":"127.0.0.1:4002","metadata":{}}}`))
+			_, _ = w.Write([]byte(`{"node":{},"store":{"leader":"127.0.0.1:4002","metadata":{}}}`))
 		case "/nodes":
 			// Return the test server itself as the reachable leader.
 			body := fmt.Sprintf(

--- a/drivers/rqlite/detect.go
+++ b/drivers/rqlite/detect.go
@@ -1,12 +1,20 @@
 package rqlite
 
 import (
+	"context"
 	"crypto/tls"
 	"encoding/json"
 	"errors"
 	"io"
 	"net/http"
+	"net/url"
 	"strings"
+
+	"github.com/neilotoole/sq/libsq/core/errz"
+	"github.com/neilotoole/sq/libsq/core/lg"
+	"github.com/neilotoole/sq/libsq/core/lg/lga"
+	"github.com/neilotoole/sq/libsq/driver"
+	"github.com/neilotoole/sq/libsq/source"
 )
 
 // probeIndicatesTLS reports whether the outcome of a plain-HTTP
@@ -76,4 +84,143 @@ func statusLooksRqlite(resp *http.Response, body []byte) bool {
 	}
 	_, ok := m["node"]
 	return ok
+}
+
+// Compile-time check: driveri implements driver.ConnParamDetector.
+var _ driver.ConnParamDetector = (*driveri)(nil)
+
+// DetectConnParams implements driver.ConnParamDetector. It probes
+// GET /status over plain HTTP first; if the failure indicates a
+// TLS-only endpoint, it re-probes over HTTPS with standard cert
+// verification. A confirmed HTTPS rqlite endpoint yields
+// {"tls": ["true"]}. An HTTPS endpoint with an unverifiable cert
+// yields an actionable error. Everything else steps aside with
+// (nil, nil): the Ping that follows during "sq add" reports
+// connection problems with full enrichment.
+func (d *driveri) DetectConnParams(ctx context.Context, src *source.Source) (url.Values, error) {
+	return d.detectConnParams(ctx, src, nil)
+}
+
+// detectConnParams is the testable core of DetectConnParams. If
+// transport is non-nil it is used for both probe attempts; tests
+// pass an httptest transport that trusts the test server's cert.
+// A nil transport means http.DefaultTransport (with default cert
+// verification).
+func (d *driveri) detectConnParams(ctx context.Context, src *source.Source,
+	transport http.RoundTripper,
+) (url.Values, error) {
+	log := lg.FromContext(ctx)
+
+	loc, _, err := locationWithDefaultPort(src.Location)
+	if err != nil {
+		// Malformed location: not detection's concern.
+		return nil, nil //nolint:nilerr,nilnil
+	}
+	u, err := url.Parse(loc)
+	if err != nil {
+		return nil, nil //nolint:nilerr,nilnil
+	}
+	if q := u.Query(); q.Has("tls") || q.Has("insecure") {
+		log.Debug("rqlite: conn param detection skipped: explicit tls/insecure intent",
+			lga.Src, src.Handle)
+		return nil, nil //nolint:nilnil
+	}
+
+	client := &http.Client{
+		Timeout:   driver.OptConnOpenTimeout.Get(src.Options),
+		Transport: transport, // nil means http.DefaultTransport
+		// Do not follow redirects: a redirect to https:// is itself
+		// a TLS signal that probeIndicatesTLS must see; following it
+		// silently would mis-detect an HTTPS-only endpoint as
+		// HTTP-fine.
+		CheckRedirect: func(*http.Request, []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+
+	// Step 1: plain HTTP.
+	resp, body, err := probeStatus(ctx, client, u, "http") //nolint:bodyclose
+	if err == nil && statusLooksRqlite(resp, body) {
+		// Endpoint speaks HTTP; the default is already correct.
+		log.Debug("rqlite: conn param detection: endpoint speaks plain HTTP",
+			lga.Src, src.Handle)
+		return nil, nil //nolint:nilnil
+	}
+	if !probeIndicatesTLS(resp, body, err) {
+		if ctx.Err() != nil {
+			return nil, errz.Err(ctx.Err())
+		}
+		log.Debug("rqlite: conn param detection: no TLS signal; stepping aside",
+			lga.Src, src.Handle)
+		return nil, nil //nolint:nilnil
+	}
+
+	// Step 2: HTTPS with standard cert verification.
+	resp2, body2, err2 := probeStatus(ctx, client, u, "https") //nolint:bodyclose
+	switch {
+	case err2 == nil && statusLooksRqlite(resp2, body2):
+		log.Debug("rqlite: conn param detection: TLS endpoint confirmed",
+			lga.Src, src.Handle)
+		return url.Values{"tls": []string{"true"}}, nil
+	case isCertVerificationError(err2):
+		// The one case detection reports better than Ping: we KNOW
+		// the endpoint wants TLS and we KNOW the cert won't verify,
+		// so the user gets the full prescription in one shot. The
+		// wrapped err2 is a url.Error whose message embeds the probe
+		// URL, which is credential-free (probeStatus strips
+		// userinfo into the Authorization header).
+		hint := suggestLocWithParams(src, url.Values{
+			"tls": {"true"}, "insecure": {"true"},
+		})
+		return nil, errz.Wrapf(err2,
+			"%s: the endpoint requires TLS, but its certificate could not "+
+				"be verified. If this is a self-signed or private-CA "+
+				"deployment, retry with %s, or install the CA in your "+
+				"trust store", src.Handle, hint)
+	default:
+		if ctx.Err() != nil {
+			return nil, errz.Err(ctx.Err())
+		}
+		log.Debug("rqlite: conn param detection: HTTPS probe inconclusive; stepping aside",
+			lga.Src, src.Handle)
+		return nil, nil //nolint:nilnil
+	}
+}
+
+// probeStatus issues GET <scheme>://host/status with basic auth
+// from u's userinfo, returning the response and its (bounded) body.
+// Credentials travel in the Authorization header, never in the
+// request URL, so error messages that embed the URL are
+// credential-free.
+func probeStatus(ctx context.Context, client *http.Client, u *url.URL, scheme string,
+) (*http.Response, []byte, error) {
+	pu := *u
+	pu.Scheme = scheme
+	pu.Path = "/status"
+	pu.RawQuery = ""
+	pu.Fragment = ""
+	user := pu.User
+	pu.User = nil
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, pu.String(), nil)
+	if err != nil {
+		return nil, nil, errz.Err(err)
+	}
+	if user != nil && user.Username() != "" {
+		pw, _ := user.Password()
+		req.SetBasicAuth(user.Username(), pw)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, nil, err // raw chain: the classifiers need errors.As to work
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	const maxBody = 64 * 1024
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxBody))
+	if err != nil {
+		return resp, nil, err // raw chain: the classifiers need errors.As to work
+	}
+	return resp, body, nil
 }

--- a/drivers/rqlite/detect.go
+++ b/drivers/rqlite/detect.go
@@ -34,7 +34,12 @@ import (
 //     not follow redirects, or this signal is invisible and the
 //     endpoint is mis-detected as plain HTTP.
 //  3. Transport-level tls.RecordHeaderError or EOF mid-response:
-//     TLS-only servers that hang up instead of answering.
+//     TLS-only servers that hang up instead of answering. EOF is a
+//     deliberately weak signal: any abrupt close matches, not only
+//     TLS hang-ups, so a flaky plain-HTTP server can trigger an
+//     unnecessary HTTPS probe. The strict statusLooksRqlite
+//     fingerprint on the HTTPS response is the second line of
+//     defense against a false tls=true.
 func probeIndicatesTLS(resp *http.Response, body []byte, err error) bool {
 	if err != nil {
 		var rec tls.RecordHeaderError
@@ -127,7 +132,10 @@ func (d *driveri) detectConnParams(ctx context.Context, src *source.Source,
 	}
 
 	client := &http.Client{
-		Timeout:   driver.OptConnOpenTimeout.Get(src.Options),
+		// clientTimeout honors the gorqlite-native ?timeout=N URL
+		// param (integer seconds) over conn.open-timeout, keeping the
+		// probe consistent with the documented timeout behavior.
+		Timeout:   clientTimeout(loc, src.Options),
 		Transport: transport, // nil means http.DefaultTransport
 		// Do not follow redirects: a redirect to https:// is itself
 		// a TLS signal that probeIndicatesTLS must see; following it

--- a/drivers/rqlite/detect.go
+++ b/drivers/rqlite/detect.go
@@ -214,7 +214,11 @@ func probeStatus(ctx context.Context, client *http.Client, u *url.URL, scheme st
 	if err != nil {
 		return nil, nil, errz.Err(err)
 	}
-	if user != nil && user.Username() != "" {
+	if user != nil {
+		// Send auth whenever userinfo is present, including the
+		// password-only form (rqlite://:pw@host): gorqlite sends the
+		// same header at connection time, and the probe must match
+		// so auth-gated /status endpoints behave consistently.
 		pw, _ := user.Password()
 		req.SetBasicAuth(user.Username(), pw)
 	}

--- a/drivers/rqlite/detect.go
+++ b/drivers/rqlite/detect.go
@@ -1,0 +1,79 @@
+package rqlite
+
+import (
+	"crypto/tls"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+)
+
+// probeIndicatesTLS reports whether the outcome of a plain-HTTP
+// probe suggests the endpoint actually speaks TLS. Unlike
+// isTLSSignal (which classifies gorqlite-serialized error strings,
+// where the error chain is broken), this classifier sees raw
+// net/http results, so the typed checks fire.
+//
+// Signals, in order of likelihood:
+//
+//  1. HTTP 400 whose body is Go's canonical "Client sent an HTTP
+//     request to an HTTPS server" response: a net/http TLS listener
+//     answers plaintext HTTP this way, as a normal response, not an
+//     error.
+//  2. A redirect (301/302/307/308) to an https:// URL on the same
+//     host: TLS-terminating proxies do this. The probe client must
+//     not follow redirects, or this signal is invisible and the
+//     endpoint is mis-detected as plain HTTP.
+//  3. Transport-level tls.RecordHeaderError or EOF mid-response:
+//     TLS-only servers that hang up instead of answering.
+func probeIndicatesTLS(resp *http.Response, body []byte, err error) bool {
+	if err != nil {
+		var rec tls.RecordHeaderError
+		if errors.As(err, &rec) {
+			return true
+		}
+		if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
+			return true
+		}
+		return false
+	}
+	if resp == nil {
+		return false
+	}
+
+	switch resp.StatusCode {
+	case http.StatusMovedPermanently, http.StatusFound,
+		http.StatusTemporaryRedirect, http.StatusPermanentRedirect:
+		locHdr, lerr := resp.Location()
+		if lerr == nil && locHdr.Scheme == "https" &&
+			resp.Request != nil && resp.Request.URL != nil &&
+			locHdr.Hostname() == resp.Request.URL.Hostname() {
+			return true
+		}
+	case http.StatusBadRequest:
+		if strings.Contains(string(body), "HTTP request to an HTTPS server") {
+			return true
+		}
+	}
+	return false
+}
+
+// statusLooksRqlite reports whether resp/body look like a genuine
+// rqlite /status payload: HTTP 200, JSON content type, and a JSON
+// object with a top-level "node" key. This prevents an unrelated
+// HTTP server on the target port from being "confirmed" as rqlite.
+func statusLooksRqlite(resp *http.Response, body []byte) bool {
+	if resp == nil || resp.StatusCode != http.StatusOK {
+		return false
+	}
+	if !strings.Contains(resp.Header.Get("Content-Type"), "application/json") {
+		return false
+	}
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal(body, &m); err != nil {
+		return false
+	}
+	_, ok := m["node"]
+	return ok
+}

--- a/drivers/rqlite/detect_test.go
+++ b/drivers/rqlite/detect_test.go
@@ -14,6 +14,8 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/neilotoole/sq/libsq/core/errz"
+	"github.com/neilotoole/sq/libsq/core/options"
+	"github.com/neilotoole/sq/libsq/driver"
 	"github.com/neilotoole/sq/libsq/source"
 	"github.com/neilotoole/sq/libsq/source/drivertype"
 )
@@ -32,6 +34,9 @@ func mkResp(status int, contentType, reqURL string) *http.Response {
 }
 
 func TestProbeIndicatesTLS(t *testing.T) {
+	// Keep in sync with Go's net/http TLS-listener response;
+	// TestDetectConnParams_TLS exercises the real server-generated
+	// form end-to-end.
 	const canonical400 = "Client sent an HTTP request to an HTTPS server.\n"
 
 	t.Run("nil resp nil err", func(t *testing.T) {
@@ -146,10 +151,13 @@ func TestDetectConnParams_PlainHTTP(t *testing.T) {
 	t.Cleanup(cancel)
 
 	d := &driveri{}
-	params, err := d.detectConnParams(ctx, detectTestSrc("rqlite://"+host), nil)
+	src := detectTestSrc("rqlite://" + host)
+	ogLoc := src.Location
+	params, err := d.detectConnParams(ctx, src, nil)
 	require.NoError(t, err)
 	require.Nil(t, params, "plain-HTTP endpoint: nothing to detect")
 	require.Equal(t, int64(1), hits.Load(), "exactly one probe request")
+	require.Equal(t, ogLoc, src.Location, "detector must not mutate src")
 }
 
 func TestDetectConnParams_TLS(t *testing.T) {
@@ -164,9 +172,12 @@ func TestDetectConnParams_TLS(t *testing.T) {
 	d := &driveri{}
 	// Inject the test server's transport, which trusts its cert.
 	transport := server.Client().Transport
-	params, err := d.detectConnParams(ctx, detectTestSrc("rqlite://"+host), transport)
+	src := detectTestSrc("rqlite://" + host)
+	ogLoc := src.Location
+	params, err := d.detectConnParams(ctx, src, transport)
 	require.NoError(t, err)
 	require.Equal(t, url.Values{"tls": []string{"true"}}, params)
+	require.Equal(t, ogLoc, src.Location, "detector must not mutate src")
 }
 
 func TestDetectConnParams_TLSBadCert(t *testing.T) {
@@ -180,10 +191,13 @@ func TestDetectConnParams_TLSBadCert(t *testing.T) {
 
 	d := &driveri{}
 	// nil transport: default verification distrusts the test cert.
-	_, err := d.detectConnParams(ctx, detectTestSrc("rqlite://"+host), nil)
+	_, err := d.detectConnParams(ctx,
+		detectTestSrc("rqlite://alice:secret123@"+host), nil)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "insecure=true")
 	require.Contains(t, err.Error(), "tls=true")
+	require.NotContains(t, err.Error(), "secret123",
+		"cert error must not echo the password from src.Location")
 }
 
 func TestDetectConnParams_ExplicitIntentSkips(t *testing.T) {
@@ -201,6 +215,7 @@ func TestDetectConnParams_ExplicitIntentSkips(t *testing.T) {
 		"rqlite://" + host + "?tls=true",
 		"rqlite://" + host + "?tls=false",
 		"rqlite://" + host + "?tls=true&insecure=true",
+		"rqlite://" + host + "?insecure=true",
 	} {
 		params, err := d.detectConnParams(ctx, detectTestSrc(loc), nil)
 		require.NoError(t, err)
@@ -229,14 +244,18 @@ func TestDetectConnParams_NonRqliteServer(t *testing.T) {
 
 // TestDetectConnParams_NonRqliteJSON covers the JSON-but-not-rqlite
 // case end-to-end: a 200 application/json response without a
-// top-level "node" key must not be confirmed as rqlite, must not
-// trigger the HTTPS fallback, and must step aside.
+// top-level "node" key must not be confirmed as rqlite, and must
+// step aside after a single request. (The hit count alone can't
+// distinguish "no HTTPS fallback" from "fallback attempted but the
+// TLS handshake failed before reaching the handler"; what it pins is
+// the single-request step-aside.)
 func TestDetectConnParams_NonRqliteJSON(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(
+	var hits atomic.Int64
+	server := httptest.NewServer(countingHandler(http.HandlerFunc(
 		func(w http.ResponseWriter, _ *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
 			_, _ = w.Write([]byte(`{"version":"8","status":"ok"}`))
-		}))
+		}), &hits))
 	t.Cleanup(server.Close)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
@@ -247,6 +266,7 @@ func TestDetectConnParams_NonRqliteJSON(t *testing.T) {
 		detectTestSrc("rqlite://"+server.Listener.Addr().String()), nil)
 	require.NoError(t, err)
 	require.Nil(t, params, "non-rqlite JSON server: step aside")
+	require.Equal(t, int64(1), hits.Load(), "exactly one probe request")
 }
 
 func TestDetectConnParams_Unreachable(t *testing.T) {
@@ -288,6 +308,72 @@ func TestDetectConnParams_RedirectToHTTPS(t *testing.T) {
 	require.Nil(t, params)
 	require.Equal(t, int64(1), hits.Load(),
 		"probe must not follow the redirect: exactly one request to the front")
+}
+
+// TestDetectConnParams_HangingEndpointBounded pins two behaviors: the
+// probe client's timeout comes from conn.open-timeout (a mutation
+// passing zero or ignoring src.Options hangs this test), and a
+// client-timeout failure is not a TLS signal (step aside, nil).
+func TestDetectConnParams_HangingEndpointBounded(t *testing.T) {
+	block := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(
+		func(http.ResponseWriter, *http.Request) { <-block }))
+	t.Cleanup(func() { close(block); server.Close() })
+
+	src := detectTestSrc("rqlite://" + server.Listener.Addr().String())
+	src.Options = options.Options{
+		// Duration.Get requires a typed time.Duration value; a raw
+		// "150ms" string would silently fall back to the default.
+		driver.OptConnOpenTimeout.Key(): 150 * time.Millisecond,
+	}
+
+	start := time.Now()
+	params, err := (&driveri{}).detectConnParams(context.Background(), src, nil)
+	require.NoError(t, err)
+	require.Nil(t, params, "timeout is not a TLS signal: step aside")
+	require.Less(t, time.Since(start), 5*time.Second,
+		"probe must be bounded by conn.open-timeout, not hang")
+}
+
+// TestDetectConnParams_RedirectNotFollowedToBackend pins that the
+// probe never issues requests to a redirect target: a followed
+// redirect would leak the probe (and its Authorization header) to
+// the target. The front redirects to a separate TLS backend on the
+// same hostname (different port; the classifier compares hostname
+// only); with CheckRedirect intact the backend sees zero requests.
+// Step 1 classifies the same-host https redirect as a TLS signal;
+// step 2 then probes https against the FRONT's port (never the
+// backend's), fails the handshake against the plain listener, and
+// steps aside with nil params.
+func TestDetectConnParams_RedirectNotFollowedToBackend(t *testing.T) {
+	var backendHits atomic.Int64
+	var host string
+	backend := httptest.NewTLSServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			backendHits.Add(1)
+			newRqliteMockHandler(&host).ServeHTTP(w, r)
+		}))
+	t.Cleanup(backend.Close)
+
+	front := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			http.Redirect(w, r, backend.URL+r.URL.Path, http.StatusMovedPermanently)
+		}))
+	t.Cleanup(front.Close)
+	host = front.Listener.Addr().String()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	t.Cleanup(cancel)
+
+	d := &driveri{}
+	// The injected transport trusts the backend cert, so if the
+	// client followed the redirect, the backend WOULD answer.
+	params, err := d.detectConnParams(ctx,
+		detectTestSrc("rqlite://"+host), backend.Client().Transport)
+	require.NoError(t, err)
+	require.Nil(t, params, "https probe of the plain front must step aside")
+	require.Equal(t, int64(0), backendHits.Load(),
+		"probe must never request the redirect target")
 }
 
 func TestDetectConnParams_CtxCanceled(t *testing.T) {

--- a/drivers/rqlite/detect_test.go
+++ b/drivers/rqlite/detect_test.go
@@ -414,3 +414,33 @@ func TestDetectConnParams_BasicAuth(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, gotAuth.Load(), "probe must carry basic auth from the location userinfo")
 }
+
+// TestDetectConnParams_BasicAuthPasswordOnly pins that the
+// password-only userinfo form (rqlite://:pw@host) also produces an
+// Authorization header, matching what gorqlite sends at connection
+// time. Without this, an auth-gated /status on a TLS endpoint would
+// 401 the probe and detection would silently step aside.
+func TestDetectConnParams_BasicAuthPasswordOnly(t *testing.T) {
+	var host string
+	var gotAuth atomic.Bool
+	inner := newRqliteMockHandler(&host)
+	server := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			if u, p, ok := r.BasicAuth(); ok && u == "" && p == "pw" {
+				gotAuth.Store(true)
+			}
+			inner.ServeHTTP(w, r)
+		}))
+	t.Cleanup(server.Close)
+	host = server.Listener.Addr().String()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	t.Cleanup(cancel)
+
+	d := &driveri{}
+	_, err := d.detectConnParams(ctx,
+		detectTestSrc("rqlite://:pw@"+host), nil)
+	require.NoError(t, err)
+	require.True(t, gotAuth.Load(),
+		"password-only userinfo must still produce an Authorization header")
+}

--- a/drivers/rqlite/detect_test.go
+++ b/drivers/rqlite/detect_test.go
@@ -1,15 +1,21 @@
 package rqlite
 
 import (
+	"context"
 	"crypto/tls"
 	"io"
 	"net/http"
+	"net/http/httptest"
 	"net/url"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/neilotoole/sq/libsq/core/errz"
+	"github.com/neilotoole/sq/libsq/source"
+	"github.com/neilotoole/sq/libsq/source/drivertype"
 )
 
 func mkResp(status int, contentType, reqURL string) *http.Response {
@@ -111,4 +117,214 @@ func TestStatusLooksRqlite(t *testing.T) {
 	t.Run("nil resp", func(t *testing.T) {
 		require.False(t, statusLooksRqlite(nil, []byte(`{"node":{}}`)))
 	})
+}
+
+// countingHandler wraps h, counting requests.
+func countingHandler(h http.Handler, n *atomic.Int64) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n.Add(1)
+		h.ServeHTTP(w, r)
+	})
+}
+
+func detectTestSrc(loc string) *source.Source {
+	return &source.Source{
+		Handle:   "@rq",
+		Type:     drivertype.Rqlite,
+		Location: loc,
+	}
+}
+
+func TestDetectConnParams_PlainHTTP(t *testing.T) {
+	var host string
+	var hits atomic.Int64
+	server := httptest.NewServer(countingHandler(newRqliteMockHandler(&host), &hits))
+	t.Cleanup(server.Close)
+	host = server.Listener.Addr().String()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	t.Cleanup(cancel)
+
+	d := &driveri{}
+	params, err := d.detectConnParams(ctx, detectTestSrc("rqlite://"+host), nil)
+	require.NoError(t, err)
+	require.Nil(t, params, "plain-HTTP endpoint: nothing to detect")
+	require.Equal(t, int64(1), hits.Load(), "exactly one probe request")
+}
+
+func TestDetectConnParams_TLS(t *testing.T) {
+	var host string
+	server := httptest.NewTLSServer(newRqliteMockHandler(&host))
+	t.Cleanup(server.Close)
+	host = server.Listener.Addr().String()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	t.Cleanup(cancel)
+
+	d := &driveri{}
+	// Inject the test server's transport, which trusts its cert.
+	transport := server.Client().Transport
+	params, err := d.detectConnParams(ctx, detectTestSrc("rqlite://"+host), transport)
+	require.NoError(t, err)
+	require.Equal(t, url.Values{"tls": []string{"true"}}, params)
+}
+
+func TestDetectConnParams_TLSBadCert(t *testing.T) {
+	var host string
+	server := httptest.NewTLSServer(newRqliteMockHandler(&host))
+	t.Cleanup(server.Close)
+	host = server.Listener.Addr().String()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	t.Cleanup(cancel)
+
+	d := &driveri{}
+	// nil transport: default verification distrusts the test cert.
+	_, err := d.detectConnParams(ctx, detectTestSrc("rqlite://"+host), nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "insecure=true")
+	require.Contains(t, err.Error(), "tls=true")
+}
+
+func TestDetectConnParams_ExplicitIntentSkips(t *testing.T) {
+	var host string
+	var hits atomic.Int64
+	server := httptest.NewServer(countingHandler(newRqliteMockHandler(&host), &hits))
+	t.Cleanup(server.Close)
+	host = server.Listener.Addr().String()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	t.Cleanup(cancel)
+
+	d := &driveri{}
+	for _, loc := range []string{
+		"rqlite://" + host + "?tls=true",
+		"rqlite://" + host + "?tls=false",
+		"rqlite://" + host + "?tls=true&insecure=true",
+	} {
+		params, err := d.detectConnParams(ctx, detectTestSrc(loc), nil)
+		require.NoError(t, err)
+		require.Nil(t, params)
+	}
+	require.Equal(t, int64(0), hits.Load(), "explicit intent must mean zero probes")
+}
+
+func TestDetectConnParams_NonRqliteServer(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "text/html")
+			_, _ = w.Write([]byte("<html>hello</html>"))
+		}))
+	t.Cleanup(server.Close)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	t.Cleanup(cancel)
+
+	d := &driveri{}
+	params, err := d.detectConnParams(ctx,
+		detectTestSrc("rqlite://"+server.Listener.Addr().String()), nil)
+	require.NoError(t, err)
+	require.Nil(t, params, "non-rqlite server: step aside")
+}
+
+// TestDetectConnParams_NonRqliteJSON covers the JSON-but-not-rqlite
+// case end-to-end: a 200 application/json response without a
+// top-level "node" key must not be confirmed as rqlite, must not
+// trigger the HTTPS fallback, and must step aside.
+func TestDetectConnParams_NonRqliteJSON(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"version":"8","status":"ok"}`))
+		}))
+	t.Cleanup(server.Close)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	t.Cleanup(cancel)
+
+	d := &driveri{}
+	params, err := d.detectConnParams(ctx,
+		detectTestSrc("rqlite://"+server.Listener.Addr().String()), nil)
+	require.NoError(t, err)
+	require.Nil(t, params, "non-rqlite JSON server: step aside")
+}
+
+func TestDetectConnParams_Unreachable(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	t.Cleanup(cancel)
+
+	d := &driveri{}
+	// Port 1 on localhost: reliably refused.
+	params, err := d.detectConnParams(ctx, detectTestSrc("rqlite://127.0.0.1:1"), nil)
+	require.NoError(t, err)
+	require.Nil(t, params, "unreachable endpoint: step aside, Ping reports it")
+}
+
+func TestDetectConnParams_RedirectToHTTPS(t *testing.T) {
+	// httptest cannot serve http and https on one port, so this test
+	// verifies the redirect CLASSIFICATION path end-to-end: the front
+	// is a plain-HTTP server that redirects to https:// on its own
+	// host:port. Step 1 sees the same-host https redirect (a TLS
+	// signal; the probe client must NOT follow it), step 2 probes
+	// https:// against the plain listener, fails the handshake, and
+	// steps aside. The front's hit count proves the redirect was not
+	// followed: exactly one request.
+	var hits atomic.Int64
+	front := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			hits.Add(1)
+			target := "https://" + r.Host + r.URL.Path
+			http.Redirect(w, r, target, http.StatusMovedPermanently)
+		}))
+	t.Cleanup(front.Close)
+	host := front.Listener.Addr().String()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	t.Cleanup(cancel)
+
+	d := &driveri{}
+	params, err := d.detectConnParams(ctx, detectTestSrc("rqlite://"+host), nil)
+	require.NoError(t, err)
+	require.Nil(t, params)
+	require.Equal(t, int64(1), hits.Load(),
+		"probe must not follow the redirect: exactly one request to the front")
+}
+
+func TestDetectConnParams_CtxCanceled(t *testing.T) {
+	var host string
+	server := httptest.NewServer(newRqliteMockHandler(&host))
+	t.Cleanup(server.Close)
+	host = server.Listener.Addr().String()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // canceled before the probe starts
+
+	d := &driveri{}
+	_, err := d.detectConnParams(ctx, detectTestSrc("rqlite://"+host), nil)
+	require.Error(t, err)
+	require.ErrorIs(t, err, context.Canceled)
+}
+
+func TestDetectConnParams_BasicAuth(t *testing.T) {
+	var host string
+	var gotAuth atomic.Bool
+	inner := newRqliteMockHandler(&host)
+	server := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			if u, p, ok := r.BasicAuth(); ok && u == "alice" && p == "pw" {
+				gotAuth.Store(true)
+			}
+			inner.ServeHTTP(w, r)
+		}))
+	t.Cleanup(server.Close)
+	host = server.Listener.Addr().String()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	t.Cleanup(cancel)
+
+	d := &driveri{}
+	_, err := d.detectConnParams(ctx,
+		detectTestSrc("rqlite://alice:pw@"+host), nil)
+	require.NoError(t, err)
+	require.True(t, gotAuth.Load(), "probe must carry basic auth from the location userinfo")
 }

--- a/drivers/rqlite/detect_test.go
+++ b/drivers/rqlite/detect_test.go
@@ -1,0 +1,114 @@
+package rqlite
+
+import (
+	"crypto/tls"
+	"io"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/neilotoole/sq/libsq/core/errz"
+)
+
+func mkResp(status int, contentType, reqURL string) *http.Response {
+	u, _ := url.Parse(reqURL)
+	resp := &http.Response{
+		StatusCode: status,
+		Header:     http.Header{},
+		Request:    &http.Request{URL: u},
+	}
+	if contentType != "" {
+		resp.Header.Set("Content-Type", contentType)
+	}
+	return resp
+}
+
+func TestProbeIndicatesTLS(t *testing.T) {
+	const canonical400 = "Client sent an HTTP request to an HTTPS server.\n"
+
+	t.Run("nil resp nil err", func(t *testing.T) {
+		require.False(t, probeIndicatesTLS(nil, nil, nil))
+	})
+
+	t.Run("tls record header error", func(t *testing.T) {
+		require.True(t, probeIndicatesTLS(nil, nil, tls.RecordHeaderError{Msg: "x"}))
+	})
+
+	t.Run("io.EOF", func(t *testing.T) {
+		require.True(t, probeIndicatesTLS(nil, nil, io.EOF))
+	})
+
+	t.Run("io.ErrUnexpectedEOF", func(t *testing.T) {
+		require.True(t, probeIndicatesTLS(nil, nil, io.ErrUnexpectedEOF))
+	})
+
+	t.Run("unrelated error", func(t *testing.T) {
+		require.False(t, probeIndicatesTLS(nil, nil, errz.New("conn refused")))
+	})
+
+	t.Run("400 with canonical body", func(t *testing.T) {
+		resp := mkResp(400, "text/plain", "http://h:4001/status")
+		require.True(t, probeIndicatesTLS(resp, []byte(canonical400), nil))
+	})
+
+	t.Run("400 with other body", func(t *testing.T) {
+		resp := mkResp(400, "text/plain", "http://h:4001/status")
+		require.False(t, probeIndicatesTLS(resp, []byte("bad request"), nil))
+	})
+
+	t.Run("redirect to https same host", func(t *testing.T) {
+		resp := mkResp(301, "", "http://h:4001/status")
+		resp.Header.Set("Location", "https://h:4001/status")
+		require.True(t, probeIndicatesTLS(resp, nil, nil))
+	})
+
+	t.Run("redirect to https different host", func(t *testing.T) {
+		resp := mkResp(301, "", "http://h:4001/status")
+		resp.Header.Set("Location", "https://other.example.com/status")
+		require.False(t, probeIndicatesTLS(resp, nil, nil))
+	})
+
+	t.Run("redirect to http is not a tls signal", func(t *testing.T) {
+		resp := mkResp(302, "", "http://h:4001/status")
+		resp.Header.Set("Location", "http://h:4001/other")
+		require.False(t, probeIndicatesTLS(resp, nil, nil))
+	})
+
+	t.Run("plain 200 is not a tls signal", func(t *testing.T) {
+		resp := mkResp(200, "application/json", "http://h:4001/status")
+		require.False(t, probeIndicatesTLS(resp, []byte("{}"), nil))
+	})
+}
+
+func TestStatusLooksRqlite(t *testing.T) {
+	t.Run("rqlite-shaped json", func(t *testing.T) {
+		resp := mkResp(200, "application/json", "http://h/status")
+		require.True(t, statusLooksRqlite(resp, []byte(`{"node":{"start_time":"x"}}`)))
+	})
+
+	t.Run("non-200", func(t *testing.T) {
+		resp := mkResp(401, "application/json", "http://h/status")
+		require.False(t, statusLooksRqlite(resp, []byte(`{"node":{}}`)))
+	})
+
+	t.Run("wrong content type", func(t *testing.T) {
+		resp := mkResp(200, "text/html", "http://h/status")
+		require.False(t, statusLooksRqlite(resp, []byte(`{"node":{}}`)))
+	})
+
+	t.Run("json without node key", func(t *testing.T) {
+		resp := mkResp(200, "application/json", "http://h/status")
+		require.False(t, statusLooksRqlite(resp, []byte(`{"version":"8"}`)))
+	})
+
+	t.Run("non-json body", func(t *testing.T) {
+		resp := mkResp(200, "application/json", "http://h/status")
+		require.False(t, statusLooksRqlite(resp, []byte(`<html></html>`)))
+	})
+
+	t.Run("nil resp", func(t *testing.T) {
+		require.False(t, statusLooksRqlite(nil, []byte(`{"node":{}}`)))
+	})
+}

--- a/drivers/rqlite/dsn_test.go
+++ b/drivers/rqlite/dsn_test.go
@@ -218,21 +218,21 @@ func TestValidateSource_AllowsPlaceholderLocation(t *testing.T) {
 	require.Same(t, src, got)
 }
 
-func TestInsecureClientTimeout(t *testing.T) {
+func TestClientTimeout(t *testing.T) {
 	// The gorqlite-native ?timeout param wins over the option default.
-	got := insecureClientTimeout("https://host:4001?timeout=30", options.Options{})
+	got := clientTimeout("https://host:4001?timeout=30", options.Options{})
 	require.Equal(t, 30*time.Second, got)
 
 	// No param: falls back to OptConnOpenTimeout's default.
-	got = insecureClientTimeout("https://host:4001", options.Options{})
+	got = clientTimeout("https://host:4001", options.Options{})
 	require.Equal(t, driver.OptConnOpenTimeout.Get(options.Options{}), got)
 
 	// Invalid param: falls back.
-	got = insecureClientTimeout("https://host:4001?timeout=abc", options.Options{})
+	got = clientTimeout("https://host:4001?timeout=abc", options.Options{})
 	require.Equal(t, driver.OptConnOpenTimeout.Get(options.Options{}), got)
 
 	// Non-positive param: falls back.
-	got = insecureClientTimeout("https://host:4001?timeout=0", options.Options{})
+	got = clientTimeout("https://host:4001?timeout=0", options.Options{})
 	require.Equal(t, driver.OptConnOpenTimeout.Get(options.Options{}), got)
 }
 

--- a/drivers/rqlite/rqlite.go
+++ b/drivers/rqlite/rqlite.go
@@ -194,7 +194,7 @@ func (d *driveri) doOpen(ctx context.Context, src *source.Source) (*sql.DB, erro
 	if opts.insecure {
 		db = sql.OpenDB(&insecureConnector{
 			dsn:    dsn,
-			client: newInsecureHTTPClient(insecureClientTimeout(dsn, src.Options)),
+			client: newInsecureHTTPClient(clientTimeout(dsn, src.Options)),
 		})
 	} else {
 		db, err = sql.Open(sqDBDrvrName, dsn)
@@ -209,14 +209,15 @@ func (d *driveri) doOpen(ctx context.Context, src *source.Source) (*sql.DB, erro
 	return db, nil
 }
 
-// insecureClientTimeout returns the HTTP client timeout for the
-// insecure (skip-verify) connection path. gorqlite applies the
+// clientTimeout returns the HTTP client timeout for the clients that
+// sq constructs itself: the insecure (skip-verify) connection path
+// and the conn param detection probe. gorqlite applies the
 // gorqlite-native ?timeout=N URL param (integer seconds) only when it
-// constructs its own http.Client; sq passes a custom client on the
-// insecure path, so the param must be honored here. ?timeout takes
-// precedence over conn.open-timeout, matching what gorqlite does on
-// the default path when no custom client is supplied.
-func insecureClientTimeout(dsn string, o options.Options) time.Duration {
+// constructs its own http.Client; sq passes a custom client on these
+// paths, so the param must be honored here. ?timeout takes precedence
+// over conn.open-timeout, matching what gorqlite does on the default
+// path when no custom client is supplied.
+func clientTimeout(dsn string, o options.Options) time.Duration {
 	timeout := driver.OptConnOpenTimeout.Get(o)
 	if u, err := url.Parse(dsn); err == nil {
 		if v := u.Query().Get("timeout"); v != "" {

--- a/libsq/driver/detect.go
+++ b/libsq/driver/detect.go
@@ -1,0 +1,72 @@
+package driver
+
+import (
+	"context"
+	"net/url"
+
+	"github.com/neilotoole/sq/libsq/source"
+)
+
+// ConnParamDetector is an optional interface that drivers can
+// implement to detect omitted connection parameters by inspecting
+// the live endpoint that a source location points at. The canonical
+// example is the rqlite driver detecting that an endpoint requires
+// TLS and returning {"tls": ["true"]}, sparing the user a failed
+// add and a manual retry with the corrected location.
+//
+// sq exercises this interface only when a source location is being
+// established. Today that means "sq add": after the source has been
+// validated, before it is persisted, and never when --skip-verify
+// is set. It is not invoked at Open, Ping, or query time, and a
+// persisted source is never re-detected; if an endpoint's transport
+// changes later, the user sees a connection error with a hint, not
+// a silent config rewrite. Implementations must not depend on this
+// schedule: it is caller policy, and detection must be safe to
+// invoke at any lifecycle point, which follows from the requirement
+// that implementations mutate neither src nor any other state.
+//
+// Detection inspects the live endpoint and therefore touches the
+// network. That is definitional, not incidental: it is why
+// --skip-verify suppresses detection. A parameter that can be
+// derived offline from the location string alone is not detection
+// but canonicalization (the family of the drivers' MungeLocation
+// functions), and must not be implemented via this interface,
+// because canonicalization must not be suppressed by
+// --skip-verify. Implementations must honor ctx cancellation and
+// should bound each network attempt, e.g. via OptConnOpenTimeout.
+type ConnParamDetector interface {
+	// DetectConnParams inspects the endpoint that src.Location
+	// points at, and returns connection query parameters to be
+	// merged into the location before it is persisted. src arrives
+	// with secret placeholders already resolved. The caller owns
+	// the merge onto the stored (possibly placeholder-bearing)
+	// form, and the caller decides disposition: implementations
+	// MUST NOT assume that returned params will be applied.
+	//
+	// The returned keys must be a subset of the keys advertised by
+	// SQLDriver.ConnParams. Values must be high-confidence
+	// observations of the endpoint, never guesses: when in doubt,
+	// return nothing.
+	//
+	// A (nil, nil) return means "nothing detected, or nothing to
+	// do", and is the expected result in most situations,
+	// including:
+	//
+	//   - The location already expresses explicit intent (e.g. the
+	//     user typed ?tls=true or ?tls=false): detection must not
+	//     second-guess the user.
+	//   - The endpoint is unreachable or the response is
+	//     ambiguous: connection failures are not this method's
+	//     concern, and surface with full context from the Ping
+	//     that follows during "sq add".
+	//
+	// A non-nil error aborts the add. It is reserved for the case
+	// where detection has learned something that dooms the add AND
+	// can be reported more usefully here than by the subsequent
+	// Ping. For example: the endpoint demands TLS but presents an
+	// unverifiable certificate, where the actionable error names
+	// the ?insecure=true escape hatch and the install-the-CA
+	// alternative in one message. Errors must be actionable and
+	// must not leak credentials from src.Location.
+	DetectConnParams(ctx context.Context, src *source.Source) (url.Values, error)
+}

--- a/libsq/driver/detect.go
+++ b/libsq/driver/detect.go
@@ -33,7 +33,10 @@ import (
 // functions), and must not be implemented via this interface,
 // because canonicalization must not be suppressed by
 // --skip-verify. Implementations must honor ctx cancellation and
-// should bound each network attempt, e.g. via OptConnOpenTimeout.
+// should bound each network attempt, e.g. via OptConnOpenTimeout or
+// a driver-native timeout param when one exists (the rqlite driver
+// gives its ?timeout=N param precedence over OptConnOpenTimeout,
+// matching its connection-time behavior).
 type ConnParamDetector interface {
 	// DetectConnParams inspects the endpoint that src.Location
 	// points at, and returns connection query parameters to be

--- a/libsq/source/location/location.go
+++ b/libsq/source/location/location.go
@@ -692,8 +692,9 @@ func redactBestEffort(loc string) string {
 
 // MergeQuery returns loc with the given query params set, replacing
 // any existing values for the same keys. Other query params are
-// preserved. loc must be a parseable URL; locations bearing secret
-// placeholders are the caller's responsibility to exclude.
+// preserved. loc must be a parseable URL with a scheme; locations
+// bearing secret placeholders are the caller's responsibility to
+// exclude.
 func MergeQuery(loc string, params url.Values) (string, error) {
 	if len(params) == 0 {
 		return loc, nil
@@ -707,6 +708,12 @@ func MergeQuery(loc string, params url.Values) (string, error) {
 			err = uerr.Err
 		}
 		return "", errz.Wrapf(err, "merge query: invalid location: %s",
+			redactBestEffort(loc))
+	}
+	if u.Scheme == "" {
+		// url.Parse accepts bare file paths; without a scheme there is
+		// no URL to merge query params into.
+		return "", errz.Errorf("merge query: location has no scheme: %s",
 			redactBestEffort(loc))
 	}
 	q := u.Query()

--- a/libsq/source/location/location.go
+++ b/libsq/source/location/location.go
@@ -692,7 +692,9 @@ func redactBestEffort(loc string) string {
 
 // MergeQuery returns loc with the given query params set, replacing
 // any existing values for the same keys. Other query params are
-// preserved. loc must be a parseable URL with a scheme; locations
+// preserved. loc must be parseable by net/url and have a scheme:
+// driver-native DSN forms that net/url cannot parse (e.g. mysql's
+// "user@tcp(host)/db" shape) must not be passed here, and locations
 // bearing secret placeholders are the caller's responsibility to
 // exclude.
 func MergeQuery(loc string, params url.Values) (string, error) {

--- a/libsq/source/location/location.go
+++ b/libsq/source/location/location.go
@@ -689,3 +689,33 @@ func redactBestEffort(loc string) string {
 	loc = redactRawDSNPw.ReplaceAllString(loc, "${1}xxxxx")
 	return loc
 }
+
+// MergeQuery returns loc with the given query params set, replacing
+// any existing values for the same keys. Other query params are
+// preserved. loc must be a parseable URL; locations bearing secret
+// placeholders are the caller's responsibility to exclude.
+func MergeQuery(loc string, params url.Values) (string, error) {
+	if len(params) == 0 {
+		return loc, nil
+	}
+	u, err := url.Parse(loc)
+	if err != nil {
+		// url.Error embeds the raw input (which may carry inline
+		// credentials); strip the wrapper and redact the loc.
+		var uerr *url.Error
+		if errors.As(err, &uerr) {
+			err = uerr.Err
+		}
+		return "", errz.Wrapf(err, "merge query: invalid location: %s",
+			redactBestEffort(loc))
+	}
+	q := u.Query()
+	for k, vs := range params {
+		q.Del(k)
+		for _, v := range vs {
+			q.Add(k, v)
+		}
+	}
+	u.RawQuery = q.Encode()
+	return u.String(), nil
+}

--- a/libsq/source/location/location_test.go
+++ b/libsq/source/location/location_test.go
@@ -193,3 +193,64 @@ func TestParseRqliteMalformedRedaction(t *testing.T) {
 	require.NotContains(t, err.Error(), "secret")
 	require.Contains(t, err.Error(), "xxxxx")
 }
+
+func TestMergeQuery(t *testing.T) {
+	testCases := []struct {
+		name    string
+		loc     string
+		params  url.Values
+		want    string
+		wantErr bool
+	}{
+		{
+			name:   "nil params returns loc unchanged",
+			loc:    "rqlite://host:4001",
+			params: nil,
+			want:   "rqlite://host:4001",
+		},
+		{
+			name:   "single param on bare loc",
+			loc:    "rqlite://host:4001",
+			params: url.Values{"tls": {"true"}},
+			want:   "rqlite://host:4001?tls=true",
+		},
+		{
+			name:   "existing unrelated params preserved",
+			loc:    "rqlite://host:4001?level=strong",
+			params: url.Values{"tls": {"true"}},
+			want:   "rqlite://host:4001?level=strong&tls=true",
+		},
+		{
+			name:   "existing same-key param replaced not duplicated",
+			loc:    "rqlite://host:4001?tls=false",
+			params: url.Values{"tls": {"true"}},
+			want:   "rqlite://host:4001?tls=true",
+		},
+		{
+			name:   "credentials round-trip unchanged",
+			loc:    "rqlite://alice:pw@host:4001",
+			params: url.Values{"tls": {"true"}},
+			want:   "rqlite://alice:pw@host:4001?tls=true",
+		},
+		{
+			name:    "unparseable loc errors without echoing it",
+			loc:     "rqlite://alice:secret@[::1",
+			params:  url.Values{"tls": {"true"}},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := location.MergeQuery(tc.loc, tc.params)
+			if tc.wantErr {
+				require.Error(t, err)
+				require.NotContains(t, err.Error(), "secret",
+					"merge errors must not echo credentials")
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/libsq/source/location/location_test.go
+++ b/libsq/source/location/location_test.go
@@ -238,6 +238,12 @@ func TestMergeQuery(t *testing.T) {
 			params:  url.Values{"tls": {"true"}},
 			wantErr: true,
 		},
+		{
+			name:    "scheme-less loc rejected",
+			loc:     "/path/to/file.db",
+			params:  url.Values{"tls": {"true"}},
+			wantErr: true,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/site/content/en/docs/drivers/rqlite.md
+++ b/site/content/en/docs/drivers/rqlite.md
@@ -138,10 +138,11 @@ Prefer installing the CA in your trust store for production use.
 You usually don't need to specify `tls=true` yourself: at
 [`sq add`](/docs/cmd/add) time, `sq` probes the endpoint, and if it detects that
 the server requires TLS, it stores `tls=true` on the source automatically. The
-probe is skipped if you pass `--skip-verify`, or if the location already
-specifies `tls` or `insecure`. If the server requires TLS but presents a
-certificate that can't be verified, `sq add` fails with instructions: add
-`insecure=true`, or install the CA in your trust store.
+probe is skipped if you pass `--skip-verify`, if the location already includes
+a `tls` or `insecure` param, or if the location contains `${...}` secret
+placeholders (such as those written by `--store keyring`). If the server
+requires TLS but presents a certificate that can't be verified, `sq add` fails
+with instructions: add `insecure=true`, or install the CA in your trust store.
 
 ## Write behavior
 

--- a/site/content/en/docs/drivers/rqlite.md
+++ b/site/content/en/docs/drivers/rqlite.md
@@ -135,6 +135,14 @@ $ sq add 'rqlite://node.example.com:4001?tls=true&insecure=true'
 `insecure=true` skips TLS certificate verification for the source.
 Prefer installing the CA in your trust store for production use.
 
+You usually don't need to specify `tls=true` yourself: at
+[`sq add`](/docs/cmd/add) time, `sq` probes the endpoint, and if it detects that
+the server requires TLS, it stores `tls=true` on the source automatically. The
+probe is skipped if you pass `--skip-verify`, or if the location already
+specifies `tls` or `insecure`. If the server requires TLS but presents a
+certificate that can't be verified, `sq add` fails with instructions: add
+`insecure=true`, or install the CA in your trust store.
+
 ## Write behavior
 
 rqlite has no interactive transactions; its HTTP API exposes single

--- a/skills/sq/references/rqlite.md
+++ b/skills/sq/references/rqlite.md
@@ -6,7 +6,7 @@ Networked distributed SQLite via [rqlite](https://rqlite.io). Driver type in `sq
 
 ## Add a source
 
-Use [`sq add`](https://sq.io/docs/cmd/add) with an HTTP(S) URL. Default port: `4001` (auto-applied when missing). Driver type is inferred from the `rqlite://` scheme. TLS is opt-in via `?tls=true`, but `sq add` auto-detects TLS-only endpoints and applies it; add `?tls=true&insecure=true` to accept self-signed certificates.
+Use [`sq add`](https://sq.io/docs/cmd/add) with an HTTP(S) URL. Default port: `4001` (auto-applied when missing). Driver type is inferred from the `rqlite://` scheme. TLS is opt-in via `?tls=true`, but `sq add` auto-detects TLS-only endpoints and applies it (skipped with `--skip-verify`, explicit `tls`/`insecure` params, or `${...}` placeholder locations); add `?tls=true&insecure=true` to accept self-signed certificates.
 
 **Common setups:**
 

--- a/skills/sq/references/rqlite.md
+++ b/skills/sq/references/rqlite.md
@@ -6,7 +6,7 @@ Networked distributed SQLite via [rqlite](https://rqlite.io). Driver type in `sq
 
 ## Add a source
 
-Use [`sq add`](https://sq.io/docs/cmd/add) with an HTTP(S) URL. Default port: `4001` (auto-applied when missing). Driver type is inferred from the `rqlite://` scheme. TLS is opt-in via `?tls=true`; add `?tls=true&insecure=true` to accept self-signed certificates.
+Use [`sq add`](https://sq.io/docs/cmd/add) with an HTTP(S) URL. Default port: `4001` (auto-applied when missing). Driver type is inferred from the `rqlite://` scheme. TLS is opt-in via `?tls=true`, but `sq add` auto-detects TLS-only endpoints and applies it; add `?tls=true&insecure=true` to accept self-signed certificates.
 
 **Common setups:**
 


### PR DESCRIPTION
## Summary

`sq add 'rqlite://host:4001'` against a TLS-only endpoint now succeeds in one
invocation: sq probes the endpoint, detects that it requires TLS, and persists
`?tls=true` on the source. Previously (per #756) the add failed and the error hint
told the user to retry with `?tls=true`; this PR removes that re-run.

The mechanism is a new generic optional driver interface, `driver.ConnParamDetector`,
with the rqlite driver as the first implementer. This is the work deferred from #756
and tracked by #764.

Closes #764.

## The interface: `driver.ConnParamDetector`

```go
type ConnParamDetector interface {
    DetectConnParams(ctx context.Context, src *source.Source) (url.Values, error)
}
```

New file `libsq/driver/detect.go`. The contract encodes several deliberate design
decisions (the godoc is the authoritative statement):

- **Named for the stage's contribution, not the pipeline's goal.** The detector
  returns facts about the endpoint, delivered as conn params; the CLI decides where
  to write them. Candidate names evaluated and rejected during design: `Prober`
  (mechanism-named; collides conceptually with `Ping`), `Suggester` (implies a
  reviewing party; the result is auto-applied), `Discoverer` (collides with rqlite's
  own `disableClusterDiscovery`), `Resolver`/`Completer` (taken by secrets and shell
  completion), `LocationSolver`/`Finalizer` (name the pipeline, not the stage).
  `Detect` joins an existing consistent cluster: `files.TypeDetectFunc`,
  `kind.Detector`, stdlib `http.DetectContentType` — all mean "examine the real
  artifact to infer config the user didn't supply, conservative fallback when unsure."
- **Capability, not hook.** The add-time-only schedule is caller policy, recorded in
  godoc; the implementation body is lifecycle-independent. The add-coupling is named
  at the CLI helper (`detectConnParamsForAdd`), not the interface.
- **Disposition-agnostic.** Implementations must not assume returned params are
  applied; a future interactive confirm flow needs zero interface changes.
- **Network-definitional.** Detection inspects the live endpoint; that is why
  `--skip-verify` suppresses it. Offline derivations belong in the
  canonicalization family (MungeLocation), which must NOT be suppressed by
  `--skip-verify`.
- **Additive-only error contract.** `(nil, nil)` is the default posture: unreachable
  endpoints, ambiguous responses, and non-rqlite servers all step aside, because the
  Ping that follows reports those failures with the full #756 error enrichment. The
  error return is reserved for the single case detection reports better than Ping:
  endpoint demands TLS but the cert is unverifiable, where the user gets the full
  prescription (`?tls=true&insecure=true` or install the CA) in one shot.

## The rqlite implementation (`drivers/rqlite/detect.go`)

Two-step probe of `GET /status`:

| Step | Outcome | Action |
| --- | --- | --- |
| 1: plain HTTP | 200 + rqlite-shaped JSON | Endpoint speaks HTTP; nothing to detect |
| 1 | TLS signal (below) | Go to step 2 |
| 1 | Anything else | Step aside (`nil, nil`) |
| 2: HTTPS, standard verification | 200 + rqlite-shaped JSON | Return `{"tls": ["true"]}` |
| 2 | Cert verification failure | Actionable error naming `?insecure=true` + install-the-CA |
| 2 | Anything else | Step aside |

**TLS-signal classifier** (`probeIndicatesTLS`): the canonical Go 400 body ("Client
sent an HTTP request to an HTTPS server" — arrives as a normal response, not an
error), a same-host `https://` redirect (TLS-terminating proxies), or transport-level
`tls.RecordHeaderError` / mid-response EOF. Unlike #756's `isTLSSignal` (which
classifies gorqlite-serialized strings with a broken error chain), the probe talks
`net/http` directly, so the typed `errors.As` checks actually fire. The EOF arm is
documented as a deliberately weak signal (any abrupt close matches) with the
response-validation fingerprint as the second line of defense.

**Response validation** (`statusLooksRqlite`): only HTTP 200 + JSON content type + a
top-level `"node"` key counts as rqlite, so a random HTTP server on the target port
cannot be "confirmed."

**Probe hygiene:**

- Credentials travel in the Authorization header, never the probe URL, so
  error-embedded URLs (Go's `url.Error` format) are credential-free by construction.
- The probe client never follows redirects (`CheckRedirect: ErrUseLastResponse`): a
  same-host https redirect IS the TLS signal, and following one would both hide the
  signal and leak the Authorization header to redirect targets.
- Per-attempt timeout via the `clientTimeout` helper (renamed from #766's
  `insecureClientTimeout`), which honors the gorqlite-native `?timeout=N` URL param
  over `conn.open-timeout` — keeping the probe consistent with the documented
  behavior that `?timeout` applies to every request the driver makes.
- The probe body read is bounded (64 KiB) and never logged or embedded in errors.

## CLI wiring (`cli/cmd_add.go`)

`detectConnParamsForAdd` runs in `execSrcAdd` between source construction and
persistence (`DriverFor` is hoisted above `Collection.Add` so the detector and Ping
share the driver instance). Gates, in order:

1. `--skip-verify` set: skip (same flag, same meaning as skipping Ping).
2. Driver doesn't implement the interface: skip.
3. Location contains `${...}` secret placeholders (e.g. minted by `--store keyring`):
   skip. Detected params would have to be merged into a stored form whose URL
   structure is opaque; composition-aware rewriting is future work. Mirrors
   `ValidateSource`'s placeholder posture.
4. Driver-side intent gate (in the rqlite impl): user already typed `?tls=...` or
   `?insecure=...`: detection never second-guesses explicit intent, with zero
   network contact.

Returned params are filtered to the subset advertised by the driver's `ConnParams()`
(`filterToAdvertisedParams`, drop-and-warn: a driver bug must not fail the user's
add; a non-SQLDriver advertises nothing, so everything is dropped), then merged into
the stored location via the new `location.MergeQuery` helper (replace-not-duplicate
semantics; rejects unparseable and scheme-less inputs with redacted errors).

Detection runs BEFORE Ping, so Ping verifies the rewritten location. Detection
failures before `ConfigStore.Save` are covered by the existing keyring-rollback
defer. Operation is silent: `slog.Debug` breadcrumbs only (the stderr `AddHinter`
mechanism, #755, remains separate and unbuilt).

## Testing

~600 lines of new tests, all httptest-based (no Docker required for the new paths):

- **Classifier/validator tables**: all three signal families, different-host and
  http-target redirects rejected, JSON-without-node rejected, nil-safety.
- **Probe end-to-end** (`detect_test.go`): plain HTTP (exactly one request,
  hit-counted), TLS success (injected transport trusting the test cert), bad cert
  (error contains both `tls=true` and `insecure=true`, and does NOT echo the
  password from a credentialed location), non-rqlite HTML and non-rqlite JSON,
  unreachable, redirect-not-followed (redirect target hit-counted at zero),
  hanging endpoint bounded by a 150ms `conn.open-timeout` (pins both the timeout
  plumbing and timeout-is-not-a-TLS-signal), ctx cancellation, basic auth
  delivery, explicit-intent skip with zero requests (including insecure-only), and
  no-mutation assertions on `src`.
- **CLI seam** (`cmd_add_test.go`): TLS endpoint gets `tls=true` persisted (swaps
  `http.DefaultTransport` so both the probe and gorqlite's Ping trust the test
  cert; deliberately non-parallel); plain endpoint not rewritten; `--skip-verify`
  produces zero network requests; placeholder location persisted byte-identical;
  placeholder gate isolated via error-mode discrimination (with the gate, the add
  fails with Ping's `appears to require TLS` hint; without it, with detection's
  cert error); subset filter drop behavior including the non-SQLDriver drop-all
  case (stub driver).
- **Mutation checks performed and documented**: removing the
  `detectConnParamsForAdd` call fails the TLS seam test (failing with the #756
  hint — direct proof the two features compose); disabling the placeholder gate
  flips the placeholder subtest's failure mode. A reviewer-run mutation sweep
  (9 mutations) drove four additional tests that killed the survivors.
- `location.MergeQuery` unit table: replace/preserve/credential round-trip,
  unparseable and scheme-less rejection without credential echo.

## Docs

- `site/content/en/docs/drivers/rqlite.md`: TLS section describes auto-detection,
  all three suppression conditions (`--skip-verify`, explicit `tls`/`insecure`
  params, `${...}` placeholder locations), and the unverifiable-cert failure.
- `skills/sq/references/rqlite.md`: same, terse form.
- `CHANGELOG.md`: `[#764]` sub-bullet under the `#444` rqlite bullet (rqlite remains
  unreleased; matches the #756 precedent).

## Review provenance

- Four-lens deep review (correctness, security, test coverage, cross-layer
  consistency) plus three Copilot review rounds; all findings fixed and threads
  resolved. Highlights: the `?timeout` probe inconsistency, the non-SQLDriver
  filter passthrough, `MergeQuery` scheme enforcement, doc corrections for the
  placeholder skip, and a credential-safety test gap where the property held only
  by accident of two independent mechanisms.
- Security lens verdict: clean. A MITM on the HTTP path can at worst *prevent* TLS
  detection (no worse than the no-probe baseline); the persisted value is
  hard-coded `tls=true`, never derived from response content.

## Relationship to prior work

- #756 shipped the single `rqlite://` scheme with `?tls=true`/`?insecure=true` and
  the error enrichment that this PR's detection now mostly preempts. The enrichment
  remains the fallback for `--skip-verify`, placeholder sources, and endpoint drift
  after add (persisted sources are never re-detected: transport changes surface as
  connection errors with hints, not silent config rewrites).
- #755 (`AddHinter`, stderr Tip lines) remains unbuilt and orthogonal.

## Test plan

- [x] `make test-short` / `make test` (full Docker suite) / `make lint` /
      `make lint-markdown`
- [x] Mutation checks (wiring, placeholder gate) verified failing-then-green
- [x] Single-call-site invariant: `ConnParamDetector` appears only in the interface
      file, the rqlite implementation, and the one `execSrcAdd` path
- [x] Branch up to date with master