### PR TITLE
Resolve secret placeholders on all code paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,17 @@ Breaking changes are annotated with ☢️, and alpha/beta features with 🐥.
 - [#750], [#752], [#757], [#759]: A batch of fixes to the `CREATE TABLE` DDL rewriting
   that backs table copy and column-kind alteration on the
   [sqlite3](https://sq.io/docs/drivers/sqlite) driver.
+- [#783]: `sq db dump cluster` no longer writes the database password to the sq log file:
+  the log rendering of external commands now masks all env values (the password was passed
+  to `pg_dumpall` via `PGPASSWORD`).
+- [#783]: [`sq cache clear @src`](https://sq.io/docs/cmd/cache-clear) now clears every
+  cache dir belonging to the source, including stale dirs left over from a changed
+  location, schema, or ingest options. Previously only the dir for the source's current
+  configuration was cleared, silently leaving the rest on disk.
+- [#783]: [`sq add`](https://sq.io/docs/cmd/add) and [`sq mv`](https://sq.io/docs/cmd/mv)
+  no longer permit a source handle nested below an existing source's handle (e.g. adding
+  `@prod/db/x` when `@prod` exists). The conflict check was previously inconsistent:
+  it caught `@prod/x`, but not deeper nesting, and `sq mv` didn't check at all.
 
 ## [v0.53.0] - 2026-05-25
 
@@ -1665,6 +1676,7 @@ make working with lots of sources much easier.
 [#752]: https://github.com/neilotoole/sq/issues/752
 [#757]: https://github.com/neilotoole/sq/issues/757
 [#759]: https://github.com/neilotoole/sq/issues/759
+[#783]: https://github.com/neilotoole/sq/issues/783
 
 [v0.15.2]: https://github.com/neilotoole/sq/releases/tag/v0.15.2
 [v0.15.3]: https://github.com/neilotoole/sq/compare/v0.15.2...v0.15.3

--- a/cli/cmd_cache.go
+++ b/cli/cmd_cache.go
@@ -127,21 +127,12 @@ func execCacheClear(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	// The ingest cache dir is hashed from the resolved location:
-	// Grips.doOpen hands the doc driver a resolved clone of src, and
-	// Files hashes src.Location. Resolve here too, so that the lock and
-	// the clear target the dir that ingest actually used.
-	if src, err = driver.ResolveSourceSecrets(ctx, src); err != nil {
-		return err
-	}
-
-	unlock, err := ru.Files.CacheLockAcquire(ctx, src)
-	if err != nil {
-		return err
-	}
-	defer unlock()
-
-	return ru.Files.CacheClearSource(ctx, src, true)
+	// CacheClearSourceAll removes every cache dir for the handle, no
+	// matter which location hash each was created under. The obvious
+	// alternative (hash the location, clear that one dir) requires
+	// resolving any ${scheme:path} placeholders, and silently misses
+	// dirs ingested under a previous value of the secret.
+	return ru.Files.CacheClearSourceAll(ctx, src, ru.Config.Collection.Handles())
 }
 
 func newCacheTreeCmd() *cobra.Command {

--- a/cli/cmd_cache.go
+++ b/cli/cmd_cache.go
@@ -127,6 +127,14 @@ func execCacheClear(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	// The ingest cache dir is hashed from the resolved location:
+	// Grips.doOpen hands the doc driver a resolved clone of src, and
+	// Files hashes src.Location. Resolve here too, so that the lock and
+	// the clear target the dir that ingest actually used.
+	if src, err = driver.ResolveSourceSecrets(ctx, src); err != nil {
+		return err
+	}
+
 	unlock, err := ru.Files.CacheLockAcquire(ctx, src)
 	if err != nil {
 		return err

--- a/cli/cmd_cache.go
+++ b/cli/cmd_cache.go
@@ -127,11 +127,8 @@ func execCacheClear(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	// CacheClearSourceAll removes every cache dir for the handle, no
-	// matter which location hash each was created under. The obvious
-	// alternative (hash the location, clear that one dir) requires
-	// resolving any ${scheme:path} placeholders, and silently misses
-	// dirs ingested under a previous value of the secret.
+	// Clears every location-hash leaf for the handle, with no secret
+	// resolution: see CacheClearSourceAll's docs.
 	return ru.Files.CacheClearSourceAll(ctx, src, ru.Config.Collection.Handles())
 }
 

--- a/cli/cmd_cache_test.go
+++ b/cli/cmd_cache_test.go
@@ -1,6 +1,8 @@
 package cli_test
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -51,4 +53,117 @@ func TestCmdCacheClear_Placeholder(t *testing.T) {
 	require.NoError(t, tr.Exec("cache", "clear", handle))
 	require.False(t, ioz.FileAccessible(cacheDB),
 		"cache clear should have removed the ingest cache DB")
+}
+
+// TestCmdCacheClear_Placeholder_RotatedSecret verifies that cache clear
+// removes caches ingested under a previous value of the secret. The cache
+// dir leaf is keyed on a hash of the resolved location, so a clear that
+// hashes the secret's current value would miss (and silently orphan) the
+// dir created when the secret had its old value.
+func TestCmdCacheClear_Placeholder_RotatedSecret(t *testing.T) {
+	const (
+		handle = "@csv_ph_rot"
+		envar  = "SQ_TEST_CSV_LOC_ROT"
+	)
+
+	th := testh.New(t)
+	realLoc := th.Source(sakila.CSVActor).Location
+	t.Setenv(envar, realLoc)
+
+	phSrc := &source.Source{
+		Handle:   handle,
+		Type:     drivertype.CSV,
+		Location: "${env:" + envar + "}",
+	}
+
+	tr := testrun.New(th.Context, t, nil)
+	tr.Add(*phSrc)
+	require.NoError(t, tr.Exec("--csv", handle+".data"))
+
+	resolved := phSrc.Clone()
+	resolved.Location = realLoc
+	_, cacheDB, _, err := tr.Run.Files.CachePaths(resolved)
+	require.NoError(t, err)
+	require.True(t, ioz.FileAccessible(cacheDB))
+
+	// Rotate the secret: the resolved location no longer matches the one
+	// the cache was ingested under.
+	t.Setenv(envar, filepath.Join(t.TempDir(), "other.csv"))
+
+	tr = testrun.New(th.Context, t, tr)
+	require.NoError(t, tr.Exec("cache", "clear", handle))
+	require.False(t, ioz.FileAccessible(cacheDB),
+		"cache clear should remove caches ingested under previous secret values")
+}
+
+// TestCmdCacheClear_Placeholder_UnresolvableSecret verifies that cache
+// clear works when the secret cannot be resolved at all. Clearing is a
+// local filesystem operation; it must not depend on the secret backend
+// being healthy (an unavailable backend is precisely when a user may
+// want to clean up).
+func TestCmdCacheClear_Placeholder_UnresolvableSecret(t *testing.T) {
+	const (
+		handle = "@csv_ph_gone"
+		envar  = "SQ_TEST_CSV_LOC_GONE"
+	)
+
+	th := testh.New(t)
+	realLoc := th.Source(sakila.CSVActor).Location
+	t.Setenv(envar, realLoc) // Setenv also restores the var on test cleanup.
+
+	phSrc := &source.Source{
+		Handle:   handle,
+		Type:     drivertype.CSV,
+		Location: "${env:" + envar + "}",
+	}
+
+	tr := testrun.New(th.Context, t, nil)
+	tr.Add(*phSrc)
+	require.NoError(t, tr.Exec("--csv", handle+".data"))
+
+	resolved := phSrc.Clone()
+	resolved.Location = realLoc
+	_, cacheDB, _, err := tr.Run.Files.CachePaths(resolved)
+	require.NoError(t, err)
+	require.True(t, ioz.FileAccessible(cacheDB))
+
+	// The secret is now unresolvable.
+	require.NoError(t, os.Unsetenv(envar))
+
+	tr = testrun.New(th.Context, t, tr)
+	require.NoError(t, tr.Exec("cache", "clear", handle),
+		"cache clear must not require the secret to be resolvable")
+	require.False(t, ioz.FileAccessible(cacheDB))
+}
+
+// TestCmdCacheClear_NestedHandleCachePreserved verifies that clearing a
+// source's cache doesn't touch the cache of a source whose handle nests
+// under it: @prod and @prod/db/x can coexist (a handle is only checked
+// against its immediate group), and @prod/db/x's cache dirs live below
+// @prod's cache dir on disk.
+func TestCmdCacheClear_NestedHandleCachePreserved(t *testing.T) {
+	th := testh.New(t)
+	loc := th.Source(sakila.CSVActor).Location
+
+	parent := &source.Source{Handle: "@prod", Type: drivertype.CSV, Location: loc}
+	nested := &source.Source{Handle: "@prod/db/x", Type: drivertype.CSV, Location: loc}
+
+	tr := testrun.New(th.Context, t, nil)
+	tr.Add(*parent, *nested)
+	require.NoError(t, tr.Exec("--csv", parent.Handle+".data"))
+	tr = testrun.New(th.Context, t, tr)
+	require.NoError(t, tr.Exec("--csv", nested.Handle+".data"))
+
+	_, parentDB, _, err := tr.Run.Files.CachePaths(parent)
+	require.NoError(t, err)
+	_, nestedDB, _, err := tr.Run.Files.CachePaths(nested)
+	require.NoError(t, err)
+	require.True(t, ioz.FileAccessible(parentDB))
+	require.True(t, ioz.FileAccessible(nestedDB))
+
+	tr = testrun.New(th.Context, t, tr)
+	require.NoError(t, tr.Exec("cache", "clear", parent.Handle))
+	require.False(t, ioz.FileAccessible(parentDB))
+	require.True(t, ioz.FileAccessible(nestedDB),
+		"clearing @prod must not clear @prod/db/x's cache")
 }

--- a/cli/cmd_cache_test.go
+++ b/cli/cmd_cache_test.go
@@ -1,0 +1,54 @@
+package cli_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/neilotoole/sq/cli/testrun"
+	"github.com/neilotoole/sq/libsq/core/ioz"
+	"github.com/neilotoole/sq/libsq/source"
+	"github.com/neilotoole/sq/libsq/source/drivertype"
+	"github.com/neilotoole/sq/testh"
+	"github.com/neilotoole/sq/testh/sakila"
+)
+
+// TestCmdCacheClear_Placeholder verifies that "sq cache clear @src" clears
+// the actual ingest cache for a source whose location is a ${scheme:path}
+// placeholder. The ingest cache dir is hashed from the resolved location
+// (Grips.doOpen hands the doc driver a resolved clone), so cache clear must
+// hash the resolved location too; hashing the raw config location clears a
+// nonexistent dir and silently leaves the real cache intact.
+//
+// See: https://github.com/neilotoole/sq/issues/783.
+func TestCmdCacheClear_Placeholder(t *testing.T) {
+	const handle = "@csv_ph"
+
+	th := testh.New(t)
+	realLoc := th.Source(sakila.CSVActor).Location
+	t.Setenv("SQ_TEST_CSV_LOC", realLoc)
+
+	phSrc := &source.Source{
+		Handle:   handle,
+		Type:     drivertype.CSV,
+		Location: "${env:SQ_TEST_CSV_LOC}",
+	}
+
+	tr := testrun.New(th.Context, t, nil)
+	tr.Add(*phSrc)
+
+	// Query the source, ingesting it into the cache.
+	require.NoError(t, tr.Exec("--csv", handle+".data"))
+
+	resolved := phSrc.Clone()
+	resolved.Location = realLoc
+	_, cacheDB, _, err := tr.Run.Files.CachePaths(resolved)
+	require.NoError(t, err)
+	require.True(t, ioz.FileAccessible(cacheDB),
+		"ingest should have populated the cache under the resolved-location hash")
+
+	tr = testrun.New(th.Context, t, tr)
+	require.NoError(t, tr.Exec("cache", "clear", handle))
+	require.False(t, ioz.FileAccessible(cacheDB),
+		"cache clear should have removed the ingest cache DB")
+}

--- a/cli/cmd_cache_test.go
+++ b/cli/cmd_cache_test.go
@@ -15,31 +15,26 @@ import (
 	"github.com/neilotoole/sq/testh/sakila"
 )
 
-// TestCmdCacheClear_Placeholder verifies that "sq cache clear @src" clears
-// the actual ingest cache for a source whose location is a ${scheme:path}
-// placeholder. The ingest cache dir is hashed from the resolved location
-// (Grips.doOpen hands the doc driver a resolved clone), so cache clear must
-// hash the resolved location too; hashing the raw config location clears a
-// nonexistent dir and silently leaves the real cache intact.
-//
-// See: https://github.com/neilotoole/sq/issues/783.
-func TestCmdCacheClear_Placeholder(t *testing.T) {
-	const handle = "@csv_ph"
+// setupPlaceholderCSVCache adds a CSV source with handle whose location is
+// an ${env:envar} placeholder backed by the sakila actor fixture, ingests
+// it by executing a query, and returns the TestRun plus the path of the
+// now-populated ingest cache DB (which lives under the resolved-location
+// hash: Grips.doOpen hands the doc driver a resolved clone of the source).
+func setupPlaceholderCSVCache(t *testing.T, handle, envar string) (tr *testrun.TestRun, cacheDB string) {
+	t.Helper()
 
 	th := testh.New(t)
 	realLoc := th.Source(sakila.CSVActor).Location
-	t.Setenv("SQ_TEST_CSV_LOC", realLoc)
+	t.Setenv(envar, realLoc) // Setenv also restores the var on test cleanup.
 
 	phSrc := &source.Source{
 		Handle:   handle,
 		Type:     drivertype.CSV,
-		Location: "${env:SQ_TEST_CSV_LOC}",
+		Location: "${env:" + envar + "}",
 	}
 
-	tr := testrun.New(th.Context, t, nil)
+	tr = testrun.New(th.Context, t, nil)
 	tr.Add(*phSrc)
-
-	// Query the source, ingesting it into the cache.
 	require.NoError(t, tr.Exec("--csv", handle+".data"))
 
 	resolved := phSrc.Clone()
@@ -49,48 +44,44 @@ func TestCmdCacheClear_Placeholder(t *testing.T) {
 	require.True(t, ioz.FileAccessible(cacheDB),
 		"ingest should have populated the cache under the resolved-location hash")
 
-	tr = testrun.New(th.Context, t, tr)
+	return tr, cacheDB
+}
+
+// TestCmdCacheClear_Placeholder verifies that "sq cache clear @src" clears
+// the actual ingest cache for a source whose location is a ${scheme:path}
+// placeholder. The ingest cache dir is hashed from the resolved location,
+// so a clear that hashed the raw config location would clear a nonexistent
+// dir and silently leave the real cache intact. The clear is
+// hash-independent: it removes every cache dir under the handle without
+// resolving anything (see Files.CacheClearSourceAll).
+//
+// See: https://github.com/neilotoole/sq/issues/783.
+func TestCmdCacheClear_Placeholder(t *testing.T) {
+	const handle = "@csv_ph"
+	tr, cacheDB := setupPlaceholderCSVCache(t, handle, "SQ_TEST_CSV_LOC")
+
+	tr = testrun.New(tr.Context, t, tr)
 	require.NoError(t, tr.Exec("cache", "clear", handle))
 	require.False(t, ioz.FileAccessible(cacheDB),
 		"cache clear should have removed the ingest cache DB")
 }
 
 // TestCmdCacheClear_Placeholder_RotatedSecret verifies that cache clear
-// removes caches ingested under a previous value of the secret. The cache
-// dir leaf is keyed on a hash of the resolved location, so a clear that
-// hashes the secret's current value would miss (and silently orphan) the
-// dir created when the secret had its old value.
+// removes caches ingested under a previous value of the secret: a clear
+// that hashed the secret's current value would miss (and silently orphan)
+// the dir created when the secret had its old value.
 func TestCmdCacheClear_Placeholder_RotatedSecret(t *testing.T) {
 	const (
 		handle = "@csv_ph_rot"
 		envar  = "SQ_TEST_CSV_LOC_ROT"
 	)
-
-	th := testh.New(t)
-	realLoc := th.Source(sakila.CSVActor).Location
-	t.Setenv(envar, realLoc)
-
-	phSrc := &source.Source{
-		Handle:   handle,
-		Type:     drivertype.CSV,
-		Location: "${env:" + envar + "}",
-	}
-
-	tr := testrun.New(th.Context, t, nil)
-	tr.Add(*phSrc)
-	require.NoError(t, tr.Exec("--csv", handle+".data"))
-
-	resolved := phSrc.Clone()
-	resolved.Location = realLoc
-	_, cacheDB, _, err := tr.Run.Files.CachePaths(resolved)
-	require.NoError(t, err)
-	require.True(t, ioz.FileAccessible(cacheDB))
+	tr, cacheDB := setupPlaceholderCSVCache(t, handle, envar)
 
 	// Rotate the secret: the resolved location no longer matches the one
 	// the cache was ingested under.
 	t.Setenv(envar, filepath.Join(t.TempDir(), "other.csv"))
 
-	tr = testrun.New(th.Context, t, tr)
+	tr = testrun.New(tr.Context, t, tr)
 	require.NoError(t, tr.Exec("cache", "clear", handle))
 	require.False(t, ioz.FileAccessible(cacheDB),
 		"cache clear should remove caches ingested under previous secret values")
@@ -106,64 +97,19 @@ func TestCmdCacheClear_Placeholder_UnresolvableSecret(t *testing.T) {
 		handle = "@csv_ph_gone"
 		envar  = "SQ_TEST_CSV_LOC_GONE"
 	)
-
-	th := testh.New(t)
-	realLoc := th.Source(sakila.CSVActor).Location
-	t.Setenv(envar, realLoc) // Setenv also restores the var on test cleanup.
-
-	phSrc := &source.Source{
-		Handle:   handle,
-		Type:     drivertype.CSV,
-		Location: "${env:" + envar + "}",
-	}
-
-	tr := testrun.New(th.Context, t, nil)
-	tr.Add(*phSrc)
-	require.NoError(t, tr.Exec("--csv", handle+".data"))
-
-	resolved := phSrc.Clone()
-	resolved.Location = realLoc
-	_, cacheDB, _, err := tr.Run.Files.CachePaths(resolved)
-	require.NoError(t, err)
-	require.True(t, ioz.FileAccessible(cacheDB))
+	tr, cacheDB := setupPlaceholderCSVCache(t, handle, envar)
 
 	// The secret is now unresolvable.
 	require.NoError(t, os.Unsetenv(envar))
 
-	tr = testrun.New(th.Context, t, tr)
+	tr = testrun.New(tr.Context, t, tr)
 	require.NoError(t, tr.Exec("cache", "clear", handle),
 		"cache clear must not require the secret to be resolvable")
 	require.False(t, ioz.FileAccessible(cacheDB))
 }
 
-// TestCmdCacheClear_NestedHandleCachePreserved verifies that clearing a
-// source's cache doesn't touch the cache of a source whose handle nests
-// under it: @prod and @prod/db/x can coexist (a handle is only checked
-// against its immediate group), and @prod/db/x's cache dirs live below
-// @prod's cache dir on disk.
-func TestCmdCacheClear_NestedHandleCachePreserved(t *testing.T) {
-	th := testh.New(t)
-	loc := th.Source(sakila.CSVActor).Location
-
-	parent := &source.Source{Handle: "@prod", Type: drivertype.CSV, Location: loc}
-	nested := &source.Source{Handle: "@prod/db/x", Type: drivertype.CSV, Location: loc}
-
-	tr := testrun.New(th.Context, t, nil)
-	tr.Add(*parent, *nested)
-	require.NoError(t, tr.Exec("--csv", parent.Handle+".data"))
-	tr = testrun.New(th.Context, t, tr)
-	require.NoError(t, tr.Exec("--csv", nested.Handle+".data"))
-
-	_, parentDB, _, err := tr.Run.Files.CachePaths(parent)
-	require.NoError(t, err)
-	_, nestedDB, _, err := tr.Run.Files.CachePaths(nested)
-	require.NoError(t, err)
-	require.True(t, ioz.FileAccessible(parentDB))
-	require.True(t, ioz.FileAccessible(nestedDB))
-
-	tr = testrun.New(th.Context, t, tr)
-	require.NoError(t, tr.Exec("cache", "clear", parent.Handle))
-	require.False(t, ioz.FileAccessible(parentDB))
-	require.True(t, ioz.FileAccessible(nestedDB),
-		"clearing @prod must not clear @prod/db/x's cache")
-}
+// Note: the nested-handle protection of cache clear (clearing @prod must
+// not touch @prod/db/x's cache dirs, which live below @prod's dir) is
+// covered at the files level by TestFiles_CacheClearSourceAll_*: such
+// nesting can no longer be created via Collection.Add or sq mv, but may
+// exist in legacy or hand-edited configs.

--- a/cli/cmd_db.go
+++ b/cli/cmd_db.go
@@ -2,6 +2,9 @@ package cli
 
 import (
 	"github.com/spf13/cobra"
+
+	"github.com/neilotoole/sq/libsq/driver"
+	"github.com/neilotoole/sq/libsq/source"
 )
 
 func newDBCmd() *cobra.Command {
@@ -15,4 +18,15 @@ func newDBCmd() *cobra.Command {
 	}
 
 	return cmd
+}
+
+// resolveToolCmdSource resolves any ${scheme:path} placeholders in
+// src.Location, returning a clone if resolution occurred. The db commands
+// construct external tool invocations (pg_dump etc.) directly from
+// src.Location, bypassing Grips.doOpen, which performs this resolution for
+// the query path. Every db command must call this before handing src to a
+// tool command builder: forgetting it hands the tool the literal
+// placeholder text.
+func resolveToolCmdSource(cmd *cobra.Command, src *source.Source) (*source.Source, error) {
+	return driver.ResolveSourceSecrets(cmd.Context(), src)
 }

--- a/cli/cmd_db_dump.go
+++ b/cli/cmd_db_dump.go
@@ -13,6 +13,7 @@ import (
 	"github.com/neilotoole/sq/libsq/core/execz"
 	"github.com/neilotoole/sq/libsq/core/lg"
 	"github.com/neilotoole/sq/libsq/core/lg/lga"
+	"github.com/neilotoole/sq/libsq/driver"
 	"github.com/neilotoole/sq/libsq/source"
 	"github.com/neilotoole/sq/libsq/source/drivertype"
 )
@@ -113,6 +114,14 @@ func execDBDumpCatalog(cmd *cobra.Command, args []string) error {
 		if dumpFile = strings.TrimSpace(dumpFile); dumpFile == "" {
 			return errz.Errorf("%s: %s is specified, but empty", errPrefix, flag.FileOutput)
 		}
+	}
+
+	// Resolve ${scheme:path} placeholders in src.Location before handing
+	// src to the tool command builder. Grips.doOpen does this for the
+	// query path; the db commands construct pg_dump etc. directly from
+	// src.Location, so resolution must happen here.
+	if src, err = driver.ResolveSourceSecrets(cmd.Context(), src); err != nil {
+		return err
 	}
 
 	var execCmd *execz.Cmd
@@ -225,6 +234,13 @@ func execDBDumpCluster(cmd *cobra.Command, args []string) error {
 		if dumpFile = strings.TrimSpace(dumpFile); dumpFile == "" {
 			return errz.Errorf("%s: %s is specified, but empty", errPrefix, flag.FileOutput)
 		}
+	}
+
+	// Resolve placeholders at the call site: see execDBDumpCatalog.
+	// Without this, DumpClusterCmd would set PGPASSWORD to the literal
+	// placeholder text.
+	if src, err = driver.ResolveSourceSecrets(cmd.Context(), src); err != nil {
+		return err
 	}
 
 	var execCmd *execz.Cmd

--- a/cli/cmd_db_dump.go
+++ b/cli/cmd_db_dump.go
@@ -13,7 +13,6 @@ import (
 	"github.com/neilotoole/sq/libsq/core/execz"
 	"github.com/neilotoole/sq/libsq/core/lg"
 	"github.com/neilotoole/sq/libsq/core/lg/lga"
-	"github.com/neilotoole/sq/libsq/driver"
 	"github.com/neilotoole/sq/libsq/source"
 	"github.com/neilotoole/sq/libsq/source/drivertype"
 )
@@ -116,11 +115,7 @@ func execDBDumpCatalog(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	// Resolve ${scheme:path} placeholders in src.Location before handing
-	// src to the tool command builder. Grips.doOpen does this for the
-	// query path; the db commands construct pg_dump etc. directly from
-	// src.Location, so resolution must happen here.
-	if src, err = driver.ResolveSourceSecrets(cmd.Context(), src); err != nil {
+	if src, err = resolveToolCmdSource(cmd, src); err != nil {
 		return err
 	}
 
@@ -236,10 +231,7 @@ func execDBDumpCluster(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	// Resolve placeholders at the call site: see execDBDumpCatalog.
-	// Without this, DumpClusterCmd would set PGPASSWORD to the literal
-	// placeholder text.
-	if src, err = driver.ResolveSourceSecrets(cmd.Context(), src); err != nil {
+	if src, err = resolveToolCmdSource(cmd, src); err != nil {
 		return err
 	}
 
@@ -255,7 +247,7 @@ func execDBDumpCluster(cmd *cobra.Command, args []string) error {
 		}
 		execCmd, err = postgres.DumpClusterCmd(src, params)
 	default:
-		err = errz.Errorf("%s: not supported for %s", errPrefix, src.Type)
+		return errz.Errorf("%s: not supported for %s", errPrefix, src.Type)
 	}
 
 	if err != nil {

--- a/cli/cmd_db_exec.go
+++ b/cli/cmd_db_exec.go
@@ -13,6 +13,7 @@ import (
 	"github.com/neilotoole/sq/libsq/core/execz"
 	"github.com/neilotoole/sq/libsq/core/lg"
 	"github.com/neilotoole/sq/libsq/core/lg/lga"
+	"github.com/neilotoole/sq/libsq/driver"
 	"github.com/neilotoole/sq/libsq/source"
 	"github.com/neilotoole/sq/libsq/source/drivertype"
 )
@@ -103,6 +104,11 @@ func execDBExec(cmd *cobra.Command, args []string) error {
 	}
 
 	if err = applySourceOptions(cmd, src); err != nil {
+		return err
+	}
+
+	// Resolve placeholders at the call site: see execDBDumpCatalog.
+	if src, err = driver.ResolveSourceSecrets(cmd.Context(), src); err != nil {
 		return err
 	}
 

--- a/cli/cmd_db_exec.go
+++ b/cli/cmd_db_exec.go
@@ -13,7 +13,6 @@ import (
 	"github.com/neilotoole/sq/libsq/core/execz"
 	"github.com/neilotoole/sq/libsq/core/lg"
 	"github.com/neilotoole/sq/libsq/core/lg/lga"
-	"github.com/neilotoole/sq/libsq/driver"
 	"github.com/neilotoole/sq/libsq/source"
 	"github.com/neilotoole/sq/libsq/source/drivertype"
 )
@@ -107,8 +106,7 @@ func execDBExec(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	// Resolve placeholders at the call site: see execDBDumpCatalog.
-	if src, err = driver.ResolveSourceSecrets(cmd.Context(), src); err != nil {
+	if src, err = resolveToolCmdSource(cmd, src); err != nil {
 		return err
 	}
 

--- a/cli/cmd_db_restore.go
+++ b/cli/cmd_db_restore.go
@@ -13,6 +13,7 @@ import (
 	"github.com/neilotoole/sq/libsq/core/execz"
 	"github.com/neilotoole/sq/libsq/core/lg"
 	"github.com/neilotoole/sq/libsq/core/lg/lga"
+	"github.com/neilotoole/sq/libsq/driver"
 	"github.com/neilotoole/sq/libsq/source"
 	"github.com/neilotoole/sq/libsq/source/drivertype"
 )
@@ -102,6 +103,11 @@ func execDBRestoreCatalog(cmd *cobra.Command, args []string) error {
 
 	verbose := OptVerbose.Get(src.Options)
 	noOwner := cmdFlagBool(cmd, flag.DBRestoreNoOwner)
+
+	// Resolve placeholders at the call site: see execDBDumpCatalog.
+	if src, err = driver.ResolveSourceSecrets(cmd.Context(), src); err != nil {
+		return err
+	}
 
 	var execCmd *execz.Cmd
 
@@ -217,6 +223,11 @@ func execDBRestoreCluster(cmd *cobra.Command, args []string) error {
 
 	// FIXME: get rid of noOwner from this command?
 	// noOwner := cmdFlagBool(cmd, flag.RestoreNoOwner)
+
+	// Resolve placeholders at the call site: see execDBDumpCatalog.
+	if src, err = driver.ResolveSourceSecrets(cmd.Context(), src); err != nil {
+		return err
+	}
 
 	var execCmd *execz.Cmd
 

--- a/cli/cmd_db_restore.go
+++ b/cli/cmd_db_restore.go
@@ -13,7 +13,6 @@ import (
 	"github.com/neilotoole/sq/libsq/core/execz"
 	"github.com/neilotoole/sq/libsq/core/lg"
 	"github.com/neilotoole/sq/libsq/core/lg/lga"
-	"github.com/neilotoole/sq/libsq/driver"
 	"github.com/neilotoole/sq/libsq/source"
 	"github.com/neilotoole/sq/libsq/source/drivertype"
 )
@@ -104,8 +103,7 @@ func execDBRestoreCatalog(cmd *cobra.Command, args []string) error {
 	verbose := OptVerbose.Get(src.Options)
 	noOwner := cmdFlagBool(cmd, flag.DBRestoreNoOwner)
 
-	// Resolve placeholders at the call site: see execDBDumpCatalog.
-	if src, err = driver.ResolveSourceSecrets(cmd.Context(), src); err != nil {
+	if src, err = resolveToolCmdSource(cmd, src); err != nil {
 		return err
 	}
 
@@ -224,8 +222,7 @@ func execDBRestoreCluster(cmd *cobra.Command, args []string) error {
 	// FIXME: get rid of noOwner from this command?
 	// noOwner := cmdFlagBool(cmd, flag.RestoreNoOwner)
 
-	// Resolve placeholders at the call site: see execDBDumpCatalog.
-	if src, err = driver.ResolveSourceSecrets(cmd.Context(), src); err != nil {
+	if src, err = resolveToolCmdSource(cmd, src); err != nil {
 		return err
 	}
 

--- a/cli/cmd_db_test.go
+++ b/cli/cmd_db_test.go
@@ -1,6 +1,7 @@
 package cli_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -9,6 +10,7 @@ import (
 	"github.com/neilotoole/sq/libsq/source"
 	"github.com/neilotoole/sq/libsq/source/drivertype"
 	"github.com/neilotoole/sq/testh"
+	"github.com/neilotoole/sq/testh/sakila"
 )
 
 // TestCmdDB_Placeholder_Resolved verifies that the db dump/restore/exec
@@ -55,6 +57,59 @@ func TestCmdDB_Placeholder_Resolved(t *testing.T) {
 				"printed cmd should contain the resolved secret")
 			require.NotContains(t, got, "${env:",
 				"printed cmd should not contain the unresolved placeholder")
+		})
+	}
+}
+
+// TestCmdDB_UnsupportedDriver_ErrMsg verifies the error message when a db
+// command is invoked against a source type that doesn't support it. The
+// error prefix must appear exactly once: the "dump cluster" path used to
+// assign the prefixed error to err and then wrap it with the same prefix
+// again, yielding "db dump cluster: @x: db dump cluster: @x: ...".
+func TestCmdDB_UnsupportedDriver_ErrMsg(t *testing.T) {
+	testCases := []struct {
+		name      string
+		args      []string
+		errPrefix string
+	}{
+		{
+			name:      "dump_catalog",
+			args:      []string{"db", "dump", "catalog", sakila.CSVActor, "--print"},
+			errPrefix: "db dump catalog: " + sakila.CSVActor,
+		},
+		{
+			name:      "dump_cluster",
+			args:      []string{"db", "dump", "cluster", sakila.CSVActor, "--print"},
+			errPrefix: "db dump cluster: " + sakila.CSVActor,
+		},
+		{
+			name:      "restore_catalog",
+			args:      []string{"db", "restore", "catalog", sakila.CSVActor, "--print"},
+			errPrefix: "db restore catalog: " + sakila.CSVActor,
+		},
+		{
+			name:      "restore_cluster",
+			args:      []string{"db", "restore", "cluster", sakila.CSVActor, "--print"},
+			errPrefix: "db restore cluster: " + sakila.CSVActor,
+		},
+		{
+			name:      "exec",
+			args:      []string{"db", "exec", sakila.CSVActor, "--command", "SELECT 1", "--print"},
+			errPrefix: "db exec: " + sakila.CSVActor,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			th := testh.New(t)
+			tr := testrun.New(th.Context, t, nil)
+			tr.Add(*th.Source(sakila.CSVActor))
+
+			err := tr.Exec(tc.args...)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), tc.errPrefix)
+			require.Equal(t, 1, strings.Count(err.Error(), tc.errPrefix),
+				"error prefix must appear exactly once")
 		})
 	}
 }

--- a/cli/cmd_db_test.go
+++ b/cli/cmd_db_test.go
@@ -1,0 +1,60 @@
+package cli_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/neilotoole/sq/cli/testrun"
+	"github.com/neilotoole/sq/libsq/source"
+	"github.com/neilotoole/sq/libsq/source/drivertype"
+	"github.com/neilotoole/sq/testh"
+)
+
+// TestCmdDB_Placeholder_Resolved verifies that the db dump/restore/exec
+// commands resolve ${scheme:path} placeholders in the source location
+// before constructing the db-native tool command. These commands build
+// pg_dump/pg_dumpall/pg_restore/psql invocations directly from
+// src.Location, bypassing Grips.doOpen (which performs resolution for
+// the query path), so they must resolve at the call site. The --print
+// flag exposes the constructed command without needing a live server.
+//
+// See: https://github.com/neilotoole/sq/issues/783.
+func TestCmdDB_Placeholder_Resolved(t *testing.T) {
+	const (
+		handle = "@pg_ph"
+		envar  = "SQ_TEST_PG_PW"
+		pw     = "hunter2"
+	)
+
+	testCases := []struct {
+		name string
+		args []string
+	}{
+		{name: "dump_catalog", args: []string{"db", "dump", "catalog", handle, "--print"}},
+		{name: "dump_cluster", args: []string{"db", "dump", "cluster", handle, "--print"}},
+		{name: "restore_catalog", args: []string{"db", "restore", "catalog", handle, "--print"}},
+		{name: "restore_cluster", args: []string{"db", "restore", "cluster", handle, "--print"}},
+		{name: "exec", args: []string{"db", "exec", handle, "--command", "SELECT 1", "--print"}},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv(envar, pw)
+			th := testh.New(t)
+			tr := testrun.New(th.Context, t, nil)
+			tr.Add(source.Source{
+				Handle:   handle,
+				Type:     drivertype.Pg,
+				Location: "postgres://alice:${env:" + envar + "}@db.acme.com:5432/sakila",
+			})
+
+			require.NoError(t, tr.Exec(tc.args...))
+			got := tr.OutString()
+			require.Contains(t, got, pw,
+				"printed cmd should contain the resolved secret")
+			require.NotContains(t, got, "${env:",
+				"printed cmd should not contain the unresolved placeholder")
+		})
+	}
+}

--- a/cli/cmd_inspect_test.go
+++ b/cli/cmd_inspect_test.go
@@ -885,6 +885,37 @@ func TestCmdInspect_mode_catalogs(t *testing.T) {
 	}
 }
 
+// TestCmdInspect_FlagActiveSchema_Placeholder verifies that --src.schema
+// validation works for a source whose location is a ${scheme:path}
+// placeholder. verifySourceCatalogSchema opens the source directly,
+// deliberately bypassing the grip cache, and thereby also bypassing the
+// secret resolution that Grips.doOpen performs; it must resolve at the
+// call site.
+//
+// See: https://github.com/neilotoole/sq/issues/783.
+func TestCmdInspect_FlagActiveSchema_Placeholder(t *testing.T) {
+	const handle = "@sl3_ph"
+
+	th := testh.New(t)
+	src := th.Source(sakila.SL3)
+	t.Setenv("SQ_TEST_SL3_LOC", src.Location)
+
+	tr := testrun.New(th.Context, t, nil)
+	tr.Add(source.Source{
+		Handle:   handle,
+		Type:     drivertype.SQLite,
+		Location: "${env:SQ_TEST_SL3_LOC}",
+	})
+
+	err := tr.Exec("inspect", handle, "--src.schema", "main", "--json")
+	require.NoError(t, err,
+		"--src.schema validation should resolve the placeholder location")
+
+	srcMeta := &metadata.Source{}
+	require.NoError(t, json.Unmarshal(tr.Out.Bytes(), srcMeta))
+	require.Contains(t, srcMeta.TableNames(), sakila.TblActor)
+}
+
 // TestCmdInspect_NumericSchema tests "sq inspect --src.schema" with numeric
 // and numeric-prefixed schema names. This validates the grammar fix for issue #470.
 // See: https://github.com/neilotoole/sq/issues/470

--- a/cli/cmd_x.go
+++ b/cli/cmd_x.go
@@ -15,6 +15,7 @@ import (
 	"github.com/neilotoole/sq/libsq/core/lg"
 	"github.com/neilotoole/sq/libsq/core/lg/lga"
 	"github.com/neilotoole/sq/libsq/core/progress"
+	"github.com/neilotoole/sq/libsq/driver"
 	"github.com/neilotoole/sq/libsq/files"
 )
 
@@ -50,6 +51,13 @@ func execXLockSrcCmd(cmd *cobra.Command, args []string) error {
 	ru := run.FromContext(ctx)
 	src, err := ru.Config.Collection.Get(args[0])
 	if err != nil {
+		return err
+	}
+
+	// The cache lock path is derived from a hash that includes the
+	// resolved location; ingest locks the resolved leaf, so this
+	// command must too, or it locks a dir nothing else uses.
+	if src, err = driver.ResolveSourceSecrets(ctx, src); err != nil {
 		return err
 	}
 

--- a/cli/source.go
+++ b/cli/source.go
@@ -169,7 +169,16 @@ func verifySourceCatalogSchema(ctx context.Context, ru *run.Run, src *source.Sou
 	// case the hint prevents the cached-grip pitfalls described in
 	// the godoc above.
 	openCtx := driver.WithReadOnly(ctx)
-	grip, err := d.Open(openCtx, src)
+
+	// Bypassing Grips also bypasses the ${scheme:path} placeholder
+	// resolution that Grips.doOpen performs, so resolve here before
+	// handing src to the driver.
+	openSrc, err := driver.ResolveSourceSecrets(openCtx, src)
+	if err != nil {
+		return err
+	}
+
+	grip, err := d.Open(openCtx, openSrc)
 	if err != nil {
 		return err
 	}

--- a/drivers/postgres/tools.go
+++ b/drivers/postgres/tools.go
@@ -167,10 +167,11 @@ func DumpClusterCmd(src *source.Source, p *ToolParams) (*execz.Cmd, error) {
 	cmd := &execz.Cmd{
 		Name:       "pg_dumpall",
 		CmdDirPath: true,
-		Env:        []string{"PGPASSWORD=" + cfg.ConnConfig.Password},
+		// The password lands in the env verbatim; execz.Cmd's log
+		// rendering masks all env values, so it doesn't leak to logs.
+		Env: []string{"PGPASSWORD=" + cfg.ConnConfig.Password},
 	}
 
-	// FIXME: need mechanism to indicate that env contains password
 	if p.Verbose {
 		cmd.ProgressFromStderr = true
 		cmd.Args = append(cmd.Args, p.flag(flagVerbose))

--- a/libsq/core/execz/execz.go
+++ b/libsq/core/execz/execz.go
@@ -138,15 +138,14 @@ func (c *Cmd) redactedEnv(escape bool) []string {
 			continue
 		}
 
-		// If the envar value is a SQL or HTTP location, redact it,
-		// preserving the non-sensitive parts. Mask any other value
-		// entirely: env vars passed to external tools exist to carry
-		// connection material (e.g. PGPASSWORD), so default to deny.
-		if location.TypeOf(parts[1]).IsURL() {
-			parts[1] = location.Redact(parts[1])
-		} else {
-			parts[1] = stringz.Redacted
-		}
+		// Mask every env value: env vars passed to external tools exist
+		// to carry connection material (e.g. PGPASSWORD), so default to
+		// deny. URL-shaped values are masked entirely too, rather than
+		// partially redacted via location.Redact, because that only
+		// masks the userinfo password and would leak secrets carried in
+		// the query string (e.g. "?sslpassword=..."). Unlike args, env
+		// values don't need to stay informative in logs.
+		parts[1] = stringz.Redacted
 
 		if escape {
 			envars[i] = parts[0] + "=" + stringz.ShellEscape(parts[1])

--- a/libsq/core/execz/execz.go
+++ b/libsq/core/execz/execz.go
@@ -138,9 +138,14 @@ func (c *Cmd) redactedEnv(escape bool) []string {
 			continue
 		}
 
-		// If the envar value is a SQL or HTTP location, redact it.
+		// If the envar value is a SQL or HTTP location, redact it,
+		// preserving the non-sensitive parts. Mask any other value
+		// entirely: env vars passed to external tools exist to carry
+		// connection material (e.g. PGPASSWORD), so default to deny.
 		if location.TypeOf(parts[1]).IsURL() {
 			parts[1] = location.Redact(parts[1])
+		} else {
+			parts[1] = stringz.Redacted
 		}
 
 		if escape {

--- a/libsq/core/execz/execz_test.go
+++ b/libsq/core/execz/execz_test.go
@@ -13,11 +13,17 @@ import (
 // TestCmd_LogValue_RedactsEnv verifies that logging a [execz.Cmd] does not
 // leak env values. Env vars passed to external tools exist to carry
 // connection material (e.g. PGPASSWORD set by postgres.DumpClusterCmd), so
-// the log rendering must mask every env value, not just URL-shaped ones.
+// the log rendering must mask every env value. URL-shaped values are masked
+// entirely too: partial URL redaction keeps only the userinfo password
+// secret, and would leak credentials carried in the query string (e.g.
+// "?sslpassword=..." or a presigned "?X-Amz-Signature=...").
 func TestCmd_LogValue_RedactsEnv(t *testing.T) {
 	cmd := &execz.Cmd{
 		Name: "pg_dumpall",
-		Env:  []string{"PGPASSWORD=hunter2"},
+		Env: []string{
+			"PGPASSWORD=hunter2",
+			"DSN=postgres://alice@db.acme.com:5432/sakila?sslpassword=hunter2",
+		},
 		Args: []string{"--dbname", "postgres://alice:hunter2@db.acme.com:5432/sakila"},
 	}
 
@@ -27,13 +33,25 @@ func TestCmd_LogValue_RedactsEnv(t *testing.T) {
 	got := buf.String()
 
 	require.NotContains(t, got, "hunter2",
-		"secret must not appear in log output")
+		"secret must not appear in log output, whether the env value is URL-shaped or not")
 	require.Contains(t, got, "PGPASSWORD=",
 		"env var name should remain visible")
+	require.Contains(t, got, "DSN=",
+		"env var name should remain visible")
 	require.Contains(t, got, "db.acme.com",
-		"non-sensitive URL parts should remain visible")
+		"non-sensitive parts of URL-shaped args should remain visible")
+}
 
-	// Cmd.String is the executable (shell) rendering: it intentionally
-	// includes the secret, per its godoc.
+// TestCmd_String_IncludesCredentials pins [execz.Cmd.String]'s documented
+// behavior: it is the executable (shell) rendering used by the db commands'
+// --print flag, and intentionally includes credentials.
+func TestCmd_String_IncludesCredentials(t *testing.T) {
+	cmd := &execz.Cmd{
+		Name: "pg_dumpall",
+		Env:  []string{"PGPASSWORD=hunter2"},
+		Args: []string{"--dbname", "postgres://alice:hunter2@db.acme.com:5432/sakila"},
+	}
+
 	require.Contains(t, cmd.String(), "PGPASSWORD=hunter2")
+	require.Contains(t, cmd.String(), "postgres://alice:hunter2@db.acme.com:5432/sakila")
 }

--- a/libsq/core/execz/execz_test.go
+++ b/libsq/core/execz/execz_test.go
@@ -1,0 +1,39 @@
+package execz_test
+
+import (
+	"bytes"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/neilotoole/sq/libsq/core/execz"
+)
+
+// TestCmd_LogValue_RedactsEnv verifies that logging a [execz.Cmd] does not
+// leak env values. Env vars passed to external tools exist to carry
+// connection material (e.g. PGPASSWORD set by postgres.DumpClusterCmd), so
+// the log rendering must mask every env value, not just URL-shaped ones.
+func TestCmd_LogValue_RedactsEnv(t *testing.T) {
+	cmd := &execz.Cmd{
+		Name: "pg_dumpall",
+		Env:  []string{"PGPASSWORD=hunter2"},
+		Args: []string{"--dbname", "postgres://alice:hunter2@db.acme.com:5432/sakila"},
+	}
+
+	buf := &bytes.Buffer{}
+	log := slog.New(slog.NewTextHandler(buf, nil))
+	log.Info("exec", "cmd", cmd)
+	got := buf.String()
+
+	require.NotContains(t, got, "hunter2",
+		"secret must not appear in log output")
+	require.Contains(t, got, "PGPASSWORD=",
+		"env var name should remain visible")
+	require.Contains(t, got, "db.acme.com",
+		"non-sensitive URL parts should remain visible")
+
+	// Cmd.String is the executable (shell) rendering: it intentionally
+	// includes the secret, per its godoc.
+	require.Contains(t, cmd.String(), "PGPASSWORD=hunter2")
+}

--- a/libsq/core/secret/memo_test.go
+++ b/libsq/core/secret/memo_test.go
@@ -1,0 +1,64 @@
+package secret_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/neilotoole/sq/libsq/core/secret"
+)
+
+// countingResolver counts Resolve invocations.
+type countingResolver struct {
+	err   error
+	value string
+	count int
+}
+
+func (r *countingResolver) Resolve(_ context.Context, _ string) (string, error) {
+	r.count++
+	if r.err != nil {
+		return "", r.err
+	}
+	return r.value, nil
+}
+
+// TestRegistry_MemoizesResolutions verifies that a Registry resolves each
+// distinct scheme:path at most once for the Registry's lifetime (one CLI
+// invocation). Several code paths resolve the same source location
+// independently (e.g. --src.schema validation opens a probe connection,
+// then Grips.doOpen opens the real one); without memoization each pass
+// costs a fresh backend hit, which for the keyring scheme is an OS
+// keychain roundtrip that may prompt the user.
+func TestRegistry_MemoizesResolutions(t *testing.T) {
+	ctx := context.Background()
+
+	reg := secret.NewRegistry()
+	counter := &countingResolver{value: "hunter2"}
+	reg.Register("test", counter)
+
+	for range 3 {
+		got, err := reg.Expand(ctx, "postgres://alice:${test:pw}@db.acme.com/sakila")
+		require.NoError(t, err)
+		require.Contains(t, got, "hunter2")
+	}
+	require.Equal(t, 1, counter.count,
+		"repeated resolution of the same placeholder should hit the backend once")
+
+	// A distinct path is a distinct memo entry.
+	_, err := reg.Expand(ctx, "${test:other}")
+	require.NoError(t, err)
+	require.Equal(t, 2, counter.count)
+
+	// Failures are not memoized: each attempt retries the backend.
+	failing := &countingResolver{err: errors.New("backend down")}
+	reg.Register("fail", failing)
+	for range 2 {
+		_, err = reg.Expand(ctx, "${fail:x}")
+		require.Error(t, err)
+	}
+	require.Equal(t, 2, failing.count,
+		"failed resolutions must not be cached")
+}

--- a/libsq/core/secret/secret.go
+++ b/libsq/core/secret/secret.go
@@ -33,7 +33,19 @@ type Resolver interface {
 // Registry maps schemes to Resolvers.
 type Registry struct {
 	resolvers map[string]Resolver
-	mu        sync.RWMutex
+
+	// memo caches successful resolutions, keyed by scheme and path, for
+	// the Registry's lifetime, which is a single CLI invocation. Several
+	// code paths resolve the same location independently (e.g.
+	// --src.schema validation opens a probe connection, then Grips.doOpen
+	// opens the real one); without the memo each pass costs a fresh
+	// backend hit, which for keyring is an OS keychain roundtrip that may
+	// prompt the user. The memo also gives one invocation a consistent
+	// view of each secret. Failures are not cached, so transient backend
+	// errors don't stick.
+	memo sync.Map
+
+	mu sync.RWMutex
 }
 
 // NewRegistry returns an empty Registry.
@@ -50,15 +62,29 @@ func (r *Registry) Register(scheme string, resolver Resolver) {
 }
 
 // ResolveScheme dispatches a single scheme/path pair to the appropriate
-// Resolver. Returns ErrUnknownScheme if scheme has no Resolver.
+// Resolver, memoizing successful resolutions for the Registry's lifetime.
+// Returns ErrUnknownScheme if scheme has no Resolver.
 func (r *Registry) ResolveScheme(ctx context.Context, scheme, path string) (string, error) {
+	// NUL can't occur in a scheme (validateScheme permits only
+	// [a-z0-9]), so the key is unambiguous.
+	key := scheme + "\x00" + path
+	if v, ok := r.memo.Load(key); ok {
+		return v.(string), nil
+	}
+
 	r.mu.RLock()
 	resolver, ok := r.resolvers[scheme]
 	r.mu.RUnlock()
 	if !ok {
 		return "", ErrUnknownScheme
 	}
-	return resolver.Resolve(ctx, path)
+
+	v, err := resolver.Resolve(ctx, path)
+	if err != nil {
+		return "", err
+	}
+	r.memo.Store(key, v)
+	return v, nil
 }
 
 type ctxKey struct{}

--- a/libsq/files/cache.go
+++ b/libsq/files/cache.go
@@ -343,10 +343,94 @@ func (fs *Files) CacheClearAll(ctx context.Context) error {
 // CacheClearSource clears the ingest cache for src. If arg downloads is true,
 // the source's download dir is also cleared. The caller should typically
 // first acquire the cache lock for src via Files.cacheLockFor.
+//
+// Note that this clears only the cache dir for src's current location
+// hash (see CacheDirFor). It is used internally by ingest, which holds
+// that dir's lock and knows the resolved location. For clearing a
+// source's cache wholesale, see CacheClearSourceAll.
 func (fs *Files) CacheClearSource(ctx context.Context, src *source.Source, clearDownloads bool) error {
 	fs.mu.Lock()
 	defer fs.mu.Unlock()
 	return fs.doCacheClearSource(ctx, src, clearDownloads)
+}
+
+// CacheClearSourceAll clears the ingest cache for src by removing every
+// cache dir belonging to src.Handle, regardless of location hash. The
+// per-source cache dir leaf (see CacheDirFor) is keyed on a hash that
+// incorporates src.Location: for a location containing ${scheme:path}
+// placeholders that's the resolved location, whose hash cannot be
+// recomputed if the secret has rotated or become unavailable. Removing
+// every leaf under the handle's dir catches them all, including leaves
+// orphaned by changed options, catalog, or schema, and requires no
+// secret resolution. Downloads are cleared too.
+//
+// collHandles is the set of all handles in the active collection. It is
+// needed because a handle may coincide with a group prefix of another
+// handle (e.g. @prod and @prod/db/x can coexist), in which case the
+// nested source's cache dirs live below this handle's dir and must be
+// left untouched.
+func (fs *Files) CacheClearSourceAll(ctx context.Context, src *source.Source, collHandles []string) error {
+	fs.mu.Lock()
+	defer fs.mu.Unlock()
+
+	log := lg.FromContext(ctx)
+
+	handle := src.Handle
+	if err := source.ValidHandle(handle); err != nil {
+		return errz.Wrapf(err, "clear cache: invalid handle: %s", handle)
+	}
+
+	handleDir := filepath.Join(
+		fs.cacheDir,
+		"sources",
+		filepath.Join(strings.Split(strings.TrimPrefix(handle, "@"), "/")...),
+	)
+	if !ioz.DirExists(handleDir) {
+		return nil
+	}
+
+	// Child dirs of handleDir are location-hash leaves, except where
+	// another source's handle nests under this handle: its first path
+	// segment below this handle names a child dir that must survive.
+	nested := map[string]bool{}
+	prefix := strings.TrimPrefix(handle, "@") + "/"
+	for _, h := range collHandles {
+		if hp := strings.TrimPrefix(h, "@"); strings.HasPrefix(hp, prefix) {
+			nested[strings.SplitN(strings.TrimPrefix(hp, prefix), "/", 2)[0]] = true
+		}
+	}
+
+	entries, err := os.ReadDir(handleDir)
+	if err != nil {
+		return errz.Wrapf(err, "%s: clear cache", handle)
+	}
+
+	tmpDir := DefaultTempDir()
+	if err = ioz.RequireDir(tmpDir); err != nil {
+		return errz.Wrapf(err, "%s: clear cache", handle)
+	}
+
+	for _, entry := range entries {
+		if !entry.IsDir() || nested[entry.Name()] {
+			continue
+		}
+
+		// As with doCacheClearAll, relocate each leaf before deleting,
+		// which copes with another sq instance holding an open pid lock
+		// inside the leaf.
+		leafDir := filepath.Join(handleDir, entry.Name())
+		relocateDir := filepath.Join(tmpDir, "dead_cache_"+stringz.Uniq8())
+		if err = os.Rename(leafDir, relocateDir); err != nil {
+			return errz.Wrapf(err, "%s: clear cache: relocate", handle)
+		}
+		if err = os.RemoveAll(relocateDir); err != nil {
+			log.Warn("Could not delete relocated source cache dir",
+				lga.Src, src, lga.Path, relocateDir, lga.Err, err)
+		}
+	}
+
+	log.With(lga.Src, src, lga.Dir, handleDir).Info("Cleared source cache")
+	return nil
 }
 
 func (fs *Files) doCacheClearSource(ctx context.Context, src *source.Source, clearDownloads bool) error {

--- a/libsq/files/cache.go
+++ b/libsq/files/cache.go
@@ -63,14 +63,19 @@ func (fs *Files) CacheDirFor(src *source.Source) (dir string, err error) {
 		handle += "_" + stringz.UniqN(32)
 	}
 
-	dir = filepath.Join(
+	return filepath.Join(fs.sourceHandleDir(handle), fs.sourceHash(src)), nil
+}
+
+// sourceHandleDir returns the parent dir of all of handle's cache dirs:
+// CacheDirFor returns sourceHandleDir(handle)/<location-hash>. This is
+// the single encoding of the handle-to-path layout; keep CacheDirFor and
+// CacheClearSourceAll in sync by changing only this function.
+func (fs *Files) sourceHandleDir(handle string) string {
+	return filepath.Join(
 		fs.cacheDir,
 		"sources",
 		filepath.Join(strings.Split(strings.TrimPrefix(handle, "@"), "/")...),
-		fs.sourceHash(src),
 	)
-
-	return dir, nil
 }
 
 // WriteIngestChecksum is invoked (after successful ingestion) to write the
@@ -309,19 +314,26 @@ func (fs *Files) CacheLockAcquire(ctx context.Context, src *source.Source) (unlo
 		return nil, err
 	}
 
+	return lockAcquire(ctx, lock, src.Handle)
+}
+
+// lockAcquire acquires lock, honoring [OptCacheLockTimeout] from ctx
+// options and displaying a progress waiter labeled with label. The caller
+// must invoke the returned unlock func.
+func lockAcquire(ctx context.Context, lock lockfile.Lockfile, label string) (unlock func(), err error) {
 	lockTimeout := OptCacheLockTimeout.Get(options.FromContext(ctx))
-	log := lg.FromContext(ctx).With(lga.Src, src, lga.Timeout, lockTimeout, lga.Lock, lock)
-	log.Debug("Acquiring cache lock for source")
+	log := lg.FromContext(ctx).With(lga.Timeout, lockTimeout, lga.Lock, lock)
+	log.Debug("Acquiring cache lock")
 
 	bar := progress.FromContext(ctx).NewTimeoutWaiter(
-		src.Handle+": acquire lock",
+		label+": acquire lock",
 		time.Now().Add(lockTimeout),
 	)
 
 	err = lock.Lock(ctx, lockTimeout)
 	bar.Stop()
 	if err != nil {
-		return nil, errz.Wrap(err, src.Handle+": acquire cache lock")
+		return nil, errz.Wrap(err, label+": acquire cache lock")
 	}
 
 	return func() {
@@ -364,11 +376,16 @@ func (fs *Files) CacheClearSource(ctx context.Context, src *source.Source, clear
 // orphaned by changed options, catalog, or schema, and requires no
 // secret resolution. Downloads are cleared too.
 //
+// Each leaf's cache lock is acquired (honoring [OptCacheLockTimeout])
+// before that leaf is cleared, so a concurrent ingest is not disrupted.
+//
 // collHandles is the set of all handles in the active collection. It is
 // needed because a handle may coincide with a group prefix of another
-// handle (e.g. @prod and @prod/db/x can coexist), in which case the
-// nested source's cache dirs live below this handle's dir and must be
-// left untouched.
+// handle (e.g. @prod and @prod/db/x), in which case the nested source's
+// cache dirs live below this handle's dir and must be left untouched.
+// Collection.Add and the sq mv paths now reject creating such nesting,
+// but it can exist in configs created before that validation, or
+// hand-edited YAML, which is never re-validated for nesting.
 func (fs *Files) CacheClearSourceAll(ctx context.Context, src *source.Source, collHandles []string) error {
 	fs.mu.Lock()
 	defer fs.mu.Unlock()
@@ -380,11 +397,7 @@ func (fs *Files) CacheClearSourceAll(ctx context.Context, src *source.Source, co
 		return errz.Wrapf(err, "clear cache: invalid handle: %s", handle)
 	}
 
-	handleDir := filepath.Join(
-		fs.cacheDir,
-		"sources",
-		filepath.Join(strings.Split(strings.TrimPrefix(handle, "@"), "/")...),
-	)
+	handleDir := fs.sourceHandleDir(handle)
 	if !ioz.DirExists(handleDir) {
 		return nil
 	}
@@ -405,29 +418,42 @@ func (fs *Files) CacheClearSourceAll(ctx context.Context, src *source.Source, co
 		return errz.Wrapf(err, "%s: clear cache", handle)
 	}
 
-	tmpDir := DefaultTempDir()
-	if err = ioz.RequireDir(tmpDir); err != nil {
-		return errz.Wrapf(err, "%s: clear cache", handle)
-	}
-
 	for _, entry := range entries {
 		if !entry.IsDir() || nested[entry.Name()] {
 			continue
 		}
 
-		// As with doCacheClearAll, relocate each leaf before deleting,
-		// which copes with another sq instance holding an open pid lock
-		// inside the leaf.
+		// Acquire the leaf's cache lock before touching it: a concurrent
+		// ingest (Grips.OpenIngest) holds this lock for the duration of
+		// the ingest, and must not have the cache yanked out from under
+		// it mid-write.
 		leafDir := filepath.Join(handleDir, entry.Name())
-		relocateDir := filepath.Join(tmpDir, "dead_cache_"+stringz.Uniq8())
-		if err = os.Rename(leafDir, relocateDir); err != nil {
-			return errz.Wrapf(err, "%s: clear cache: relocate", handle)
+		lock, lockErr := lockfile.New(filepath.Join(leafDir, "pid.lock"))
+		if lockErr != nil {
+			return errz.Wrapf(lockErr, "%s: clear cache", handle)
 		}
-		if err = os.RemoveAll(relocateDir); err != nil {
-			log.Warn("Could not delete relocated source cache dir",
-				lga.Src, src, lga.Path, relocateDir, lga.Err, err)
+		unlock, lockErr := lockAcquire(ctx, lock, handle)
+		if lockErr != nil {
+			return lockErr
 		}
+
+		err = clearCacheDirContents(leafDir, true, handle)
+		unlock()
+		if err != nil {
+			return err
+		}
+
+		// The leaf is now empty: its contents are cleared and unlock
+		// removed pid.lock. Remove the dir itself, non-recursively: if a
+		// concurrent process re-acquired the lock in the interim, the
+		// dir is non-empty and Remove fails, which is fine, as the
+		// leaf's cache contents are already gone.
+		_ = os.Remove(leafDir)
 	}
+
+	// Best-effort: prune handleDir (and the handle's group dirs) if now
+	// empty. Failure is fine: doCacheSweep prunes empty dirs eventually.
+	_ = os.Remove(handleDir)
 
 	log.With(lga.Src, src, lga.Dir, handleDir).Info("Cleared source cache")
 	return nil
@@ -443,9 +469,24 @@ func (fs *Files) doCacheClearSource(ctx context.Context, src *source.Source, cle
 		return nil
 	}
 
+	if err = clearCacheDirContents(cacheDir, clearDownloads, src.Handle); err != nil {
+		return err
+	}
+
+	lg.FromContext(ctx).
+		With("clear_downloads", clearDownloads, lga.Src, src, lga.Dir, cacheDir).
+		Info("Cleared source cache")
+	return nil
+}
+
+// clearCacheDirContents removes the contents of the cache dir, always
+// preserving pid.lock (which may be held, including by the caller), and
+// preserving the download dir if clearDownloads is false. Arg handle is
+// used for error messages only.
+func clearCacheDirContents(cacheDir string, clearDownloads bool, handle string) error {
 	entries, err := os.ReadDir(cacheDir)
 	if err != nil {
-		return errz.Wrapf(err, "%s: clear cache", src.Handle)
+		return errz.Wrapf(err, "%s: clear cache", handle)
 	}
 
 	for _, entry := range entries {
@@ -460,13 +501,9 @@ func (fs *Files) doCacheClearSource(ctx context.Context, src *source.Source, cle
 		}
 
 		if err = os.RemoveAll(filepath.Join(cacheDir, entry.Name())); err != nil {
-			return errz.Wrapf(err, "%s: clear cache", src.Handle)
+			return errz.Wrapf(err, "%s: clear cache", handle)
 		}
 	}
-
-	lg.FromContext(ctx).
-		With("clear_downloads", clearDownloads, lga.Src, src, lga.Dir, cacheDir).
-		Info("Cleared source cache")
 	return nil
 }
 

--- a/libsq/files/cache_test.go
+++ b/libsq/files/cache_test.go
@@ -1,0 +1,126 @@
+package files_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/neilotoole/sq/libsq/core/ioz"
+	"github.com/neilotoole/sq/libsq/core/lg"
+	"github.com/neilotoole/sq/libsq/core/lg/lgt"
+	"github.com/neilotoole/sq/libsq/core/options"
+	"github.com/neilotoole/sq/libsq/files"
+	"github.com/neilotoole/sq/libsq/source"
+	"github.com/neilotoole/sq/libsq/source/drivertype"
+	"github.com/neilotoole/sq/testh"
+	"github.com/neilotoole/sq/testh/tu"
+)
+
+func newTestFiles(t *testing.T) (context.Context, *files.Files) {
+	t.Helper()
+	ctx := lg.NewContext(context.Background(), lgt.New(t))
+	optReg := &options.Registry{}
+	optReg.Add(files.OptCacheLockTimeout)
+	fs, err := files.New(
+		ctx,
+		optReg,
+		testh.TempLockFunc(t),
+		tu.TempDir(t, "temp"),
+		tu.TempDir(t, "cache"),
+	)
+	require.NoError(t, err)
+	return ctx, fs
+}
+
+// populateLeaf creates a fake ingest-cache leaf dir with a cache DB file,
+// returning the cache DB path.
+func populateLeaf(t *testing.T, leafDir string) (cacheDB string) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(leafDir, 0o700))
+	cacheDB = filepath.Join(leafDir, "cache.sqlite.db")
+	require.NoError(t, os.WriteFile(cacheDB, []byte("fake"), 0o600))
+	return cacheDB
+}
+
+// TestFiles_CacheClearSourceAll_ClearsAllLeaves verifies that every cache
+// leaf under the handle's dir is cleared, not just the leaf for the
+// source's current location hash: leaves accumulate when the location
+// (e.g. a rotated secret), options, or schema change.
+func TestFiles_CacheClearSourceAll_ClearsAllLeaves(t *testing.T) {
+	ctx, fs := newTestFiles(t)
+
+	src := &source.Source{Handle: "@prod", Type: drivertype.CSV, Location: "/tmp/a.csv"}
+
+	currentLeaf, currentDB, _, err := fs.CachePaths(src)
+	require.NoError(t, err)
+	populateLeaf(t, currentLeaf)
+
+	// A leaf left over from a previous location hash.
+	staleDB := populateLeaf(t, filepath.Join(filepath.Dir(currentLeaf), "deadbeef"))
+
+	require.NoError(t, fs.CacheClearSourceAll(ctx, src, []string{src.Handle}))
+	require.False(t, ioz.FileAccessible(currentDB))
+	require.False(t, ioz.FileAccessible(staleDB))
+}
+
+// TestFiles_CacheClearSourceAll_PreservesNestedHandleDirs verifies that
+// clearing @prod doesn't touch cache dirs of a source whose handle nests
+// under it (e.g. @prod/db/x): such nesting can exist in legacy or
+// hand-edited configs, and the nested source's cache dirs live below
+// @prod's cache dir on disk.
+func TestFiles_CacheClearSourceAll_PreservesNestedHandleDirs(t *testing.T) {
+	ctx, fs := newTestFiles(t)
+
+	parent := &source.Source{Handle: "@prod", Type: drivertype.CSV, Location: "/tmp/a.csv"}
+	nested := &source.Source{Handle: "@prod/db/x", Type: drivertype.CSV, Location: "/tmp/b.csv"}
+
+	parentLeaf, parentDB, _, err := fs.CachePaths(parent)
+	require.NoError(t, err)
+	populateLeaf(t, parentLeaf)
+
+	nestedLeaf, nestedDB, _, err := fs.CachePaths(nested)
+	require.NoError(t, err)
+	populateLeaf(t, nestedLeaf)
+
+	require.NoError(t, fs.CacheClearSourceAll(ctx, parent,
+		[]string{parent.Handle, nested.Handle}))
+	require.False(t, ioz.FileAccessible(parentDB))
+	require.True(t, ioz.FileAccessible(nestedDB),
+		"clearing @prod must not clear @prod/db/x's cache")
+}
+
+// TestFiles_CacheClearSourceAll_BlockedByLockHolder verifies that clear
+// respects the per-leaf cache lock: a concurrent ingest (Grips.OpenIngest)
+// holds the leaf's pid.lock for the duration of the ingest, and clear must
+// not yank the cache dir out from under it.
+func TestFiles_CacheClearSourceAll_BlockedByLockHolder(t *testing.T) {
+	ctx, fs := newTestFiles(t)
+
+	src := &source.Source{Handle: "@prod", Type: drivertype.CSV, Location: "/tmp/a.csv"}
+	leafDir, cacheDB, _, err := fs.CachePaths(src)
+	require.NoError(t, err)
+	populateLeaf(t, leafDir)
+
+	// Simulate another process holding the leaf's cache lock. The pid
+	// must belong to a live foreign process: the lockfile package treats
+	// a lock held by our own pid as acquirable, so the test process's
+	// parent pid is used.
+	lockPath := filepath.Join(leafDir, "pid.lock")
+	require.NoError(t, os.WriteFile(lockPath,
+		[]byte(strconv.Itoa(os.Getppid())+"\n"), 0o600))
+
+	// Short lock timeout so the test fails fast.
+	ctx = options.NewContext(ctx, options.Options{
+		files.OptCacheLockTimeout.Key(): "25ms",
+	})
+
+	err = fs.CacheClearSourceAll(ctx, src, []string{src.Handle})
+	require.Error(t, err,
+		"clear must not proceed while another process holds the leaf's cache lock")
+	require.True(t, ioz.FileAccessible(cacheDB),
+		"the locked leaf's cache must be untouched")
+}

--- a/libsq/source/collection.go
+++ b/libsq/source/collection.go
@@ -150,18 +150,40 @@ func (c *Collection) Add(src *Source) error {
 		return errz.Errorf("conflict: source with handle %s already exists", src.Handle)
 	}
 
-	srcGroup := src.Group()
-	if c.isExistingHandle("@" + srcGroup) {
-		return errz.Errorf("conflict: source's group %q conflicts with existing handle %s",
-			srcGroup, "@"+srcGroup)
+	if err := c.requireNoAncestorHandle(src.Group()); err != nil {
+		return err
 	}
 
 	if c.isExistingGroup(src.Handle[1:]) {
 		return errz.Errorf("conflict: handle %s clashes with existing group %q",
-			src.Handle, src.Handle[1])
+			src.Handle, src.Handle[1:])
 	}
 
 	c.data.Sources = append(c.data.Sources, src)
+	return nil
+}
+
+// requireNoAncestorHandle returns an error if group, or any ancestor of
+// group, is the name of an existing handle. For group "prod/db" it checks
+// handles @prod and @prod/db. This prevents a source (or group) from
+// nesting below an existing handle: handles and groups share path
+// semantics (e.g. the cache dir layout maps handle path segments to
+// directories), so e.g. @prod and @prod/db/x must not coexist. The
+// reverse direction (a new handle clashing with an existing group) is
+// enforced via isExistingGroup, whose groups() expansion is transitive.
+func (c *Collection) requireNoAncestorHandle(group string) error {
+	if group == "" || group == "/" {
+		return nil
+	}
+
+	parts := strings.Split(group, "/")
+	for i := range parts {
+		ancestor := "@" + strings.Join(parts[:i+1], "/")
+		if c.isExistingHandle(ancestor) {
+			return errz.Errorf("conflict: group %q conflicts with existing handle %s",
+				group, ancestor)
+		}
+	}
 	return nil
 }
 
@@ -232,6 +254,10 @@ func (c *Collection) renameSource(oldHandle, newHandle string) (*Source, error) 
 			newHandle, newHandle[1:])
 	}
 
+	if err = c.requireNoAncestorHandle(groupFromHandle(newHandle)); err != nil {
+		return nil, err
+	}
+
 	oldGroup := src.Group()
 
 	// Do the actual renaming of the handle.
@@ -278,9 +304,8 @@ func (c *Collection) RenameGroup(oldGroup, newGroup string) ([]*Source, error) {
 		return nil, err
 	}
 
-	if c.isExistingHandle("@" + newGroup) {
-		return nil, errz.Errorf("conflict: new group %q conflicts with existing handle %s",
-			newGroup, "@"+newGroup)
+	if err := c.requireNoAncestorHandle(newGroup); err != nil {
+		return nil, err
 	}
 
 	if newGroup == "/" {
@@ -339,9 +364,10 @@ func (c *Collection) MoveHandleToGroup(handle, toGroup string) (*Source, error) 
 		return nil, err
 	}
 
-	if c.isExistingHandle("@" + toGroup) {
-		return nil, errz.Errorf("conflict: dest group %q conflicts with existing handle %s",
-			toGroup, "@"+toGroup)
+	if toGroup != "/" {
+		if err := c.requireNoAncestorHandle(toGroup); err != nil {
+			return nil, err
+		}
 	}
 
 	var newHandle string

--- a/libsq/source/handle.go
+++ b/libsq/source/handle.go
@@ -7,7 +7,6 @@ import (
 	"slices"
 	"strconv"
 	"strings"
-	"unicode"
 
 	"github.com/neilotoole/sq/libsq/core/errz"
 	"github.com/neilotoole/sq/libsq/core/secret"
@@ -185,10 +184,6 @@ func SuggestHandle(coll *Collection, typ drivertype.Type, loc string) (string, e
 	// suggest time, because the resolved value would be machine-
 	// dependent (defeats placeholder portability).
 	if name, ok := suggestNameFromPlaceholder(loc); ok {
-		// Sanitize just like the URL-parse branch below: hyphens, dots,
-		// spaces etc. in the placeholder body are legal there but
-		// illegal in a handle.
-		name = stringz.SanitizeAlphaNumeric(name, '_')
 		return finalizeSuggestedHandle(coll, name), nil
 	}
 
@@ -221,21 +216,38 @@ func SuggestHandle(coll *Collection, typ drivertype.Type, loc string) (string, e
 	// UX reports will suggest that "@prod/csv/actor" is preferable,
 	// and thus we would still need ext.
 	_ = ext
-	name := stringz.SanitizeAlphaNumeric(locFields.Name, '_')
 
-	return finalizeSuggestedHandle(coll, name), nil
+	return finalizeSuggestedHandle(coll, locFields.Name), nil
 }
 
-// finalizeSuggestedHandle takes a raw name (already alphanumeric-ish)
-// and produces the final "@[group/]<name>[<n>]" handle, applying the
-// 'h'-prefix rule for non-letter starts, the active-group prefix, and
-// the uniqueness-suffix loop.
+// finalizeSuggestedHandle takes a raw name and produces the final
+// "@[group/]<name>[<n>]" handle: it sanitizes runes that are illegal in
+// a handle, applies the 'h'-prefix rule for non-letter starts, the
+// active-group prefix, and the uniqueness-suffix loop.
 func finalizeSuggestedHandle(coll *Collection, name string) string {
+	// Sanitize: the handle grammar (see handlePattern) permits only
+	// ASCII [a-zA-Z0-9_] in a segment, so every other rune becomes
+	// underscore. Note that stringz.SanitizeAlphaNumeric is NOT
+	// sufficient here: it keeps non-ASCII unicode letters (e.g. 'ö')
+	// that ValidHandle rejects.
+	rs := []rune(name)
+	for i, r := range rs {
+		switch {
+		case r == '_',
+			r >= 'a' && r <= 'z',
+			r >= 'A' && r <= 'Z',
+			r >= '0' && r <= '9':
+		default:
+			rs[i] = '_'
+		}
+	}
+	name = string(rs)
+
 	// if the name is empty, we use "h" (for "handle"), e.g "@h".
 	if name == "" {
 		name = "h"
-	} else if !unicode.IsLetter([]rune(name)[0]) {
-		// If the first rune is not a letter, we prepend "h".
+	} else if !isASCIILetter(name[0]) {
+		// If the first char is not a letter, we prepend "h".
 		// So "123" becomes "h123", or "_123" becomes "h_123".
 		name = "h" + name
 	}

--- a/libsq/source/handle.go
+++ b/libsq/source/handle.go
@@ -185,6 +185,10 @@ func SuggestHandle(coll *Collection, typ drivertype.Type, loc string) (string, e
 	// suggest time, because the resolved value would be machine-
 	// dependent (defeats placeholder portability).
 	if name, ok := suggestNameFromPlaceholder(loc); ok {
+		// Sanitize just like the URL-parse branch below: hyphens, dots,
+		// spaces etc. in the placeholder body are legal there but
+		// illegal in a handle.
+		name = stringz.SanitizeAlphaNumeric(name, '_')
 		return finalizeSuggestedHandle(coll, name), nil
 	}
 

--- a/libsq/source/handle_test.go
+++ b/libsq/source/handle_test.go
@@ -173,6 +173,16 @@ func TestSuggestHandle_FromPlaceholder(t *testing.T) {
 		{loc: "${keyring:@sakila/conn_str}", want: "@sakila"},
 		{loc: "${keyring:@prod_db/password}", want: "@prod_db"},
 
+		// Names containing runes illegal in handles (hyphens, dots,
+		// spaces) must be sanitized to underscore, matching the URL
+		// branch of SuggestHandle. Without this, the suggested handle
+		// fails ValidHandle and the add aborts.
+		{loc: "${file:/secrets/pg-prod.dsn}", want: "@pg_prod"},
+		{loc: "${file:/secrets/my db.dsn}", want: "@my_db"},
+		{loc: "${env:MY-DSN}", want: "@my_dsn"},
+		{loc: "${op://Private/sakila-pg/dsn}", want: "@sakila_pg"},
+		{loc: "${vault:secret/data/pg.prod}", want: "@pg_prod"},
+
 		// keyring opaque (Crockford) — falls through to the generic
 		// path, which produces the existing "h"-prefixed ugly form.
 		// We don't try to make this pretty; rare hand-crafted case.

--- a/libsq/source/handle_test.go
+++ b/libsq/source/handle_test.go
@@ -183,6 +183,12 @@ func TestSuggestHandle_FromPlaceholder(t *testing.T) {
 		{loc: "${op://Private/sakila-pg/dsn}", want: "@sakila_pg"},
 		{loc: "${vault:secret/data/pg.prod}", want: "@pg_prod"},
 
+		// Non-ASCII letters are also illegal in handles (the handle
+		// grammar is ASCII [a-zA-Z][a-zA-Z0-9_]*), so they sanitize to
+		// underscore too.
+		{loc: "${file:/secrets/börse.dsn}", want: "@b_rse"},
+		{loc: "${env:CAFÉ_DSN}", want: "@caf__dsn"},
+
 		// keyring opaque (Crockford) — falls through to the generic
 		// path, which produces the existing "h"-prefixed ugly form.
 		// We don't try to make this pretty; rare hand-crafted case.

--- a/libsq/source/source_test.go
+++ b/libsq/source/source_test.go
@@ -399,6 +399,63 @@ func TestCollection_Add_groupConflictsWithSource(t *testing.T) {
 	require.Error(t, coll.Add(src2), "handle group (sakila) conflicts with source @sakila")
 }
 
+// TestCollection_Add_rejectsNestingUnderAncestorHandle verifies that a new
+// handle cannot nest below an existing handle at any depth. The immediate
+// case (@sakila, then @sakila/sakiladb) is covered by
+// TestCollection_Add_groupConflictsWithSource; this exercises the deeper
+// case that previously slipped through: only the new handle's immediate
+// group was checked against existing handles, so @prod followed by
+// @prod/db/x was accepted, while the reverse order was rejected. Handles
+// and groups share path semantics (e.g. the cache dir layout), so the
+// check must be symmetric and transitive in both directions.
+func TestCollection_Add_rejectsNestingUnderAncestorHandle(t *testing.T) {
+	coll := &source.Collection{}
+	require.NoError(t, coll.Add(newSource("@prod")))
+
+	err := coll.Add(newSource("@prod/db/x"))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "@prod")
+}
+
+// TestCollection_RenameSource_rejectsNestingUnderHandle verifies that
+// renaming (sq mv @x @prod/x) cannot create a handle nested below an
+// existing handle: RenameSource previously performed no such check at
+// all, so it could create nesting that Add would reject.
+func TestCollection_RenameSource_rejectsNestingUnderHandle(t *testing.T) {
+	coll := &source.Collection{}
+	require.NoError(t, coll.Add(newSource("@prod")))
+	require.NoError(t, coll.Add(newSource("@x")))
+
+	_, err := coll.RenameSource("@x", "@prod/x")
+	require.Error(t, err, "depth-1 nesting under @prod must be rejected")
+
+	_, err = coll.RenameSource("@x", "@prod/db/x")
+	require.Error(t, err, "deep nesting under @prod must be rejected")
+}
+
+// TestCollection_MoveHandleToGroup_rejectsNestingUnderHandle: moving a
+// source into a group whose path nests below an existing handle must be
+// rejected, including when only an ancestor of the dest group collides.
+func TestCollection_MoveHandleToGroup_rejectsNestingUnderHandle(t *testing.T) {
+	coll := &source.Collection{}
+	require.NoError(t, coll.Add(newSource("@prod")))
+	require.NoError(t, coll.Add(newSource("@x")))
+
+	_, err := coll.MoveHandleToGroup("@x", "prod/db")
+	require.Error(t, err, "moving @x into group prod/db nests it under handle @prod")
+}
+
+// TestCollection_RenameGroup_rejectsNestingUnderHandle: renaming a group
+// to a path nested below an existing handle must be rejected.
+func TestCollection_RenameGroup_rejectsNestingUnderHandle(t *testing.T) {
+	coll := &source.Collection{}
+	require.NoError(t, coll.Add(newSource("@g/x")))
+	require.NoError(t, coll.Add(newSource("@prod")))
+
+	_, err := coll.RenameGroup("g", "prod/sub")
+	require.Error(t, err, "renaming group g to prod/sub nests its sources under handle @prod")
+}
+
 func TestCollection_RenameGroup(t *testing.T) {
 	coll := &source.Collection{}
 

--- a/site/content/en/docs/cmd/driver-ls.output.txt
+++ b/site/content/en/docs/cmd/driver-ls.output.txt
@@ -1,5 +1,6 @@
 DRIVER      DESCRIPTION                            USER-DEFINED  DOC
 sqlite3     SQLite                                 false         https://github.com/mattn/go-sqlite3
+rqlite      rqlite                                 false         https://rqlite.io
 duckdb      DuckDB                                 false         https://duckdb.org
 postgres    PostgreSQL                             false         https://github.com/jackc/pgx
 sqlserver   Microsoft SQL Server                   false         https://github.com/microsoft/go-mssqldb

--- a/site/content/en/docs/cmd/sql.help.txt
+++ b/site/content/en/docs/cmd/sql.help.txt
@@ -54,6 +54,8 @@ Flags:
       --no-cache                       Don't cache ingest data
       --driver.csv.delim string        Delimiter for ingest CSV data (default "comma")
       --driver.csv.empty-as-null       Treat ingest empty CSV fields as NULL (default true)
+      --readonly                       Open sources read-only (DuckDB only; other drivers ignore)
+      --ro                             Alias for --readonly
       --help                           help for sql
 
 Global Flags:


### PR DESCRIPTION
Fixes #783, the four placeholder-resolution gaps found in the v0.54.0 pre-release review. Placeholder resolution lives inside `Grips.doOpen`, so code paths that use `src.Location` without going through it operated on the literal `${scheme:path}` text.

## Changes

- **`sq db dump|restore|exec`**: resolve placeholders at the call site (all five command funcs) before building the `pg_dump`/`pg_dumpall`/`pg_restore`/`psql` command. Previously the tools received the raw placeholder DSN and failed auth, and `DumpClusterCmd` set `PGPASSWORD` to the literal placeholder text. With `--print`, the printed command now contains the resolved DSN, consistent with the documented behavior for inline-credential sources ("the output will include DB credentials").
- **`--src.schema` validation**: `verifySourceCatalogSchema` deliberately bypasses the grip cache via `d.Open`, which also bypassed resolution. It now resolves before handing the source to the driver, keeping the resolved clone local so nothing templated is overwritten.
- **`sq cache clear @src`**: the ingest cache dir is hashed from the resolved location (doc drivers receive the resolved clone from `Grips.doOpen`), but cache clear hashed the raw config location: it cleared a nonexistent dir, reported success, left the real cache intact, and its cache lock guarded the wrong dir. It now resolves before acquiring the lock and clearing.
- **`sq add` handle suggestion**: the bare-placeholder branch of `SuggestHandle` skipped `stringz.SanitizeAlphaNumeric`, so `sq add '${file:/secrets/pg-prod.dsn}'` suggested `@pg-prod`, which `ValidHandle` rejects, aborting the add. The placeholder branch now sanitizes like the URL branch: `@pg_prod`.

Each fix follows the existing call-site-resolution precedent in `cmd_ping.go`/`cmd_add.go`. The broader restructuring (moving resolve-vs-cache inside `Grips`, centralizing per-command opt-ins) stays with #779/#780.

## Tests

Each fix was reproduced by a failing test first:

- `TestCmdDB_Placeholder_Resolved` (new `cli/cmd_db_test.go`): all five db subcommands via `--print` with a `${env:...}` placeholder pg source; asserts the resolved secret appears and the placeholder text does not.
- `TestCmdInspect_FlagActiveSchema_Placeholder`: `sq inspect --src.schema main` against a SQLite source whose location is a bare placeholder; previously failed with `invalid sqlite3 location`.
- `TestCmdCacheClear_Placeholder` (new `cli/cmd_cache_test.go`): ingests a placeholder CSV source, asserts the cache DB lands under the resolved-location hash, then asserts `cache clear` actually removes it; previously the clear reported success while the cache survived.
- `TestSuggestHandle_FromPlaceholder`: new cases for hyphenated, dotted, and space-containing names across the `file`/`env`/`op`/`vault` schemes.

No CHANGELOG entry: all four bugs only manifest with `${scheme:path}` placeholder locations, which ship in the same release as the fixes (#441 is still under Unreleased).

`make lint` clean; `go test -short ./...` passes.

## Review follow-ups (second commit)

A code review of the first commit surfaced two issues, fixed in the follow-up commit:

- **Secret leak to logs**: once placeholders resolve before `DumpClusterCmd`, the resolved password landed in `PGPASSWORD` in `execz.Cmd.Env`, and the log rendering (`Cmd.LogValue`) only redacted URL-shaped env values, so `sq db dump cluster` wrote the plaintext secret to the log file. The log rendering now masks every env value (URL-shaped values keep their non-sensitive parts via `location.Redact`). `Cmd.String`, used by `--print`, is unchanged: it's documented to include credentials. This also resolves the old `FIXME: need mechanism to indicate that env contains password` in `tools.go`.
- **Cache clear made hash-independent**: resolving the location and clearing the one dir under that hash failed outright when the secret was unavailable, and silently missed dirs ingested under a previous value of the secret. `sq cache clear @src` now uses a new `Files.CacheClearSourceAll`, which removes every cache dir belonging to the handle (no secret resolution at all), using the `doCacheClearAll` relocate-then-delete pattern. It skips dirs belonging to sources whose handles nest under `@src`: `@prod` and `@prod/db/x` can coexist (`Collection.Add` only checks the immediate group), and the nested source's cache lives below `@prod`'s dir. New tests cover the rotated-secret, unresolvable-secret, and nested-handle cases.


## Deep-review fixes (third commit)

A second, deeper review pass (after Copilot reviewed with no comments) surfaced further issues, all fixed in the third commit:

- **execz env redaction completed**: URL-shaped env values were only partially redacted via `location.Redact` (userinfo password only), so a query-string secret (`?sslpassword=...`) would survive into logs. The log rendering now masks every env value outright; `Cmd.String` / `--print` unchanged.
- **`CacheClearSourceAll` regressions fixed**: the relocate-to-temp-dir approach failed with `EXDEV` whenever the cache dir and `os.TempDir()` are on different filesystems (tmpfs `/tmp` on Fedora/Arch), took no cross-process lock (a concurrent ingest could have its leaf renamed away mid-write, and the displaced `pid.lock` let a third process double-acquire), and downgraded deletion errors to warnings. Leaves are now cleared in place, each under its own `pid.lock` (honoring `cache.lock.timeout`), with errors propagated. The handle-to-path layout is now encoded once in `fs.sourceHandleDir`.
- **Root cause of handle nesting fixed in `Collection`**: `@prod` + `@prod/db/x` could coexist because `Add` checked only the immediate group against handles (the reverse check was transitive), and `RenameSource`/`MoveHandleToGroup`/`RenameGroup` checked less or nothing, so `sq mv @x @prod/x` could create nesting `Add` rejects. All four paths now reject ancestor-handle conflicts. The `collHandles` defense in `CacheClearSourceAll` is retained for legacy/hand-edited configs. Also fixes a `Handle[1]`-vs-`Handle[1:]` typo in `Add`'s error message.
- **Secret resolution memoized per run**: `--src.schema` flows resolved the same secret twice (validation open + real open); the `Registry` now memoizes successful resolutions for its lifetime (one CLI invocation), so keyring/op backends are hit once. Failures are not cached.
- **Handle suggestion hardened**: sanitization moved into `finalizeSuggestedHandle` (single funnel for the placeholder and URL branches) and made ASCII-strict, fixing the residual non-ASCII case (`${file:/secrets/börse.dsn}` suggested `@börse`, which `ValidHandle` rejects).
- Smaller items: shared `resolveToolCmdSource` helper replaces the five copy-pasted resolve blocks; `db dump cluster`'s unsupported-driver error no longer doubles its prefix; hidden `sq x lock-src-cache` resolves placeholders so it locks the leaf ingest actually uses; cache-test fixture deduplicated; stale test godoc corrected.

CHANGELOG entries added for the changes affecting released behavior (PGPASSWORD logging, cache clear coverage, nesting validation). New tests throughout, each written failing-first where the fix changes behavior.
