### PR TITLE
rqlite: docs restructure, cluster helper scenario flags, enriched connection errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -132,17 +132,17 @@ keyring support) and support for [rqlite](https://sq.io/docs/drivers/rqlite).
   - Subcommands that don't print a source location (e.g. [`sq sql`](https://sq.io/docs/cmd/sql),
     `sq slq`, `sq tbl`) accept `--expand` as a silent no-op, so a global alias like
     `alias sq='sq --reveal --expand'` is safe.
-- [#742]: The [rqlite driver](https://sq.io/docs/drivers/rqlite) now surfaces an
-  actionable hint when a single-node localhost setup hits gorqlite's cluster-discovery
-  default. Any command that opens an `rqlite://` source whose host is loopback
-  (e.g. `localhost`, `127.0.0.1`, `::1`), including [`sq add`](https://sq.io/docs/cmd/add)
-  and [`sq ping`](https://sq.io/docs/cmd/ping), logs a one-line `WARN` pointing at
-  `?disableClusterDiscovery=true` and the
-  [single-node-localhost docs](https://sq.io/docs/drivers/rqlite#single-node-localhost)
-  when the parameter is not explicitly set to `true` or `false`. If the peer-discovery
-  DNS lookup actually fails with "no such host", the error message is rewritten to
-  name the unreachable peer and suggest the same fix, instead of surfacing gorqlite's
-  raw `tried all peers unsuccessfully` text.
+- [#742]: rqlite connection failures now surface concise, actionable error messages
+  instead of gorqlite's raw `tried all peers unsuccessfully` text. When cluster
+  discovery routes a request to an advertised peer that the client can't resolve or
+  reach (the
+  [single-node-localhost trap](https://sq.io/docs/drivers/rqlite#single-node-localhost)),
+  the error names the peer and points at `?disableClusterDiscovery=true`. Auth (401),
+  TLS-mismatch (both directions), and certificate-verification failures get the same
+  treatment. The concise form prints in text and JSON error output; full diagnostic
+  detail remains in verbose output and the log file. And because the driver's ping now
+  performs a real round-trip query, a broken source fails at
+  [`sq add`](https://sq.io/docs/cmd/add) time instead of at first query.
 - Internal: `sq add` shell completion reworked atop a declarative
   per-driver `LocationShape` model. Each SQL driver declares its URL
   syntax via the new `driver.LocationShape` type; the completer is a

--- a/cli/error.go
+++ b/cli/error.go
@@ -137,12 +137,12 @@ func PrintError(ctx context.Context, ru *run.Run, err error) {
 		return
 	}
 
-	// Not JSON and not a renderable parse error: print the plain error to
+	// Not JSON and not a renderable parse error: print the human form to
 	// errOut, consistent with the JSON and parse-error paths above. pr carries
 	// the correct color setting for errOut (getOutputConfig matches errOutPr to
 	// the errOut writer; the pr == nil fallback above forces no color), so
 	// there's no need for a separate terminal check against os.Stderr.
-	pr.Error.Fprintln(errOut, "sq: "+err.Error())
+	pr.Error.Fprintln(errOut, "sq: "+humanErr.Error())
 }
 
 // bootstrapIsFormatJSON is a last-gasp attempt to check if the user
@@ -197,16 +197,12 @@ func humanizeError(err error) error {
 		return nil
 	}
 
-	// An error anywhere in the chain that implements errz.HumanReadable
-	// supplies its own concise user-facing message, replacing the full
-	// rendered chain (which remains in the log and in verbose output).
-	var hr errz.HumanReadable
-	if errors.As(err, &hr) {
-		return errz.New(hr.HumanError())
-	}
-
 	switch {
-	// Friendlier messages for context errors.
+	// Friendlier messages for context errors. These take precedence
+	// over the HumanReadable check below: cancellation and timeout
+	// reflect the user's own action (or their deadline), and a
+	// confident domain diagnosis of the interrupted operation would
+	// mislead.
 	default:
 	case errors.Is(err, bufio.ErrTooLong):
 		err = errz.Errorf(
@@ -227,6 +223,14 @@ func humanizeError(err error) error {
 		// For generic context.DeadlineExceeded errors, we
 		// just return "timeout".
 		err = errz.New("timeout")
+	}
+
+	// An error anywhere in the chain that implements errz.HumanReadable
+	// supplies its own concise user-facing message, replacing the full
+	// rendered chain (which remains in the log and in verbose output).
+	var hr errz.HumanReadable
+	if errors.As(err, &hr) {
+		return errz.New(hr.HumanError())
 	}
 
 	return err

--- a/cli/error.go
+++ b/cli/error.go
@@ -197,6 +197,14 @@ func humanizeError(err error) error {
 		return nil
 	}
 
+	// An error anywhere in the chain that implements errz.HumanReadable
+	// supplies its own concise user-facing message, replacing the full
+	// rendered chain (which remains in the log and in verbose output).
+	var hr errz.HumanReadable
+	if errors.As(err, &hr) {
+		return errz.New(hr.HumanError())
+	}
+
 	switch {
 	// Friendlier messages for context errors.
 	default:

--- a/cli/error_test.go
+++ b/cli/error_test.go
@@ -128,3 +128,28 @@ func TestHumanizeError_HumanReadable(t *testing.T) {
 	plain := errz.New("ordinary failure")
 	require.Equal(t, "ordinary failure", cli.HumanizeError(plain).Error())
 }
+
+// TestPrintError_HumanReadable_EndToEnd covers the full path from
+// PrintError through the run's error writer: a HumanReadable error in
+// the chain must yield the concise human form on stderr, not the full
+// diagnostic chain.
+func TestPrintError_HumanReadable_EndToEnd(t *testing.T) {
+	th := testh.New(t)
+	tr := testrun.New(th.Context, t, nil)
+	// Run a trivial command so the run's writers are initialized.
+	require.NoError(t, tr.Exec("ls"))
+
+	inner := &humanReadableError{
+		human: "@x: short human form",
+		full:  "long diagnostic dump: tried all peers unsuccessfully",
+	}
+	err := errz.Wrap(errz.Err(inner), "failed to read @x source metadata")
+	cli.PrintError(th.Context, tr.Run, err)
+
+	got := tr.ErrOut.String()
+	require.Contains(t, got, "short human form")
+	require.NotContains(t, got, "long diagnostic dump",
+		"text output must print the human form, not the full chain")
+	require.NotContains(t, got, "failed to read @x source metadata",
+		"humanization replaces the outer operation context too")
+}

--- a/cli/error_test.go
+++ b/cli/error_test.go
@@ -106,3 +106,25 @@ func TestPrintError_GenericError_Bootstrap(t *testing.T) {
 	require.Contains(t, tr.ErrOut.String(), "sq: something broke",
 		"generic bootstrap error must reach errOut, consistent with the parse-error path")
 }
+
+// humanReadableError is a test double implementing errz.HumanReadable.
+type humanReadableError struct{ human, full string }
+
+func (e *humanReadableError) Error() string      { return e.full }
+func (e *humanReadableError) HumanError() string { return e.human }
+
+func TestHumanizeError_HumanReadable(t *testing.T) {
+	inner := &humanReadableError{
+		human: "short and friendly (see docs).",
+		full:  "long diagnostic dump: tried all peers unsuccessfully...",
+	}
+	err := errz.Wrap(errz.Err(inner), "failed to read @rq source metadata")
+
+	got := cli.HumanizeError(err)
+	require.Equal(t, inner.human, got.Error(),
+		"a HumanReadable in the chain must replace the full rendered chain")
+
+	// Plain errors pass through with message intact.
+	plain := errz.New("ordinary failure")
+	require.Equal(t, "ordinary failure", cli.HumanizeError(plain).Error())
+}

--- a/cli/error_test.go
+++ b/cli/error_test.go
@@ -1,6 +1,7 @@
 package cli_test
 
 import (
+	"context"
 	"encoding/json"
 	"testing"
 
@@ -152,4 +153,12 @@ func TestPrintError_HumanReadable_EndToEnd(t *testing.T) {
 		"text output must print the human form, not the full chain")
 	require.NotContains(t, got, "failed to read @x source metadata",
 		"humanization replaces the outer operation context too")
+}
+
+// TestHumanizeError_ContextPrecedence pins that cancellation/timeout
+// messages win over a HumanReadable in the same chain: the user's own
+// interruption must not be reported as a confident domain diagnosis.
+func TestHumanizeError_ContextPrecedence(t *testing.T) {
+	err := errz.WithHuman(errz.Err(context.Canceled), "@x: confident domain diagnosis")
+	require.Equal(t, "canceled", cli.HumanizeError(err).Error())
 }

--- a/cli/internal_test.go
+++ b/cli/internal_test.go
@@ -12,6 +12,7 @@ var (
 	RenderSQLSupportsFormat   = renderSQLSupportsFormat
 	ErrBinaryFormatToTerminal = errBinaryFormatToTerminal
 	FilterToAdvertisedParams  = filterToAdvertisedParams
+	HumanizeError             = humanizeError
 )
 
 // The legacy parsedLoc/plocStage parser was removed when

--- a/cli/output/csvw/pingwriter.go
+++ b/cli/output/csvw/pingwriter.go
@@ -38,7 +38,8 @@ func (p *pingWriter) Result(src *source.Source, d time.Duration, err error) erro
 		if errors.Is(err, context.DeadlineExceeded) {
 			rec[2] = "timeout exceeded"
 		} else {
-			rec[2] = err.Error()
+			// Concise human form when available.
+			rec[2] = errz.HumanMessage(err)
 		}
 	} else {
 		rec[2] = "pong"

--- a/cli/output/jsonw/pingwriter.go
+++ b/cli/output/jsonw/pingwriter.go
@@ -52,7 +52,9 @@ func (p pingWriter) Result(src *source.Source, d time.Duration, err error) error
 	}
 
 	if err != nil {
-		r.Error = err.Error()
+		// Concise human form when available, matching the error
+		// rendering of error.format=json.
+		r.Error = errz.HumanMessage(err)
 	}
 
 	enc := jsoncolor.NewEncoder(p.out)

--- a/cli/output/tablew/pingwriter.go
+++ b/cli/output/tablew/pingwriter.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/neilotoole/sq/cli/output"
+	"github.com/neilotoole/sq/libsq/core/errz"
 	"github.com/neilotoole/sq/libsq/source"
 )
 
@@ -59,7 +60,10 @@ func (w *PingWriter) Result(src *source.Source, d time.Duration, err error) erro
 
 	default: // err other than timeout err
 		w.pr.Error.Fprintf(w.out, "fail")
-		fmt.Fprintf(w.out, "  %s", err)
+		// HumanMessage keeps the one-row-per-source layout intact:
+		// some enriched driver errors carry multi-line diagnostic
+		// chains in Error().
+		fmt.Fprintf(w.out, "  %s", errz.HumanMessage(err))
 	}
 
 	fmt.Fprintf(w.out, "\n")

--- a/drivers/rqlite/connector_test.go
+++ b/drivers/rqlite/connector_test.go
@@ -24,7 +24,9 @@ import (
 //     gorqlite falls through to the /nodes fallback.
 //   - GET /nodes   — returns the test server itself as the single reachable
 //     leader, using *hostPtr resolved at call time.
-//   - GET /db/query — returns a no-op single-row result (used by PingContext).
+//   - GET /db/query — returns a no-op single-row result. gorqlite routes
+//     both PingContext and SELECT queries (e.g. the driver Ping's
+//     "SELECT 1") here.
 func newRqliteMockHandler(hostPtr *string) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")

--- a/drivers/rqlite/detect.go
+++ b/drivers/rqlite/detect.go
@@ -180,11 +180,14 @@ func (d *driveri) detectConnParams(ctx context.Context, src *source.Source,
 		hint := suggestLocWithParams(src, url.Values{
 			"tls": {"true"}, "insecure": {"true"},
 		})
-		return nil, errz.Wrapf(err2,
-			"%s: the endpoint requires TLS, but its certificate could not "+
-				"be verified. If this is a self-signed or private-CA "+
-				"deployment, retry with %s, or install the CA in your "+
-				"trust store", src.Handle, hint)
+		return nil, errz.WithHuman(
+			errz.Wrapf(err2,
+				"%s: the endpoint requires TLS, but its certificate could not "+
+					"be verified. If this is a self-signed or private-CA "+
+					"deployment, retry with %s, or install the CA in your "+
+					"trust store", src.Handle, hint),
+			humanMsg(src, "rqlite: endpoint requires TLS, but cert verification failed"),
+		)
 	default:
 		if ctx.Err() != nil {
 			return nil, errz.Err(ctx.Err())

--- a/drivers/rqlite/detect_test.go
+++ b/drivers/rqlite/detect_test.go
@@ -3,6 +3,7 @@ package rqlite
 import (
 	"context"
 	"crypto/tls"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -198,6 +199,14 @@ func TestDetectConnParams_TLSBadCert(t *testing.T) {
 	require.Contains(t, err.Error(), "tls=true")
 	require.NotContains(t, err.Error(), "secret123",
 		"cert error must not echo the password from src.Location")
+
+	// The human form carries the concise one-liner; the retry remedy
+	// stays in the long form above.
+	var hr errz.HumanReadable
+	require.True(t, errors.As(err, &hr))
+	require.Equal(t,
+		"@rq: rqlite: endpoint requires TLS, but cert verification failed",
+		hr.HumanError())
 }
 
 func TestDetectConnParams_ExplicitIntentSkips(t *testing.T) {

--- a/drivers/rqlite/errors.go
+++ b/drivers/rqlite/errors.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"errors"
+	"fmt"
 	"io"
 	"net"
 	"net/url"
@@ -35,8 +36,8 @@ func errw(err error) error {
 }
 
 // docsLocalhostAnchor is the docs URL for the single-node-localhost
-// case. Kept as a package-level constant so the add-time hint and the
-// DNS error rewrite point at the same place.
+// case. Used only in log output: user-facing error messages say
+// "see docs" rather than embedding URLs.
 const docsLocalhostAnchor = "https://sq.io/docs/drivers/rqlite#single-node-localhost"
 
 // maybeWarnLocalhostDiscovery emits a one-line Warn log when src's URL
@@ -104,9 +105,80 @@ const gorqlitePeersPreamble = "tried all peers unsuccessfully"
 //	peer #0: http://user:xxxxx@rqlite1:4001/db/query?... failed due to ...
 var peerURLPattern = regexp.MustCompile(`peer #\d+: (https?://[^\s"]+)`)
 
+// DiscoveryError indicates that gorqlite cluster discovery routed a
+// request to an advertised peer that this client cannot use: the
+// single-node-localhost trap (a Docker node advertising a
+// container-internal hostname) and its variants. It implements
+// errz.HumanReadable so the CLI can print a concise, actionable
+// message while the full diagnostic chain (the serialized gorqlite
+// "tried all peers" detail) stays available via Error and Unwrap for
+// logs and verbose output.
+type DiscoveryError struct {
+	cause error
+
+	// Handle is the source handle, e.g. "@rq".
+	Handle string
+
+	// Peer is the advertised peer host that failed, e.g. "rqlite1".
+	Peer string
+
+	// UserHost is the host from the source location, e.g. "localhost".
+	UserHost string
+
+	// Resolve is true when the peer hostname failed DNS resolution
+	// ("no such host"), false when the peer address resolved but could
+	// not be reached (dial timeout, connection refused).
+	Resolve bool
+}
+
+// Error implements error. It carries the full diagnostic form: the
+// hint plus the underlying cause chain.
+func (e *DiscoveryError) Error() string {
+	verb, desc := e.verbDesc()
+	msg := fmt.Sprintf(
+		"rqlite: cluster-discovery failed to %s advertised peer %q "+
+			"(not %q from the source URL); this usually means the rqlite "+
+			"node advertised %s. Try ?disableClusterDiscovery=true",
+		verb, e.Peer, e.UserHost, desc,
+	)
+	if e.cause == nil {
+		return msg
+	}
+	return msg + ": " + e.cause.Error()
+}
+
+// Unwrap returns the underlying cause.
+func (e *DiscoveryError) Unwrap() error { return e.cause }
+
+// HumanError implements errz.HumanReadable.
+func (e *DiscoveryError) HumanError() string {
+	adj := "reachable"
+	if e.Resolve {
+		adj = "resolvable"
+	}
+	prefix := ""
+	if e.Handle != "" {
+		prefix = e.Handle + ": "
+	}
+	return fmt.Sprintf(
+		"%srqlite cluster discovery failed: the node advertised peer %q, "+
+			"which is not %s from this host. Try adding "+
+			"?disableClusterDiscovery=true to the source location (see docs).",
+		prefix, e.Peer, adj,
+	)
+}
+
+// verbDesc returns the resolution-vs-reachability wording pair.
+func (e *DiscoveryError) verbDesc() (verb, desc string) {
+	if e.Resolve {
+		return "resolve", "an internal hostname not resolvable from the host"
+	}
+	return "reach", "an internal address not reachable from this host"
+}
+
 // rewritePeerDiscoveryError rewrites a gorqlite cluster-discovery
-// failure into an actionable message naming the problematic advertised
-// peer and pointing at ?disableClusterDiscovery=true and the docs.
+// failure into a *DiscoveryError naming the problematic advertised
+// peer and pointing at ?disableClusterDiscovery=true.
 // Pass-through in every other case (nil err, unrelated err, the
 // failing host matches the host the user typed, discovery already
 // disabled, src.Location unparseable).
@@ -162,13 +234,13 @@ func rewritePeerDiscoveryError(err error, src *source.Source) error {
 			// would be wrong.
 			return err
 		}
-		return errz.Wrapf(err,
-			"rqlite: cluster-discovery failed to resolve advertised peer %q "+
-				"(not %q from the source URL); this usually means the rqlite "+
-				"node advertised an internal hostname not resolvable from the "+
-				"host. Try ?disableClusterDiscovery=true, or see "+docsLocalhostAnchor,
-			dnsErr.Name, userHost,
-		)
+		return errz.Err(&DiscoveryError{
+			cause:    err,
+			Handle:   src.Handle,
+			Peer:     dnsErr.Name,
+			UserHost: userHost,
+			Resolve:  true,
+		})
 	}
 
 	// Path 2: gorqlite string-serialized "tried all peers" failure.
@@ -182,17 +254,13 @@ func rewritePeerDiscoveryError(err error, src *source.Source) error {
 		// parsed): not the discovery trap.
 		return err
 	}
-	verb, desc := "reach", "an internal address not reachable from this host"
-	if strings.Contains(text, "no such host") {
-		verb, desc = "resolve", "an internal hostname not resolvable from the host"
-	}
-	return errz.Wrapf(err,
-		"rqlite: cluster-discovery failed to %s advertised peer %q "+
-			"(not %q from the source URL); this usually means the rqlite "+
-			"node advertised %s. Try ?disableClusterDiscovery=true, or see "+
-			docsLocalhostAnchor,
-		verb, peerHost, userHost, desc,
-	)
+	return errz.Err(&DiscoveryError{
+		cause:    err,
+		Handle:   src.Handle,
+		Peer:     peerHost,
+		UserHost: userHost,
+		Resolve:  strings.Contains(text, "no such host"),
+	})
 }
 
 // firstForeignPeerHost parses the peer URLs out of gorqlite's

--- a/drivers/rqlite/errors.go
+++ b/drivers/rqlite/errors.go
@@ -136,7 +136,7 @@ type DiscoveryError struct {
 func (e *DiscoveryError) Error() string {
 	verb, desc := e.verbDesc()
 	msg := fmt.Sprintf(
-		"rqlite: cluster-discovery failed to %s advertised peer %q "+
+		"rqlite: cluster discovery failed to %s advertised peer %q "+
 			"(not %q from the source URL); this usually means the rqlite "+
 			"node advertised %s. Try ?disableClusterDiscovery=true",
 		verb, e.Peer, e.UserHost, desc,
@@ -161,7 +161,7 @@ func (e *DiscoveryError) HumanError() string {
 		prefix = e.Handle + ": "
 	}
 	return fmt.Sprintf(
-		"%srqlite: cluster-discovery failed: advertised peer %q is not %s "+
+		"%srqlite: cluster discovery failed: advertised peer %q is not %s "+
 			"from this host",
 		prefix, e.Peer, adj,
 	)
@@ -175,7 +175,7 @@ func (e *DiscoveryError) verbDesc() (verb, desc string) {
 	return "reach", "an internal address not reachable from this host"
 }
 
-// rewritePeerDiscoveryError rewrites a gorqlite cluster-discovery
+// rewritePeerDiscoveryError rewrites a gorqlite cluster discovery
 // failure into a *DiscoveryError naming the problematic advertised
 // peer and pointing at ?disableClusterDiscovery=true.
 // Pass-through in every other case (nil err, unrelated err, the

--- a/drivers/rqlite/errors.go
+++ b/drivers/rqlite/errors.go
@@ -198,15 +198,11 @@ func rewritePeerDiscoveryError(err error, src *source.Source) error {
 	}
 
 	// Path 2: gorqlite string-serialized "tried all peers" failure.
+	// firstForeignPeer applies the connection-level classification
+	// per peer segment: only a foreign peer whose own failure is
+	// DNS lookup or dial level indicates the discovery trap.
 	text := err.Error()
 	if !strings.Contains(text, gorqlitePeersPreamble) {
-		return err
-	}
-	// Only connection-level failures (DNS lookup, dial) indicate the
-	// discovery trap. An HTTP-level response from a reachable peer
-	// (e.g. 401 Unauthorized) is a different problem, and must not be
-	// rewritten into a disableClusterDiscovery suggestion.
-	if !strings.Contains(text, "no such host") && !strings.Contains(text, "dial tcp") {
 		return err
 	}
 	peerHost, resolve := firstForeignPeer(text, userHost)
@@ -226,16 +222,29 @@ func rewritePeerDiscoveryError(err error, src *source.Source) error {
 
 // firstForeignPeer parses the peer entries out of gorqlite's
 // serialized "tried all peers" error text and returns the host of the
-// first peer whose host differs from userHost, plus whether that
-// peer's own failure was a DNS not-found (resolve=true) as opposed to
-// a dial failure (resolve=false). The marker check is scoped to the
-// chosen peer's text segment: with multiple peers failing differently,
-// a whole-text check would misattribute another peer's failure class.
-// Returns an empty host when no peer URL parses, or every parsed peer
-// host equals userHost. Loopback hosts count as equal ("localhost" vs
-// "127.0.0.1" vs "::1"): a node legitimately advertising loopback to a
-// loopback-typed source is not the discovery trap, even when the
-// strings differ.
+// first peer that exhibits the discovery trap: a foreign host (differs
+// from userHost) whose own failure segment is connection-level. The
+// returned resolve is true for a DNS not-found, false for a dial
+// failure. All classification is scoped to each peer's own text
+// segment: with multiple peers failing differently, a whole-text check
+// would misattribute one peer's failure class to another.
+//
+// Skipped peers, in addition to unparseable ones:
+//
+//   - Same host as userHost. Loopback hosts count as equal
+//     ("localhost" vs "127.0.0.1" vs "::1"): a node legitimately
+//     advertising loopback to a loopback-typed source is not the
+//     trap, even when the strings differ.
+//   - Canceled attempts ("operation was canceled", "context
+//     canceled"): the user or a context aborted mid-dial, which says
+//     nothing about the peer being unusable. Deadline expiries remain
+//     eligible: an unroutable advertised peer typically surfaces as a
+//     dial timeout.
+//   - HTTP-level failures (e.g. a 401): the peer was reached; that's
+//     a different problem, not the discovery trap.
+//
+// Marker matching is case-insensitive so platform variants match
+// (Windows: "No such host is known").
 func firstForeignPeer(text, userHost string) (host string, resolve bool) {
 	userLoopback := isLoopbackHost(userHost)
 	matches := peerURLPattern.FindAllStringSubmatchIndex(text, -1)
@@ -257,7 +266,18 @@ func firstForeignPeer(text, userHost string) (host string, resolve bool) {
 		if i+1 < len(matches) {
 			end = matches[i+1][0]
 		}
-		return h, strings.Contains(text[m[0]:end], "no such host")
+		segment := strings.ToLower(text[m[0]:end])
+		switch {
+		case strings.Contains(segment, "operation was canceled"),
+			strings.Contains(segment, "context canceled"):
+			continue
+		case strings.Contains(segment, "no such host"):
+			return h, true
+		case strings.Contains(segment, "dial tcp"):
+			return h, false
+		default:
+			continue
+		}
 	}
 	return "", false
 }
@@ -307,12 +327,15 @@ func (e *AuthError) HumanError() string {
 }
 
 // rewriteAuthError rewrites a 401 Unauthorized failure from the
-// rqlite node into a *AuthError. gorqlite serializes HTTP-status
-// failures into its error text (e.g. "got: 401 Unauthorized"), so
-// detection is text-based, like the other gorqlite-path checks.
-// Pass-through for nil and non-401 errors.
+// rqlite node into a *AuthError. Detection is text-based, like the
+// other gorqlite-path checks, and anchored to gorqlite's exact
+// serialization: its doOnce is the module's only HTTP call site, and
+// it formats every non-200 as "got: <status>, message: <body>", so
+// "got: 401 Unauthorized" covers every gorqlite 401 path while not
+// matching quoted content (e.g. a non-401 response body that merely
+// mentions a 401). Pass-through for nil and non-401 errors.
 func rewriteAuthError(err error, src *source.Source) error {
-	if err == nil || !strings.Contains(err.Error(), "401 Unauthorized") {
+	if err == nil || !strings.Contains(err.Error(), "got: 401 Unauthorized") {
 		return err
 	}
 	// Conservative default: if the location can't be parsed (e.g. it

--- a/drivers/rqlite/errors.go
+++ b/drivers/rqlite/errors.go
@@ -307,7 +307,7 @@ type AuthError struct {
 // Error implements error. It carries the full diagnostic form: the
 // hint plus the underlying cause chain.
 func (e *AuthError) Error() string {
-	msg := "rqlite: authentication failed (401 Unauthorized)"
+	msg := "rqlite: auth failed (401 Unauthorized)"
 	if e.cause == nil {
 		return msg
 	}
@@ -324,11 +324,11 @@ func (e *AuthError) HumanError() string {
 		prefix = e.Handle + ": "
 	}
 	if e.HasCreds {
-		return prefix + "rqlite authentication failed: the node rejected " +
-			"the source's credentials."
+		return prefix + "rqlite auth failed: the node rejected the " +
+			"source's credentials."
 	}
-	return prefix + "rqlite authentication failed: the node requires " +
-		"credentials, but the source location has none."
+	return prefix + "rqlite auth failed: the node requires credentials, " +
+		"but the source location has none."
 }
 
 // rewriteAuthError rewrites a 401 Unauthorized failure from the

--- a/drivers/rqlite/errors.go
+++ b/drivers/rqlite/errors.go
@@ -325,11 +325,10 @@ func (e *AuthError) HumanError() string {
 	}
 	if e.HasCreds {
 		return prefix + "rqlite authentication failed: the node rejected " +
-			"the source's credentials. Check username and password."
+			"the source's credentials."
 	}
 	return prefix + "rqlite authentication failed: the node requires " +
-		"credentials, but the source location has none. Add user:password " +
-		"to the location (see docs)."
+		"credentials, but the source location has none."
 }
 
 // rewriteAuthError rewrites a 401 Unauthorized failure from the

--- a/drivers/rqlite/errors.go
+++ b/drivers/rqlite/errors.go
@@ -162,7 +162,7 @@ func (e *DiscoveryError) HumanError() string {
 	}
 	return fmt.Sprintf(
 		"%srqlite cluster discovery failed: advertised peer %q is not %s "+
-			"from this host.",
+			"from this host",
 		prefix, e.Peer, adj,
 	)
 }
@@ -325,10 +325,10 @@ func (e *AuthError) HumanError() string {
 	}
 	if e.HasCreds {
 		return prefix + "rqlite auth failed: the node rejected the " +
-			"source's credentials."
+			"source's credentials"
 	}
 	return prefix + "rqlite auth failed: the node requires credentials, " +
-		"but the source location has none."
+		"but the source has none"
 }
 
 // rewriteAuthError rewrites a 401 Unauthorized failure from the

--- a/drivers/rqlite/errors.go
+++ b/drivers/rqlite/errors.go
@@ -161,7 +161,7 @@ func (e *DiscoveryError) HumanError() string {
 		prefix = e.Handle + ": "
 	}
 	return fmt.Sprintf(
-		"%srqlite cluster discovery failed: advertised peer %q is not %s "+
+		"%srqlite: cluster-discovery failed: advertised peer %q is not %s "+
 			"from this host",
 		prefix, e.Peer, adj,
 	)
@@ -324,9 +324,9 @@ func (e *AuthError) HumanError() string {
 		prefix = e.Handle + ": "
 	}
 	if e.HasCreds {
-		return prefix + "rqlite auth failed: node rejected credentials"
+		return prefix + "rqlite: auth failed: node rejected credentials"
 	}
-	return prefix + "rqlite auth failed: node requires credentials, " +
+	return prefix + "rqlite: auth failed: node requires credentials, " +
 		"but source has none"
 }
 

--- a/drivers/rqlite/errors.go
+++ b/drivers/rqlite/errors.go
@@ -431,6 +431,36 @@ func humanMsg(src *source.Source, msg string) string {
 	return src.Handle + ": " + msg
 }
 
+// rewritePlainHTTPSignalError is the inverse of rewriteTLSSignalError:
+// if err looks like an HTTPS request answered by a plain-HTTP server,
+// and the source has ?tls=true set, the source's TLS setting is the
+// mismatch. Pass-through in every other case. Like the other
+// gorqlite-path checks, detection is text-based: Go's http transport
+// emits the canonical "server gave HTTP response to HTTPS client"
+// message, which survives gorqlite's string serialization.
+func rewritePlainHTTPSignalError(err error, src *source.Source) error {
+	if err == nil ||
+		!strings.Contains(err.Error(), "server gave HTTP response to HTTPS client") {
+		return err
+	}
+	// Only rewrite when the source actually opts into TLS: that's the
+	// setting the message blames. (Without tls=true, sq doesn't speak
+	// HTTPS on this path, so the signal would be something else.)
+	if !locHasTLSTrue(src.Location) {
+		return err
+	}
+	// No URL hint in the long form: the remedy is removing params
+	// (tls=true, and insecure=true if present), which
+	// suggestLocWithParams cannot express.
+	return errz.WithHuman(
+		errz.Wrapf(err,
+			"%s: tls=true is set, but the endpoint serves plain HTTP; "+
+				"remove tls=true (and insecure=true, if set) from the "+
+				"source location", src.Handle),
+		humanMsg(src, "rqlite: TLS mismatch: endpoint serves HTTP, but source uses HTTPS"),
+	)
+}
+
 // locHasTLSTrue reports whether loc has ?tls=true set. Used to gate
 // TLS-signal error enrichment: if the user has already opted into
 // TLS, an io.EOF or TLS handshake failure is NOT a "wrong scheme"
@@ -510,12 +540,14 @@ func rewriteCertVerificationError(err error, src *source.Source) error {
 // in a fixed order. Each inner check returns the input unchanged
 // if it doesn't match, so the composition is safe and idempotent.
 // Order matters only for readability: peer discovery first (most
-// specific), then auth (401), then TLS signal (HTTP→HTTPS), then
-// cert verification (HTTPS with bad cert).
+// specific), then auth (401), then the two TLS-mismatch signals
+// (HTTP→HTTPS and HTTPS→HTTP, mutually exclusive via the tls=true
+// gate), then cert verification (HTTPS with bad cert).
 func enrichConnError(err error, src *source.Source) error {
 	err = rewritePeerDiscoveryError(err, src)
 	err = rewriteAuthError(err, src)
 	err = rewriteTLSSignalError(err, src)
+	err = rewritePlainHTTPSignalError(err, src)
 	err = rewriteCertVerificationError(err, src)
 	return err
 }

--- a/drivers/rqlite/errors.go
+++ b/drivers/rqlite/errors.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net"
 	"net/url"
+	"regexp"
 	"strings"
 
 	"github.com/neilotoole/sq/libsq/core/errz"
@@ -87,40 +88,57 @@ func isLoopbackHost(host string) bool {
 	return ip != nil && ip.IsLoopback()
 }
 
-// rewritePeerDNSError rewrites a gorqlite cluster-discovery DNS
-// failure into an actionable message naming the unreachable peer and
-// pointing at ?disableClusterDiscovery=true and the docs. Pass-through
-// in every other case (nil err, non-DNS err, user-supplied host
-// matches the failing name, discovery already disabled, src.Location
-// unparseable).
+// gorqlitePeersPreamble is the prefix gorqlite puts on the error it
+// builds when every peer attempt failed. gorqlite serializes that
+// error to a flat string (errors.New on a strings.Builder), so on the
+// query path this substring is the only discovery-failure signal that
+// survives. gorqlite-specific phrasing; revisit if gorqlite changes
+// its error construction (same tradeoff as isTLSSignal's substring
+// check).
+const gorqlitePeersPreamble = "tried all peers unsuccessfully"
+
+// peerURLPattern extracts candidate peer URLs from gorqlite's
+// serialized "tried all peers" error text, which lists each attempt
+// in the form:
 //
-// The rewrite preserves the underlying *net.DNSError so upstream
-// errors.As classification continues to work.
-func rewritePeerDNSError(err error, src *source.Source) error {
+//	peer #0: http://user:xxxxx@rqlite1:4001/db/query?... failed due to ...
+var peerURLPattern = regexp.MustCompile(`peer #\d+: (https?://[^\s"]+)`)
+
+// rewritePeerDiscoveryError rewrites a gorqlite cluster-discovery
+// failure into an actionable message naming the problematic advertised
+// peer and pointing at ?disableClusterDiscovery=true and the docs.
+// Pass-through in every other case (nil err, unrelated err, the
+// failing host matches the host the user typed, discovery already
+// disabled, src.Location unparseable).
+//
+// Two detection paths:
+//
+//  1. Chain-preserving: err wraps a *net.DNSError with IsNotFound set.
+//     This only fires for errors that preserve the error chain (e.g.
+//     sq-side code wrapping a transport error); gorqlite's query path
+//     never produces these.
+//  2. Text: gorqlite's rqliteApiCall serializes transport errors to a
+//     flat string, so on the query path the message text is the only
+//     available signal. When the text carries gorqlite's "tried all
+//     peers" preamble, the peer URLs are parsed out and compared
+//     against the host from src.Location. A peer host that differs
+//     from the user's host is the discovery trap: the node advertised
+//     an address (internal hostname, container IP) that this client
+//     cannot use. This catches both unresolvable hostnames ("no such
+//     host") and resolvable-but-unreachable addresses (dial timeouts,
+//     connection refused).
+//
+// The chain-preserving rewrite keeps the underlying *net.DNSError
+// reachable so upstream errors.As classification continues to work.
+func rewritePeerDiscoveryError(err error, src *source.Source) error {
 	if err == nil {
 		return nil
-	}
-	var dnsErr *net.DNSError
-	if !errors.As(err, &dnsErr) || !dnsErr.IsNotFound {
-		// Only the "no such host" case (IsNotFound) is the
-		// cluster-discovery DNS failure we want to rewrite. DNS
-		// timeouts, temporary failures, and refusals are unrelated
-		// classes and shouldn't be rewritten into a
-		// disableClusterDiscovery suggestion.
-		return err
 	}
 	u, parseErr := url.Parse(src.Location)
 	if parseErr != nil {
 		// Defensive: doOpen validates this URL earlier, but if we
 		// somehow can't parse it here, pass the error through rather
 		// than producing a misleading rewrite.
-		return err
-	}
-	userHost := u.Hostname()
-	if strings.EqualFold(dnsErr.Name, userHost) {
-		// The failing hostname is the one the user typed. That's
-		// their problem to fix; suggesting disableClusterDiscovery
-		// would be wrong.
 		return err
 	}
 	if strings.EqualFold(u.Query().Get("disableClusterDiscovery"), "true") {
@@ -131,13 +149,67 @@ func rewritePeerDNSError(err error, src *source.Source) error {
 		// user "try ?disableClusterDiscovery=true" when they already have.
 		return err
 	}
+	userHost := u.Hostname()
+
+	// Path 1: chain-preserved DNS not-found. Timeouts, temporary
+	// failures, and refusals are unrelated classes and shouldn't be
+	// rewritten into a disableClusterDiscovery suggestion.
+	var dnsErr *net.DNSError
+	if errors.As(err, &dnsErr) && dnsErr.IsNotFound {
+		if strings.EqualFold(dnsErr.Name, userHost) {
+			// The failing hostname is the one the user typed. That's
+			// their problem to fix; suggesting disableClusterDiscovery
+			// would be wrong.
+			return err
+		}
+		return errz.Wrapf(err,
+			"rqlite: cluster-discovery failed to resolve advertised peer %q "+
+				"(not %q from the source URL); this usually means the rqlite "+
+				"node advertised an internal hostname not resolvable from the "+
+				"host. Try ?disableClusterDiscovery=true, or see "+docsLocalhostAnchor,
+			dnsErr.Name, userHost,
+		)
+	}
+
+	// Path 2: gorqlite string-serialized "tried all peers" failure.
+	text := err.Error()
+	if !strings.Contains(text, gorqlitePeersPreamble) {
+		return err
+	}
+	peerHost := firstForeignPeerHost(text, userHost)
+	if peerHost == "" {
+		// Every parseable peer is the host the user typed (or none
+		// parsed): not the discovery trap.
+		return err
+	}
+	verb, desc := "reach", "an internal address not reachable from this host"
+	if strings.Contains(text, "no such host") {
+		verb, desc = "resolve", "an internal hostname not resolvable from the host"
+	}
 	return errz.Wrapf(err,
-		"rqlite: cluster-discovery failed to resolve advertised peer %q "+
+		"rqlite: cluster-discovery failed to %s advertised peer %q "+
 			"(not %q from the source URL); this usually means the rqlite "+
-			"node advertised an internal hostname not resolvable from the "+
-			"host. Try ?disableClusterDiscovery=true, or see "+docsLocalhostAnchor,
-		dnsErr.Name, userHost,
+			"node advertised %s. Try ?disableClusterDiscovery=true, or see "+
+			docsLocalhostAnchor,
+		verb, peerHost, userHost, desc,
 	)
+}
+
+// firstForeignPeerHost parses the peer URLs out of gorqlite's
+// serialized "tried all peers" error text and returns the host of the
+// first peer whose host differs from userHost. Returns empty string
+// when no peer URL parses, or every parsed peer host equals userHost.
+func firstForeignPeerHost(text, userHost string) string {
+	for _, m := range peerURLPattern.FindAllStringSubmatch(text, -1) {
+		pu, err := url.Parse(m[1])
+		if err != nil {
+			continue
+		}
+		if h := pu.Hostname(); h != "" && !strings.EqualFold(h, userHost) {
+			return h
+		}
+	}
+	return ""
 }
 
 // suggestLocWithParams builds a hint URL by merging the given query
@@ -272,11 +344,11 @@ func rewriteCertVerificationError(err error, src *source.Source) error {
 // enrichConnError applies the known connection-error enrichments
 // in a fixed order. Each inner check returns the input unchanged
 // if it doesn't match, so the composition is safe and idempotent.
-// Order matters only for readability: DNS first (most specific),
-// then TLS signal (HTTP→HTTPS), then cert verification (HTTPS
-// with bad cert).
+// Order matters only for readability: peer discovery first (most
+// specific), then TLS signal (HTTP→HTTPS), then cert verification
+// (HTTPS with bad cert).
 func enrichConnError(err error, src *source.Source) error {
-	err = rewritePeerDNSError(err, src)
+	err = rewritePeerDiscoveryError(err, src)
 	err = rewriteTLSSignalError(err, src)
 	err = rewriteCertVerificationError(err, src)
 	return err

--- a/drivers/rqlite/errors.go
+++ b/drivers/rqlite/errors.go
@@ -162,7 +162,7 @@ func (e *DiscoveryError) HumanError() string {
 	}
 	return fmt.Sprintf(
 		"%srqlite cluster discovery failed: advertised peer %q is not %s "+
-			"from this host. Try ?disableClusterDiscovery=true (see docs).",
+			"from this host. See disableClusterDiscovery param in docs.",
 		prefix, e.Peer, adj,
 	)
 }

--- a/drivers/rqlite/errors.go
+++ b/drivers/rqlite/errors.go
@@ -209,7 +209,7 @@ func rewritePeerDiscoveryError(err error, src *source.Source) error {
 	if !strings.Contains(text, "no such host") && !strings.Contains(text, "dial tcp") {
 		return err
 	}
-	peerHost := firstForeignPeerHost(text, userHost)
+	peerHost, resolve := firstForeignPeer(text, userHost)
 	if peerHost == "" {
 		// Every parseable peer is the host the user typed (or none
 		// parsed): not the discovery trap.
@@ -220,21 +220,27 @@ func rewritePeerDiscoveryError(err error, src *source.Source) error {
 		Handle:   src.Handle,
 		Peer:     peerHost,
 		UserHost: userHost,
-		Resolve:  strings.Contains(text, "no such host"),
+		Resolve:  resolve,
 	})
 }
 
-// firstForeignPeerHost parses the peer URLs out of gorqlite's
+// firstForeignPeer parses the peer entries out of gorqlite's
 // serialized "tried all peers" error text and returns the host of the
-// first peer whose host differs from userHost. Returns empty string
-// when no peer URL parses, or every parsed peer host equals userHost.
-// Loopback hosts count as equal ("localhost" vs "127.0.0.1" vs "::1"):
-// a node legitimately advertising loopback to a loopback-typed source
-// is not the discovery trap, even when the strings differ.
-func firstForeignPeerHost(text, userHost string) string {
+// first peer whose host differs from userHost, plus whether that
+// peer's own failure was a DNS not-found (resolve=true) as opposed to
+// a dial failure (resolve=false). The marker check is scoped to the
+// chosen peer's text segment: with multiple peers failing differently,
+// a whole-text check would misattribute another peer's failure class.
+// Returns an empty host when no peer URL parses, or every parsed peer
+// host equals userHost. Loopback hosts count as equal ("localhost" vs
+// "127.0.0.1" vs "::1"): a node legitimately advertising loopback to a
+// loopback-typed source is not the discovery trap, even when the
+// strings differ.
+func firstForeignPeer(text, userHost string) (host string, resolve bool) {
 	userLoopback := isLoopbackHost(userHost)
-	for _, m := range peerURLPattern.FindAllStringSubmatch(text, -1) {
-		pu, err := url.Parse(m[1])
+	matches := peerURLPattern.FindAllStringSubmatchIndex(text, -1)
+	for i, m := range matches {
+		pu, err := url.Parse(text[m[2]:m[3]])
 		if err != nil {
 			continue
 		}
@@ -245,9 +251,15 @@ func firstForeignPeerHost(text, userHost string) string {
 		if userLoopback && isLoopbackHost(h) {
 			continue
 		}
-		return h
+		// This peer's failure detail runs from its entry to the next
+		// peer entry (or the end of the text).
+		end := len(text)
+		if i+1 < len(matches) {
+			end = matches[i+1][0]
+		}
+		return h, strings.Contains(text[m[0]:end], "no such host")
 	}
-	return ""
+	return "", false
 }
 
 // AuthError indicates that the rqlite node rejected a request as

--- a/drivers/rqlite/errors.go
+++ b/drivers/rqlite/errors.go
@@ -247,6 +247,13 @@ func rewritePeerDiscoveryError(err error, src *source.Source) error {
 	if !strings.Contains(text, gorqlitePeersPreamble) {
 		return err
 	}
+	// Only connection-level failures (DNS lookup, dial) indicate the
+	// discovery trap. An HTTP-level response from a reachable peer
+	// (e.g. 401 Unauthorized) is a different problem, and must not be
+	// rewritten into a disableClusterDiscovery suggestion.
+	if !strings.Contains(text, "no such host") && !strings.Contains(text, "dial tcp") {
+		return err
+	}
 	peerHost := firstForeignPeerHost(text, userHost)
 	if peerHost == "" {
 		// Every parseable peer is the host the user typed (or none
@@ -277,6 +284,75 @@ func firstForeignPeerHost(text, userHost string) string {
 		}
 	}
 	return ""
+}
+
+// AuthError indicates that the rqlite node rejected a request as
+// unauthorized (HTTP 401): the node requires credentials that the
+// source either doesn't carry or that the node doesn't accept. It
+// implements errz.HumanReadable so the CLI can print a concise,
+// actionable message while the full diagnostic chain stays available
+// via Error and Unwrap for logs and verbose output.
+type AuthError struct {
+	cause error
+
+	// Handle is the source handle, e.g. "@rq".
+	Handle string
+
+	// HasCreds is true when the source location carries userinfo
+	// (username and/or password). It selects between the "supply
+	// credentials" and "check credentials" remedies.
+	HasCreds bool
+}
+
+// Error implements error. It carries the full diagnostic form: the
+// hint plus the underlying cause chain.
+func (e *AuthError) Error() string {
+	msg := "rqlite: authentication failed (401 Unauthorized)"
+	if e.cause == nil {
+		return msg
+	}
+	return msg + ": " + e.cause.Error()
+}
+
+// Unwrap returns the underlying cause.
+func (e *AuthError) Unwrap() error { return e.cause }
+
+// HumanError implements errz.HumanReadable.
+func (e *AuthError) HumanError() string {
+	prefix := ""
+	if e.Handle != "" {
+		prefix = e.Handle + ": "
+	}
+	if e.HasCreds {
+		return prefix + "rqlite authentication failed: the node rejected " +
+			"the source's credentials. Check username and password."
+	}
+	return prefix + "rqlite authentication failed: the node requires " +
+		"credentials, but the source location has none. Add user:password " +
+		"to the location (see docs)."
+}
+
+// rewriteAuthError rewrites a 401 Unauthorized failure from the
+// rqlite node into a *AuthError. gorqlite serializes HTTP-status
+// failures into its error text (e.g. "got: 401 Unauthorized"), so
+// detection is text-based, like the other gorqlite-path checks.
+// Pass-through for nil and non-401 errors.
+func rewriteAuthError(err error, src *source.Source) error {
+	if err == nil || !strings.Contains(err.Error(), "401 Unauthorized") {
+		return err
+	}
+	// Conservative default: if the location can't be parsed (e.g. it
+	// carries secret placeholders in userinfo, which net/url rejects),
+	// userinfo is present, so treat creds as supplied.
+	hasCreds := true
+	if u, parseErr := url.Parse(src.Location); parseErr == nil {
+		hasCreds = u.User != nil && u.User.String() != ""
+	}
+	return errz.Err(&AuthError{
+		cause:    err,
+		Handle:   src.Handle,
+		HasCreds: hasCreds,
+	})
 }
 
 // suggestLocWithParams builds a hint URL by merging the given query
@@ -412,10 +488,11 @@ func rewriteCertVerificationError(err error, src *source.Source) error {
 // in a fixed order. Each inner check returns the input unchanged
 // if it doesn't match, so the composition is safe and idempotent.
 // Order matters only for readability: peer discovery first (most
-// specific), then TLS signal (HTTP→HTTPS), then cert verification
-// (HTTPS with bad cert).
+// specific), then auth (401), then TLS signal (HTTP→HTTPS), then
+// cert verification (HTTPS with bad cert).
 func enrichConnError(err error, src *source.Source) error {
 	err = rewritePeerDiscoveryError(err, src)
+	err = rewriteAuthError(err, src)
 	err = rewriteTLSSignalError(err, src)
 	err = rewriteCertVerificationError(err, src)
 	return err

--- a/drivers/rqlite/errors.go
+++ b/drivers/rqlite/errors.go
@@ -324,11 +324,10 @@ func (e *AuthError) HumanError() string {
 		prefix = e.Handle + ": "
 	}
 	if e.HasCreds {
-		return prefix + "rqlite auth failed: the node rejected the " +
-			"source's credentials"
+		return prefix + "rqlite auth failed: node rejected credentials"
 	}
-	return prefix + "rqlite auth failed: the node requires credentials, " +
-		"but the source has none"
+	return prefix + "rqlite auth failed: node requires credentials, " +
+		"but source has none"
 }
 
 // rewriteAuthError rewrites a 401 Unauthorized failure from the

--- a/drivers/rqlite/errors.go
+++ b/drivers/rqlite/errors.go
@@ -491,19 +491,34 @@ func rewriteCertVerificationError(err error, src *source.Source) error {
 	)
 }
 
-// enrichConnError applies the known connection-error enrichments
-// in a fixed order. Each inner check returns the input unchanged
-// if it doesn't match, so the composition is safe and idempotent.
-// Order matters only for readability: peer discovery first (most
-// specific), then auth (401), then the two TLS-mismatch signals
-// (HTTP→HTTPS and HTTPS→HTTP, mutually exclusive via the tls=true
-// gate), then cert verification (HTTPS with bad cert).
+// enrichConnError applies the known connection-error enrichments,
+// returning the result of the first rewrite that matches.
+// First-match-wins matters: a serialized gorqlite "tried all peers"
+// failure can carry multiple signals at once (e.g. a dial failure on
+// one peer and a 401 from another), and because each wrapper's
+// Error() embeds the cause text, a later check would re-match on the
+// already-wrapped error and bury the first diagnosis under a second
+// wrapper. Order: peer discovery first (most specific), then auth
+// (401), then the two TLS-mismatch signals (HTTP→HTTPS and
+// HTTPS→HTTP, mutually exclusive via the tls=true gate), then cert
+// verification (HTTPS with bad cert).
 func enrichConnError(err error, src *source.Source) error {
-	err = rewritePeerDiscoveryError(err, src)
-	err = rewriteAuthError(err, src)
-	err = rewriteTLSSignalError(err, src)
-	err = rewritePlainHTTPSignalError(err, src)
-	err = rewriteCertVerificationError(err, src)
+	if err == nil {
+		return nil
+	}
+	for _, rewrite := range []func(error, *source.Source) error{
+		rewritePeerDiscoveryError,
+		rewriteAuthError,
+		rewriteTLSSignalError,
+		rewritePlainHTTPSignalError,
+		rewriteCertVerificationError,
+	} {
+		// Identity comparison, not errors.Is: every rewrite returns
+		// the input unchanged when it doesn't match.
+		if out := rewrite(err, src); out != err { //nolint:errorlint
+			return out
+		}
+	}
 	return err
 }
 

--- a/drivers/rqlite/errors.go
+++ b/drivers/rqlite/errors.go
@@ -273,15 +273,24 @@ func rewritePeerDiscoveryError(err error, src *source.Source) error {
 // serialized "tried all peers" error text and returns the host of the
 // first peer whose host differs from userHost. Returns empty string
 // when no peer URL parses, or every parsed peer host equals userHost.
+// Loopback hosts count as equal ("localhost" vs "127.0.0.1" vs "::1"):
+// a node legitimately advertising loopback to a loopback-typed source
+// is not the discovery trap, even when the strings differ.
 func firstForeignPeerHost(text, userHost string) string {
+	userLoopback := isLoopbackHost(userHost)
 	for _, m := range peerURLPattern.FindAllStringSubmatch(text, -1) {
 		pu, err := url.Parse(m[1])
 		if err != nil {
 			continue
 		}
-		if h := pu.Hostname(); h != "" && !strings.EqualFold(h, userHost) {
-			return h
+		h := pu.Hostname()
+		if h == "" || strings.EqualFold(h, userHost) {
+			continue
 		}
+		if userLoopback && isLoopbackHost(h) {
+			continue
+		}
+		return h
 	}
 	return ""
 }
@@ -404,10 +413,22 @@ func rewriteTLSSignalError(err error, src *source.Source) error {
 		return err
 	}
 	hint := suggestLocWithParams(src, url.Values{"tls": {"true"}})
-	return errz.Wrapf(err,
-		"%s appears to require TLS; retry with %s "+
-			"(add &insecure=true for self-signed certs)",
-		src.Handle, hint)
+	return errz.WithHuman(
+		errz.Wrapf(err,
+			"%s appears to require TLS; retry with %s "+
+				"(add &insecure=true for self-signed certs)",
+			src.Handle, hint),
+		humanMsg(src, "rqlite: TLS required: endpoint serves HTTPS, but source uses HTTP"),
+	)
+}
+
+// humanMsg prefixes msg with the source handle, yielding the standard
+// human-message shape: "@handle: driver: category failed: detail".
+func humanMsg(src *source.Source, msg string) string {
+	if src == nil || src.Handle == "" {
+		return msg
+	}
+	return src.Handle + ": " + msg
 }
 
 // locHasTLSTrue reports whether loc has ?tls=true set. Used to gate
@@ -475,11 +496,14 @@ func rewriteCertVerificationError(err error, src *source.Source) error {
 		return err
 	}
 	hint := suggestLocWithParams(src, url.Values{"tls": {"true"}, "insecure": {"true"}})
-	return errz.Wrapf(err,
-		"%s: TLS certificate verification failed. If this is a "+
-			"self-signed or private-CA deployment, retry with "+
-			"%s, or install the CA in your trust store",
-		src.Handle, hint)
+	return errz.WithHuman(
+		errz.Wrapf(err,
+			"%s: TLS certificate verification failed. If this is a "+
+				"self-signed or private-CA deployment, retry with "+
+				"%s, or install the CA in your trust store",
+			src.Handle, hint),
+		humanMsg(src, "rqlite: TLS cert verification failed"),
+	)
 }
 
 // enrichConnError applies the known connection-error enrichments

--- a/drivers/rqlite/errors.go
+++ b/drivers/rqlite/errors.go
@@ -162,7 +162,7 @@ func (e *DiscoveryError) HumanError() string {
 	}
 	return fmt.Sprintf(
 		"%srqlite cluster discovery failed: advertised peer %q is not %s "+
-			"from this host. See disableClusterDiscovery param in docs.",
+			"from this host.",
 		prefix, e.Peer, adj,
 	)
 }

--- a/drivers/rqlite/errors.go
+++ b/drivers/rqlite/errors.go
@@ -1,7 +1,6 @@
 package rqlite
 
 import (
-	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"errors"
@@ -13,8 +12,6 @@ import (
 	"strings"
 
 	"github.com/neilotoole/sq/libsq/core/errz"
-	"github.com/neilotoole/sq/libsq/core/lg"
-	"github.com/neilotoole/sq/libsq/core/lg/lga"
 	"github.com/neilotoole/sq/libsq/driver"
 	"github.com/neilotoole/sq/libsq/source"
 )
@@ -33,48 +30,6 @@ func errw(err error) error {
 	default:
 		return errz.Err(err)
 	}
-}
-
-// docsLocalhostAnchor is the docs URL for the single-node-localhost
-// case. Used only in log output: user-facing error messages say
-// "see docs" rather than embedding URLs.
-const docsLocalhostAnchor = "https://sq.io/docs/drivers/rqlite#single-node-localhost"
-
-// maybeWarnLocalhostDiscovery emits a one-line Warn log when src's URL
-// host is loopback AND disableClusterDiscovery is not explicitly set on
-// the query string. Single-node localhost (Docker container reached
-// from the host) is the most common newcomer setup and gorqlite's
-// default cluster discovery fails opaquely there; a Warn at add/open
-// time provides a breadcrumb in the log file pointing at the docs.
-//
-// Best-effort: any failure to parse src.Location or extract the host
-// is a silent no-op. The warning must never affect Open behavior.
-func maybeWarnLocalhostDiscovery(ctx context.Context, src *source.Source) {
-	u, err := url.Parse(src.Location)
-	if err != nil {
-		return
-	}
-	v := u.Query().Get("disableClusterDiscovery")
-	if strings.EqualFold(v, "true") || strings.EqualFold(v, "false") {
-		// User has made an explicit choice (true or false). Don't
-		// second-guess them. Empty or unrecognized values fall through
-		// to the warning so a typo like ?disableClusterDiscovery=yes
-		// still gets surfaced.
-		return
-	}
-	host := u.Hostname()
-	if host == "" {
-		return
-	}
-	if !isLoopbackHost(host) {
-		return
-	}
-	lg.FromContext(ctx).Warn(
-		"rqlite: source points at loopback but disableClusterDiscovery is not set; "+
-			"single-node localhost setups typically need ?disableClusterDiscovery=true "+
-			"to avoid peer-discovery failures from the host. See "+docsLocalhostAnchor,
-		lga.Src, src.Handle,
-	)
 }
 
 // isLoopbackHost reports whether host is a literal loopback reference.

--- a/drivers/rqlite/errors.go
+++ b/drivers/rqlite/errors.go
@@ -161,9 +161,8 @@ func (e *DiscoveryError) HumanError() string {
 		prefix = e.Handle + ": "
 	}
 	return fmt.Sprintf(
-		"%srqlite cluster discovery failed: the node advertised peer %q, "+
-			"which is not %s from this host. Try adding "+
-			"?disableClusterDiscovery=true to the source location (see docs).",
+		"%srqlite cluster discovery failed: advertised peer %q is not %s "+
+			"from this host. Try ?disableClusterDiscovery=true (see docs).",
 		prefix, e.Peer, adj,
 	)
 }

--- a/drivers/rqlite/errors_test.go
+++ b/drivers/rqlite/errors_test.go
@@ -110,6 +110,53 @@ func TestRewriteTLSSignalError(t *testing.T) {
 	})
 }
 
+func TestRewritePlainHTTPSignalError(t *testing.T) {
+	srcTLS := &source.Source{
+		Handle:   "@rq",
+		Type:     drivertype.Rqlite,
+		Location: "rqlite://host:4001?tls=true",
+	}
+	gorqliteErr := errz.New("tried all peers unsuccessfully. here are the results:\n" +
+		`   peer #0: https://host:4001/db/query failed due to ` +
+		`Get "https://host:4001/db/query": ` +
+		"http: server gave HTTP response to HTTPS client")
+
+	t.Run("nil passes through", func(t *testing.T) {
+		require.NoError(t, rewritePlainHTTPSignalError(nil, srcTLS))
+	})
+
+	t.Run("unrelated error passes through unchanged", func(t *testing.T) {
+		in := errz.New("connection refused")
+		require.Same(t, in, rewritePlainHTTPSignalError(in, srcTLS))
+	})
+
+	t.Run("signal without tls=true passes through", func(t *testing.T) {
+		src := newTestSrc(t) // no tls param
+		require.Same(t, gorqliteErr, rewritePlainHTTPSignalError(gorqliteErr, src))
+	})
+
+	t.Run("signal with tls=true gets mismatch message", func(t *testing.T) {
+		out := rewritePlainHTTPSignalError(gorqliteErr, srcTLS)
+		require.Error(t, out)
+		require.Contains(t, out.Error(), "endpoint serves plain HTTP")
+		require.Contains(t, out.Error(), "remove tls=true")
+		require.Contains(t, out.Error(), "server gave HTTP response to HTTPS client")
+
+		var hr errz.HumanReadable
+		require.True(t, errors.As(out, &hr))
+		require.Equal(t,
+			"@rq: rqlite: TLS mismatch: endpoint serves HTTP, but source uses HTTPS",
+			hr.HumanError())
+	})
+
+	t.Run("enrichConnError routes the signal here", func(t *testing.T) {
+		out := enrichConnError(gorqliteErr, srcTLS)
+		var hr errz.HumanReadable
+		require.True(t, errors.As(out, &hr))
+		require.Contains(t, hr.HumanError(), "TLS mismatch")
+	})
+}
+
 func TestIsCertVerificationError(t *testing.T) {
 	testCases := []struct {
 		name string

--- a/drivers/rqlite/errors_test.go
+++ b/drivers/rqlite/errors_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
+	"errors"
 	"io"
 	"net/http/httptest"
 	"testing"
@@ -73,6 +74,14 @@ func TestRewriteTLSSignalError(t *testing.T) {
 		require.Contains(t, out.Error(), "?tls=true")
 		require.Contains(t, out.Error(), "&insecure=true")
 		require.Contains(t, out.Error(), "@rq")
+
+		// The human form is the concise one-liner; the retry remedy
+		// stays in the long form.
+		var hr errz.HumanReadable
+		require.True(t, errors.As(out, &hr))
+		require.Equal(t,
+			"@rq: rqlite: TLS required: endpoint serves HTTPS, but source uses HTTP",
+			hr.HumanError())
 	})
 
 	t.Run("tls signal hint preserves existing query params", func(t *testing.T) {
@@ -174,6 +183,13 @@ func TestRewriteCertVerificationError(t *testing.T) {
 		require.Contains(t, out.Error(), "tls=true")
 		require.Contains(t, out.Error(), "insecure=true")
 		require.Contains(t, out.Error(), "@rq")
+
+		// The human form is the concise one-liner; the retry remedy
+		// stays in the long form.
+		var hr errz.HumanReadable
+		require.True(t, errors.As(out, &hr))
+		require.Equal(t, "@rq: rqlite: TLS cert verification failed",
+			hr.HumanError())
 	})
 
 	t.Run("cert error hint uses & when location already has ?", func(t *testing.T) {

--- a/drivers/rqlite/errors_test.go
+++ b/drivers/rqlite/errors_test.go
@@ -135,6 +135,15 @@ func TestRewritePlainHTTPSignalError(t *testing.T) {
 		require.Same(t, gorqliteErr, rewritePlainHTTPSignalError(gorqliteErr, src))
 	})
 
+	t.Run("signal with unparseable location passes through", func(t *testing.T) {
+		src := &source.Source{
+			Handle:   "@rq",
+			Type:     drivertype.Rqlite,
+			Location: "rqlite://%zz",
+		}
+		require.Same(t, gorqliteErr, rewritePlainHTTPSignalError(gorqliteErr, src))
+	})
+
 	t.Run("signal with tls=true gets mismatch message", func(t *testing.T) {
 		out := rewritePlainHTTPSignalError(gorqliteErr, srcTLS)
 		require.Error(t, out)

--- a/drivers/rqlite/grip.go
+++ b/drivers/rqlite/grip.go
@@ -32,7 +32,7 @@ func (g *grip) DB(context.Context) (*sql.DB, error) {
 // wrapped so that ErrWrapFunc can enrich errors with source-specific
 // hints: libsq obtains its error-wrap func via
 // grip.SQLDriver().ErrWrapFunc() on the query path, and the
-// connection-error enrichments (cluster-discovery, TLS, cert) need
+// connection-error enrichments (cluster discovery, TLS, cert) need
 // the source's host and query params to apply their guards.
 func (g *grip) SQLDriver() driver.SQLDriver {
 	return &enrichingSQLDriver{SQLDriver: g.drvr, src: g.src}

--- a/drivers/rqlite/grip.go
+++ b/drivers/rqlite/grip.go
@@ -28,9 +28,29 @@ func (g *grip) DB(context.Context) (*sql.DB, error) {
 	return g.db, nil
 }
 
-// SQLDriver implements driver.Grip.
+// SQLDriver implements driver.Grip. It returns the package driveri
+// wrapped so that ErrWrapFunc can enrich errors with source-specific
+// hints: libsq obtains its error-wrap func via
+// grip.SQLDriver().ErrWrapFunc() on the query path, and the
+// connection-error enrichments (cluster-discovery, TLS, cert) need
+// the source's host and query params to apply their guards.
 func (g *grip) SQLDriver() driver.SQLDriver {
-	return g.drvr
+	return &enrichingSQLDriver{SQLDriver: g.drvr, src: g.src}
+}
+
+// enrichingSQLDriver wraps the source-agnostic driveri so that
+// ErrWrapFunc closes over the grip's source. All other SQLDriver
+// methods pass through to the embedded driveri.
+type enrichingSQLDriver struct {
+	driver.SQLDriver
+	src *source.Source
+}
+
+// ErrWrapFunc implements driver.SQLDriver.
+func (d *enrichingSQLDriver) ErrWrapFunc() func(error) error {
+	return func(err error) error {
+		return enrichConnError(errw(err), d.src)
+	}
 }
 
 // Source implements driver.Grip.
@@ -40,12 +60,14 @@ func (g *grip) Source() *source.Source {
 
 // TableMetadata implements driver.Grip.
 func (g *grip) TableMetadata(ctx context.Context, tblName string) (*metadata.Table, error) {
-	return getTableMetadata(ctx, g.db, tblName)
+	md, err := getTableMetadata(ctx, g.db, tblName)
+	return md, enrichConnError(err, g.src)
 }
 
 // SourceMetadata implements driver.Grip.
 func (g *grip) SourceMetadata(ctx context.Context, noSchema bool) (*metadata.Source, error) {
-	return getSourceMetadata(ctx, g.src, g.db, noSchema)
+	md, err := getSourceMetadata(ctx, g.src, g.db, noSchema)
+	return md, enrichConnError(err, g.src)
 }
 
 // Close implements driver.Grip. Subsequent calls to Close are no-op and

--- a/drivers/rqlite/grip.go
+++ b/drivers/rqlite/grip.go
@@ -20,6 +20,7 @@ type grip struct {
 	db        *sql.DB
 	src       *source.Source
 	drvr      *driveri
+	drvrw     *enrichingSQLDriver
 	closeOnce sync.Once
 }
 
@@ -35,14 +36,17 @@ func (g *grip) DB(context.Context) (*sql.DB, error) {
 // connection-error enrichments (cluster discovery, TLS, cert) need
 // the source's host and query params to apply their guards.
 func (g *grip) SQLDriver() driver.SQLDriver {
-	return &enrichingSQLDriver{SQLDriver: g.drvr, src: g.src}
+	return g.drvrw
 }
 
 // enrichingSQLDriver wraps the source-agnostic driveri so that
-// ErrWrapFunc closes over the grip's source. All other SQLDriver
-// methods pass through to the embedded driveri.
+// ErrWrapFunc closes over the grip's source. It embeds the concrete
+// *driveri (not the SQLDriver interface) so that optional interfaces
+// implemented by driveri, e.g. driver.ConnParamDetector, remain
+// visible through type assertions on the wrapper. The grip constructs
+// one wrapper at Open and reuses it.
 type enrichingSQLDriver struct {
-	driver.SQLDriver
+	*driveri
 	src *source.Source
 }
 

--- a/drivers/rqlite/internal_test.go
+++ b/drivers/rqlite/internal_test.go
@@ -398,8 +398,6 @@ func Test_DiscoveryError(t *testing.T) {
 	require.Contains(t, human, "@rq")
 	require.Contains(t, human, `"rqlite1"`)
 	require.Contains(t, human, "resolvable")
-	require.Contains(t, human, "disableClusterDiscovery")
-	require.Contains(t, human, "docs")
 	require.NotContains(t, human, "tried all peers")
 	require.NotContains(t, human, "sq.io")
 

--- a/drivers/rqlite/internal_test.go
+++ b/drivers/rqlite/internal_test.go
@@ -644,6 +644,21 @@ func Test_rewritePeerDiscoveryError(t *testing.T) {
 			wantSubstrAll: []string{`"rqlite1"`, "disableClusterDiscovery=true"},
 		},
 		{
+			// Resolve must come from the chosen peer's own failure
+			// segment, not the whole text: the first foreign peer here
+			// failed a dial (reach), while a later peer failed DNS.
+			name: "mixed failure classes: verb follows the chosen peer",
+			err: errors.New("tried all peers unsuccessfully. here are the results:\n" +
+				"   peer #0: http://172.17.0.2:4001/db/query failed due to " +
+				`Post "http://172.17.0.2:4001/db/query": ` +
+				"dial tcp 172.17.0.2:4001: connect: connection refused\n" +
+				`   peer #1: http://rqlite1:4001/db/query failed due to ` +
+				`Post "http://rqlite1:4001/db/query": dial tcp: lookup rqlite1: no such host`),
+			loc:           userLoc,
+			wantRewrite:   true,
+			wantSubstrAll: []string{"reach advertised peer", `"172.17.0.2"`},
+		},
+		{
 			// "localhost" vs "127.0.0.1" is not the discovery trap: a
 			// local node legitimately advertises loopback, and a dial
 			// failure there just means the node is down.

--- a/drivers/rqlite/internal_test.go
+++ b/drivers/rqlite/internal_test.go
@@ -411,6 +411,70 @@ func Test_DiscoveryError(t *testing.T) {
 	require.Contains(t, reachErr.HumanError(), "reachable")
 }
 
+// Test_rewriteAuthError verifies the 401 rewrite and the two faces of
+// AuthError: the credential-state-tailored HumanError() the CLI
+// prints, and the full diagnostic Error() for logs and verbose output.
+func Test_rewriteAuthError(t *testing.T) {
+	gorqlite401 := errors.New("tried all peers unsuccessfully. here are the results:\n" +
+		`   peer #0: http://localhost:4001/db/query?timings&level=weak&transaction ` +
+		"failed due to got: 401 Unauthorized, message:")
+
+	newSrc := func(loc string) *source.Source {
+		return &source.Source{Handle: "@rq", Location: loc, Type: drivertype.Rqlite}
+	}
+
+	t.Run("nil", func(t *testing.T) {
+		require.Nil(t, rewriteAuthError(nil, newSrc("rqlite://localhost:4001")))
+	})
+
+	t.Run("non-401 passes through", func(t *testing.T) {
+		in := errors.New("connection refused")
+		require.True(t, errors.Is(rewriteAuthError(in, newSrc("rqlite://localhost:4001")), in))
+	})
+
+	t.Run("401 without creds in location", func(t *testing.T) {
+		got := rewriteAuthError(gorqlite401, newSrc("rqlite://localhost:4001?disableClusterDiscovery=true"))
+		var authErr *AuthError
+		require.True(t, errors.As(got, &authErr))
+		require.False(t, authErr.HasCreds)
+		var hr errz.HumanReadable
+		require.True(t, errors.As(got, &hr))
+		human := hr.HumanError()
+		require.Contains(t, human, "@rq")
+		require.Contains(t, human, "the source location has none")
+		require.Contains(t, human, "user:password")
+		require.NotContains(t, human, "tried all peers")
+		// Full diagnostic form keeps the cause chain.
+		require.Contains(t, got.Error(), "401 Unauthorized")
+		require.Contains(t, got.Error(), "tried all peers")
+	})
+
+	t.Run("401 with creds in location", func(t *testing.T) {
+		got := rewriteAuthError(gorqlite401, newSrc("rqlite://sakila:wrongpw@localhost:4001"))
+		var authErr *AuthError
+		require.True(t, errors.As(got, &authErr))
+		require.True(t, authErr.HasCreds)
+		require.Contains(t, authErr.HumanError(), "rejected the source's credentials")
+		require.Contains(t, authErr.HumanError(), "Check username and password")
+	})
+
+	t.Run("unparseable location defaults to creds present", func(t *testing.T) {
+		got := rewriteAuthError(gorqlite401, newSrc("rqlite://sakila:${env:PW}@localhost:4001"))
+		var authErr *AuthError
+		require.True(t, errors.As(got, &authErr))
+		require.True(t, authErr.HasCreds)
+	})
+
+	t.Run("enrichConnError routes 401 to AuthError", func(t *testing.T) {
+		got := enrichConnError(gorqlite401, newSrc("rqlite://localhost:4001"))
+		var authErr *AuthError
+		require.True(t, errors.As(got, &authErr))
+		var discErr *DiscoveryError
+		require.False(t, errors.As(got, &discErr),
+			"a 401 must not be diagnosed as the discovery trap")
+	})
+}
+
 // Test_enrichingSQLDriver_ErrWrapFunc verifies the grip-level wiring:
 // libsq obtains its error-wrap func via grip.SQLDriver().ErrWrapFunc()
 // on the query path, and that func must apply the connection-error
@@ -570,6 +634,17 @@ func Test_rewritePeerDiscoveryError(t *testing.T) {
 		{
 			name:        "serialized preamble without parseable peer URL",
 			err:         errors.New("tried all peers unsuccessfully. here are the results: (none)"),
+			loc:         userLoc,
+			wantRewrite: false,
+		},
+		{
+			// A 401 from a reachable foreign peer is an auth problem,
+			// not the discovery trap; suggesting disableClusterDiscovery
+			// would be wrong. rewriteAuthError handles it instead.
+			name: "serialized 401 from foreign peer is not the discovery trap",
+			err: errors.New("tried all peers unsuccessfully. here are the results:\n" +
+				`   peer #0: http://rqlite1:4001/db/query failed due to ` +
+				"got: 401 Unauthorized, message:"),
 			loc:         userLoc,
 			wantRewrite: false,
 		},

--- a/drivers/rqlite/internal_test.go
+++ b/drivers/rqlite/internal_test.go
@@ -1,15 +1,11 @@
 package rqlite
 
 import (
-	"bytes"
 	"context"
 	"database/sql"
-	"encoding/json"
 	"errors"
 	"fmt"
-	"log/slog"
 	"net"
-	"strings"
 	"testing"
 
 	_ "github.com/mattn/go-sqlite3" // For TestWriteAtomic_DBTypeCheck.
@@ -18,7 +14,6 @@ import (
 
 	"github.com/neilotoole/sq/libsq/core/errz"
 	"github.com/neilotoole/sq/libsq/core/kind"
-	"github.com/neilotoole/sq/libsq/core/lg"
 	"github.com/neilotoole/sq/libsq/core/record"
 	"github.com/neilotoole/sq/libsq/core/schema"
 	"github.com/neilotoole/sq/libsq/source"
@@ -312,56 +307,6 @@ func TestBuildCreateTableStmt_ForeignKey(t *testing.T) {
 	require.Contains(t, got, `ON DELETE CASCADE ON UPDATE CASCADE`)
 	require.Contains(t, got, `ON DELETE RESTRICT ON UPDATE SET NULL`)
 	require.Contains(t, got, `"film_id" INTEGER UNIQUE`)
-}
-
-func Test_maybeWarnLocalhostDiscovery(t *testing.T) {
-	testCases := []struct {
-		name    string
-		loc     string
-		wantLog bool
-	}{
-		{name: "localhost", loc: "rqlite://localhost:4001", wantLog: true},
-		{name: "localhost upper", loc: "rqlite://LOCALHOST:4001", wantLog: true},
-		{name: "127.0.0.1", loc: "rqlite://127.0.0.1:4001", wantLog: true},
-		{name: "ipv6 loopback", loc: "rqlite://[::1]:4001", wantLog: true},
-		{name: "127.0.0.5", loc: "rqlite://127.0.0.5:4001", wantLog: true},
-		{name: "remote host", loc: "rqlite://example.com:4001", wantLog: false},
-		{name: "discovery off explicit", loc: "rqlite://localhost:4001?disableClusterDiscovery=true", wantLog: false},
-		{name: "discovery on explicit", loc: "rqlite://localhost:4001?disableClusterDiscovery=false", wantLog: false},
-		{name: "localhost other params", loc: "rqlite://localhost:4001?level=strong", wantLog: true},
-		{name: "https loopback", loc: "rqlite://localhost:4001?tls=true", wantLog: true},
-		{name: "malformed", loc: "rqlite://%zz", wantLog: false},
-		{name: "discovery empty value", loc: "rqlite://localhost:4001?disableClusterDiscovery=", wantLog: true},
-		{name: "discovery bare key", loc: "rqlite://localhost:4001?disableClusterDiscovery", wantLog: true},
-		{name: "discovery upper TRUE", loc: "rqlite://localhost:4001?disableClusterDiscovery=TRUE", wantLog: false},
-		{name: "discovery upper FALSE", loc: "rqlite://localhost:4001?disableClusterDiscovery=False", wantLog: false},
-		{name: "discovery garbage value", loc: "rqlite://localhost:4001?disableClusterDiscovery=yes", wantLog: true},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			var buf bytes.Buffer
-			h := slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})
-			ctx := lg.NewContext(context.Background(), slog.New(h))
-
-			src := &source.Source{Handle: "@rq", Location: tc.loc, Type: drivertype.Rqlite}
-			maybeWarnLocalhostDiscovery(ctx, src)
-
-			raw := strings.TrimSpace(buf.String())
-			if !tc.wantLog {
-				require.Empty(t, raw, "expected no log output, got: %s", raw)
-				return
-			}
-
-			require.NotEmpty(t, raw, "expected one log entry, got none")
-			var entry map[string]any
-			require.NoError(t, json.Unmarshal([]byte(raw), &entry), "log line: %s", raw)
-			require.Equal(t, "WARN", entry["level"], "expected level=WARN, got: %v", entry["level"])
-			msg, _ := entry["msg"].(string)
-			require.Contains(t, msg, "disableClusterDiscovery",
-				"msg missing disableClusterDiscovery: %s", msg)
-		})
-	}
 }
 
 // Test_DiscoveryError verifies the two faces of DiscoveryError: the

--- a/drivers/rqlite/internal_test.go
+++ b/drivers/rqlite/internal_test.go
@@ -442,7 +442,6 @@ func Test_rewriteAuthError(t *testing.T) {
 		human := hr.HumanError()
 		require.Contains(t, human, "@rq")
 		require.Contains(t, human, "the source location has none")
-		require.Contains(t, human, "user:password")
 		require.NotContains(t, human, "tried all peers")
 		// Full diagnostic form keeps the cause chain.
 		require.Contains(t, got.Error(), "401 Unauthorized")
@@ -455,7 +454,6 @@ func Test_rewriteAuthError(t *testing.T) {
 		require.True(t, errors.As(got, &authErr))
 		require.True(t, authErr.HasCreds)
 		require.Contains(t, authErr.HumanError(), "rejected the source's credentials")
-		require.Contains(t, authErr.HumanError(), "Check username and password")
 	})
 
 	t.Run("unparseable location defaults to creds present", func(t *testing.T) {

--- a/drivers/rqlite/internal_test.go
+++ b/drivers/rqlite/internal_test.go
@@ -3,6 +3,7 @@ package rqlite
 import (
 	"context"
 	"database/sql"
+	sqldriver "database/sql/driver"
 	"errors"
 	"fmt"
 	"net"
@@ -346,12 +347,14 @@ func Test_DiscoveryError(t *testing.T) {
 	require.NotContains(t, human, "tried all peers")
 	require.NotContains(t, human, "sq.io")
 
-	// The reach variant words it differently.
+	// The reach variant words it differently, in both forms.
 	reachErr := &DiscoveryError{
 		cause: cause, Handle: "@rq", Peer: "172.17.0.2",
 		UserHost: "localhost", Resolve: false,
 	}
 	require.Contains(t, reachErr.HumanError(), "reachable")
+	require.Contains(t, reachErr.Error(), "reach advertised peer")
+	require.Contains(t, reachErr.Error(), "not reachable from this host")
 }
 
 // Test_rewriteAuthError verifies the 401 rewrite and the two faces of
@@ -414,6 +417,55 @@ func Test_rewriteAuthError(t *testing.T) {
 		require.False(t, errors.As(got, &discErr),
 			"a 401 must not be diagnosed as the discovery trap")
 	})
+
+	t.Run("first-match-wins: mixed dial+401 diagnoses discovery, not auth", func(t *testing.T) {
+		// One peer is the unresolvable-hostname trap, another returns
+		// 401. Discovery matches first; the 401 substring survives in
+		// the wrapped error's text, but enrichConnError must not
+		// re-wrap the result as an AuthError.
+		mixed := errors.New("tried all peers unsuccessfully. here are the results:\n" +
+			`   peer #0: http://rqlite1:4001/db/query failed due to ` +
+			`Post "http://rqlite1:4001/db/query": dial tcp: lookup rqlite1: no such host` + "\n" +
+			"   peer #1: http://rqlite2:4001/db/query failed due to got: 401 Unauthorized, message:")
+		got := enrichConnError(mixed, newSrc("rqlite://localhost:4001"))
+		var discErr *DiscoveryError
+		require.True(t, errors.As(got, &discErr))
+		var authErr *AuthError
+		require.False(t, errors.As(got, &authErr),
+			"first-match-wins: the discovery wrap must not be re-wrapped as auth")
+	})
+}
+
+// failConnector is a database/sql connector whose Connect always fails
+// with a fixed error. It backs Test_grip_MetadataEnrichment.
+type failConnector struct{ err error }
+
+func (c *failConnector) Connect(context.Context) (sqldriver.Conn, error) { return nil, c.err }
+func (c *failConnector) Driver() sqldriver.Driver                        { return nil }
+
+// Test_grip_MetadataEnrichment pins the grip-level wiring: errors from
+// SourceMetadata and TableMetadata must pass through enrichConnError.
+func Test_grip_MetadataEnrichment(t *testing.T) {
+	gorqliteErr := errors.New("tried all peers unsuccessfully. here are the results:\n" +
+		`   peer #0: http://rqlite1:4001/db/query failed due to ` +
+		`Post "http://rqlite1:4001/db/query": dial tcp: lookup rqlite1: no such host`)
+	db := sql.OpenDB(&failConnector{err: gorqliteErr})
+	t.Cleanup(func() { _ = db.Close() })
+	src := &source.Source{
+		Handle:   "@rq",
+		Location: "rqlite://localhost:4001",
+		Type:     drivertype.Rqlite,
+	}
+	g := &grip{db: db, src: src}
+
+	_, err := g.SourceMetadata(context.Background(), false)
+	var discErr *DiscoveryError
+	require.True(t, errors.As(err, &discErr),
+		"SourceMetadata must route errors through enrichConnError, got: %v", err)
+
+	_, err = g.TableMetadata(context.Background(), "actor")
+	require.True(t, errors.As(err, &discErr),
+		"TableMetadata must route errors through enrichConnError, got: %v", err)
 }
 
 // Test_enrichingSQLDriver_ErrWrapFunc verifies the grip-level wiring:
@@ -577,6 +629,19 @@ func Test_rewritePeerDiscoveryError(t *testing.T) {
 			err:         errors.New("tried all peers unsuccessfully. here are the results: (none)"),
 			loc:         userLoc,
 			wantRewrite: false,
+		},
+		{
+			// The foreign-peer scan must skip same-host peers and keep
+			// looking, not give up at the first peer.
+			name: "first peer same-host, second peer foreign",
+			err: errors.New("tried all peers unsuccessfully. here are the results:\n" +
+				`   peer #0: http://localhost:4001/db/query failed due to ` +
+				"dial tcp 127.0.0.1:4001: connect: connection refused\n" +
+				`   peer #1: http://rqlite1:4001/db/query failed due to ` +
+				`Post "http://rqlite1:4001/db/query": dial tcp: lookup rqlite1: no such host`),
+			loc:           userLoc,
+			wantRewrite:   true,
+			wantSubstrAll: []string{`"rqlite1"`, "disableClusterDiscovery=true"},
 		},
 		{
 			// "localhost" vs "127.0.0.1" is not the discovery trap: a

--- a/drivers/rqlite/internal_test.go
+++ b/drivers/rqlite/internal_test.go
@@ -363,7 +363,34 @@ func Test_maybeWarnLocalhostDiscovery(t *testing.T) {
 	}
 }
 
-func Test_rewritePeerDNSError(t *testing.T) {
+// Test_enrichingSQLDriver_ErrWrapFunc verifies the grip-level wiring:
+// libsq obtains its error-wrap func via grip.SQLDriver().ErrWrapFunc()
+// on the query path, and that func must apply the connection-error
+// enrichments with the grip's source in scope.
+func Test_enrichingSQLDriver_ErrWrapFunc(t *testing.T) {
+	src := &source.Source{
+		Handle:   "@rq",
+		Location: "rqlite://localhost:4001",
+		Type:     drivertype.Rqlite,
+	}
+	g := &grip{src: src}
+	wrapFn := g.SQLDriver().ErrWrapFunc()
+
+	require.Nil(t, wrapFn(nil))
+
+	gorqliteErr := errors.New("tried all peers unsuccessfully. here are the results:\n" +
+		`   peer #0: http://rqlite1:4001/db/query failed due to ` +
+		`Post "http://rqlite1:4001/db/query": dial tcp: lookup rqlite1: no such host`)
+	got := wrapFn(gorqliteErr)
+	require.Error(t, got)
+	require.Contains(t, got.Error(), `"rqlite1"`)
+	require.Contains(t, got.Error(), "disableClusterDiscovery=true")
+
+	// Unrelated errors keep plain errw semantics.
+	require.Contains(t, wrapFn(errors.New("boom")).Error(), "boom")
+}
+
+func Test_rewritePeerDiscoveryError(t *testing.T) {
 	// fakeDNSErr builds a *net.DNSError with the given peer name.
 	// All real fields of net.DNSError (Err, Server, IsTimeout, etc.)
 	// are zero/false — only Name matters to the helper under test.
@@ -453,12 +480,65 @@ func Test_rewritePeerDNSError(t *testing.T) {
 			loc:         "rqlite://localhost:4001?disableClusterDiscovery=TRUE",
 			wantRewrite: false,
 		},
+
+		// Text-path cases: gorqlite serializes transport errors to flat
+		// strings, so no *net.DNSError is reachable via errors.As. The
+		// rewrite must fire on the message text alone.
+		{
+			name: "serialized dns failure (the sq inspect case)",
+			err: errors.New("tried all peers unsuccessfully. here are the results:\n" +
+				"   peer #0: http://sakila:xxxxx@rqlite1:4001/db/query?timings&level=weak&transaction " +
+				`failed due to Post "http://sakila:xxxxx@rqlite1:4001/db/query` +
+				`?timings&level=weak&transaction": dial tcp: lookup rqlite1: no such host`),
+			loc:         userLoc,
+			wantRewrite: true,
+			wantSubstrAll: []string{
+				"resolve", `"rqlite1"`, `"localhost"`,
+				"disableClusterDiscovery=true", "sq.io/docs/drivers/rqlite",
+			},
+		},
+		{
+			name: "serialized dial failure to unroutable peer ip",
+			err: errors.New("tried all peers unsuccessfully. here are the results:\n" +
+				"   peer #0: http://172.17.0.2:4001/db/query?timings&level=weak&transaction " +
+				`failed due to Post "http://172.17.0.2:4001/db/query": ` +
+				"dial tcp 172.17.0.2:4001: connect: connection refused"),
+			loc:         userLoc,
+			wantRewrite: true,
+			wantSubstrAll: []string{
+				"reach", `"172.17.0.2"`, `"localhost"`,
+				"disableClusterDiscovery=true", "sq.io/docs/drivers/rqlite",
+			},
+		},
+		{
+			name: "serialized failure but peer host equals user host",
+			err: errors.New("tried all peers unsuccessfully. here are the results:\n" +
+				`   peer #0: http://localhost:4001/db/query failed due to ` +
+				`Post "http://localhost:4001/db/query": ` +
+				"dial tcp 127.0.0.1:4001: connect: connection refused"),
+			loc:         userLoc,
+			wantRewrite: false,
+		},
+		{
+			name:        "serialized preamble without parseable peer URL",
+			err:         errors.New("tried all peers unsuccessfully. here are the results: (none)"),
+			loc:         userLoc,
+			wantRewrite: false,
+		},
+		{
+			name: "serialized failure with discovery already off",
+			err: errors.New("tried all peers unsuccessfully. here are the results:\n" +
+				`   peer #0: http://rqlite1:4001/db/query failed due to ` +
+				`Post "http://rqlite1:4001/db/query": dial tcp: lookup rqlite1: no such host`),
+			loc:         userLocOff,
+			wantRewrite: false,
+		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			src := &source.Source{Handle: "@rq", Location: tc.loc, Type: drivertype.Rqlite}
-			got := rewritePeerDNSError(tc.err, src)
+			got := rewritePeerDiscoveryError(tc.err, src)
 
 			if tc.err == nil {
 				require.Nil(t, got)

--- a/drivers/rqlite/internal_test.go
+++ b/drivers/rqlite/internal_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/require"
 
+	"github.com/neilotoole/sq/libsq/core/errz"
 	"github.com/neilotoole/sq/libsq/core/kind"
 	"github.com/neilotoole/sq/libsq/core/lg"
 	"github.com/neilotoole/sq/libsq/core/record"
@@ -363,6 +364,53 @@ func Test_maybeWarnLocalhostDiscovery(t *testing.T) {
 	}
 }
 
+// Test_DiscoveryError verifies the two faces of DiscoveryError: the
+// full diagnostic Error() for logs and verbose output, and the concise
+// HumanError() the CLI prints.
+func Test_DiscoveryError(t *testing.T) {
+	cause := errors.New("tried all peers unsuccessfully. here are the results: detail dump")
+	src := &source.Source{
+		Handle:   "@rq",
+		Location: "rqlite://localhost:4001",
+		Type:     drivertype.Rqlite,
+	}
+	gorqliteErr := errors.New("tried all peers unsuccessfully. here are the results:\n" +
+		`   peer #0: http://rqlite1:4001/db/query failed due to ` +
+		`Post "http://rqlite1:4001/db/query": dial tcp: lookup rqlite1: no such host`)
+
+	got := rewritePeerDiscoveryError(gorqliteErr, src)
+
+	// The concrete type must be reachable through the errz wrap, and
+	// must satisfy errz.HumanReadable.
+	var discErr *DiscoveryError
+	require.True(t, errors.As(got, &discErr))
+	var hr errz.HumanReadable
+	require.True(t, errors.As(got, &hr))
+
+	// Error(): full diagnostic, hint plus cause chain.
+	require.Contains(t, got.Error(), "tried all peers unsuccessfully")
+	require.Contains(t, got.Error(), "disableClusterDiscovery=true")
+	require.NotContains(t, got.Error(), "sq.io",
+		"user-facing messages must not embed docs URLs")
+
+	// HumanError(): concise, self-contained, no gorqlite dump, no URL.
+	human := hr.HumanError()
+	require.Contains(t, human, "@rq")
+	require.Contains(t, human, `"rqlite1"`)
+	require.Contains(t, human, "resolvable")
+	require.Contains(t, human, "?disableClusterDiscovery=true")
+	require.Contains(t, human, "(see docs)")
+	require.NotContains(t, human, "tried all peers")
+	require.NotContains(t, human, "sq.io")
+
+	// The reach variant words it differently.
+	reachErr := &DiscoveryError{
+		cause: cause, Handle: "@rq", Peer: "172.17.0.2",
+		UserHost: "localhost", Resolve: false,
+	}
+	require.Contains(t, reachErr.HumanError(), "reachable")
+}
+
 // Test_enrichingSQLDriver_ErrWrapFunc verifies the grip-level wiring:
 // libsq obtains its error-wrap func via grip.SQLDriver().ErrWrapFunc()
 // on the query path, and that func must apply the connection-error
@@ -432,7 +480,7 @@ func Test_rewritePeerDiscoveryError(t *testing.T) {
 			err:           fakeDNSErr("rqlite1"),
 			loc:           userLoc,
 			wantRewrite:   true,
-			wantSubstrAll: []string{"rqlite1", "localhost", "disableClusterDiscovery=true", "sq.io/docs/drivers/rqlite"},
+			wantSubstrAll: []string{"rqlite1", "localhost", "disableClusterDiscovery=true"},
 		},
 		{
 			name: "discovered peer mismatch wrapped via fmt.Errorf",
@@ -494,7 +542,7 @@ func Test_rewritePeerDiscoveryError(t *testing.T) {
 			wantRewrite: true,
 			wantSubstrAll: []string{
 				"resolve", `"rqlite1"`, `"localhost"`,
-				"disableClusterDiscovery=true", "sq.io/docs/drivers/rqlite",
+				"disableClusterDiscovery=true",
 			},
 		},
 		{
@@ -507,7 +555,7 @@ func Test_rewritePeerDiscoveryError(t *testing.T) {
 			wantRewrite: true,
 			wantSubstrAll: []string{
 				"reach", `"172.17.0.2"`, `"localhost"`,
-				"disableClusterDiscovery=true", "sq.io/docs/drivers/rqlite",
+				"disableClusterDiscovery=true",
 			},
 		},
 		{

--- a/drivers/rqlite/internal_test.go
+++ b/drivers/rqlite/internal_test.go
@@ -634,6 +634,18 @@ func Test_rewritePeerDiscoveryError(t *testing.T) {
 			wantRewrite: false,
 		},
 		{
+			// "localhost" vs "127.0.0.1" is not the discovery trap: a
+			// local node legitimately advertises loopback, and a dial
+			// failure there just means the node is down.
+			name: "loopback peer equals loopback user host despite differing strings",
+			err: errors.New("tried all peers unsuccessfully. here are the results:\n" +
+				`   peer #0: http://127.0.0.1:4001/db/query failed due to ` +
+				`Post "http://127.0.0.1:4001/db/query": ` +
+				"dial tcp 127.0.0.1:4001: connect: connection refused"),
+			loc:         userLoc,
+			wantRewrite: false,
+		},
+		{
 			// A 401 from a reachable foreign peer is an auth problem,
 			// not the discovery trap; suggesting disableClusterDiscovery
 			// would be wrong. rewriteAuthError handles it instead.

--- a/drivers/rqlite/internal_test.go
+++ b/drivers/rqlite/internal_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/neilotoole/sq/libsq/core/kind"
 	"github.com/neilotoole/sq/libsq/core/record"
 	"github.com/neilotoole/sq/libsq/core/schema"
+	"github.com/neilotoole/sq/libsq/driver"
 	"github.com/neilotoole/sq/libsq/source"
 	"github.com/neilotoole/sq/libsq/source/drivertype"
 	"github.com/neilotoole/sq/testh/tu"
@@ -418,6 +419,25 @@ func Test_rewriteAuthError(t *testing.T) {
 			"a 401 must not be diagnosed as the discovery trap")
 	})
 
+	t.Run("same-host dial plus foreign 401 routes to AuthError", func(t *testing.T) {
+		// Finding from review: the user's own node down (dial failure,
+		// same host) plus a foreign peer that responded 401. The
+		// discovery rewrite must decline (the 401 peer was reached)
+		// and the auth rewrite gets its turn.
+		mixed := errors.New("tried all peers unsuccessfully. here are the results:\n" +
+			"   peer #0: http://localhost:4001/db/query failed due to " +
+			`Post "http://localhost:4001/db/query": ` +
+			"dial tcp 127.0.0.1:4001: connect: connection refused\n" +
+			"   peer #1: http://rqlite1:4001/db/query failed due to " +
+			"got: 401 Unauthorized, message:")
+		got := enrichConnError(mixed, newSrc("rqlite://localhost:4001"))
+		var authErr *AuthError
+		require.True(t, errors.As(got, &authErr),
+			"the reachable-but-unauthorized peer is an auth problem")
+		var discErr *DiscoveryError
+		require.False(t, errors.As(got, &discErr))
+	})
+
 	t.Run("first-match-wins: mixed dial+401 diagnoses discovery, not auth", func(t *testing.T) {
 		// One peer is the unresolvable-hostname trap, another returns
 		// 401. Discovery matches first; the 401 substring survives in
@@ -478,7 +498,13 @@ func Test_enrichingSQLDriver_ErrWrapFunc(t *testing.T) {
 		Location: "rqlite://localhost:4001",
 		Type:     drivertype.Rqlite,
 	}
-	g := &grip{src: src}
+	g := &grip{src: src, drvrw: &enrichingSQLDriver{driveri: &driveri{}, src: src}}
+
+	// Optional interfaces implemented by driveri must remain visible
+	// through the wrapper (it embeds the concrete *driveri).
+	_, ok := g.SQLDriver().(driver.ConnParamDetector)
+	require.True(t, ok, "wrapper must not erase optional interfaces")
+
 	wrapFn := g.SQLDriver().ErrWrapFunc()
 
 	require.Nil(t, wrapFn(nil))
@@ -642,6 +668,55 @@ func Test_rewritePeerDiscoveryError(t *testing.T) {
 			loc:           userLoc,
 			wantRewrite:   true,
 			wantSubstrAll: []string{`"rqlite1"`, "disableClusterDiscovery=true"},
+		},
+		{
+			// Eligibility is per-peer: the same-host dial failure must
+			// not qualify the foreign 401 peer as the discovery trap.
+			name: "same-host dial failure plus foreign 401 is not the trap",
+			err: errors.New("tried all peers unsuccessfully. here are the results:\n" +
+				"   peer #0: http://localhost:4001/db/query failed due to " +
+				`Post "http://localhost:4001/db/query": ` +
+				"dial tcp 127.0.0.1:4001: connect: connection refused\n" +
+				"   peer #1: http://rqlite1:4001/db/query failed due to " +
+				"got: 401 Unauthorized, message:"),
+			loc:         userLoc,
+			wantRewrite: false,
+		},
+		{
+			// A canceled dial says nothing about the peer: Ctrl-C or a
+			// context cancel mid-dial must not be diagnosed as the trap.
+			name: "canceled dial to foreign peer is not the trap",
+			err: errors.New("tried all peers unsuccessfully. here are the results:\n" +
+				"   peer #0: http://rqlite1:4001/db/query failed due to " +
+				`Post "http://rqlite1:4001/db/query": ` +
+				"dial tcp 172.18.0.2:4001: operation was canceled"),
+			loc:         userLoc,
+			wantRewrite: false,
+		},
+		{
+			// Marker matching is case-insensitive: Windows reports
+			// "No such host is known".
+			name: "windows-style DNS failure classifies as resolve",
+			err: errors.New("tried all peers unsuccessfully. here are the results:\n" +
+				"   peer #0: http://rqlite1:4001/db/query failed due to " +
+				`Post "http://rqlite1:4001/db/query": ` +
+				"dial tcp: lookup rqlite1: getaddrinfow: No such host is known."),
+			loc:           userLoc,
+			wantRewrite:   true,
+			wantSubstrAll: []string{"resolve advertised peer", `"rqlite1"`},
+		},
+		{
+			// The scan skips ineligible foreign peers (HTTP-level
+			// failure) and keeps looking for a trap-shaped one.
+			name: "foreign 401 peer first, foreign DNS peer second",
+			err: errors.New("tried all peers unsuccessfully. here are the results:\n" +
+				"   peer #0: http://rqlite1:4001/db/query failed due to " +
+				"got: 401 Unauthorized, message:\n" +
+				"   peer #1: http://rqlite2:4001/db/query failed due to " +
+				`Post "http://rqlite2:4001/db/query": dial tcp: lookup rqlite2: no such host`),
+			loc:           userLoc,
+			wantRewrite:   true,
+			wantSubstrAll: []string{"resolve advertised peer", `"rqlite2"`},
 		},
 		{
 			// Resolve must come from the chosen peer's own failure

--- a/drivers/rqlite/internal_test.go
+++ b/drivers/rqlite/internal_test.go
@@ -439,7 +439,7 @@ func Test_rewriteAuthError(t *testing.T) {
 		require.True(t, errors.As(got, &hr))
 		human := hr.HumanError()
 		require.Contains(t, human, "@rq")
-		require.Contains(t, human, "the source has none")
+		require.Contains(t, human, "source has none")
 		require.NotContains(t, human, "tried all peers")
 		// Full diagnostic form keeps the cause chain.
 		require.Contains(t, got.Error(), "401 Unauthorized")
@@ -451,7 +451,7 @@ func Test_rewriteAuthError(t *testing.T) {
 		var authErr *AuthError
 		require.True(t, errors.As(got, &authErr))
 		require.True(t, authErr.HasCreds)
-		require.Contains(t, authErr.HumanError(), "rejected the source's credentials")
+		require.Contains(t, authErr.HumanError(), "node rejected credentials")
 	})
 
 	t.Run("unparseable location defaults to creds present", func(t *testing.T) {

--- a/drivers/rqlite/internal_test.go
+++ b/drivers/rqlite/internal_test.go
@@ -398,8 +398,8 @@ func Test_DiscoveryError(t *testing.T) {
 	require.Contains(t, human, "@rq")
 	require.Contains(t, human, `"rqlite1"`)
 	require.Contains(t, human, "resolvable")
-	require.Contains(t, human, "?disableClusterDiscovery=true")
-	require.Contains(t, human, "(see docs)")
+	require.Contains(t, human, "disableClusterDiscovery")
+	require.Contains(t, human, "docs")
 	require.NotContains(t, human, "tried all peers")
 	require.NotContains(t, human, "sq.io")
 

--- a/drivers/rqlite/internal_test.go
+++ b/drivers/rqlite/internal_test.go
@@ -439,7 +439,7 @@ func Test_rewriteAuthError(t *testing.T) {
 		require.True(t, errors.As(got, &hr))
 		human := hr.HumanError()
 		require.Contains(t, human, "@rq")
-		require.Contains(t, human, "the source location has none")
+		require.Contains(t, human, "the source has none")
 		require.NotContains(t, human, "tried all peers")
 		// Full diagnostic form keeps the cause chain.
 		require.Contains(t, got.Error(), "401 Unauthorized")

--- a/drivers/rqlite/rqlite.go
+++ b/drivers/rqlite/rqlite.go
@@ -315,7 +315,13 @@ func (d *driveri) ValidateSource(src *source.Source) (*source.Source, error) {
 	return src, nil
 }
 
-// Ping implements driver.Driver.
+// Ping implements driver.Driver. gorqlite's database/sql conn doesn't
+// implement driver.Pinger, and gorqlite tolerates some failures (e.g.
+// a 401 response) at connect time, so db.PingContext alone only
+// verifies that a client can be constructed. Ping instead executes a
+// real round-trip query, so that it verifies the source is actually
+// usable: this surfaces auth, cluster-discovery, and transport
+// problems at add time rather than at first query.
 func (d *driveri) Ping(ctx context.Context, src *source.Source) error {
 	db, err := d.doOpen(ctx, src)
 	if err != nil {
@@ -323,7 +329,8 @@ func (d *driveri) Ping(ctx context.Context, src *source.Source) error {
 	}
 	defer lg.WarnIfCloseError(d.log, lgm.CloseDB, db)
 
-	if err = db.PingContext(ctx); err != nil {
+	var n int
+	if err = db.QueryRowContext(ctx, "SELECT 1").Scan(&n); err != nil {
 		return errz.Wrapf(enrichConnError(errw(err), src),
 			"ping %s: %s", src.Handle, src.RedactedLocation())
 	}

--- a/drivers/rqlite/rqlite.go
+++ b/drivers/rqlite/rqlite.go
@@ -172,8 +172,6 @@ func (d *driveri) Open(ctx context.Context, src *source.Source) (driver.Grip, er
 }
 
 func (d *driveri) doOpen(ctx context.Context, src *source.Source) (*sql.DB, error) {
-	maybeWarnLocalhostDiscovery(ctx, src)
-
 	loc, portAdded, err := locationWithDefaultPort(src.Location)
 	if err != nil {
 		return nil, err

--- a/drivers/rqlite/rqlite.go
+++ b/drivers/rqlite/rqlite.go
@@ -320,7 +320,7 @@ func (d *driveri) ValidateSource(src *source.Source) (*source.Source, error) {
 // a 401 response) at connect time, so db.PingContext alone only
 // verifies that a client can be constructed. Ping instead executes a
 // real round-trip query, so that it verifies the source is actually
-// usable: this surfaces auth, cluster-discovery, and transport
+// usable: this surfaces auth, cluster discovery, and transport
 // problems at add time rather than at first query.
 func (d *driveri) Ping(ctx context.Context, src *source.Source) error {
 	db, err := d.doOpen(ctx, src)

--- a/drivers/rqlite/rqlite.go
+++ b/drivers/rqlite/rqlite.go
@@ -168,7 +168,10 @@ func (d *driveri) Open(ctx context.Context, src *source.Source) (driver.Grip, er
 		return nil, enrichConnError(err, src)
 	}
 
-	return &grip{log: d.log, db: db, src: src, drvr: d}, nil
+	return &grip{
+		log: d.log, db: db, src: src, drvr: d,
+		drvrw: &enrichingSQLDriver{driveri: d, src: src},
+	}, nil
 }
 
 func (d *driveri) doOpen(ctx context.Context, src *source.Source) (*sql.DB, error) {
@@ -253,21 +256,24 @@ func (d *driveri) Truncate(ctx context.Context, src *source.Source, tbl string, 
 	}
 	defer lg.WarnIfFuncError(d.log, lgm.CloseDB, db.Close)
 
+	// Truncate has src in hand (unlike most SQLDriver methods, which
+	// take a bare db), so its errors get the connection-error
+	// enrichments too, consistent with the query and metadata paths.
 	affected, err := sqlz.ExecAffected(ctx, db, fmt.Sprintf("DELETE FROM %q", tbl))
 	if err != nil {
-		return affected, errw(err)
+		return affected, enrichConnError(errw(err), src)
 	}
 
 	if reset {
 		const seqProbe = `SELECT COUNT(name) FROM sqlite_master WHERE type='table' AND name='sqlite_sequence'`
 		var seqCount int64
 		if err = db.QueryRowContext(ctx, seqProbe).Scan(&seqCount); err != nil {
-			return affected, errw(err)
+			return affected, enrichConnError(errw(err), src)
 		}
 		if seqCount > 0 {
 			if _, err = db.ExecContext(ctx,
 				"UPDATE sqlite_sequence SET seq = 0 WHERE name = ?", tbl); err != nil {
-				return affected, errw(err)
+				return affected, enrichConnError(errw(err), src)
 			}
 		}
 	}

--- a/drivers/rqlite/sakila-start-rqlite-cluster.sh
+++ b/drivers/rqlite/sakila-start-rqlite-cluster.sh
@@ -136,6 +136,7 @@ if [[ "$AUTH" == "true" ]]; then
     cat > "$DATA_DIR/creds.json" <<CREDS
 [{"username": "$RQ_USER", "password": "$RQ_PASSWORD", "perms": ["all"]}]
 CREDS
+    chmod 600 "$DATA_DIR/creds.json"
     auth_flags=(-auth="$DATA_DIR/creds.json")
     # Joining nodes must authenticate their join requests against the
     # cluster; -join-as names the creds.json user whose credentials

--- a/drivers/rqlite/sakila-start-rqlite-cluster.sh
+++ b/drivers/rqlite/sakila-start-rqlite-cluster.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# sakila-start-rqlite-nodes.sh
+# sakila-start-rqlite-cluster.sh
 #
 # Start a 3-node rqlite cluster on 127.0.0.1 (HTTP ports 4001/4003/4005,
 # Raft ports 4002/4004/4006) and load the Sakila sample database into
@@ -20,7 +20,7 @@
 # argument or an environment variable) to generate a self-signed
 # certificate and serve the HTTP API over HTTPS instead:
 #
-#   ./sakila-start-rqlite-nodes.sh HTTPS=true
+#   ./sakila-start-rqlite-cluster.sh HTTPS=true
 #
 # Prerequisites: rqlited + curl on PATH, plus openssl for HTTPS mode.
 # On macOS: `brew install rqlite`.
@@ -58,7 +58,7 @@ if [[ "$HTTPS" == "true" ]]; then
     }
 fi
 
-DATA_DIR="$(mktemp -d -t sakila-rq-nodes.XXXX)"
+DATA_DIR="$(mktemp -d -t sakila-rq-cluster.XXXX)"
 
 scheme=http
 tls_flags=()

--- a/drivers/rqlite/sakila-start-rqlite-cluster.sh
+++ b/drivers/rqlite/sakila-start-rqlite-cluster.sh
@@ -155,7 +155,13 @@ cleanup() {
     rm -rf "$DATA_DIR"
     echo "Done."
 }
-trap cleanup EXIT INT TERM HUP
+# Signal handlers exit so that cleanup (via the EXIT trap) runs exactly
+# once and the script cannot continue against a torn-down cluster: a
+# trap that merely runs cleanup would return into the interrupted wait
+# loops (whose curl sits in an if-condition, exempt from set -e).
+trap cleanup EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM HUP
 
 auth_label="auth"
 [[ "$AUTH" == "true" ]] || auth_label="no auth"

--- a/drivers/rqlite/sakila-start-rqlite-cluster.sh
+++ b/drivers/rqlite/sakila-start-rqlite-cluster.sh
@@ -216,6 +216,9 @@ for _ in {1..30}; do
     node_count=$(curl -fsS ${curl_opts[@]+"${curl_opts[@]}"} \
         "$scheme://127.0.0.1:4001/nodes?ver=2" 2>/dev/null \
         | grep -o '"id":' | wc -l || true)
+    # Defensive: guarantee a numeric value even if the pipeline
+    # produced no output.
+    node_count="${node_count:-0}"
     if [[ "$node_count" -eq 3 ]]; then
         break
     fi

--- a/drivers/rqlite/sakila-start-rqlite-cluster.sh
+++ b/drivers/rqlite/sakila-start-rqlite-cluster.sh
@@ -31,6 +31,10 @@
 
 set -euo pipefail
 
+# Sakila SQLite database loaded into the cluster leader. Overridable
+# via the environment.
+SAKILA_DB_URL="${SAKILA_DB_URL:-https://raw.githubusercontent.com/neilotoole/sq/master/drivers/sqlite3/testdata/sakila.db}"
+
 HTTPS="${HTTPS:-false}"
 for arg in "$@"; do
     case "$arg" in
@@ -146,7 +150,7 @@ fi
 
 echo "Loading Sakila into leader..."
 sakila_db="$DATA_DIR/sakila.db"
-curl -fsSL https://sq.io/testdata/sakila.db -o "$sakila_db"
+curl -fsSL "$SAKILA_DB_URL" -o "$sakila_db"
 curl -fsS ${curl_opts[@]+"${curl_opts[@]}"} \
     -X POST "$scheme://127.0.0.1:4001/db/load" \
     -H 'Content-Type: application/octet-stream' \

--- a/drivers/rqlite/sakila-start-rqlite-cluster.sh
+++ b/drivers/rqlite/sakila-start-rqlite-cluster.sh
@@ -256,8 +256,8 @@ Cluster ready: 3 nodes, leader on $scheme://localhost:4001.
 
 Try it from another terminal (note: no disableClusterDiscovery):
 
-    sq add '$add_loc' --handle @rq_local
-    sq inspect @rq_local
+    sq add '$add_loc' --handle @rq
+    sq inspect @rq
 $https_note
 Logs: $DATA_DIR/node{1,2,3}.log
 

--- a/drivers/rqlite/sakila-start-rqlite-cluster.sh
+++ b/drivers/rqlite/sakila-start-rqlite-cluster.sh
@@ -2,10 +2,10 @@
 #
 # sakila-start-rqlite-cluster.sh
 #
-# Start a 3-node rqlite cluster on 127.0.0.1 (HTTP ports 4001/4003/4005,
-# Raft ports 4002/4004/4006) and load the Sakila sample database into
-# the leader. Because every node binds and advertises 127.0.0.1,
-# gorqlite's cluster discovery returns host-reachable addresses, so
+# Start a 3-node rqlite cluster on 127.0.0.1 (HTTP API ports
+# 4001/4003/4005, Raft ports 4002/4004/4006) and load the Sakila sample
+# database into the leader. Because every node binds and advertises
+# 127.0.0.1, cluster discovery returns host-reachable addresses, so
 # `sq` can talk to the cluster WITHOUT ?disableClusterDiscovery=true,
 # exercising the real discovery + leader-redirect path.
 #
@@ -16,11 +16,29 @@
 # resolve). For the equivalent single-node Docker setup with Sakila
 # preloaded, see sakila-start-local.sh at the repo root.
 #
-# By default the nodes serve plain HTTP. Pass HTTPS=true (as an
-# argument or an environment variable) to generate a self-signed
-# certificate and serve the HTTP API over HTTPS instead:
+# Usage:
 #
-#   ./sakila-start-rqlite-cluster.sh HTTPS=true
+#   ./sakila-start-rqlite-cluster.sh [HTTPS=true|false] [AUTH=true|false]
+#
+# By default the cluster serves HTTPS with a generated self-signed
+# certificate (HTTPS=true) and requires basic-auth credentials
+# sakila / p_ssW0rd (AUTH=true), matching the defaults of the
+# sakiladb/rqlite Docker image. The flags combine in any order:
+#
+#   ./sakila-start-rqlite-cluster.sh                          # HTTPS + auth
+#   ./sakila-start-rqlite-cluster.sh AUTH=false               # HTTPS, no auth
+#   ./sakila-start-rqlite-cluster.sh HTTPS=false              # plain HTTP + auth
+#   ./sakila-start-rqlite-cluster.sh HTTPS=false AUTH=false   # plain HTTP, no auth
+#
+# Once the cluster is ready, the script prints the `sq add` command
+# matching the chosen scenario. With HTTPS=true the certificate is
+# self-signed, so the printed location includes ?tls=true&insecure=true.
+# Adding the bare location instead demonstrates sq's add-time probe,
+# which detects TLS, fails certificate verification, and errors with
+# instructions.
+#
+# The generated certificate and credentials file live in the cluster's
+# temp data dir alongside the node data and logs.
 #
 # Prerequisites: rqlited + curl on PATH, plus openssl for HTTPS mode.
 # On macOS: `brew install rqlite`.
@@ -31,17 +49,38 @@
 
 set -euo pipefail
 
-# Sakila SQLite database loaded into the cluster leader. Overridable
-# via the environment.
-SAKILA_DB_URL="${SAKILA_DB_URL:-https://raw.githubusercontent.com/neilotoole/sq/master/drivers/sqlite3/testdata/sakila.db}"
+# Sakila SQLite database loaded into the cluster leader.
+SAKILA_DB_URL="https://raw.githubusercontent.com/neilotoole/sq/master/drivers/sqlite3/testdata/sakila.db"
 
-HTTPS="${HTTPS:-false}"
+# Credentials required when AUTH=true. These match the defaults of the
+# sakiladb/rqlite Docker image.
+RQ_USER="sakila"
+RQ_PASSWORD="p_ssW0rd"
+
+HTTPS=true
+AUTH=true
 for arg in "$@"; do
     case "$arg" in
         HTTPS=true) HTTPS=true ;;
         HTTPS=false) HTTPS=false ;;
+        AUTH=true) AUTH=true ;;
+        AUTH=false) AUTH=false ;;
         *)
-            echo "Usage: $0 [HTTPS=true]" >&2
+            cat >&2 <<USAGE
+Invalid argument: $arg
+
+Usage: $0 [HTTPS=true|false] [AUTH=true|false]
+
+  HTTPS=true|false   Serve the HTTP API over HTTPS with a generated
+                     self-signed certificate. Default: true.
+  AUTH=true|false    Require basic-auth credentials $RQ_USER / $RQ_PASSWORD.
+                     Default: true.
+
+Examples:
+  $0                          # HTTPS + auth (the defaults)
+  $0 AUTH=false               # HTTPS, no auth
+  $0 HTTPS=false AUTH=false   # plain HTTP, no auth
+USAGE
             exit 1
             ;;
     esac
@@ -66,7 +105,10 @@ DATA_DIR="$(mktemp -d -t sakila-rq-cluster.XXXX)"
 
 scheme=http
 tls_flags=()
+auth_flags=()
+join_auth_flags=()
 curl_opts=()
+
 if [[ "$HTTPS" == "true" ]]; then
     scheme=https
     # Self-signed cert with SANs for localhost/127.0.0.1: Go's TLS
@@ -87,7 +129,19 @@ CNF
         -keyout "$DATA_DIR/key.pem" -out "$DATA_DIR/cert.pem" \
         -config "$DATA_DIR/openssl.cnf" 2>/dev/null
     tls_flags=(-http-cert="$DATA_DIR/cert.pem" -http-key="$DATA_DIR/key.pem")
-    curl_opts=(--cacert "$DATA_DIR/cert.pem")
+    curl_opts+=(--cacert "$DATA_DIR/cert.pem")
+fi
+
+if [[ "$AUTH" == "true" ]]; then
+    cat > "$DATA_DIR/creds.json" <<CREDS
+[{"username": "$RQ_USER", "password": "$RQ_PASSWORD", "perms": ["all"]}]
+CREDS
+    auth_flags=(-auth="$DATA_DIR/creds.json")
+    # Joining nodes must authenticate their join requests against the
+    # cluster; -join-as names the creds.json user whose credentials
+    # are presented.
+    join_auth_flags=(-join-as="$RQ_USER")
+    curl_opts+=(-u "$RQ_USER:$RQ_PASSWORD")
 fi
 
 cleanup() {
@@ -102,7 +156,9 @@ cleanup() {
 }
 trap cleanup EXIT INT TERM HUP
 
-echo "Starting rqlite cluster ($scheme; data dir: $DATA_DIR)"
+auth_label="auth"
+[[ "$AUTH" == "true" ]] || auth_label="no auth"
+echo "Starting rqlite cluster ($scheme, $auth_label; data dir: $DATA_DIR)"
 
 # ${arr[@]+...} expansions guard against empty arrays under set -u
 # with macOS's bash 3.2.
@@ -111,6 +167,7 @@ rqlited \
     -http-addr=127.0.0.1:4001 \
     -raft-addr=127.0.0.1:4002 \
     ${tls_flags[@]+"${tls_flags[@]}"} \
+    ${auth_flags[@]+"${auth_flags[@]}"} \
     "$DATA_DIR/node1" &> "$DATA_DIR/node1.log" &
 
 # Let node1 bind its Raft port before node2/3 try to join.
@@ -122,6 +179,8 @@ rqlited \
     -raft-addr=127.0.0.1:4004 \
     -join=127.0.0.1:4002 \
     ${tls_flags[@]+"${tls_flags[@]}"} \
+    ${auth_flags[@]+"${auth_flags[@]}"} \
+    ${join_auth_flags[@]+"${join_auth_flags[@]}"} \
     "$DATA_DIR/node2" &> "$DATA_DIR/node2.log" &
 
 rqlited \
@@ -130,6 +189,8 @@ rqlited \
     -raft-addr=127.0.0.1:4006 \
     -join=127.0.0.1:4002 \
     ${tls_flags[@]+"${tls_flags[@]}"} \
+    ${auth_flags[@]+"${auth_flags[@]}"} \
+    ${join_auth_flags[@]+"${join_auth_flags[@]}"} \
     "$DATA_DIR/node3" &> "$DATA_DIR/node3.log" &
 
 # Wait up to 30s for the leader's /readyz to return 200.
@@ -148,6 +209,24 @@ if ! curl -fsS ${curl_opts[@]+"${curl_opts[@]}"} \
     exit 1
 fi
 
+# Wait up to 30s for all 3 nodes to join the cluster. Don't claim a
+# cluster that didn't actually form.
+node_count=0
+for _ in {1..30}; do
+    node_count=$(curl -fsS ${curl_opts[@]+"${curl_opts[@]}"} \
+        "$scheme://127.0.0.1:4001/nodes?ver=2" 2>/dev/null \
+        | grep -o '"id":' | wc -l || true)
+    if [[ "$node_count" -eq 3 ]]; then
+        break
+    fi
+    sleep 1
+done
+if [[ "$node_count" -ne 3 ]]; then
+    echo "Expected 3 nodes in the cluster, but found $node_count." >&2
+    echo "Inspect $DATA_DIR/node{1,2,3}.log for details." >&2
+    exit 1
+fi
+
 echo "Loading Sakila into leader..."
 sakila_db="$DATA_DIR/sakila.db"
 curl -fsSL "$SAKILA_DB_URL" -o "$sakila_db"
@@ -157,9 +236,12 @@ curl -fsS ${curl_opts[@]+"${curl_opts[@]}"} \
     --data-binary "@$sakila_db" >/dev/null
 
 add_loc="rqlite://localhost:4001"
+if [[ "$AUTH" == "true" ]]; then
+    add_loc="rqlite://$RQ_USER:$RQ_PASSWORD@localhost:4001"
+fi
 https_note=""
 if [[ "$HTTPS" == "true" ]]; then
-    add_loc="rqlite://localhost:4001?tls=true&insecure=true"
+    add_loc="$add_loc?tls=true&insecure=true"
     https_note="
 The certificate is self-signed, hence insecure=true. Adding the bare
 location rqlite://localhost:4001 instead demonstrates sq's add-time

--- a/drivers/rqlite/sakila-start-rqlite-nodes.sh
+++ b/drivers/rqlite/sakila-start-rqlite-nodes.sh
@@ -16,13 +16,32 @@
 # resolve). For the equivalent single-node Docker setup with Sakila
 # preloaded, see sakila-start-local.sh at the repo root.
 #
-# Prerequisites: rqlited + curl on PATH. On macOS: `brew install rqlite`.
+# By default the nodes serve plain HTTP. Pass HTTPS=true (as an
+# argument or an environment variable) to generate a self-signed
+# certificate and serve the HTTP API over HTTPS instead:
+#
+#   ./sakila-start-rqlite-nodes.sh HTTPS=true
+#
+# Prerequisites: rqlited + curl on PATH, plus openssl for HTTPS mode.
+# On macOS: `brew install rqlite`.
 # See https://rqlite.io/docs/install-rqlite/ for other platforms.
 #
 # Run in the foreground. Ctrl-C tears down all three nodes and removes
 # their data directory.
 
 set -euo pipefail
+
+HTTPS="${HTTPS:-false}"
+for arg in "$@"; do
+    case "$arg" in
+        HTTPS=true) HTTPS=true ;;
+        HTTPS=false) HTTPS=false ;;
+        *)
+            echo "Usage: $0 [HTTPS=true]" >&2
+            exit 1
+            ;;
+    esac
+done
 
 command -v rqlited >/dev/null || {
     echo "rqlited not found; on macOS install via 'brew install rqlite'" >&2
@@ -32,8 +51,40 @@ command -v curl >/dev/null || {
     echo "curl not found on PATH" >&2
     exit 1
 }
+if [[ "$HTTPS" == "true" ]]; then
+    command -v openssl >/dev/null || {
+        echo "openssl not found on PATH (required for HTTPS mode)" >&2
+        exit 1
+    }
+fi
 
 DATA_DIR="$(mktemp -d -t sakila-rq-nodes.XXXX)"
+
+scheme=http
+tls_flags=()
+curl_opts=()
+if [[ "$HTTPS" == "true" ]]; then
+    scheme=https
+    # Self-signed cert with SANs for localhost/127.0.0.1: Go's TLS
+    # stack ignores CN-only certs. The -config form (rather than
+    # -addext) also works with the older LibreSSL shipped on macOS.
+    cat > "$DATA_DIR/openssl.cnf" <<'CNF'
+[req]
+distinguished_name = dn
+x509_extensions = ext
+prompt = no
+[dn]
+CN = localhost
+[ext]
+subjectAltName = DNS:localhost, IP:127.0.0.1
+CNF
+    echo "Generating self-signed certificate..."
+    openssl req -x509 -newkey rsa:2048 -nodes -sha256 -days 1 \
+        -keyout "$DATA_DIR/key.pem" -out "$DATA_DIR/cert.pem" \
+        -config "$DATA_DIR/openssl.cnf" 2>/dev/null
+    tls_flags=(-http-cert="$DATA_DIR/cert.pem" -http-key="$DATA_DIR/key.pem")
+    curl_opts=(--cacert "$DATA_DIR/cert.pem")
+fi
 
 cleanup() {
     echo
@@ -47,12 +98,15 @@ cleanup() {
 }
 trap cleanup EXIT INT TERM HUP
 
-echo "Starting rqlite cluster (data dir: $DATA_DIR)"
+echo "Starting rqlite cluster ($scheme; data dir: $DATA_DIR)"
 
+# ${arr[@]+...} expansions guard against empty arrays under set -u
+# with macOS's bash 3.2.
 rqlited \
     -node-id=1 \
     -http-addr=127.0.0.1:4001 \
     -raft-addr=127.0.0.1:4002 \
+    ${tls_flags[@]+"${tls_flags[@]}"} \
     "$DATA_DIR/node1" &> "$DATA_DIR/node1.log" &
 
 # Let node1 bind its Raft port before node2/3 try to join.
@@ -63,6 +117,7 @@ rqlited \
     -http-addr=127.0.0.1:4003 \
     -raft-addr=127.0.0.1:4004 \
     -join=127.0.0.1:4002 \
+    ${tls_flags[@]+"${tls_flags[@]}"} \
     "$DATA_DIR/node2" &> "$DATA_DIR/node2.log" &
 
 rqlited \
@@ -70,17 +125,20 @@ rqlited \
     -http-addr=127.0.0.1:4005 \
     -raft-addr=127.0.0.1:4006 \
     -join=127.0.0.1:4002 \
+    ${tls_flags[@]+"${tls_flags[@]}"} \
     "$DATA_DIR/node3" &> "$DATA_DIR/node3.log" &
 
 # Wait up to 30s for the leader's /readyz to return 200.
 for _ in {1..30}; do
-    if curl -fsS http://127.0.0.1:4001/readyz >/dev/null 2>&1; then
+    if curl -fsS ${curl_opts[@]+"${curl_opts[@]}"} \
+        "$scheme://127.0.0.1:4001/readyz" >/dev/null 2>&1; then
         break
     fi
     sleep 1
 done
 
-if ! curl -fsS http://127.0.0.1:4001/readyz >/dev/null 2>&1; then
+if ! curl -fsS ${curl_opts[@]+"${curl_opts[@]}"} \
+    "$scheme://127.0.0.1:4001/readyz" >/dev/null 2>&1; then
     echo "Leader did not become ready within 30s." >&2
     echo "Inspect $DATA_DIR/node1.log for details." >&2
     exit 1
@@ -89,19 +147,32 @@ fi
 echo "Loading Sakila into leader..."
 sakila_db="$DATA_DIR/sakila.db"
 curl -fsSL https://sq.io/testdata/sakila.db -o "$sakila_db"
-curl -fsS -X POST 'http://127.0.0.1:4001/db/load' \
+curl -fsS ${curl_opts[@]+"${curl_opts[@]}"} \
+    -X POST "$scheme://127.0.0.1:4001/db/load" \
     -H 'Content-Type: application/octet-stream' \
     --data-binary "@$sakila_db" >/dev/null
 
+add_loc="rqlite://localhost:4001"
+https_note=""
+if [[ "$HTTPS" == "true" ]]; then
+    add_loc="rqlite://localhost:4001?tls=true&insecure=true"
+    https_note="
+The certificate is self-signed, hence insecure=true. Adding the bare
+location rqlite://localhost:4001 instead demonstrates sq's add-time
+probe: it detects TLS, fails certificate verification, and errors with
+instructions.
+"
+fi
+
 cat <<MSG
 
-Cluster ready: 3 nodes, leader on http://localhost:4001.
+Cluster ready: 3 nodes, leader on $scheme://localhost:4001.
 
 Try it from another terminal (note: no disableClusterDiscovery):
 
-    sq add 'rqlite://localhost:4001' --handle @rq_local
+    sq add '$add_loc' --handle @rq_local
     sq inspect @rq_local
-
+$https_note
 Logs: $DATA_DIR/node{1,2,3}.log
 
 Press Ctrl-C here to stop the cluster.

--- a/libsq/core/errz/errz.go
+++ b/libsq/core/errz/errz.go
@@ -456,3 +456,33 @@ type HumanReadable interface {
 	// HumanError returns the concise, user-facing form of the error.
 	HumanError() string
 }
+
+// WithHuman returns an error that attaches the concise human-readable
+// message to err for end-user display. The returned error implements
+// [HumanReadable]; its Error() text and chain (Unwrap) are those of
+// err, unchanged. Use this when the error carries no structured data
+// beyond the message; define a dedicated HumanReadable type when it
+// does. Returns nil if err is nil, and err unchanged if human is
+// empty.
+func WithHuman(err error, human string) error {
+	if err == nil {
+		return nil
+	}
+	if human == "" {
+		return err
+	}
+	return &humanizedError{error: err, human: human}
+}
+
+// humanizedError implements HumanReadable by pairing an error with a
+// concise display message.
+type humanizedError struct {
+	error
+	human string
+}
+
+// Unwrap returns the wrapped error.
+func (e *humanizedError) Unwrap() error { return e.error }
+
+// HumanError implements HumanReadable.
+func (e *humanizedError) HumanError() string { return e.human }

--- a/libsq/core/errz/errz.go
+++ b/libsq/core/errz/errz.go
@@ -439,3 +439,20 @@ func IsContextStop(ctx context.Context) bool {
 // printed. This is useful in the case where any error information may already
 // have been printed as part of the command output.
 var ErrNoMsg = errors.New("")
+
+// HumanReadable is implemented by errors that can render a concise,
+// actionable, self-contained message for end-user display, distinct from
+// Error(), which typically carries the full diagnostic chain. The CLI
+// prefers the HumanError text when printing an error that implements this
+// interface; the full Error() chain remains available in logs and verbose
+// output (e.g. the base_error field of verbose JSON error output).
+//
+// HumanError messages must stand alone: humanization replaces the entire
+// rendered error chain, including any outer operation context, so the
+// message should identify the subject (e.g. the source handle) itself.
+type HumanReadable interface {
+	error
+
+	// HumanError returns the concise, user-facing form of the error.
+	HumanError() string
+}

--- a/libsq/core/errz/errz.go
+++ b/libsq/core/errz/errz.go
@@ -475,7 +475,9 @@ func WithHuman(err error, human string) error {
 }
 
 // humanizedError implements HumanReadable by pairing an error with a
-// concise display message.
+// concise display message. Everything except HumanError defers to the
+// wrapped error, so attaching a human message doesn't degrade verbose
+// rendering, structured logging, or stack collection.
 type humanizedError struct {
 	error
 	human string
@@ -486,3 +488,50 @@ func (e *humanizedError) Unwrap() error { return e.error }
 
 // HumanError implements HumanReadable.
 func (e *humanizedError) HumanError() string { return e.human }
+
+// inner implements stackTracer, so LastStack walks through the
+// wrapper to the stacks beneath it.
+func (e *humanizedError) inner() error { return e.error }
+
+// stackTrace implements stackTracer. It deliberately returns nil
+// rather than delegating: Stacks collects per chain element via
+// Unwrap, so delegation would report the inner stack twice.
+func (e *humanizedError) stackTrace() *StackTrace { return nil }
+
+// Format implements fmt.Formatter, delegating to the wrapped error so
+// that verbose rendering (%+v) keeps the chain and stack output.
+func (e *humanizedError) Format(s fmt.State, verb rune) {
+	if f, ok := e.error.(fmt.Formatter); ok {
+		f.Format(s, verb)
+		return
+	}
+	switch verb {
+	case 'v', 's':
+		_, _ = io.WriteString(s, e.Error())
+	case 'q':
+		_, _ = fmt.Fprintf(s, "%q", e.Error())
+	}
+}
+
+// LogValue implements slog.LogValuer, delegating to the wrapped error.
+func (e *humanizedError) LogValue() slog.Value {
+	if lv, ok := e.error.(slog.LogValuer); ok {
+		return lv.LogValue()
+	}
+	return slog.StringValue(e.Error())
+}
+
+// HumanMessage returns the concise HumanReadable form when any error
+// in err's chain implements HumanReadable; otherwise err.Error().
+// Returns the empty string if err is nil. Use this when rendering an
+// error in space-constrained output (e.g. one row per source).
+func HumanMessage(err error) string {
+	if err == nil {
+		return ""
+	}
+	var hr HumanReadable
+	if errors.As(err, &hr) {
+		return hr.HumanError()
+	}
+	return err.Error()
+}

--- a/libsq/core/errz/errz_test.go
+++ b/libsq/core/errz/errz_test.go
@@ -279,3 +279,31 @@ func TestWithHuman(t *testing.T) {
 	require.True(t, errors.As(got, &hr))
 	require.Equal(t, "short form", hr.HumanError())
 }
+
+// TestWithHuman_Fidelity verifies that attaching a human message does
+// not degrade verbose rendering or stack collection.
+func TestWithHuman_Fidelity(t *testing.T) {
+	base := errz.Wrap(errz.New("root cause"), "context")
+	got := errz.WithHuman(base, "short form")
+
+	// %+v must delegate to the wrapped error: identical rendering,
+	// including stack frames.
+	verbose := fmt.Sprintf("%+v", got)
+	require.Equal(t, fmt.Sprintf("%+v", base), verbose,
+		"Format must delegate to the wrapped error")
+	require.Contains(t, verbose, ".go:",
+		"verbose rendering must include stack frames from the wrapped chain")
+
+	// Stack collection must see through the wrapper without duplicating.
+	require.Equal(t, len(errz.Stacks(base)), len(errz.Stacks(got)),
+		"WithHuman must neither hide nor duplicate stacks")
+	require.NotNil(t, errz.LastStack(got),
+		"LastStack must walk through the wrapper")
+}
+
+func TestHumanMessage(t *testing.T) {
+	require.Empty(t, errz.HumanMessage(nil))
+	require.Equal(t, "plain", errz.HumanMessage(errz.New("plain")))
+	err := errz.WithHuman(errz.New("long diagnostic"), "short form")
+	require.Equal(t, "short form", errz.HumanMessage(err))
+}

--- a/libsq/core/errz/errz_test.go
+++ b/libsq/core/errz/errz_test.go
@@ -261,3 +261,21 @@ func TestWithExitCode(t *testing.T) {
 	require.Equal(t, 3, errz.ExitCode(err))
 	require.True(t, errors.Is(err, errz.ErrNoMsg))
 }
+
+func TestWithHuman(t *testing.T) {
+	require.Nil(t, errz.WithHuman(nil, "msg"))
+
+	base := errz.New("long diagnostic dump")
+	require.Same(t, base, errz.WithHuman(base, ""),
+		"empty human message must return err unchanged")
+
+	got := errz.WithHuman(base, "short form")
+	require.Equal(t, "long diagnostic dump", got.Error(),
+		"Error() must be unchanged by WithHuman")
+	require.True(t, errors.Is(got, base),
+		"chain must remain intact through WithHuman")
+
+	var hr errz.HumanReadable
+	require.True(t, errors.As(got, &hr))
+	require.Equal(t, "short form", hr.HumanError())
+}

--- a/site/content/en/docs/drivers/rqlite.md
+++ b/site/content/en/docs/drivers/rqlite.md
@@ -52,6 +52,48 @@ rqlite://username:password@hostname:port
 rqlite://username:password@hostname:port?param=value
 ```
 
+## HTTP vs HTTPS
+
+rqlite serves plain HTTP by default, and so does this driver: a bare
+`rqlite://host:4001` location connects over HTTP. To connect over HTTPS
+instead, add `tls=true`:
+
+```shell
+$ sq add 'rqlite://node.example.com:4001?tls=true'
+```
+
+You usually don't need to specify `tls=true` yourself. At
+[`sq add`](/docs/cmd/add) time, `sq` probes the endpoint, and if it
+detects that the server requires TLS, it stores `tls=true` on the source
+automatically:
+
+```shell
+# node.example.com is TLS-only: sq detects this, and persists the
+# location as rqlite://node.example.com:4001?tls=true
+$ sq add 'rqlite://node.example.com:4001'
+```
+
+The probe is skipped if you pass `--skip-verify`, if the location
+already includes a `tls` or `insecure` param, or if the location
+contains `${...}` secret placeholders (such as those written by
+`--store keyring`). A source is probed only when it's added: if the
+server's transport changes later, connections fail with an error that
+suggests the fix; the saved location is never silently rewritten.
+
+### Self-signed certificates
+
+If the server presents a self-signed certificate or one issued by a
+private CA, certificate verification fails, and `sq add` errors with
+instructions. To accept the certificate, add `insecure=true` (valid
+only in combination with `tls=true`):
+
+```shell
+$ sq add 'rqlite://node.example.com:4001?tls=true&insecure=true'
+```
+
+`insecure=true` skips TLS certificate verification for the source.
+Prefer installing the CA in your trust store for production use.
+
 ## Common setups
 
 | Setup                                                       | Recommended URL                                                                  |
@@ -117,32 +159,17 @@ makes to the rqlite node. Integer-valued; defaults to `10`. Increase it
 for slow links or large multi-statement batches; decrease it to
 fail-fast against a flaky node.
 
-### TLS
+### `tls`
 
-By default rqlite serves plain HTTP. To connect over HTTPS, add `tls=true`:
+`true` or `false` (the default). Connect over HTTPS instead of plain
+HTTP. Usually set automatically at add time: see
+[HTTP vs HTTPS](#http-vs-https).
 
-```shell
-$ sq add 'rqlite://node.example.com:4001?tls=true'
-```
+### `insecure`
 
-If the server presents a self-signed certificate or one issued by a
-private CA, add `insecure=true` (valid only with `tls=true`):
-
-```shell
-$ sq add 'rqlite://node.example.com:4001?tls=true&insecure=true'
-```
-
-`insecure=true` skips TLS certificate verification for the source.
-Prefer installing the CA in your trust store for production use.
-
-You usually don't need to specify `tls=true` yourself: at
-[`sq add`](/docs/cmd/add) time, `sq` probes the endpoint, and if it detects that
-the server requires TLS, it stores `tls=true` on the source automatically. The
-probe is skipped if you pass `--skip-verify`, if the location already includes
-a `tls` or `insecure` param, or if the location contains `${...}` secret
-placeholders (such as those written by `--store keyring`). If the server
-requires TLS but presents a certificate that can't be verified, `sq add` fails
-with instructions: add `insecure=true`, or install the CA in your trust store.
+`true` or `false` (the default). Skip TLS certificate verification.
+Valid only in combination with `tls=true`. See
+[Self-signed certificates](#self-signed-certificates).
 
 ## Write behavior
 

--- a/site/content/en/docs/drivers/rqlite.md
+++ b/site/content/en/docs/drivers/rqlite.md
@@ -253,15 +253,16 @@ endpoints, SQLite pragmas, and `sqlite_master`.
 
 ## Example usage
 
-Both examples use the
-[`sakiladb/rqlite`](https://hub.docker.com/r/sakiladb/rqlite) image, which
-ships rqlite preloaded with the
-[Sakila](https://dev.mysql.com/doc/sakila/en/) sample database. Default
-credentials are `sakila` / `p_ssW0rd`.
+Both examples stand up a local rqlite loaded with the
+[Sakila](https://dev.mysql.com/doc/sakila/en/) sample database.
 
 ### Single node
 
-Start a single-node container, add the source, and inspect:
+This example uses the
+[`sakiladb/rqlite`](https://hub.docker.com/r/sakiladb/rqlite) Docker image,
+which ships rqlite preloaded with Sakila. Default credentials are
+`sakila` / `p_ssW0rd`. Start a single-node container, add the source, and
+inspect:
 
 ```shell
 # Port 4001 is rqlite's HTTP API.

--- a/site/content/en/docs/drivers/rqlite.md
+++ b/site/content/en/docs/drivers/rqlite.md
@@ -260,7 +260,7 @@ Both examples stand up a local rqlite loaded with the
 
 This example uses the
 [`sakiladb/rqlite`](https://hub.docker.com/r/sakiladb/rqlite) Docker image,
-which ships rqlite preloaded with Sakila. Default credentials are
+which ships rqlite preloaded with Sakila and serves HTTP. Default credentials are
 `sakila` / `p_ssW0rd`. Start a single-node container, add the source, and
 inspect:
 

--- a/site/content/en/docs/drivers/rqlite.md
+++ b/site/content/en/docs/drivers/rqlite.md
@@ -84,9 +84,9 @@ and writes a placeholder to the config in its place.
 
 ## TLS and certificates
 
-rqlite serves plain HTTP by default, and so does this driver: a bare
-`rqlite://host:4001` location connects over HTTP. To connect over HTTPS
-instead, add `tls=true`:
+rqlite serves plain HTTP by default, and the driver's default matches:
+a bare `rqlite://host:4001` location connects over HTTP. To connect
+over HTTPS instead, add `tls=true`:
 
 ```shell
 # No tls param; defaults to HTTP

--- a/site/content/en/docs/drivers/rqlite.md
+++ b/site/content/en/docs/drivers/rqlite.md
@@ -40,6 +40,11 @@ $ sq add 'rqlite://node.example.com:4001?tls=true&insecure=true'
 
 If the port is omitted, `sq` auto-applies the default port `4001`.
 
+`sq add` verifies the connection with a round-trip query, so a
+misconfigured source (unreachable node, bad credentials, TLS mismatch)
+fails at add time rather than at first query. Pass `--skip-verify` to
+add the source without contacting the node.
+
 ## HTTP vs HTTPS
 
 rqlite serves plain HTTP by default, and so does this driver: a bare
@@ -71,15 +76,15 @@ $ sq add 'rqlite://node.example.com:4001'
 The probe is skipped if you pass `--skip-verify`, if the location already includes a `tls` or
 `insecure` param, or if the location contains [secret placeholders](/docs/secrets/#placeholders).
 A source is probed only when it's added: if the server's transport changes later, connections fail
-with an error that suggests the fix; the saved location is never silently rewritten.
+with an error describing the mismatch; the saved location is never silently rewritten.
 {{< /alert >}}
 
 ### Self-signed certificates
 
 If the server presents a self-signed certificate or one issued by a
-private CA, certificate verification fails, and `sq add` errors with
-instructions. To accept the certificate, add `insecure=true` (valid
-only in combination with `tls=true`):
+private CA, certificate verification fails and `sq add` errors. To
+accept the certificate, add `insecure=true` (valid only in combination
+with `tls=true`):
 
 ```shell
 $ sq add 'rqlite://node.example.com:4001?tls=true&insecure=true'
@@ -103,12 +108,11 @@ host (the most common newcomer setup), discovery backfires. The node
 truthfully reports its own internal advertise address, which is
 typically a container-only hostname like `rqlite1` for the
 `sakiladb/rqlite` image or the container's short ID for the official
-`rqlite/rqlite` image. Your host can't resolve either of those, and the
-connection fails with:
+`rqlite/rqlite` image. Your host can't resolve either of those, and
+`sq add` fails with:
 
 ```text
-tried all peers unsuccessfully. ...
-dial tcp: lookup rqlite1: no such host
+sq: @rq: rqlite: cluster discovery failed: advertised peer "rqlite1" is not resolvable from this host
 ```
 
 The fix is `?disableClusterDiscovery=true` on the source URL. A

--- a/site/content/en/docs/drivers/rqlite.md
+++ b/site/content/en/docs/drivers/rqlite.md
@@ -314,3 +314,15 @@ $ sq inspect @rq_local
 
 Ctrl-C in the first terminal tears the cluster down and removes its
 data directory.
+
+To serve the cluster over HTTPS instead, pass `HTTPS=true`. The script
+generates a self-signed certificate, so add the source with
+`?tls=true&insecure=true` (the script prints the exact command). Adding
+the bare location instead demonstrates the add-time probe error
+described in [Self-signed certificates](#self-signed-certificates):
+
+```shell
+$ ./sakila-start-rqlite-nodes.sh HTTPS=true
+...
+$ sq add 'rqlite://localhost:4001?tls=true&insecure=true' --handle @rq_local
+```

--- a/site/content/en/docs/drivers/rqlite.md
+++ b/site/content/en/docs/drivers/rqlite.md
@@ -7,32 +7,27 @@ weight: 4045
 toc: true
 url: /docs/drivers/rqlite
 ---
-The `sq` rqlite driver implements connectivity for
-[rqlite](https://rqlite.io), the lightweight distributed SQLite database.
-It uses the [`rqlite/gorqlite`](https://github.com/rqlite/gorqlite)
-library and talks to rqlite over HTTP.
 
-Unlike `sq`'s built-in [SQLite driver](/docs/drivers/sqlite), rqlite is
-networked: there is no local file mode. The SQL dialect underneath is
-still SQLite, so queries written for `@my_sqlite` translate verbatim
-to `@my_rqlite`. Most optional `sq` SQL-driver features are supported;
-see [Limitations](#limitations) for what isn't.
+The `sq` rqlite driver implements connectivity for
+[rqlite](https://rqlite.io), the lightweight distributed SQLite database. It uses the
+[`rqlite/gorqlite`](https://github.com/rqlite/gorqlite) library and talks to rqlite over HTTP(S).
+The SQL dialect underneath is still SQLite, so queries written for a source `@sqlite` translate
+verbatim to `@rqlite`.
 
 ## Add source
 
-Use [`sq add`](/docs/cmd/add) to add a source. The location argument is
-an HTTP(S) URL using the `rqlite://` scheme:
+Use [`sq add`](/docs/cmd/add) to add a source.
 
 ```shell
-# Single-node setup (the common local case): disable cluster discovery
+# Single-node HTTP setup (the common local case): disable cluster discovery
 # so the client talks directly to localhost rather than chasing a
-# container-internal Raft hostname. See "Single-node localhost" below.
+# container-internal Raft hostname. See "Cluster discovery" below.
 $ sq add 'rqlite://localhost:4001?disableClusterDiscovery=true'
 
-# With credentials and a custom handle
-$ sq add 'rqlite://sakila:p_ssW0rd@localhost:4001?disableClusterDiscovery=true' --handle @rq
+# With credentials.
+$ sq add 'rqlite://sakila:p_ssW0rd@localhost:4001?disableClusterDiscovery=true'
 
-# Multi-node cluster: leave discovery on. gorqlite follows leader
+# Multi-node HTTP cluster: leave discovery on. The driver follows leader
 # redirects automatically.
 $ sq add 'rqlite://node1.example.com:4001'
 
@@ -45,13 +40,6 @@ $ sq add 'rqlite://node.example.com:4001?tls=true&insecure=true'
 
 If the port is omitted, `sq` auto-applies the default port `4001`.
 
-## Connection string format
-
-```text
-rqlite://username:password@hostname:port
-rqlite://username:password@hostname:port?param=value
-```
-
 ## HTTP vs HTTPS
 
 rqlite serves plain HTTP by default, and so does this driver: a bare
@@ -59,12 +47,19 @@ rqlite serves plain HTTP by default, and so does this driver: a bare
 instead, add `tls=true`:
 
 ```shell
+# No tls param; defaults to HTTP
+$ sq add 'rqlite://node.example.com:4001'
+
+# Explicitly HTTP
+$ sq add 'rqlite://node.example.com:4001?tls=false'
+
+# HTTPS
 $ sq add 'rqlite://node.example.com:4001?tls=true'
 ```
 
-You usually don't need to specify `tls=true` yourself. At
-[`sq add`](/docs/cmd/add) time, `sq` probes the endpoint, and if it
-detects that the server requires TLS, it stores `tls=true` on the source
+{{< alert icon="👉" >}}
+If an explicit `tls` param is not provided, at [`sq add`](/docs/cmd/add) time, `sq` probes the
+endpoint, and if it detects that the server requires TLS, it stores `tls=true` on the source
 automatically:
 
 ```shell
@@ -73,12 +68,11 @@ automatically:
 $ sq add 'rqlite://node.example.com:4001'
 ```
 
-The probe is skipped if you pass `--skip-verify`, if the location
-already includes a `tls` or `insecure` param, or if the location
-contains `${...}` secret placeholders (such as those written by
-`--store keyring`). A source is probed only when it's added: if the
-server's transport changes later, connections fail with an error that
-suggests the fix; the saved location is never silently rewritten.
+The probe is skipped if you pass `--skip-verify`, if the location already includes a `tls` or
+`insecure` param, or if the location contains [secret placeholders](/docs/secrets/#placeholders).
+A source is probed only when it's added: if the server's transport changes later, connections fail
+with an error that suggests the fix; the saved location is never silently rewritten.
+{{< /alert >}}
 
 ### Self-signed certificates
 
@@ -94,23 +88,23 @@ $ sq add 'rqlite://node.example.com:4001?tls=true&insecure=true'
 `insecure=true` skips TLS certificate verification for the source.
 Prefer installing the CA in your trust store for production use.
 
-## Common setups
+## Cluster discovery
 
-| Setup                                                       | Recommended URL                                                                  |
-|-------------------------------------------------------------|----------------------------------------------------------------------------------|
-| Single-node `docker run -p 4001:4001 rqlite/rqlite` (host)  | `rqlite://localhost:4001?disableClusterDiscovery=true`                           |
-| Single-node `sakiladb/rqlite` (host, with Sakila preloaded) | `rqlite://sakila:p_ssW0rd@localhost:4001?disableClusterDiscovery=true`           |
-| Multi-node cluster (production)                             | `rqlite://user:pass@node1:4001` (any node; leave discovery on)                   |
+By default, the driver asks the node it connects to for its cluster
+peers, then uses the peer list for leader redirects and failover. In a
+multi-node cluster whose node hostnames are resolvable from the client
+(typically via internal DNS), leave discovery enabled: it's what makes
+connecting via any node work.
 
-## Single-node localhost
+### Single-node localhost
 
 When you run a single rqlite node in Docker and connect to it from your
-host (the most common newcomer setup), `gorqlite`'s default behavior is to
-ask the node for its cluster peers. The node truthfully reports its own
-internal advertise address, which is typically a container-only hostname
-like `rqlite1` for the `sakiladb/rqlite` image or the container's short
-ID for the official `rqlite/rqlite` image. Your host can't resolve
-either of those, and the connection fails with:
+host (the most common newcomer setup), discovery backfires. The node
+truthfully reports its own internal advertise address, which is
+typically a container-only hostname like `rqlite1` for the
+`sakiladb/rqlite` image or the container's short ID for the official
+`rqlite/rqlite` image. Your host can't resolve either of those, and the
+connection fails with:
 
 ```text
 tried all peers unsuccessfully. ...
@@ -119,11 +113,14 @@ dial tcp: lookup rqlite1: no such host
 
 The fix is `?disableClusterDiscovery=true` on the source URL. A
 single-node setup has no peers to discover, so disabling discovery costs
-nothing and avoids the hostname trap. The
-[Common setups](#common-setups) table above includes this for both
-common images.
+nothing and avoids the hostname trap.
 
-## Connection parameters
+## Connection string
+
+```text
+rqlite://username:password@hostname:port
+rqlite://username:password@hostname:port?param=value
+```
 
 Pass parameters as URL query strings:
 
@@ -145,12 +142,12 @@ See [rqlite consistency docs](https://rqlite.io/docs/api/read-consistency/).
 
 ### `disableClusterDiscovery`
 
-`true` or `false`. Turns off `gorqlite`'s automatic peer discovery.
-Required for the [single-node localhost](#single-node-localhost) case
-described above; also useful when the rqlite node is reachable only
-through a proxy and shouldn't be probed for cluster peers. Multi-node
-cluster users should leave it off (the default) so leader redirects and
-failover work automatically.
+`true` or `false`. Turns off the driver's automatic peer discovery.
+Required for the [single-node localhost](#single-node-localhost) case;
+also useful when the rqlite node is reachable only through a proxy and
+shouldn't be probed for cluster peers. Multi-node cluster users should
+leave it off (the default) so leader redirects and failover work
+automatically.
 
 ### `timeout`
 
@@ -171,7 +168,9 @@ HTTP. Usually set automatically at add time: see
 Valid only in combination with `tls=true`. See
 [Self-signed certificates](#self-signed-certificates).
 
-## Write behavior
+## Notes
+
+### Write behavior
 
 rqlite has no interactive transactions; its HTTP API exposes single
 statements via `/db/execute` and atomic batches via the same endpoint
@@ -182,28 +181,25 @@ with multiple statements. `sq` maps onto this as follows:
   one HTTP call and is atomic at the rqlite layer.
 - **Multi-statement atomic operations** (`sq tbl copy`'s
   CREATE+INSERT-SELECT, and the `ALTER COLUMN TYPE` table-rebuild dance)
-  are sent as a single atomic batch via `gorqlite`'s
-  `WriteParameterizedContext`. If any statement fails, rqlite rolls the
-  whole batch back.
+  are sent as a single atomic batch. If any statement fails, rqlite
+  rolls the whole batch back.
 - **`sq tbl truncate`** issues `DELETE FROM tbl` and (with reset) a
   follow-up `UPDATE sqlite_sequence`. These two statements are
   deliberately not atomic relative to each other. The simpler path
   reports the deleted-row count accurately, and the AUTOINCREMENT-counter
   reset is informational.
 
-## Quirks
+### Quirks
 
 A few rqlite-specific behaviors are smoothed over inside the driver so
 the cross-driver experience matches the rest of `sq`. Worth knowing if
-you're comparing notes against raw `gorqlite` results:
+you're comparing notes against rqlite's HTTP API:
 
-- **Column types for empty tables.** `gorqlite`'s `database/sql` adapter
-  doesn't expose column type names to callers, so a fresh
+- **Column types for empty tables.** With no rows to go on, a fresh
   `CREATE TABLE` followed by an empty `SELECT` would normally yield
-  `kind.Unknown` for every column. `sq`'s rqlite driver wraps the
-  underlying `gorqlite` SQL driver to expose the type names that `gorqlite`
-  has been carrying all along, so `sq inspect` and the SLQ engine see
-  proper kinds even on empty tables.
+  `kind.Unknown` for every column. The driver recovers the declared
+  column types from rqlite's response metadata, so `sq inspect` and
+  the SLQ engine see proper kinds even on empty tables.
 - **JSON-numeric coercion.** rqlite returns all numeric column values
   as JSON numbers, which Go unmarshals to `float64` by default. The
   driver coerces these at materialization time: integer-kind columns
@@ -213,7 +209,7 @@ you're comparing notes against raw `gorqlite` results:
   `SELECT actor_id FROM actor` against an `INTEGER PRIMARY KEY` column
   comes back as `int64` in your output, not `float64`.
 
-## Limitations
+### Limitations
 
 - **`sq tbl copy` and `ALTER TABLE` kind swaps don't carry indexes or
   triggers.** The table DDL itself is preserved via SQL-text rewrite
@@ -231,7 +227,7 @@ you're comparing notes against raw `gorqlite` results:
   `DropSchema`, and catalog operations return explicit "not supported"
   errors.
 
-## Inspect field provenance
+## Inspect
 
 [`sq inspect`](/docs/inspect) populates the fields below from rqlite's HTTP status
 endpoints, SQLite pragmas, and `sqlite_master`.
@@ -284,21 +280,24 @@ $ docker stop sakila-rq
 
 ### Multiple nodes
 
-For a real local cluster that exercises `gorqlite`'s discovery and
-leader redirects (i.e. WITHOUT `?disableClusterDiscovery=true`), the
-simplest approach on a developer machine is three native `rqlited`
-processes on `127.0.0.1`, each advertising a host-reachable address.
-The sq source tree includes a helper that brings the cluster up and
-loads Sakila into the leader. It requires the `rqlited` binary
-(`brew install rqlite` on macOS; see
-[rqlite.io](https://rqlite.io/docs/install-rqlite/) for other
+This (macOS-tested) example demonstrates a real local cluster that exercises cluster discovery and
+leader redirects (i.e. _without_ `?disableClusterDiscovery=true`). It starts three native `rqlited`
+processes on `127.0.0.1`, each advertising a host-reachable address. Native processes, not Docker:
+multi-node Docker setups such as `sakiladb/rqlite`'s
+[`cluster-compose.yml`](https://github.com/sakiladb/rqlite/blob/master/cluster-compose.yml)
+advertise container-internal hostnames that the host can't resolve, the same trap described in
+[Single-node localhost](#single-node-localhost).
+
+The example
+[`sakila-start-rqlite-nodes.sh`](https://raw.githubusercontent.com/neilotoole/sq/master/drivers/rqlite/sakila-start-rqlite-nodes.sh)
+script brings the cluster up and loads Sakila into the leader. It requires the `rqlited` binary
+(`brew install rqlite` on macOS; see [rqlite.io](https://rqlite.io/docs/install-rqlite/) for other
 platforms):
 
 ```shell
-# In one terminal, download the helper, take a look at it, and run it.
+# In one terminal, download the helper and run it.
 $ curl -fsSL -o sakila-start-rqlite-nodes.sh \
     https://raw.githubusercontent.com/neilotoole/sq/master/drivers/rqlite/sakila-start-rqlite-nodes.sh
-$ less sakila-start-rqlite-nodes.sh   # inspect before running
 $ chmod +x sakila-start-rqlite-nodes.sh
 $ ./sakila-start-rqlite-nodes.sh
 Starting rqlite cluster (data dir: /tmp/sakila-rq-nodes.XXXX)
@@ -315,19 +314,3 @@ $ sq inspect @rq_local
 
 Ctrl-C in the first terminal tears the cluster down and removes its
 data directory.
-
-In a production deployment where node hostnames are resolvable from
-clients (typically via internal DNS), leave discovery enabled (the
-default) so leader redirects and failover work automatically:
-
-```shell
-$ sq add 'rqlite://user:pass@rqlite1.internal:4001' --handle @rq_prod
-```
-
-Docker-based multi-node images such as `sakiladb/rqlite`'s
-[`cluster-compose.yml`](https://github.com/sakiladb/rqlite/blob/master/cluster-compose.yml)
-advertise container-internal hostnames (`rqlite1`, `rqlite2`,
-`rqlite3`) that aren't resolvable from the host, so a host-side client
-would have to either disable discovery and point at one specific node,
-or rewrite the advertised addresses to host-reachable values plus add
-`/etc/hosts` entries. The bare-metal helper above sidesteps both.

--- a/site/content/en/docs/drivers/rqlite.md
+++ b/site/content/en/docs/drivers/rqlite.md
@@ -282,7 +282,8 @@ $ docker stop sakila-rq
 
 This (macOS-tested) example demonstrates a real local cluster that exercises cluster discovery and
 leader redirects (i.e. _without_ `?disableClusterDiscovery=true`). It starts three native `rqlited`
-processes on `127.0.0.1`, each advertising a host-reachable address.
+processes on `127.0.0.1`, each advertising a host-reachable address (Docker-based clusters
+advertise container-internal hostnames; see [Single-node localhost](#single-node-localhost)).
 
 First, download the [`sakila-start-rqlite-nodes.sh`](https://raw.githubusercontent.com/neilotoole/sq/master/drivers/rqlite/sakila-start-rqlite-nodes.sh)
 example script. Note that the script requires the `rqlited` binary

--- a/site/content/en/docs/drivers/rqlite.md
+++ b/site/content/en/docs/drivers/rqlite.md
@@ -24,7 +24,7 @@ Use [`sq add`](/docs/cmd/add) to add a source.
 # container-internal Raft hostname. See "Cluster discovery" below.
 $ sq add 'rqlite://localhost:4001?disableClusterDiscovery=true'
 
-# With credentials.
+# With credentials. See "Authentication" below.
 $ sq add 'rqlite://sakila:p_ssW0rd@localhost:4001?disableClusterDiscovery=true'
 
 # Multi-node HTTP cluster: leave discovery on. The driver follows leader
@@ -40,12 +40,49 @@ $ sq add 'rqlite://node.example.com:4001?tls=true&insecure=true'
 
 If the port is omitted, `sq` auto-applies the default port `4001`.
 
-`sq add` verifies the connection with a round-trip query, so a
-misconfigured source (unreachable node, bad credentials, TLS mismatch)
-fails at add time rather than at first query. Pass `--skip-verify` to
-add the source without contacting the node.
+### Verification
 
-## HTTP vs HTTPS
+At add time, `sq` does two things before persisting the source:
+
+1. If the location has no explicit `tls` or `insecure` param, `sq` probes the endpoint's
+   transport, and stores `tls=true` on the source if the server requires TLS. See
+   [TLS and certificates](#tls-and-certificates).
+2. `sq` verifies the connection with a round-trip query, so a misconfigured source fails
+   at add time rather than at first query.
+
+Pass `--skip-verify` to skip both steps and add the source without contacting the node.
+
+A failed add (or a failed connection to an already-added source) produces a one-line
+error naming the problem. Each failure mode has a section on this page:
+
+| Error                                           | Cause                                                  | See                                                       |
+|-------------------------------------------------|--------------------------------------------------------|-----------------------------------------------------------|
+| `rqlite: auth failed: ...`                      | node requires credentials, or rejected them            | [Authentication](#authentication)                         |
+| `rqlite: TLS required` / `rqlite: TLS mismatch` | the source's `tls` setting doesn't match the endpoint  | [TLS and certificates](#tls-and-certificates)             |
+| `rqlite: TLS cert verification failed`          | self-signed or private-CA certificate                  | [Self-signed certificates](#self-signed-certificates)     |
+| `rqlite: cluster discovery failed: ...`         | node advertised a peer address this host can't use     | [Cluster discovery](#cluster-discovery)                   |
+
+## Authentication
+
+rqlite supports HTTP basic auth. Supply credentials in the source location:
+
+```shell
+$ sq add 'rqlite://sakila:p_ssW0rd@localhost:4001?disableClusterDiscovery=true'
+```
+
+If the node requires credentials but the source has none, or the node rejects the
+supplied credentials, `sq add` (or any later use of the source) fails:
+
+```text
+sq: @rq: rqlite: auth failed: node requires credentials, but source has none
+sq: @rq: rqlite: auth failed: node rejected credentials
+```
+
+To keep the password out of sq's config file, store it as a [secret](/docs/secrets):
+e.g. pass `--store keyring` to `sq add`, which puts the password in the OS keyring
+and writes a placeholder to the config in its place.
+
+## TLS and certificates
 
 rqlite serves plain HTTP by default, and so does this driver: a bare
 `rqlite://host:4001` location connects over HTTP. To connect over HTTPS
@@ -62,10 +99,9 @@ $ sq add 'rqlite://node.example.com:4001?tls=false'
 $ sq add 'rqlite://node.example.com:4001?tls=true'
 ```
 
-{{< alert icon="👉" >}}
-If an explicit `tls` param is not provided, at [`sq add`](/docs/cmd/add) time, `sq` probes the
-endpoint, and if it detects that the server requires TLS, it stores `tls=true` on the source
-automatically:
+You usually don't need to set `tls=true` yourself: at add time, `sq` probes the
+endpoint, and if it detects that the server requires TLS, it stores `tls=true` on
+the source automatically:
 
 ```shell
 # node.example.com is TLS-only: sq detects this, and persists the
@@ -73,11 +109,12 @@ automatically:
 $ sq add 'rqlite://node.example.com:4001'
 ```
 
-The probe is skipped if you pass `--skip-verify`, if the location already includes a `tls` or
-`insecure` param, or if the location contains [secret placeholders](/docs/secrets/#placeholders).
-A source is probed only when it's added: if the server's transport changes later, connections fail
-with an error describing the mismatch; the saved location is never silently rewritten.
-{{< /alert >}}
+The probe is skipped if you pass `--skip-verify`, if the location already includes
+a `tls` or `insecure` param, or if the location contains
+[secret placeholders](/docs/secrets/#placeholders). A source is probed only when
+it's added: if the server's transport changes later, connections fail with a
+`TLS required` or `TLS mismatch` error; the saved location is never silently
+rewritten.
 
 ### Self-signed certificates
 
@@ -164,7 +201,7 @@ fail-fast against a flaky node.
 
 `true` or `false` (the default). Connect over HTTPS instead of plain
 HTTP. Usually set automatically at add time: see
-[HTTP vs HTTPS](#http-vs-https).
+[TLS and certificates](#tls-and-certificates).
 
 ### `insecure`
 

--- a/site/content/en/docs/drivers/rqlite.md
+++ b/site/content/en/docs/drivers/rqlite.md
@@ -292,8 +292,8 @@ platforms):
 
 ```shell
 $ curl -fsSL -o sakila-start-rqlite-nodes.sh \
-    https://raw.githubusercontent.com/neilotoole/sq/master/drivers/rqlite/sakila-start-rqlite-nodes.sh
-$ chmod +x sakila-start-rqlite-nodes.sh
+    https://raw.githubusercontent.com/neilotoole/sq/master/drivers/rqlite/sakila-start-rqlite-nodes.sh \
+    && chmod +x sakila-start-rqlite-nodes.sh
 ```
 
 #### HTTP cluster
@@ -308,8 +308,8 @@ Cluster ready: 3 nodes, leader on http://localhost:4001.
 Press Ctrl-C here to stop the cluster.
 
 # In another terminal:
-$ sq add 'rqlite://localhost:4001' --handle @rq_local
-$ sq inspect @rq_local
+$ sq add 'rqlite://localhost:4001' --handle @rq
+$ sq inspect @rq
 ```
 
 Ctrl-C in the first terminal tears the cluster down and removes its
@@ -324,5 +324,5 @@ generates a self-signed certificate, so add the source with
 ```shell
 $ ./sakila-start-rqlite-nodes.sh HTTPS=true
 ...
-$ sq add 'rqlite://localhost:4001?tls=true&insecure=true' --handle @rq_local
+$ sq add 'rqlite://localhost:4001?tls=true&insecure=true' --handle @rq
 ```

--- a/site/content/en/docs/drivers/rqlite.md
+++ b/site/content/en/docs/drivers/rqlite.md
@@ -278,29 +278,29 @@ $ sq inspect @rq
 $ docker stop sakila-rq
 ```
 
-### Multiple nodes
+### Cluster
 
 This (macOS-tested) example demonstrates a real local cluster that exercises cluster discovery and
 leader redirects (i.e. _without_ `?disableClusterDiscovery=true`). It starts three native `rqlited`
 processes on `127.0.0.1`, each advertising a host-reachable address (Docker-based clusters
 advertise container-internal hostnames; see [Single-node localhost](#single-node-localhost)).
 
-First, download the [`sakila-start-rqlite-nodes.sh`](https://raw.githubusercontent.com/neilotoole/sq/master/drivers/rqlite/sakila-start-rqlite-nodes.sh)
+First, download the [`sakila-start-rqlite-cluster.sh`](https://raw.githubusercontent.com/neilotoole/sq/master/drivers/rqlite/sakila-start-rqlite-cluster.sh)
 example script. Note that the script requires the `rqlited` binary
 (`brew install rqlite` on macOS; see [rqlite.io](https://rqlite.io/docs/install-rqlite/) for other
 platforms):
 
 ```shell
-curl -fsSL -o sakila-start-rqlite-nodes.sh \
-    https://raw.githubusercontent.com/neilotoole/sq/master/drivers/rqlite/sakila-start-rqlite-nodes.sh \
-    && chmod +x sakila-start-rqlite-nodes.sh
+curl -fsSL -o sakila-start-rqlite-cluster.sh \
+    https://raw.githubusercontent.com/neilotoole/sq/master/drivers/rqlite/sakila-start-rqlite-cluster.sh \
+    && chmod +x sakila-start-rqlite-cluster.sh
 ```
 
 #### HTTP cluster
 
 ```shell
-$ ./sakila-start-rqlite-nodes.sh
-Starting rqlite cluster (data dir: /tmp/sakila-rq-nodes.XXXX)
+$ ./sakila-start-rqlite-cluster.sh
+Starting rqlite cluster (http; data dir: /tmp/sakila-rq-cluster.XXXX)
 Loading Sakila into leader...
 
 Cluster ready: 3 nodes, leader on http://localhost:4001.
@@ -322,7 +322,7 @@ generates a self-signed certificate, so add the source with
 `?tls=true&insecure=true` (the script prints the exact command).
 
 ```shell
-$ ./sakila-start-rqlite-nodes.sh HTTPS=true
+$ ./sakila-start-rqlite-cluster.sh HTTPS=true
 ...
 $ sq add 'rqlite://localhost:4001?tls=true&insecure=true' --handle @rq
 ```

--- a/site/content/en/docs/drivers/rqlite.md
+++ b/site/content/en/docs/drivers/rqlite.md
@@ -11,8 +11,8 @@ url: /docs/drivers/rqlite
 The `sq` rqlite driver implements connectivity for
 [rqlite](https://rqlite.io), the lightweight distributed SQLite database. It uses the
 [`rqlite/gorqlite`](https://github.com/rqlite/gorqlite) library and talks to rqlite over HTTP(S).
-The SQL dialect underneath is still SQLite, so queries written for a source `@sqlite` translate
-verbatim to `@rqlite`.
+The SQL dialect underneath is still SQLite, so queries written for a SQLite source translate
+verbatim to an rqlite source.
 
 ## Add source
 

--- a/site/content/en/docs/drivers/rqlite.md
+++ b/site/content/en/docs/drivers/rqlite.md
@@ -31,8 +31,8 @@ $ sq add 'rqlite://sakila:p_ssW0rd@localhost:4001?disableClusterDiscovery=true'
 # redirects automatically.
 $ sq add 'rqlite://node1.example.com:4001'
 
-# HTTPS
-$ sq add 'rqlite://node.example.com:4001?tls=true'
+# HTTPS, using a user-supplied handle (@rq_https).
+$ sq add 'rqlite://node.example.com:4001?tls=true' --handle @rq_https
 
 # HTTPS with a self-signed certificate
 $ sq add 'rqlite://node.example.com:4001?tls=true&insecure=true'
@@ -42,7 +42,7 @@ If the port is omitted, `sq` connects on the default port `4001`.
 
 ### Verification
 
-At add time, `sq` does two things before persisting the source:
+At `sq add` time, two things happen before persisting the source:
 
 1. If the location has no explicit `tls` or `insecure` param, `sq` probes the endpoint's
    transport, and stores `tls=true` on the source if the server requires TLS. See

--- a/site/content/en/docs/drivers/rqlite.md
+++ b/site/content/en/docs/drivers/rqlite.md
@@ -38,7 +38,7 @@ $ sq add 'rqlite://node.example.com:4001?tls=true'
 $ sq add 'rqlite://node.example.com:4001?tls=true&insecure=true'
 ```
 
-If the port is omitted, `sq` auto-applies the default port `4001`.
+If the port is omitted, `sq` connects on the default port `4001`.
 
 ### Verification
 
@@ -78,7 +78,7 @@ sq: @rq: rqlite: auth failed: node requires credentials, but source has none
 sq: @rq: rqlite: auth failed: node rejected credentials
 ```
 
-To keep the password out of sq's config file, store it as a [secret](/docs/secrets):
+To keep the password out of `sq`'s [config](/docs/config) file, store it as a [secret](/docs/secrets):
 e.g. pass `--store keyring` to `sq add`, which puts the password in the OS keyring
 and writes a placeholder to the config in its place.
 

--- a/site/content/en/docs/drivers/rqlite.md
+++ b/site/content/en/docs/drivers/rqlite.md
@@ -297,33 +297,30 @@ curl -fsSL -o sakila-start-rqlite-cluster.sh \
     && chmod +x sakila-start-rqlite-cluster.sh
 ```
 
-#### HTTP cluster
+Then start the cluster. By default it serves HTTPS (with a generated
+self-signed certificate, hence `insecure=true` below) and requires
+credentials `sakila` / `p_ssW0rd`:
 
 ```shell
 $ ./sakila-start-rqlite-cluster.sh
-Starting rqlite cluster (http; data dir: /tmp/sakila-rq-cluster.XXXX)
+Generating self-signed certificate...
+Starting rqlite cluster (https, auth; data dir: /tmp/sakila-rq-cluster.XXXX)
 Loading Sakila into leader...
 
-Cluster ready: 3 nodes, leader on http://localhost:4001.
+Cluster ready: 3 nodes, leader on https://localhost:4001.
 ...
 Press Ctrl-C here to stop the cluster.
 
 # In another terminal:
-$ sq add 'rqlite://localhost:4001' --handle @rq
+$ sq add 'rqlite://sakila:p_ssW0rd@localhost:4001?tls=true&insecure=true' --handle @rq
 $ sq inspect @rq
 ```
 
 Ctrl-C in the first terminal tears the cluster down and removes its
 data directory.
 
-#### HTTPS cluster
-
-To serve the cluster over HTTPS instead, pass `HTTPS=true`. The script
-generates a self-signed certificate, so add the source with
-`?tls=true&insecure=true` (the script prints the exact command).
-
-```shell
-$ ./sakila-start-rqlite-cluster.sh HTTPS=true
-...
-$ sq add 'rqlite://localhost:4001?tls=true&insecure=true' --handle @rq
-```
+The script accepts `HTTPS=true|false` and `AUTH=true|false` flags in any
+combination, e.g. `./sakila-start-rqlite-cluster.sh HTTPS=false AUTH=false`
+for a plain-HTTP cluster with no credentials. It prints the matching
+`sq add` command for whichever scenario it starts; see the script's
+header comments for details.

--- a/site/content/en/docs/drivers/rqlite.md
+++ b/site/content/en/docs/drivers/rqlite.md
@@ -282,23 +282,22 @@ $ docker stop sakila-rq
 
 This (macOS-tested) example demonstrates a real local cluster that exercises cluster discovery and
 leader redirects (i.e. _without_ `?disableClusterDiscovery=true`). It starts three native `rqlited`
-processes on `127.0.0.1`, each advertising a host-reachable address. Native processes, not Docker:
-multi-node Docker setups such as `sakiladb/rqlite`'s
-[`cluster-compose.yml`](https://github.com/sakiladb/rqlite/blob/master/cluster-compose.yml)
-advertise container-internal hostnames that the host can't resolve, the same trap described in
-[Single-node localhost](#single-node-localhost).
+processes on `127.0.0.1`, each advertising a host-reachable address.
 
-The example
-[`sakila-start-rqlite-nodes.sh`](https://raw.githubusercontent.com/neilotoole/sq/master/drivers/rqlite/sakila-start-rqlite-nodes.sh)
-script brings the cluster up and loads Sakila into the leader. It requires the `rqlited` binary
+First, download the [`sakila-start-rqlite-nodes.sh`](https://raw.githubusercontent.com/neilotoole/sq/master/drivers/rqlite/sakila-start-rqlite-nodes.sh)
+example script. Note that the script requires the `rqlited` binary
 (`brew install rqlite` on macOS; see [rqlite.io](https://rqlite.io/docs/install-rqlite/) for other
 platforms):
 
 ```shell
-# In one terminal, download the helper and run it.
 $ curl -fsSL -o sakila-start-rqlite-nodes.sh \
     https://raw.githubusercontent.com/neilotoole/sq/master/drivers/rqlite/sakila-start-rqlite-nodes.sh
 $ chmod +x sakila-start-rqlite-nodes.sh
+```
+
+#### HTTP cluster
+
+```shell
 $ ./sakila-start-rqlite-nodes.sh
 Starting rqlite cluster (data dir: /tmp/sakila-rq-nodes.XXXX)
 Loading Sakila into leader...
@@ -315,11 +314,11 @@ $ sq inspect @rq_local
 Ctrl-C in the first terminal tears the cluster down and removes its
 data directory.
 
+#### HTTPS cluster
+
 To serve the cluster over HTTPS instead, pass `HTTPS=true`. The script
 generates a self-signed certificate, so add the source with
-`?tls=true&insecure=true` (the script prints the exact command). Adding
-the bare location instead demonstrates the add-time probe error
-described in [Self-signed certificates](#self-signed-certificates):
+`?tls=true&insecure=true` (the script prints the exact command).
 
 ```shell
 $ ./sakila-start-rqlite-nodes.sh HTTPS=true

--- a/site/content/en/docs/drivers/rqlite.md
+++ b/site/content/en/docs/drivers/rqlite.md
@@ -291,7 +291,7 @@ example script. Note that the script requires the `rqlited` binary
 platforms):
 
 ```shell
-$ curl -fsSL -o sakila-start-rqlite-nodes.sh \
+curl -fsSL -o sakila-start-rqlite-nodes.sh \
     https://raw.githubusercontent.com/neilotoole/sq/master/drivers/rqlite/sakila-start-rqlite-nodes.sh \
     && chmod +x sakila-start-rqlite-nodes.sh
 ```


### PR DESCRIPTION
## Summary

rqlite wrap-up, three workstreams:

1. **Docs**: restructures the [rqlite driver docs page](https://sq.io/docs/drivers/rqlite) from 12 flat sections into a reader-intent-ordered skeleton matching the clickhouse/oracle layout conventions.
2. **Cluster helper**: turns `sakila-start-rqlite-cluster.sh` (renamed from `-nodes.sh`) into a scenario-testing tool with `HTTPS=true|false` / `AUTH=true|false` flags, defaulting to the production-like HTTPS + basic-auth case.
3. **Connection-error UX**: `sq add` now fails fast against broken sources (real round-trip ping), and the driver's connection failures are rewritten into concise, actionable one-liners (discovery trap, auth, TLS mismatches, cert verification), with full diagnostics preserved in logs and verbose output. Backed by a new generic `errz.HumanReadable`/`errz.WithHuman` mechanism.

The CHANGELOG's existing (unreleased) `#742` entry is updated to describe the final behavior.

## 1. Docs restructure

The page grew by accretion across #756/#764/#771: connection material spread over six peer h2 sections, the cluster-discovery gotcha explained in five places, behavior reference ungrouped, and a TOC of 12 h2s (typical driver page: 3-6).

Final heading tree (8 h2s):

- **Add source**: tightened; the redundant Common setups table is dropped.
  - **Verification** (h3): the add-time pipeline (probe, then round-trip verify, with `--skip-verify` as the opt-out), plus an error index table routing each one-line error message to its section.
- **Authentication** (new): credentials in the location, the quoted auth errors, and a pointer to the secrets docs for keyring/placeholder storage.
- **TLS and certificates**: all three `tls` variants, the probe behavior, and Self-signed certificates as h3.
- **Cluster discovery**: with Single-node localhost as h3.
- **Connection string**: format merged with the full param reference.
- **Notes**: Write behavior / Quirks / Limitations, matching clickhouse/oracle.
- **Inspect**: renamed from "Inspect field provenance"; the short name mirrors `/docs/inspect` and is intended as the cross-driver convention. Aligning other driver pages is deferred.
- **Example usage**: single-node + cluster, each runnable.

The connection half is organized around failure modes: the error messages deliberately carry no remedies, so each message family has a docs landing section, indexed by the Verification table.

Prose: `gorqlite` is credited once in the intro; everywhere else the actor is "the driver". Internals like `WriteParameterizedContext` dropped.

## 2. Cluster helper

```text
./sakila-start-rqlite-cluster.sh [HTTPS=true|false] [AUTH=true|false]   # both default to true
```

- **HTTPS=true** generates a self-signed cert with SANs for `localhost`/`127.0.0.1` (Go's TLS stack ignores CN-only certs), via an openssl config file rather than `-addext` for older-LibreSSL compatibility. Only the HTTP API gains TLS; Raft is untouched.
- **AUTH=true** writes a `creds.json` (`sakila`/`p_ssW0rd`, matching the sakiladb/rqlite image; chmod 600) and passes `-auth` to all nodes plus `-join-as` to joining nodes: without `-join-as`, nodes 2/3 fail to join with "unauthorized".
- The ready banner is now verified, not asserted: the script polls `/nodes` and fails if all 3 nodes don't join (the auth work exposed that it previously claimed "3 nodes" with one node formed).
- Sakila is fetched from the repo's raw.githubusercontent.com URL (`SAKILA_DB_URL` variable) rather than sq.io.
- The final message prints the exact `sq add` command for the chosen scenario.
- Renames are safe: the script has never shipped in a release, so no published URL breaks.

## 3. Connection-error UX

**Real ping.** gorqlite's `database/sql` conn doesn't implement `driver.Pinger` and tolerates failures like 401s at connect time, so the old `db.PingContext` only verified that a client could be constructed, so `sq add` succeeded against sources broken by missing auth or the discovery trap, deferring failure to first use. `Ping` now executes `SELECT 1`, so a broken source fails at add time with the enriched message (`--skip-verify` remains the no-contact escape hatch).

**Enrichment.** `enrichConnError` applies first-match-wins rewrites (a serialized gorqlite failure can carry multiple signals; later checks must not re-match on the first wrapper's embedded cause text). Detection is text-based where gorqlite's `errors.New(builder.String())` serialization breaks error chains, with chain-preserving paths kept for errors that retain them. Wired at open/ping, grip `SourceMetadata`/`TableMetadata`, and (via a per-grip `SQLDriver` wrapper whose `ErrWrapFunc` closes over the source) the libsq query path.

**Human messages.** All eight scenarios follow one grammar: `@handle: rqlite: category failed: detail`: telegraph style, problem statement only (no remedies, docs pointers, or URLs; no trailing period). Remedies and the full gorqlite detail remain in the long form (log file, verbose-JSON `base_error`/`tree`/`stack`).

| Scenario | Human message |
|---|---|
| Discovery, DNS | `@rq: rqlite: cluster discovery failed: advertised peer "rqlite1" is not resolvable from this host` |
| Discovery, unreachable | `@rq: rqlite: cluster discovery failed: advertised peer "172.17.0.2" is not reachable from this host` |
| Auth, no credentials | `@rq: rqlite: auth failed: node requires credentials, but source has none` |
| Auth, rejected | `@rq: rqlite: auth failed: node rejected credentials` |
| TLS signal | `@rq: rqlite: TLS required: endpoint serves HTTPS, but source uses HTTP` |
| Inverse TLS mismatch | `@rq: rqlite: TLS mismatch: endpoint serves HTTP, but source uses HTTPS` |
| Cert verification | `@rq: rqlite: TLS cert verification failed` |
| Add-time probe bad cert | `@rq: rqlite: endpoint requires TLS, but cert verification failed` |

**Mechanism.** `errz` gains `HumanReadable` (errors carrying a concise display form distinct from `Error()`) and `WithHuman(err, msg)` (attach a display message without touching the chain). `cli.humanizeError` (the existing presentation hook in `PrintError`, which already feeds writers separate system/human channels) prefers the human form. Rule of thumb, recorded in godoc: a dedicated type when the error carries structured data (`DiscoveryError` with peer/host/resolve, `AuthError` with creds-state), `WithHuman` when it's just a message (the TLS/cert trio).

**Guards** (each rewrite passes through unless its scenario is certain): discovery requires gorqlite's "tried all peers" preamble plus connection-level failure markers (an HTTP-level 401 from a reachable peer is not the discovery trap), skips when the failing host is the one the user typed or both are loopback ("localhost" vs an advertised "127.0.0.1" just means the node is down), and skips when discovery is explicitly disabled; auth tailors its message by whether the location carries userinfo; the two TLS-signal rewrites are mutually exclusive via the `tls=true` gate.

**Removed**: the proactive loopback WARN (`maybeWarnLocalhostDiscovery`, gh742). Its premises are gone (the trap now fails loudly at add time), and its loopback-without-param precondition false-positived on the healthy native-localhost cluster that the docs recommend and the helper script creates.

## Review trail

Three Copilot rounds (all threads addressed and resolved; one produced the per-peer `Resolve` fix) plus two multi-agent deep reviews. The first found: the `enrichConnError` double-wrap on mixed-signal errors (fixed, first-match-wins), the stale CHANGELOG `#742` entry (rewritten), world-readable `creds.json` (chmod 600), and five test gaps (grip metadata wiring via a failing connector, multi-peer scan ordering, reach-variant long form, unparseable-location guard, `PrintError` end-to-end human-form assertion).

The second review (7 finder angles, per-candidate verification, two findings confirmed by live experiment) produced ten fixes: fully per-peer discovery-trap classification (a foreign peer's 401 can no longer be mislabeled "not reachable" because a different peer had a dial failure; canceled dials and Windows-cased DNS errors classify correctly); context-error precedence over `HumanReadable` in `humanizeError` (Ctrl-C prints "canceled", not a confident discovery diagnosis); the cluster helper's signal traps now exit (Ctrl-C previously could tear down the cluster and keep polling it, or run cleanup twice); ping writers render the concise human form via a new `errz.HumanMessage` helper (multi-line enriched errors were corrupting the ping table); `errz.WithHuman`'s wrapper now delegates `Format`/`LogValue`/stack-walking so verbose output and logs lose nothing; the 401 match is anchored to gorqlite's exact `got: 401 Unauthorized` serialization; the grip's SQLDriver wrapper embeds the concrete driver (optional interfaces stay visible) and is built once at Open; `Truncate` errors are enriched; and the no-writer text fallback in `PrintError` prints the human form.

## Verification

- `make lint`, shellcheck, and both markdown lints: clean. `go test -short` green for `drivers/rqlite`, `libsq/core/errz`, and the cli error tests (remaining cli failures are pre-existing container-gated integration tests).
- All four helper-script flag combinations verified against live local clusters: 3-node membership via `/nodes`, 401 enforcement, Sakila loaded, scenario-correct `sq add` lines.
- Every error scenario in the table verified live against real endpoints (sakiladb/rqlite Docker container and the helper cluster in HTTPS mode), in text, `error.format=json`, and verbose-JSON modes, including that adding the suggested fixes makes the sources work.
- Site build clean; rendered heading/anchor tree confirmed, including the `#single-node-localhost` anchor that the CHANGELOG entry links to.
- Netlify deploy preview attached to this PR for visual review of the docs page.




