### PR TITLE
site/docs: rework command docs navigation and sidebar

### DIFF
--- a/site/assets/scss/common/_custom.scss
+++ b/site/assets/scss/common/_custom.scss
@@ -108,10 +108,13 @@ nav.docs-links {
   }
 }
 
-// Tables on the /docs/cmd index hug the group blurb above them. The global
-// "table { margin: 3rem 0 }" rule is meant for tables in flowing prose.
+// Tables on the /docs/cmd index hug the group blurb above them, with a clear
+// break before the next group heading. The global "table { margin: 3rem 0 }"
+// rule is meant for tables in flowing prose (and Bootstrap's .table class
+// caps margin-bottom at 1rem, which is too tight for a section break).
 .cmd-index-table {
   margin-top: 1rem;
+  margin-bottom: 3rem;
 }
 
 nav.docs-links ul li a.docs-link.changelog {

--- a/site/assets/scss/common/_custom.scss
+++ b/site/assets/scss/common/_custom.scss
@@ -108,6 +108,12 @@ nav.docs-links {
   }
 }
 
+// Tables on the /docs/cmd index hug the group blurb above them. The global
+// "table { margin: 3rem 0 }" rule is meant for tables in flowing prose.
+.cmd-index-table {
+  margin-top: 1rem;
+}
+
 nav.docs-links ul li a.docs-link.changelog {
   font-weight: bold;
   margin-top: 50px;

--- a/site/assets/scss/common/_global.scss
+++ b/site/assets/scss/common/_global.scss
@@ -141,7 +141,7 @@ body {
 
 @include media-breakpoint-up(xl) {
   .docs-sidebar {
-    flex: 0 1 320px;
+    flex: 0 1 240px;
   }
 }
 

--- a/site/assets/scss/common/_global.scss
+++ b/site/assets/scss/common/_global.scss
@@ -139,9 +139,18 @@ body {
   }
 }
 
-@include media-breakpoint-up(xl) {
+@include media-breakpoint-up(lg) {
   .docs-sidebar {
     flex: 0 1 240px;
+  }
+}
+
+// The sidebar is fixed-width while the grid columns are percentages, so the
+// row no longer sums to full width. Below xl there is no TOC column to
+// absorb the difference; let the content column grow into it.
+@include media-breakpoint-only(lg) {
+  .docs-content {
+    flex-grow: 1;
   }
 }
 

--- a/site/content/en/docs/cmd/_index.md
+++ b/site/content/en/docs/cmd/_index.md
@@ -1,6 +1,6 @@
 ---
 title: "Commands"
-description: "Command Help"
+description: "sq command reference"
 lead: ""
 date: 2020-10-06T08:49:15+00:00
 lastmod: 2020-10-06T08:49:15+00:00
@@ -8,4 +8,13 @@ draft: false
 images: []
 weight: 2000
 url: /docs/cmd
+layout: cmd-index
+sidebar_skip: true
 ---
+
+`sq` provides commands for querying data, managing sources, and configuring
+behavior. Each page below documents a single command, with usage details and
+examples.
+
+New to `sq`? Start with the [tutorial](/docs/tutorial), or see the
+[query guide](/docs/query) for query syntax.

--- a/site/content/en/docs/cmd/add.md
+++ b/site/content/en/docs/cmd/add.md
@@ -1,12 +1,12 @@
 ---
 title: "sq add"
 description: "Add data source"
+group: sources
 draft: false
 images: []
 menu:
   docs:
     parent: "cmd"
-weight: 2020
 toc: false
 url: /docs/cmd/add
 ---

--- a/site/content/en/docs/cmd/cache-clear.md
+++ b/site/content/en/docs/cmd/cache-clear.md
@@ -1,12 +1,12 @@
 ---
 title: "sq cache clear"
 description: "Clear the cache"
+group: cache
 draft: false
 images: []
 menu:
   docs:
     parent: "cmd"
-weight: 2024
 toc: false
 url: /docs/cmd/cache-clear
 ---

--- a/site/content/en/docs/cmd/cache-disable.md
+++ b/site/content/en/docs/cmd/cache-disable.md
@@ -1,12 +1,12 @@
 ---
 title: "sq cache disable"
 description: "Disable the cache"
+group: cache
 draft: false
 images: []
 menu:
   docs:
     parent: "cmd"
-weight: 2025
 toc: false
 url: /docs/cmd/cache-disable
 ---

--- a/site/content/en/docs/cmd/cache-enable.md
+++ b/site/content/en/docs/cmd/cache-enable.md
@@ -1,12 +1,12 @@
 ---
 title: "sq cache enable"
 description: "Enable the cache"
+group: cache
 draft: false
 images: []
 menu:
   docs:
     parent: "cmd"
-weight: 2026
 toc: false
 url: /docs/cmd/cache-enable
 ---

--- a/site/content/en/docs/cmd/cache-location.md
+++ b/site/content/en/docs/cmd/cache-location.md
@@ -1,12 +1,12 @@
 ---
 title: "sq cache location"
 description: "Print cache location"
+group: cache
 draft: false
 images: []
 menu:
   docs:
     parent: "cmd"
-weight: 2027
 toc: false
 url: /docs/cmd/cache-location
 ---

--- a/site/content/en/docs/cmd/cache-stat.md
+++ b/site/content/en/docs/cmd/cache-stat.md
@@ -1,12 +1,12 @@
 ---
 title: "sq cache stat"
 description: "Show cache info"
+group: cache
 draft: false
 images: []
 menu:
   docs:
     parent: "cmd"
-weight: 2028
 toc: false
 url: /docs/cmd/cache-stat
 ---

--- a/site/content/en/docs/cmd/cache-tree.md
+++ b/site/content/en/docs/cmd/cache-tree.md
@@ -1,12 +1,12 @@
 ---
 title: "sq cache tree"
 description: "Print tree view of cache dir"
+group: cache
 draft: false
 images: []
 menu:
   docs:
     parent: "cmd"
-weight: 2029
 toc: false
 url: /docs/cmd/cache-tree
 ---

--- a/site/content/en/docs/cmd/completion-bash.md
+++ b/site/content/en/docs/cmd/completion-bash.md
@@ -1,7 +1,7 @@
 ---
 title: "sq completion bash"
 description: "Generate bash shell completion script"
-group: shell
+group: misc
 draft: false
 images: []
 menu:

--- a/site/content/en/docs/cmd/completion-bash.md
+++ b/site/content/en/docs/cmd/completion-bash.md
@@ -1,12 +1,12 @@
 ---
 title: "sq completion bash"
 description: "Generate bash shell completion script"
+group: shell
 draft: false
 images: []
 menu:
   docs:
     parent: "cmd"
-weight: 2030
 toc: false
 url: /docs/cmd/completion-bash
 ---

--- a/site/content/en/docs/cmd/completion-fish.md
+++ b/site/content/en/docs/cmd/completion-fish.md
@@ -1,7 +1,7 @@
 ---
 title: "sq completion fish"
 description: "Generate fish shell completion script"
-group: shell
+group: misc
 draft: false
 images: []
 menu:

--- a/site/content/en/docs/cmd/completion-fish.md
+++ b/site/content/en/docs/cmd/completion-fish.md
@@ -1,12 +1,12 @@
 ---
 title: "sq completion fish"
 description: "Generate fish shell completion script"
+group: shell
 draft: false
 images: []
 menu:
   docs:
     parent: "cmd"
-weight: 2030
 toc: false
 url: /docs/cmd/completion-fish
 ---

--- a/site/content/en/docs/cmd/completion-powershell.md
+++ b/site/content/en/docs/cmd/completion-powershell.md
@@ -1,7 +1,7 @@
 ---
 title: "sq completion powershell"
 description: "Generate powershell shell completion script"
-group: shell
+group: misc
 draft: false
 images: []
 menu:

--- a/site/content/en/docs/cmd/completion-powershell.md
+++ b/site/content/en/docs/cmd/completion-powershell.md
@@ -1,12 +1,12 @@
 ---
 title: "sq completion powershell"
 description: "Generate powershell shell completion script"
+group: shell
 draft: false
 images: []
 menu:
   docs:
     parent: "cmd"
-weight: 2030
 toc: false
 url: /docs/cmd/completion-powershell
 ---

--- a/site/content/en/docs/cmd/completion-zsh.md
+++ b/site/content/en/docs/cmd/completion-zsh.md
@@ -1,12 +1,12 @@
 ---
 title: "sq completion zsh"
 description: "Generate zsh shell completion script"
+group: shell
 draft: false
 images: []
 menu:
   docs:
     parent: "cmd"
-weight: 2030
 toc: false
 url: /docs/cmd/completion-zsh
 ---

--- a/site/content/en/docs/cmd/completion-zsh.md
+++ b/site/content/en/docs/cmd/completion-zsh.md
@@ -1,7 +1,7 @@
 ---
 title: "sq completion zsh"
 description: "Generate zsh shell completion script"
-group: shell
+group: misc
 draft: false
 images: []
 menu:

--- a/site/content/en/docs/cmd/completion.md
+++ b/site/content/en/docs/cmd/completion.md
@@ -1,7 +1,7 @@
 ---
 title: "sq completion"
 description: "Generate shell completion scripts"
-group: shell
+group: misc
 draft: false
 images: []
 menu:

--- a/site/content/en/docs/cmd/completion.md
+++ b/site/content/en/docs/cmd/completion.md
@@ -1,12 +1,12 @@
 ---
 title: "sq completion"
 description: "Generate shell completion scripts"
+group: shell
 draft: false
 images: []
 menu:
   docs:
     parent: "cmd"
-weight: 2030
 toc: false
 url: /docs/cmd/completion
 ---

--- a/site/content/en/docs/cmd/config-edit.md
+++ b/site/content/en/docs/cmd/config-edit.md
@@ -1,12 +1,12 @@
 ---
 title: "sq config edit"
 description: "Edit config in $EDITOR"
+group: config
 draft: false
 images: []
 menu:
   docs:
     parent: "cmd"
-weight: 2038
 toc: false
 url: /docs/cmd/config-edit
 ---

--- a/site/content/en/docs/cmd/config-export.md
+++ b/site/content/en/docs/cmd/config-export.md
@@ -1,12 +1,12 @@
 ---
 title: "sq config export"
 description: "Export config as YAML"
+group: config
 draft: false
 images: []
 menu:
   docs:
     parent: "cmd"
-weight: 2038
 toc: false
 url: /docs/cmd/config-export
 ---

--- a/site/content/en/docs/cmd/config-get.md
+++ b/site/content/en/docs/cmd/config-get.md
@@ -1,12 +1,12 @@
 ---
 title: "sq config get"
 description: "Show config option"
+group: config
 draft: false
 images: []
 menu:
   docs:
     parent: "cmd"
-weight: 2038
 toc: false
 url: /docs/cmd/config-get
 ---

--- a/site/content/en/docs/cmd/config-keyring-create.md
+++ b/site/content/en/docs/cmd/config-keyring-create.md
@@ -1,12 +1,12 @@
 ---
 title: "sq config keyring create"
 description: "Create a new keyring entry"
+group: config
 draft: false
 images: []
 menu:
   docs:
     parent: "cmd"
-weight: 2038
 toc: false
 url: /docs/cmd/config-keyring-create
 ---

--- a/site/content/en/docs/cmd/config-keyring-get.md
+++ b/site/content/en/docs/cmd/config-keyring-get.md
@@ -1,12 +1,12 @@
 ---
 title: "sq config keyring get"
 description: "Print metadata or value for a keyring entry"
+group: config
 draft: false
 images: []
 menu:
   docs:
     parent: "cmd"
-weight: 2038
 toc: false
 url: /docs/cmd/config-keyring-get
 ---

--- a/site/content/en/docs/cmd/config-keyring-ls.md
+++ b/site/content/en/docs/cmd/config-keyring-ls.md
@@ -1,12 +1,12 @@
 ---
 title: "sq config keyring ls"
 description: "List keyring paths referenced by sources"
+group: config
 draft: false
 images: []
 menu:
   docs:
     parent: "cmd"
-weight: 2038
 toc: false
 url: /docs/cmd/config-keyring-ls
 ---

--- a/site/content/en/docs/cmd/config-keyring-migrate.md
+++ b/site/content/en/docs/cmd/config-keyring-migrate.md
@@ -1,12 +1,12 @@
 ---
 title: "sq config keyring migrate"
 description: "Migrate inline-credential sources to the keyring"
+group: config
 draft: false
 images: []
 menu:
   docs:
     parent: "cmd"
-weight: 2038
 toc: false
 url: /docs/cmd/config-keyring-migrate
 ---

--- a/site/content/en/docs/cmd/config-keyring-rm.md
+++ b/site/content/en/docs/cmd/config-keyring-rm.md
@@ -1,12 +1,12 @@
 ---
 title: "sq config keyring rm"
 description: "Delete a keyring entry"
+group: config
 draft: false
 images: []
 menu:
   docs:
     parent: "cmd"
-weight: 2038
 toc: false
 url: /docs/cmd/config-keyring-rm
 ---

--- a/site/content/en/docs/cmd/config-keyring-update.md
+++ b/site/content/en/docs/cmd/config-keyring-update.md
@@ -1,12 +1,12 @@
 ---
 title: "sq config keyring update"
 description: "Update an existing keyring entry"
+group: config
 draft: false
 images: []
 menu:
   docs:
     parent: "cmd"
-weight: 2038
 toc: false
 url: /docs/cmd/config-keyring-update
 ---

--- a/site/content/en/docs/cmd/config-keyring.md
+++ b/site/content/en/docs/cmd/config-keyring.md
@@ -1,12 +1,12 @@
 ---
 title: "sq config keyring"
 description: "Manage source secrets stored in the OS keyring"
+group: config
 draft: false
 images: []
 menu:
   docs:
     parent: "cmd"
-weight: 2038
 toc: false
 url: /docs/cmd/config-keyring
 ---

--- a/site/content/en/docs/cmd/config-location.md
+++ b/site/content/en/docs/cmd/config-location.md
@@ -1,12 +1,12 @@
 ---
 title: "sq config location"
 description: "Print config location"
+group: config
 draft: false
 images: []
 menu:
   docs:
     parent: "cmd"
-weight: 2038
 toc: false
 url: /docs/cmd/config-location
 ---

--- a/site/content/en/docs/cmd/config-ls.md
+++ b/site/content/en/docs/cmd/config-ls.md
@@ -1,12 +1,12 @@
 ---
 title: "sq config ls"
 description: "List config options"
+group: config
 draft: false
 images: []
 menu:
   docs:
     parent: "cmd"
-weight: 2038
 toc: false
 url: /docs/cmd/config-ls
 ---

--- a/site/content/en/docs/cmd/config-set.md
+++ b/site/content/en/docs/cmd/config-set.md
@@ -1,12 +1,12 @@
 ---
 title: "sq config set"
 description: "Set config value"
+group: config
 draft: false
 images: []
 menu:
   docs:
     parent: "cmd"
-weight: 2038
 toc: false
 url: /docs/cmd/config-set
 ---

--- a/site/content/en/docs/cmd/diff.md
+++ b/site/content/en/docs/cmd/diff.md
@@ -1,12 +1,12 @@
 ---
 title: "sq diff"
 description: "Compare metadata or row data of sources and tables"
+group: query
 draft: false
 images: []
 menu:
   docs:
     parent: "cmd"
-weight: 2038
 toc: false
 url: /docs/cmd/diff
 ---

--- a/site/content/en/docs/cmd/driver-ls.md
+++ b/site/content/en/docs/cmd/driver-ls.md
@@ -1,12 +1,12 @@
 ---
 title: "sq driver ls"
 description: "List available drivers"
+group: sources
 draft: false
 images: []
 menu:
   docs:
     parent: "cmd"
-weight: 2040
 toc: false
 url: /docs/cmd/driver-ls
 aliases:

--- a/site/content/en/docs/cmd/group.md
+++ b/site/content/en/docs/cmd/group.md
@@ -1,12 +1,12 @@
 ---
 title: "sq group"
 description: "Get or set active group"
+group: sources
 draft: false
 images: []
 menu:
   docs:
     parent: "cmd"
-weight: 2111
 toc: false
 url: /docs/cmd/group
 ---

--- a/site/content/en/docs/cmd/help.md
+++ b/site/content/en/docs/cmd/help.md
@@ -1,13 +1,13 @@
 ---
 title: "sq help"
 description: "Show sq help"
+group: misc
 draft: false
 images: []
 menu:
   docs:
     identifier: "cmd_help"
     parent: "cmd"
-weight: 2050
 toc: false
 url: /docs/cmd/help
 ---

--- a/site/content/en/docs/cmd/inspect.md
+++ b/site/content/en/docs/cmd/inspect.md
@@ -1,12 +1,12 @@
 ---
 title: "sq inspect"
 description: "Inspect data source schema and stats"
+group: query
 draft: false
 images: []
 menu:
   docs:
     parent: "cmd"
-weight: 2060
 toc: false
 url: /docs/cmd/inspect
 ---

--- a/site/content/en/docs/cmd/ls.md
+++ b/site/content/en/docs/cmd/ls.md
@@ -1,12 +1,12 @@
 ---
 title: "sq ls"
 description: "List data sources"
+group: sources
 draft: false
 images: []
 menu:
   docs:
     parent: "cmd"
-weight: 2070
 toc: false
 url: /docs/cmd/ls
 ---

--- a/site/content/en/docs/cmd/mv.md
+++ b/site/content/en/docs/cmd/mv.md
@@ -1,12 +1,12 @@
 ---
 title: "sq mv"
 description: "Move/rename sources and groups"
+group: sources
 draft: false
 images: []
 menu:
   docs:
     parent: "cmd"
-weight: 2112
 toc: false
 url: /docs/cmd/mv
 ---

--- a/site/content/en/docs/cmd/ping.md
+++ b/site/content/en/docs/cmd/ping.md
@@ -1,12 +1,12 @@
 ---
 title: "sq ping"
 description: "Ping data sources"
+group: sources
 draft: false
 images: []
 menu:
   docs:
     parent: "cmd"
-weight: 2080
 toc: false
 url: /docs/cmd/ping
 ---

--- a/site/content/en/docs/cmd/rm.md
+++ b/site/content/en/docs/cmd/rm.md
@@ -1,12 +1,12 @@
 ---
 title: "sq rm"
 description: "Remove data source"
+group: sources
 draft: false
 images: []
 menu:
   docs:
     parent: "cmd"
-weight: 2090
 toc: false
 url: /docs/cmd/rm
 ---

--- a/site/content/en/docs/cmd/sq.md
+++ b/site/content/en/docs/cmd/sq.md
@@ -1,12 +1,12 @@
 ---
 title: "sq"
 description: "Execute SLQ query against data source"
+group: query
 draft: false
 images: []
 menu:
   docs:
     parent: "cmd"
-weight: 2010
 toc: true
 url: /docs/cmd/sq
 ---

--- a/site/content/en/docs/cmd/sql.md
+++ b/site/content/en/docs/cmd/sql.md
@@ -1,12 +1,12 @@
 ---
 title: "sq sql"
 description: "Execute DB-native SQL query or statement"
+group: query
 draft: false
 images: []
 menu:
   docs:
     parent: "cmd"
-weight: 2100
 toc: true
 url: /docs/cmd/sql
 ---

--- a/site/content/en/docs/cmd/src.md
+++ b/site/content/en/docs/cmd/src.md
@@ -1,12 +1,12 @@
 ---
 title: "sq src"
 description: "Get or set active data source"
+group: sources
 draft: false
 images: []
 menu:
   docs:
     parent: "cmd"
-weight: 2110
 toc: false
 url: /docs/cmd/src
 ---

--- a/site/content/en/docs/cmd/tbl-copy.md
+++ b/site/content/en/docs/cmd/tbl-copy.md
@@ -1,12 +1,12 @@
 ---
 title: "sq tbl copy"
 description: "Make a copy of a table"
+group: tables
 draft: false
 images: []
 menu:
   docs:
     parent: "cmd"
-weight: 2120
 toc: false
 url: /docs/cmd/tbl-copy
 ---

--- a/site/content/en/docs/cmd/tbl-drop.md
+++ b/site/content/en/docs/cmd/tbl-drop.md
@@ -1,12 +1,12 @@
 ---
 title: "sq tbl drop"
 description: "Drop one or more tables"
+group: tables
 draft: false
 images: []
 menu:
   docs:
     parent: "cmd"
-weight: 2130
 toc: false
 url: /docs/cmd/tbl-drop
 ---

--- a/site/content/en/docs/cmd/tbl-truncate.md
+++ b/site/content/en/docs/cmd/tbl-truncate.md
@@ -1,12 +1,12 @@
 ---
 title: "sq tbl truncate"
 description: "Truncate one or more tables"
+group: tables
 draft: false
 images: []
 menu:
   docs:
     parent: "cmd"
-weight: 2140
 toc: false
 url: /docs/cmd/tbl-truncate
 ---

--- a/site/content/en/docs/cmd/version.md
+++ b/site/content/en/docs/cmd/version.md
@@ -1,12 +1,12 @@
 ---
 title: "sq version"
 description: "Print sq version"
+group: misc
 draft: false
 images: []
 menu:
   docs:
     parent: "cmd"
-weight: 2150
 toc: false
 url: /docs/cmd/version
 ---

--- a/site/content/en/docs/install.md
+++ b/site/content/en/docs/install.md
@@ -120,11 +120,13 @@ $ kubectl run sq-shell --image ghcr.io/neilotoole/sq
 $ kubectl exec -it sq-shell -- zsh
 ```
 
-## See also
+## Agent Skills
 
-- [Agent Skill](/docs/agent-skills) — optional Agent Skill for Claude Code,
-  Cursor, and other assistants that support the
-  [Agent Skills](https://agentskills.io/) format (after `sq` is installed).
+`sq` ships an optional [Agent Skill](https://agentskills.io/) that teaches AI
+coding assistants (Claude Code, Cursor, and others that support the format)
+how to use an installed `sq` CLI: querying with SLQ or native SQL, `@` handles,
+output formats, and more. Once `sq` is on your `PATH`, see
+[Agent Skills](/docs/agent-skills) to add the skill to your assistant.
 
 ## Upgrade
 

--- a/site/data/cmd_groups.toml
+++ b/site/data/cmd_groups.toml
@@ -31,6 +31,8 @@ order = ["tbl-copy", "tbl-drop", "tbl-truncate"]
 key = "config"
 title = "Config"
 blurb = "Manage sq's configuration and credentials."
+# The keyring command family intentionally trails via the alphabetical fallback.
+order = ["config-ls", "config-get", "config-set", "config-edit", "config-export", "config-location"]
 
 [[groups]]
 key = "cache"

--- a/site/data/cmd_groups.toml
+++ b/site/data/cmd_groups.toml
@@ -25,6 +25,7 @@ order = ["add", "src", "ls", "rm", "mv", "group", "ping", "driver-ls"]
 key = "tables"
 title = "Tables"
 blurb = "Copy, drop, and truncate tables."
+order = ["tbl-copy", "tbl-drop", "tbl-truncate"]
 
 [[groups]]
 key = "config"

--- a/site/data/cmd_groups.toml
+++ b/site/data/cmd_groups.toml
@@ -12,13 +12,13 @@
 [[groups]]
 key = "query"
 title = "Query"
-blurb = "Run queries, inspect schemas, and compare data."
+blurb = "Run [queries](/docs/query), [inspect](/docs/inspect) sources, and [diff](/docs/diff) source metadata and table data."
 order = ["sq", "sql", "inspect", "diff"]
 
 [[groups]]
 key = "sources"
 title = "Sources"
-blurb = "Add and manage data sources and source groups."
+blurb = "Add and manage data [sources](/docs/source) and source groups."
 order = ["add", "src", "ls", "rm", "mv", "group", "ping", "driver-ls"]
 
 [[groups]]

--- a/site/data/cmd_groups.toml
+++ b/site/data/cmd_groups.toml
@@ -30,7 +30,7 @@ order = ["tbl-copy", "tbl-drop", "tbl-truncate"]
 [[groups]]
 key = "config"
 title = "Config"
-blurb = "Manage `sq`'s configuration and credentials."
+blurb = "Manage `sq`'s [configuration](/docs/config) and [credentials](/docs/secrets)."
 order = [
   "config-ls",
   "config-get",

--- a/site/data/cmd_groups.toml
+++ b/site/data/cmd_groups.toml
@@ -30,7 +30,7 @@ order = ["tbl-copy", "tbl-drop", "tbl-truncate"]
 [[groups]]
 key = "config"
 title = "Config"
-blurb = "Manage sq's configuration and credentials."
+blurb = "Manage `sq`'s configuration and credentials."
 order = [
   "config-ls",
   "config-get",
@@ -50,7 +50,7 @@ order = [
 [[groups]]
 key = "cache"
 title = "Cache"
-blurb = "Manage sq's ingest cache."
+blurb = "Manage `sq`'s ingest cache."
 order = ["cache-clear", "cache-enable", "cache-disable", "cache-location", "cache-stat", "cache-tree"]
 
 [[groups]]

--- a/site/data/cmd_groups.toml
+++ b/site/data/cmd_groups.toml
@@ -50,7 +50,7 @@ order = [
 [[groups]]
 key = "cache"
 title = "Cache"
-blurb = "Manage `sq`'s ingest cache."
+blurb = "Manage `sq`'s [ingest cache](/docs/source#cache)."
 order = ["cache-clear", "cache-enable", "cache-disable", "cache-location", "cache-stat", "cache-tree"]
 
 [[groups]]

--- a/site/data/cmd_groups.toml
+++ b/site/data/cmd_groups.toml
@@ -31,8 +31,21 @@ order = ["tbl-copy", "tbl-drop", "tbl-truncate"]
 key = "config"
 title = "Config"
 blurb = "Manage sq's configuration and credentials."
-# The keyring command family intentionally trails via the alphabetical fallback.
-order = ["config-ls", "config-get", "config-set", "config-edit", "config-export", "config-location"]
+order = [
+  "config-ls",
+  "config-get",
+  "config-set",
+  "config-edit",
+  "config-export",
+  "config-location",
+  "config-keyring",
+  "config-keyring-ls",
+  "config-keyring-get",
+  "config-keyring-create",
+  "config-keyring-update",
+  "config-keyring-rm",
+  "config-keyring-migrate",
+]
 
 [[groups]]
 key = "cache"

--- a/site/data/cmd_groups.toml
+++ b/site/data/cmd_groups.toml
@@ -56,5 +56,5 @@ order = ["cache-clear", "cache-enable", "cache-disable", "cache-location", "cach
 [[groups]]
 key = "misc"
 title = "Miscellaneous"
-blurb = ""
+blurb = "Get help, print the `sq` version, and generate shell completion scripts."
 order = ["help", "version", "completion"]

--- a/site/data/cmd_groups.toml
+++ b/site/data/cmd_groups.toml
@@ -1,14 +1,19 @@
 # Ordered registry of command groups for the /docs/cmd index page
 # (rendered by layouts/docs/cmd-index.html). Pages under content/en/docs/cmd
-# declare membership via the "group" frontmatter field; this file never lists
-# individual commands. To add or reorder a group, edit here.
+# declare membership via the "group" frontmatter field; this file does not
+# control membership. To add or reorder a group, edit here.
 # NOTE: The key "other" is reserved for the layout's orphan fallback section
 # and must not be used as a group key here.
+#
+# The optional "order" list pins commands (by md file basename, e.g. "tbl-copy")
+# to the front of a group, in the given sequence; unlisted members follow
+# alphabetically. Without "order", the whole group is alphabetical.
 
 [[groups]]
 key = "query"
 title = "Query"
 blurb = "Run queries, inspect schemas, and compare data."
+order = ["sq", "sql", "inspect", "diff"]
 
 [[groups]]
 key = "sources"

--- a/site/data/cmd_groups.toml
+++ b/site/data/cmd_groups.toml
@@ -38,6 +38,7 @@ order = ["config-ls", "config-get", "config-set", "config-edit", "config-export"
 key = "cache"
 title = "Cache"
 blurb = "Manage sq's ingest cache."
+order = ["cache-clear", "cache-enable", "cache-disable", "cache-location", "cache-stat", "cache-tree"]
 
 [[groups]]
 key = "shell"

--- a/site/data/cmd_groups.toml
+++ b/site/data/cmd_groups.toml
@@ -2,6 +2,8 @@
 # (rendered by layouts/docs/cmd-index.html). Pages under content/en/docs/cmd
 # declare membership via the "group" frontmatter field; this file never lists
 # individual commands. To add or reorder a group, edit here.
+# NOTE: The key "other" is reserved for the layout's orphan fallback section
+# and must not be used as a group key here.
 
 [[groups]]
 key = "query"

--- a/site/data/cmd_groups.toml
+++ b/site/data/cmd_groups.toml
@@ -54,11 +54,7 @@ blurb = "Manage `sq`'s ingest cache."
 order = ["cache-clear", "cache-enable", "cache-disable", "cache-location", "cache-stat", "cache-tree"]
 
 [[groups]]
-key = "shell"
-title = "Shell completion"
-blurb = "Generate shell completion scripts."
-
-[[groups]]
 key = "misc"
 title = "Miscellaneous"
 blurb = ""
+order = ["help", "version", "completion"]

--- a/site/data/cmd_groups.toml
+++ b/site/data/cmd_groups.toml
@@ -19,6 +19,7 @@ order = ["sq", "sql", "inspect", "diff"]
 key = "sources"
 title = "Sources"
 blurb = "Add and manage data sources and source groups."
+order = ["add", "src", "ls", "rm", "mv", "group", "ping", "driver-ls"]
 
 [[groups]]
 key = "tables"

--- a/site/data/cmd_groups.toml
+++ b/site/data/cmd_groups.toml
@@ -1,0 +1,39 @@
+# Ordered registry of command groups for the /docs/cmd index page
+# (rendered by layouts/docs/cmd-index.html). Pages under content/en/docs/cmd
+# declare membership via the "group" frontmatter field; this file never lists
+# individual commands. To add or reorder a group, edit here.
+
+[[groups]]
+key = "query"
+title = "Query"
+blurb = "Run queries, inspect schemas, and compare data."
+
+[[groups]]
+key = "sources"
+title = "Sources"
+blurb = "Add and manage data sources and source groups."
+
+[[groups]]
+key = "tables"
+title = "Tables"
+blurb = "Copy, drop, and truncate tables."
+
+[[groups]]
+key = "config"
+title = "Config"
+blurb = "Manage sq's configuration and credentials."
+
+[[groups]]
+key = "cache"
+title = "Cache"
+blurb = "Manage sq's ingest cache."
+
+[[groups]]
+key = "shell"
+title = "Shell completion"
+blurb = "Generate shell completion scripts."
+
+[[groups]]
+key = "misc"
+title = "Miscellaneous"
+blurb = ""

--- a/site/layouts/_default/_markup/render-link.html
+++ b/site/layouts/_default/_markup/render-link.html
@@ -5,3 +5,5 @@
   {{- $dest = $dest | absURL -}}
 {{- end -}}
 <a href="{{ $dest | safeURL }}"{{ with .Title }} title="{{ . }}"{{ end }}{{ if $isExternal }} target="_blank" rel="noopener"{{ end }}>{{ .Text | safeHTML }}</a>
+{{- /* The trim above chomps this template's trailing newline, which otherwise
+       renders as whitespace between a link and adjacent punctuation. */ -}}

--- a/site/layouts/docs/cmd-index.html
+++ b/site/layouts/docs/cmd-index.html
@@ -10,7 +10,7 @@
         {{ $keys = $keys | append $g.key }}
         {{ $pages := where $cmds "Params.group" $g.key }}
         {{ if $pages }}
-          <h2 id="{{ $g.key }}">{{ $g.title }}</h2>
+          <h2 id="{{ $g.key }}">{{ $g.title }} <a href="#{{ $g.key }}" class="anchor" aria-hidden="true">#</a></h2>
           {{ with $g.blurb }}<p>{{ . }}</p>{{ end }}
           {{ partial "main/cmd-index-rows.html" $pages }}
         {{ end }}
@@ -23,7 +23,7 @@
       {{ end }}
       {{ if $orphans }}
         {{ warnf "cmd-index: %d command page(s) have a missing or unknown group; rendered under Other" (len $orphans) }}
-        <h2 id="other">Other</h2>
+        <h2 id="other">Other <a href="#other" class="anchor" aria-hidden="true">#</a></h2>
         {{ partial "main/cmd-index-rows.html" $orphans }}
       {{ end }}
     </article>

--- a/site/layouts/docs/cmd-index.html
+++ b/site/layouts/docs/cmd-index.html
@@ -1,34 +1,49 @@
 {{ define "main" }}
+{{ $cmds := .RegularPages.ByTitle }}
+{{ $keys := slice }}
+{{ $sections := slice }}
+{{ range $g := site.Data.cmd_groups.groups }}
+  {{ $keys = $keys | append $g.key }}
+  {{ $pages := where $cmds "Params.group" $g.key }}
+  {{ if $pages }}
+    {{ $sections = $sections | append (dict "key" $g.key "title" $g.title "blurb" $g.blurb "pages" $pages) }}
+  {{ end }}
+{{ end }}
+{{ $orphans := slice }}
+{{ range $cmds }}
+  {{ if not (in $keys (.Params.group | default "")) }}
+    {{ $orphans = $orphans | append . }}
+  {{ end }}
+{{ end }}
+{{ if $orphans }}
+  {{ warnf "cmd-index: %d command page(s) have a missing or unknown group; rendered under Other" (len $orphans) }}
+  {{ $sections = $sections | append (dict "key" "other" "title" "Other" "blurb" "" "pages" $orphans) }}
+{{ end }}
 <div class="row flex-xl-nowrap">
   <div class="col-lg-5 col-xl-4 docs-sidebar{{ if ne .Site.Params.options.navbarSticky true }} docs-sidebar-top{{ end }} d-none d-lg-block">
     <nav {{ if eq .Site.Params.menu.section.collapsibleSidebar false }}id="sidebar-default" {{ end }}class="docs-links" aria-label="Main navigation">
       {{ partial "sidebar/docs-menu.html" . }}
     </nav>
   </div>
-  <main class="docs-content col-lg-11 col-xl-9 mx-xl-auto">
+  <nav class="docs-toc{{ if ne .Site.Params.options.navbarSticky true }} docs-toc-top{{ end }} d-none d-xl-block col-xl-3" aria-label="Secondary navigation">
+    <div class="page-links d-none d-xl-block">
+      <h3>{{ i18n "on-this-page" }}</h3>
+      <nav id="{{ if eq .Site.Params.options.scrollSpy true }}toc{{ else }}TableOfContents{{ end }}">
+        <ul>
+          {{ range $sections }}
+          <li><a href="#{{ .key }}">{{ .title }}</a></li>
+          {{ end }}
+        </ul>
+      </nav>
+    </div>
+  </nav>
+  <main class="docs-content col-lg-11 col-xl{{ if eq .Site.Params.options.fullWidth false }}-9{{ end }}">
       <h1>{{ .Title }}</h1>
       {{ .Content }}
-      {{ $cmds := .RegularPages.ByTitle }}
-      {{ $keys := slice }}
-      {{ range $g := site.Data.cmd_groups.groups }}
-        {{ $keys = $keys | append $g.key }}
-        {{ $pages := where $cmds "Params.group" $g.key }}
-        {{ if $pages }}
-          <h2 id="{{ $g.key }}">{{ $g.title }} <a href="#{{ $g.key }}" class="anchor" aria-hidden="true">#</a></h2>
-          {{ with $g.blurb }}<p>{{ . }}</p>{{ end }}
-          {{ partial "main/cmd-index-rows.html" $pages }}
-        {{ end }}
-      {{ end }}
-      {{ $orphans := slice }}
-      {{ range $cmds }}
-        {{ if not (in $keys (.Params.group | default "")) }}
-          {{ $orphans = $orphans | append . }}
-        {{ end }}
-      {{ end }}
-      {{ if $orphans }}
-        {{ warnf "cmd-index: %d command page(s) have a missing or unknown group; rendered under Other" (len $orphans) }}
-        <h2 id="other">Other <a href="#other" class="anchor" aria-hidden="true">#</a></h2>
-        {{ partial "main/cmd-index-rows.html" $orphans }}
+      {{ range $sections }}
+        <h2 id="{{ .key }}">{{ .title }} <a href="#{{ .key }}" class="anchor" aria-hidden="true">#</a></h2>
+        {{ with .blurb }}<p>{{ . }}</p>{{ end }}
+        {{ partial "main/cmd-index-rows.html" .pages }}
       {{ end }}
   </main>
 </div>

--- a/site/layouts/docs/cmd-index.html
+++ b/site/layouts/docs/cmd-index.html
@@ -48,14 +48,7 @@
       <nav id="{{ if eq .Site.Params.options.scrollSpy true }}toc{{ else }}TableOfContents{{ end }}">
         <ul>
           {{ range $sections }}
-          <li>
-            <a href="#{{ .key }}">{{ .title }}</a>
-            <ul>
-              {{ range .pages }}
-              <li><a href="{{ .RelPermalink }}"><code>{{ .Title }}</code></a></li>
-              {{ end }}
-            </ul>
-          </li>
+          <li><a href="#{{ .key }}">{{ .title }}</a></li>
           {{ end }}
         </ul>
       </nav>

--- a/site/layouts/docs/cmd-index.html
+++ b/site/layouts/docs/cmd-index.html
@@ -66,7 +66,7 @@
       {{ .Content }}
       {{ range $sections }}
         <h2 id="{{ .key }}">{{ .title }} <a href="#{{ .key }}" class="anchor" aria-hidden="true">#</a></h2>
-        {{ with .blurb }}<p>{{ . }}</p>{{ end }}
+        {{ with .blurb }}<p>{{ . | markdownify }}</p>{{ end }}
         {{ partial "main/cmd-index-rows.html" .pages }}
       {{ end }}
   </main>

--- a/site/layouts/docs/cmd-index.html
+++ b/site/layouts/docs/cmd-index.html
@@ -1,8 +1,12 @@
 {{ define "main" }}
-<div class="row justify-content-center">
-  <div class="col-md-12 col-lg-10 col-xl-8">
-    <article>
-      <h1 class="text-center">{{ .Title }}</h1>
+<div class="row flex-xl-nowrap">
+  <div class="col-lg-5 col-xl-4 docs-sidebar{{ if ne .Site.Params.options.navbarSticky true }} docs-sidebar-top{{ end }} d-none d-lg-block">
+    <nav {{ if eq .Site.Params.menu.section.collapsibleSidebar false }}id="sidebar-default" {{ end }}class="docs-links" aria-label="Main navigation">
+      {{ partial "sidebar/docs-menu.html" . }}
+    </nav>
+  </div>
+  <main class="docs-content col-lg-11 col-xl-9 mx-xl-auto">
+      <h1>{{ .Title }}</h1>
       {{ .Content }}
       {{ $cmds := .RegularPages.ByTitle }}
       {{ $keys := slice }}
@@ -26,7 +30,6 @@
         <h2 id="other">Other <a href="#other" class="anchor" aria-hidden="true">#</a></h2>
         {{ partial "main/cmd-index-rows.html" $orphans }}
       {{ end }}
-    </article>
-  </div>
+  </main>
 </div>
 {{ end }}

--- a/site/layouts/docs/cmd-index.html
+++ b/site/layouts/docs/cmd-index.html
@@ -1,0 +1,32 @@
+{{ define "main" }}
+<div class="row justify-content-center">
+  <div class="col-md-12 col-lg-10 col-xl-8">
+    <article>
+      <h1 class="text-center">{{ .Title }}</h1>
+      {{ .Content }}
+      {{ $cmds := .RegularPages.ByTitle }}
+      {{ $keys := slice }}
+      {{ range $g := site.Data.cmd_groups.groups }}
+        {{ $keys = $keys | append $g.key }}
+        {{ $pages := where $cmds "Params.group" $g.key }}
+        {{ if $pages }}
+          <h2 id="{{ $g.key }}">{{ $g.title }}</h2>
+          {{ with $g.blurb }}<p>{{ . }}</p>{{ end }}
+          {{ partial "main/cmd-index-rows.html" $pages }}
+        {{ end }}
+      {{ end }}
+      {{ $orphans := slice }}
+      {{ range $cmds }}
+        {{ if not (in $keys (.Params.group | default "")) }}
+          {{ $orphans = $orphans | append . }}
+        {{ end }}
+      {{ end }}
+      {{ if $orphans }}
+        {{ warnf "cmd-index: %d command page(s) have a missing or unknown group; rendered under Other" (len $orphans) }}
+        <h2 id="other">Other</h2>
+        {{ partial "main/cmd-index-rows.html" $orphans }}
+      {{ end }}
+    </article>
+  </div>
+</div>
+{{ end }}

--- a/site/layouts/docs/cmd-index.html
+++ b/site/layouts/docs/cmd-index.html
@@ -5,6 +5,23 @@
 {{ range $g := site.Data.cmd_groups.groups }}
   {{ $keys = $keys | append $g.key }}
   {{ $pages := where $cmds "Params.group" $g.key }}
+  {{ with $g.order }}
+    {{ $ordered := slice }}
+    {{ range $name := . }}
+      {{ $match := where $pages "File.BaseFileName" $name }}
+      {{ if $match }}
+        {{ $ordered = $ordered | append $match }}
+      {{ else }}
+        {{ warnf "cmd-index: group %q order entry %q matches no command page" $g.key $name }}
+      {{ end }}
+    {{ end }}
+    {{ range $pages }}
+      {{ if not (in $g.order .File.BaseFileName) }}
+        {{ $ordered = $ordered | append . }}
+      {{ end }}
+    {{ end }}
+    {{ $pages = $ordered }}
+  {{ end }}
   {{ if $pages }}
     {{ $sections = $sections | append (dict "key" $g.key "title" $g.title "blurb" $g.blurb "pages" $pages) }}
   {{ end }}

--- a/site/layouts/docs/cmd-index.html
+++ b/site/layouts/docs/cmd-index.html
@@ -31,7 +31,14 @@
       <nav id="{{ if eq .Site.Params.options.scrollSpy true }}toc{{ else }}TableOfContents{{ end }}">
         <ul>
           {{ range $sections }}
-          <li><a href="#{{ .key }}">{{ .title }}</a></li>
+          <li>
+            <a href="#{{ .key }}">{{ .title }}</a>
+            <ul>
+              {{ range .pages }}
+              <li><a href="{{ .RelPermalink }}"><code>{{ .Title }}</code></a></li>
+              {{ end }}
+            </ul>
+          </li>
           {{ end }}
         </ul>
       </nav>

--- a/site/layouts/docs/list.html
+++ b/site/layouts/docs/list.html
@@ -1,9 +1,13 @@
 {{ define "main" }}
-<div class="row justify-content-center">
-  <div class="col-md-12 col-lg-10 col-xl-8">
-    <article>
-      <h1 class="text-center">{{ if eq .CurrentSection .FirstSection }}{{ .Section | humanize }}{{ else }}{{ .Title }}{{ end }}</h1>
-      <div class="text-center">{{ .Content }}</div>
+<div class="row flex-xl-nowrap">
+  <div class="col-lg-5 col-xl-4 docs-sidebar{{ if ne .Site.Params.options.navbarSticky true }} docs-sidebar-top{{ end }} d-none d-lg-block">
+    <nav {{ if eq .Site.Params.menu.section.collapsibleSidebar false }}id="sidebar-default" {{ end }}class="docs-links" aria-label="Main navigation">
+      {{ partial "sidebar/docs-menu.html" . }}
+    </nav>
+  </div>
+  <main class="docs-content col-lg-11 col-xl-9 mx-xl-auto">
+      <h1>{{ if eq .CurrentSection .FirstSection }}{{ .Section | humanize }}{{ else }}{{ .Title }}{{ end }}</h1>
+      {{ .Content }}
 			<div class="card-list">
 				{{ $currentSection := .CurrentSection }}
 				{{ range where .Site.RegularPages.ByTitle "Section" .Section }}
@@ -17,7 +21,6 @@
 					{{ end }}
 				{{ end }}
 			</div>
-    </article>
-  </div>
+  </main>
 </div>
 {{ end }}

--- a/site/layouts/docs/list.html
+++ b/site/layouts/docs/list.html
@@ -7,15 +7,11 @@
 			<div class="card-list">
 				{{ $currentSection := .CurrentSection }}
 				{{ range where .Site.RegularPages.ByTitle "Section" .Section }}
-					{{ if in (.RelPermalink | string) $currentSection.RelPermalink }}
+					{{/* Command pages are indexed by /docs/cmd (layout cmd-index), not card lists. */}}
+					{{ if and (in (.RelPermalink | string) $currentSection.RelPermalink) (not (in (.RelPermalink | string) "/docs/cmd/")) }}
 						<div class="card my-3">
 							<div class="card-body">
-                {{ if in (.RelPermalink | string) "/docs/cmd" }}
-                  {{/* Special handling for the cmd list section. */}}
-                  <code><a class="stretched-link" href="{{ .RelPermalink }}">{{ .Params.title | title | lower }} &rarr;</a></code>
-                {{ else }}
-                  <a class="stretched-link" href="{{ .RelPermalink }}">{{ .Params.title | title }} &rarr;</a>
-                {{ end }}
+                <a class="stretched-link" href="{{ .RelPermalink }}">{{ .Params.title | title }} &rarr;</a>
 							</div>
 						</div>
 					{{ end }}

--- a/site/layouts/partials/main/cmd-index-rows.html
+++ b/site/layouts/partials/main/cmd-index-rows.html
@@ -1,4 +1,4 @@
-<table class="table">
+<table class="table cmd-index-table">
   <tbody>
     {{ range . }}
     <tr>

--- a/site/layouts/partials/main/cmd-index-rows.html
+++ b/site/layouts/partials/main/cmd-index-rows.html
@@ -1,0 +1,10 @@
+<table class="table">
+  <tbody>
+    {{ range . }}
+    <tr>
+      <td class="text-nowrap"><code><a href="{{ .RelPermalink }}">{{ .Title }}</a></code></td>
+      <td>{{ .Description }}</td>
+    </tr>
+    {{ end }}
+  </tbody>
+</table>

--- a/site/layouts/partials/sidebar/auto-collapsible-menu.html
+++ b/site/layouts/partials/sidebar/auto-collapsible-menu.html
@@ -15,9 +15,9 @@
     <a class="docs-link rounded {{ if $active }} active{{ end }}" href="{{- $hackURL -}}">Install</a>
   </li>
   <li class="mb-1">
-    {{ $hackURL := "/docs/agent-skills" }}
+    {{ $hackURL := "/docs/tutorial" }}
     {{ $active := in $currentPage.RelPermalink $hackURL }}
-    <a class="docs-link rounded {{ if $active }} active{{ end }}" href="{{- $hackURL -}}">Agent Skills</a>
+    <a class="docs-link rounded {{ if $active }} active{{ end }}" href="{{- $hackURL -}}">Tutorial</a>
   </li>
   <li class="mb-1">
     {{ $hackURL := "/docs/concepts" }}
@@ -35,9 +35,9 @@
     <a class="docs-link rounded {{ if $active }} active{{ end }}" href="{{- $hackURL -}}">Sources</a>
   </li>
   <li class="mb-1">
-    {{ $hackURL := "/docs/secrets" }}
+    {{ $hackURL := "/docs/detect" }}
     {{ $active := in $currentPage.RelPermalink $hackURL }}
-    <a class="docs-link rounded {{ if $active }} active{{ end }}" href="{{- $hackURL -}}">Secrets</a>
+    <a class="docs-link rounded {{ if $active }} active{{ end }}" href="{{- $hackURL -}}">Detect</a>
   </li>
   <li class="mb-1">
     {{ $hackURL := "/docs/inspect" }}
@@ -45,14 +45,9 @@
     <a class="docs-link rounded {{ if $active }} active{{ end }}" href="{{- $hackURL -}}">Inspect</a>
   </li>
   <li class="mb-1">
-    {{ $hackURL := "/docs/config" }}
+    {{ $hackURL := "/docs/diff" }}
     {{ $active := in $currentPage.RelPermalink $hackURL }}
-    <a class="docs-link rounded {{ if $active }} active{{ end }}" href="{{- $hackURL -}}">Config</a>
-  </li>
-  <li class="mb-1">
-    {{ $hackURL := "/docs/detect" }}
-    {{ $active := in $currentPage.RelPermalink $hackURL }}
-    <a class="docs-link rounded {{ if $active }} active{{ end }}" href="{{- $hackURL -}}">Detect</a>
+    <a class="docs-link rounded {{ if $active }} active{{ end }}" href="{{- $hackURL -}}">Diff</a>
   </li>
   <li class="mb-1">
     {{ $hackURL := "/docs/output" }}
@@ -60,19 +55,24 @@
     <a class="docs-link rounded {{ if $active }} active{{ end }}" href="{{- $hackURL -}}">Output</a>
   </li>
   <li class="mb-1">
-    {{ $hackURL := "/docs/diff" }}
+    {{ $hackURL := "/docs/config" }}
     {{ $active := in $currentPage.RelPermalink $hackURL }}
-    <a class="docs-link rounded {{ if $active }} active{{ end }}" href="{{- $hackURL -}}">Diff</a>
+    <a class="docs-link rounded {{ if $active }} active{{ end }}" href="{{- $hackURL -}}">Config</a>
   </li>
   <li class="mb-1">
-    {{ $hackURL := "/docs/tutorial" }}
+    {{ $hackURL := "/docs/secrets" }}
     {{ $active := in $currentPage.RelPermalink $hackURL }}
-    <a class="docs-link rounded {{ if $active }} active{{ end }}" href="{{- $hackURL -}}">Tutorial</a>
+    <a class="docs-link rounded {{ if $active }} active{{ end }}" href="{{- $hackURL -}}">Secrets</a>
   </li>
   <li class="mb-1">
     {{ $hackURL := "/docs/cookbook" }}
     {{ $active := in $currentPage.RelPermalink $hackURL }}
     <a class="docs-link rounded {{ if $active }} active{{ end }}" href="{{- $hackURL -}}">Cookbook</a>
+  </li>
+  <li class="mb-1">
+    {{ $hackURL := "/docs/agent-skills" }}
+    {{ $active := in $currentPage.RelPermalink $hackURL }}
+    <a class="docs-link rounded {{ if $active }} active{{ end }}" href="{{- $hackURL -}}">Agent Skills</a>
   </li>
   <li class="mb-1">
     {{ $hackURL := "/docs/cmd" }}

--- a/site/layouts/partials/sidebar/auto-collapsible-menu.html
+++ b/site/layouts/partials/sidebar/auto-collapsible-menu.html
@@ -74,10 +74,16 @@
     {{ $active := in $currentPage.RelPermalink $hackURL }}
     <a class="docs-link rounded {{ if $active }} active{{ end }}" href="{{- $hackURL -}}">Cookbook</a>
   </li>
+  <li class="mb-1">
+    {{ $hackURL := "/docs/cmd" }}
+    {{ $active := in $currentPage.RelPermalink $hackURL }}
+    <a class="docs-link rounded {{ if $active }} active{{ end }}" href="{{- $hackURL -}}">Commands</a>
+  </li>
 
 
   {{ range (where .Site.Sections "Section" "in" $section) }}
     {{ range .Sections }}
+      {{ if not .Params.sidebar_skip }}
       {{ $active := in $currentPage.RelPermalink .RelPermalink }}
       <li class="mb-1">
         <button class="btn btn-toggle align-items-center rounded collapsed" data-bs-toggle="collapse" data-bs-target="#section-{{ md5 .Title }}" aria-expanded="{{ if $active }}true{{ else }}false{{ end }}">
@@ -126,6 +132,7 @@
           </ul>
         </div>
       </li>
+      {{ end }}
     {{ end }}
   {{ end }}
 

--- a/site/layouts/partials/sidebar/auto-collapsible-menu.html
+++ b/site/layouts/partials/sidebar/auto-collapsible-menu.html
@@ -80,9 +80,9 @@
     <a class="docs-link rounded {{ if $active }} active{{ end }}" href="{{- $hackURL -}}">Commands</a>
   </li>
 
-
   {{ range (where .Site.Sections "Section" "in" $section) }}
     {{ range .Sections }}
+      {{- /* Sections with sidebar_skip: true in _index.md are rendered as a hardcoded link above instead. */}}
       {{ if not .Params.sidebar_skip }}
       {{ $active := in $currentPage.RelPermalink .RelPermalink }}
       <li class="mb-1">
@@ -132,7 +132,7 @@
           </ul>
         </div>
       </li>
-      {{ end }}
+      {{ end }}{{/* if not .Params.sidebar_skip */}}
     {{ end }}
   {{ end }}
 


### PR DESCRIPTION
Closes #773 (option 1: single Commands sidebar link plus a proper grouped index), plus
follow-on navigation and polish work that grew out of reviewing it.

## Command index (/docs/cmd)

- New `cmd-index` layout renders the page as a grouped command reference: six task-area
  groups (Query, Sources, Tables, Config, Cache, Miscellaneous), each with a heading,
  a one-line blurb, and a compact table of code-styled command links plus descriptions.
- Each command page declares membership via new `group:` frontmatter. Group order,
  display names, and blurbs live in `site/data/cmd_groups.toml`; an optional per-group
  `order` list pins commands to the front (unlisted members follow alphabetically, and
  an entry matching no page warns at build time). All six groups carry pinned or
  deliberate ordering; the old drifted `weight:` frontmatter is removed from all 41
  command pages, so prev/next pagination on them is now alphabetical.
- Blurbs render as markdown and link to the relevant guides (query, inspect, diff,
  source, config, secrets, ingest cache).
- Pages with a missing or unknown group render under a trailing "Other" heading with a
  build-time warning, so nothing silently disappears.
- A right-hand "On this page" nav lists the group headings (hand-built; Hugo's
  `.TableOfContents` can't see template-generated headings). A fully nested
  per-command TOC was tried and reverted as redundant: the page body is itself an index.
- Table spacing tightened: each table hugs its blurb (1rem above) with a clear break
  before the next group (3rem below).

## Sidebar

- The auto-generated 41-entry COMMANDS tree collapses to a single hardcoded "Commands"
  link; the loop now skips sections whose `_index.md` sets `sidebar_skip: true`.
  Drivers and Develop keep their collapsible trees.
- The sidebar now renders on docs list pages too (`/docs` root, drivers, develop, and
  the cmd index), which previously had no left nav at all.
- Hardcoded links reordered to follow the reader journey: onboarding (Overview,
  Install, Tutorial), learning (Concepts, Query Guide), working with data (Sources,
  Detect, Inspect, Diff, Output), configuration (Config, Secrets), then Cookbook,
  Agent Skills, and Commands above the Drivers/Develop trees.
- Width fix: the Doks sidebar flex basis shrinks from 320px to a tighter 240px and now
  applies from lg (992px) up; at lg the content column grows to absorb the freed space
  since there is no TOC column at that breakpoint.

## Other

- Command pages are excluded from the docs card lists; the `/docs` root landing page
  drops from 68 cards to 27, and `list.html`'s old `/docs/cmd` special case is removed.
- Site-wide fix: the `render-link.html` hook emitted a trailing newline after every
  markdown link, rendering as a stray space before adjacent punctuation. Now chomped.
- The Install page's one-item "See also" is now an "Agent Skills" section with a short
  overview and a pointer to /docs/agent-skills.
- No URLs change: every command page keeps its explicit `url:` frontmatter. Site-only
  change, so no CHANGELOG entry.

## Deferred follow-ups (from #773)

- Derive the hardcoded sidebar links in `auto-collapsible-menu.html` from section pages
  so they can't drift.
- Option 2 (two-level sidebar tree) / option 3 (consolidating subcommand pages) remain
  open if the single-link approach proves insufficient.

## Test plan

- [x] `make -C site site-test` (script/style/markdown lint plus link checker) green at
  each significant step
- [x] Built-output checks: six group headings with anchors, 41 command rows with
  descriptions and pinned ordering, no orphan section, sidebar present on all docs
  pages with correct order and active states, Drivers/Develop trees intact, no stray
  whitespace after rendered links
- [ ] Eyeball the Netlify deploy preview: sidebar, /docs/cmd, /docs root, Install page,
  prev/next on a command page
