### PR TITLE
Treat source locations as placeholder templates: escape literal '$', back up config before upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,10 @@ Breaking changes are annotated with ☢️, and alpha/beta features with 🐥.
   - `secrets.reveal: true` equals legacy `redact: false`; the default remains redaction.
   - Existing configs are migrated automatically on first run, but scripts
     that call `sq config get|set redact` need updating to the new `secrets.reveal` key.
+  - [#782]: The migration escapes `$` as
+    [`$$`](https://sq.io/docs/secrets#literal-dollar-signs) in any source location that
+    the new placeholder syntax would otherwise reinterpret, so existing sources connect
+    exactly as before.
 - [#692]: [`sq inspect -f mermaid-erd`](https://sq.io/docs/inspect#mermaid-erd)
   now syntax-colors its `erDiagram` source when writing to a terminal.
 
@@ -1665,6 +1669,7 @@ make working with lots of sources much easier.
 [#752]: https://github.com/neilotoole/sq/issues/752
 [#757]: https://github.com/neilotoole/sq/issues/757
 [#759]: https://github.com/neilotoole/sq/issues/759
+[#782]: https://github.com/neilotoole/sq/issues/782
 
 [v0.15.2]: https://github.com/neilotoole/sq/releases/tag/v0.15.2
 [v0.15.3]: https://github.com/neilotoole/sq/compare/v0.15.2...v0.15.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,10 @@ Breaking changes are annotated with ☢️, and alpha/beta features with 🐥.
     [`$$`](https://sq.io/docs/secrets#literal-dollar-signs) in any source location that
     the new placeholder syntax would otherwise reinterpret, so existing sources connect
     exactly as before.
+  - Before migrating, `sq` writes a verbatim
+    [backup](https://sq.io/docs/config#upgrades) of the pre-upgrade config alongside
+    `sq.yml`, e.g. `sq.v0.53.0.bak.yml`. The backup is never touched afterward; note
+    that it preserves any inline credentials from the old config.
 - [#692]: [`sq inspect -f mermaid-erd`](https://sq.io/docs/inspect#mermaid-erd)
   now syntax-colors its `erDiagram` source when writing to a terminal.
 

--- a/cli/cmd_add.go
+++ b/cli/cmd_add.go
@@ -20,6 +20,7 @@ import (
 	"github.com/neilotoole/sq/drivers/duckdb"
 	"github.com/neilotoole/sq/drivers/sqlite3"
 	"github.com/neilotoole/sq/libsq/core/errz"
+	"github.com/neilotoole/sq/libsq/core/ioz"
 	"github.com/neilotoole/sq/libsq/core/lg"
 	"github.com/neilotoole/sq/libsq/core/lg/lga"
 	"github.com/neilotoole/sq/libsq/core/options"
@@ -302,6 +303,18 @@ func execSrcAdd(cmd *cobra.Command, args []string) (err error) {
 			return err
 		}
 
+		// The pre-detection escape check covers bare file paths; munged
+		// file-DB locations (sqlite3:///path, duckdb:///path) carry the
+		// '$$' bytes inside a DSN, so check the extracted path here.
+		// Especially important for SQLite, which CREATES missing files
+		// on open: without this, the ping would silently create and
+		// open an empty DB at the interpreted path.
+		if fpath, isFileDB := fileDBPath(typ, loc); isFileDB {
+			if err = checkPathEscape(fpath); err != nil {
+				return err
+			}
+		}
+
 		// Apply password: store in keyring or inline, per flags and config.
 		// keyringRollbackID is set when --store keyring mints a new entry;
 		// the deferred cleanup at the top of execSrcAdd undoes it on err.
@@ -490,35 +503,54 @@ func mungeLocationForType(ctx context.Context, typ drivertype.Type, loc string) 
 }
 
 // checkFileLocationEscape rejects a typed file location whose '$$'
-// escaping is almost certainly unintended. The stored location is a
-// placeholder template: '$$' means a literal '$', so the connect path
-// interprets a typed path like 'data$$file.csv' as 'data$file.csv'.
-// If a file exists at the typed bytes but not at the
-// template-interpreted bytes, the user meant the literal file and
-// forgot to escape; erroring now names the real path, rather than
-// failing later with an error citing a path the user never typed.
-// Placeholder locations, non-file locations (DSNs), and paths without
-// '$$' pass through.
+// escaping is almost certainly unintended; see checkPathEscape.
+// Placeholder locations and non-file locations (DSNs) pass through;
+// driver-prefixed file-DB paths (sqlite3:, duckdb:) are covered
+// separately post-munge via fileDBPath.
 func checkFileLocationEscape(loc string, hasPlaceholder bool) error {
-	if hasPlaceholder {
+	if hasPlaceholder || location.TypeOf(secret.Unescape(loc)) != location.TypeFile {
 		return nil
 	}
-	interpreted := secret.Unescape(loc)
-	if interpreted == loc || location.TypeOf(interpreted) != location.TypeFile {
+	return checkPathEscape(loc)
+}
+
+// checkPathEscape errors when a regular file exists at the typed
+// (template) path but not at the template-interpreted path. The
+// stored location is a placeholder template: '$$' means a literal
+// '$', so the connect path interprets a typed path like
+// 'data$$file.csv' as 'data$file.csv'. When the literal file exists
+// and the interpreted one doesn't, the user meant the literal file
+// and forgot to escape; erroring now names the real path, rather than
+// failing later with an error citing a path the user never typed.
+func checkPathEscape(typedPath string) error {
+	interpreted := secret.Unescape(typedPath)
+	if interpreted == typedPath {
 		return nil
 	}
-	if _, statErr := os.Stat(loc); statErr != nil {
-		// Nothing at the typed path either; whatever is wrong, it isn't
-		// a missed escape. Let detection or the ping surface it.
-		return nil //nolint:nilerr
+	if ioz.IsPathToRegularFile(typedPath) && !ioz.IsPathToRegularFile(interpreted) {
+		return errz.Errorf(
+			"location contains %q, which sq interprets as an escaped literal '$': "+
+				"a file exists at %s, but the interpreted path %s does not",
+			"$$", typedPath, interpreted)
 	}
-	if _, statErr := os.Stat(interpreted); statErr == nil {
-		return nil
+	return nil
+}
+
+// fileDBPath returns the file path component of a munged file-DB
+// location (sqlite3:///path, duckdb:///path) and true, or ("", false)
+// for other driver types and for non-file forms (e.g. duckdb
+// ":memory:").
+func fileDBPath(typ drivertype.Type, loc string) (string, bool) {
+	src := &source.Source{Type: typ, Location: loc}
+	if typ == drivertype.SQLite {
+		p, err := sqlite3.PathFromLocation(src)
+		return p, err == nil
 	}
-	return errz.Errorf(
-		"location contains %q, which sq interprets as an escaped literal '$': "+
-			"a file exists at %s, but the interpreted path %s does not",
-		"$$", loc, interpreted)
+	if typ == drivertype.DuckDB {
+		p, err := duckdb.PathFromLocation(src)
+		return p, err == nil
+	}
+	return "", false
 }
 
 // wrapBareSecretURI normalizes location forms that look like a URL but
@@ -595,8 +627,15 @@ func resolveDriverType(
 	// not the raw typed bytes: extension-based detection is unaffected,
 	// but the byte-sniffing fallback opens the path, and it must read
 	// the same file the connect path will open.
-	typ, err := ru.Files.DetectType(ctx, handle, secret.Unescape(loc))
+	interpreted := secret.Unescape(loc)
+	typ, err := ru.Files.DetectType(ctx, handle, interpreted)
 	if err != nil {
+		if interpreted != loc {
+			// Detection ran on the interpreted bytes; surface the typed
+			// form too, or the error cites a path the user never typed.
+			return "", errz.Wrapf(err,
+				"location %s contains %q, which sq interpreted as an escaped literal '$'", loc, "$$")
+		}
 		return "", err
 	}
 	if typ == drivertype.None {
@@ -667,6 +706,13 @@ func applyKeyring(ctx context.Context, _ *run.Run, loc string, passwd []byte) (n
 			flag.AddStore, flag.AddStoreKeyring, flag.PasswordPrompt,
 		)
 	}
+
+	// The typed loc is a placeholder template ('$$' means a literal
+	// '$'; zero refs guaranteed by the caller), but the keyring slot
+	// holds a literal that Registry.Expand splices raw at connect.
+	// Convert to literal form now, before the raw literal password is
+	// spliced in below.
+	loc = secret.Unescape(loc)
 
 	if len(passwd) > 0 {
 		var spliced string

--- a/cli/cmd_add.go
+++ b/cli/cmd_add.go
@@ -282,6 +282,10 @@ func execSrcAdd(cmd *cobra.Command, args []string) (err error) {
 		}
 	}
 
+	if err = checkFileLocationEscape(loc, hasPlaceholder); err != nil {
+		return err
+	}
+
 	if typ, err = resolveDriverType(ctx, ru, cmd, handle, loc, hasPlaceholder); err != nil {
 		return err
 	}
@@ -294,26 +298,8 @@ func execSrcAdd(cmd *cobra.Command, args []string) (err error) {
 	// non-placeholder Locations. A placeholder is opaque to sq at this
 	// stage: nothing to munge, no inline password to relocate.
 	if !hasPlaceholder {
-		if typ == drivertype.SQLite {
-			locBefore := loc
-			// Special handling for SQLite, because it's a file-based DB.
-			loc, err = sqlite3.MungeLocation(loc)
-			if err != nil {
-				return err
-			}
-
-			lg.FromContext(ctx).Debug("Munged sqlite loc", lga.Before, locBefore, lga.After, loc)
-		}
-
-		if typ == drivertype.DuckDB {
-			locBefore := loc
-			// Special handling for DuckDB, because it's a file-based DB.
-			loc, err = duckdb.MungeLocation(loc)
-			if err != nil {
-				return err
-			}
-
-			lg.FromContext(ctx).Debug("Munged duckdb loc", lga.Before, locBefore, lga.After, loc)
+		if loc, err = mungeLocationForType(ctx, typ, loc); err != nil {
+			return err
 		}
 
 		// Apply password: store in keyring or inline, per flags and config.
@@ -482,6 +468,59 @@ func applyPassword(ctx context.Context, cmd *cobra.Command, ru *run.Run, loc str
 	return loc, "", nil
 }
 
+// mungeLocationForType applies driver-specific location munging for
+// the file-based DB types (SQLite, DuckDB); other types pass through
+// unchanged. Only meaningful for non-placeholder locations.
+func mungeLocationForType(ctx context.Context, typ drivertype.Type, loc string) (string, error) {
+	locBefore := loc
+	var err error
+	if typ == drivertype.SQLite {
+		if loc, err = sqlite3.MungeLocation(loc); err != nil {
+			return "", err
+		}
+		lg.FromContext(ctx).Debug("Munged sqlite loc", lga.Before, locBefore, lga.After, loc)
+	}
+	if typ == drivertype.DuckDB {
+		if loc, err = duckdb.MungeLocation(loc); err != nil {
+			return "", err
+		}
+		lg.FromContext(ctx).Debug("Munged duckdb loc", lga.Before, locBefore, lga.After, loc)
+	}
+	return loc, nil
+}
+
+// checkFileLocationEscape rejects a typed file location whose '$$'
+// escaping is almost certainly unintended. The stored location is a
+// placeholder template: '$$' means a literal '$', so the connect path
+// interprets a typed path like 'data$$file.csv' as 'data$file.csv'.
+// If a file exists at the typed bytes but not at the
+// template-interpreted bytes, the user meant the literal file and
+// forgot to escape; erroring now names the real path, rather than
+// failing later with an error citing a path the user never typed.
+// Placeholder locations, non-file locations (DSNs), and paths without
+// '$$' pass through.
+func checkFileLocationEscape(loc string, hasPlaceholder bool) error {
+	if hasPlaceholder {
+		return nil
+	}
+	interpreted := secret.Unescape(loc)
+	if interpreted == loc || location.TypeOf(interpreted) != location.TypeFile {
+		return nil
+	}
+	if _, statErr := os.Stat(loc); statErr != nil {
+		// Nothing at the typed path either; whatever is wrong, it isn't
+		// a missed escape. Let detection or the ping surface it.
+		return nil //nolint:nilerr
+	}
+	if _, statErr := os.Stat(interpreted); statErr == nil {
+		return nil
+	}
+	return errz.Errorf(
+		"location contains %q, which sq interprets as an escaped literal '$': "+
+			"a file exists at %s, but the interpreted path %s does not",
+		"$$", loc, interpreted)
+}
+
 // wrapBareSecretURI normalizes location forms that look like a URL but
 // whose scheme belongs to an external secret resolver. Today that means
 // 1Password: "op://vault/item/field" (the literal "Copy Secret Reference"
@@ -552,7 +591,11 @@ func resolveDriverType(
 		return typ, nil
 	}
 
-	typ, err := ru.Files.DetectType(ctx, handle, loc)
+	// Detect from the template-interpreted bytes ('$$' reduced to '$'),
+	// not the raw typed bytes: extension-based detection is unaffected,
+	// but the byte-sniffing fallback opens the path, and it must read
+	// the same file the connect path will open.
+	typ, err := ru.Files.DetectType(ctx, handle, secret.Unescape(loc))
 	if err != nil {
 		return "", err
 	}

--- a/cli/cmd_add.go
+++ b/cli/cmd_add.go
@@ -633,8 +633,10 @@ func resolveDriverType(
 		if interpreted != loc {
 			// Detection ran on the interpreted bytes; surface the typed
 			// form too, or the error cites a path the user never typed.
+			// Redact: loc may be a DSN with inline credentials.
 			return "", errz.Wrapf(err,
-				"location %s contains %q, which sq interpreted as an escaped literal '$'", loc, "$$")
+				"location %s contains %q, which sq interpreted as an escaped literal '$'",
+				location.Redact(loc), "$$")
 		}
 		return "", err
 	}

--- a/cli/cmd_add.go
+++ b/cli/cmd_add.go
@@ -468,7 +468,14 @@ func applyPassword(ctx context.Context, cmd *cobra.Command, ru *run.Run, loc str
 
 	if len(passwd) > 0 {
 		// Inline path: splice the prompted/piped password into the URL.
-		if loc, err = location.WithPassword(loc, string(passwd)); err != nil {
+		// The password is a literal, but the stored location is a
+		// placeholder template in which '$$' means a literal '$', so
+		// escape it; the connect path (ResolveSourceSecrets) unescapes.
+		// Escape before WithPassword: '$' is never percent-encoded in
+		// userinfo, so the '$$' pairs survive URL encoding intact. The
+		// keyring path above needs no escaping: keyring slots hold
+		// literal values that Registry.Expand splices raw.
+		if loc, err = location.WithPassword(loc, secret.Escape(string(passwd))); err != nil {
 			return loc, "", err
 		}
 	}

--- a/cli/cmd_add_test.go
+++ b/cli/cmd_add_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strings"
 	"sync/atomic"
 	"testing"
 
@@ -814,6 +815,20 @@ func TestCmdAdd_Placeholder_StoreRejected(t *testing.T) {
 	}
 }
 
+// pipeStdin points tr's stdin at a temp file containing content, for
+// tests that exercise prompts or piped input. Run.Stdin wants an
+// *os.File, so a plain strings.Reader doesn't suffice.
+func pipeStdin(t *testing.T, tr *testrun.TestRun, content string) {
+	t.Helper()
+	f, err := os.CreateTemp(t.TempDir(), "stdin")
+	require.NoError(t, err)
+	_, err = f.WriteString(content)
+	require.NoError(t, err)
+	_, err = f.Seek(0, 0)
+	require.NoError(t, err)
+	tr.Run.Stdin = f
+}
+
 // TestCmdAdd_StoreKeyring_PromptsWhenNoPassword verifies that when
 // --store=keyring is set with --password, sq reads the password from
 // stdin and splices it into the URL before storing the full DSN in
@@ -823,18 +838,10 @@ func TestCmdAdd_StoreKeyring_PromptsWhenNoPassword(t *testing.T) {
 
 	th := testh.New(t)
 	tr := testrun.New(th.Context, t, nil)
-
-	// Simulate piped stdin: write the password to a temp file and set it as Stdin.
-	f, err := os.CreateTemp(t.TempDir(), "passwd")
-	require.NoError(t, err)
-	_, err = f.WriteString("piped-password\n")
-	require.NoError(t, err)
-	_, err = f.Seek(0, 0)
-	require.NoError(t, err)
-	tr.Run.Stdin = f
+	pipeStdin(t, tr, "piped-password\n")
 
 	const handle = "@sakila_kr_prompt"
-	err = tr.Exec("add",
+	err := tr.Exec("add",
 		"postgres://alice@localhost:5432/sakila", // no inline password
 		"--handle", handle, "--store", "keyring", "--password",
 		"--driver", "postgres", "--skip-verify")
@@ -860,17 +867,10 @@ func TestCmdAdd_StoreKeyring_PromptsWhenNoPassword(t *testing.T) {
 func TestCmdAdd_InlinePassword_EscapesDollar(t *testing.T) {
 	th := testh.New(t)
 	tr := testrun.New(th.Context, t, nil)
-
-	f, err := os.CreateTemp(t.TempDir(), "passwd")
-	require.NoError(t, err)
-	_, err = f.WriteString("pa$$word\n")
-	require.NoError(t, err)
-	_, err = f.Seek(0, 0)
-	require.NoError(t, err)
-	tr.Run.Stdin = f
+	pipeStdin(t, tr, "pa$$word\n")
 
 	const handle = "@sakila_inline_dollar"
-	err = tr.Exec("add",
+	err := tr.Exec("add",
 		"postgres://alice@localhost:5432/sakila",
 		"--handle", handle, "--store", "inline", "--password",
 		"--driver", "postgres", "--skip-verify")
@@ -897,17 +897,10 @@ func TestCmdAdd_KeyringPassword_NotEscaped(t *testing.T) {
 
 	th := testh.New(t)
 	tr := testrun.New(th.Context, t, nil)
-
-	f, err := os.CreateTemp(t.TempDir(), "passwd")
-	require.NoError(t, err)
-	_, err = f.WriteString("pa$$word\n")
-	require.NoError(t, err)
-	_, err = f.Seek(0, 0)
-	require.NoError(t, err)
-	tr.Run.Stdin = f
+	pipeStdin(t, tr, "pa$$word\n")
 
 	const handle = "@sakila_kr_dollar"
-	err = tr.Exec("add",
+	err := tr.Exec("add",
 		"postgres://alice@localhost:5432/sakila",
 		"--handle", handle, "--store", "keyring", "--password",
 		"--driver", "postgres", "--skip-verify")
@@ -921,6 +914,48 @@ func TestCmdAdd_KeyringPassword_NotEscaped(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "postgres://alice:pa$$word@localhost:5432/sakila", got,
 		"keyring holds the literal DSN, no template escaping")
+}
+
+// TestCmdAdd_FileLocation_RawDollarDollar verifies that adding a file
+// whose typed path contains '$$' fails at add time with a clear error
+// when the file exists at the typed path but not at the
+// template-interpreted path. Without this check, the add would fail at
+// the ping (or, with --skip-verify, persist a broken source) with an
+// error naming a path the user never typed, because the connect path
+// interprets '$$' as an escaped '$'.
+func TestCmdAdd_FileLocation_RawDollarDollar(t *testing.T) {
+	dir := t.TempDir()
+	fpath := filepath.Join(dir, "data$$file.csv")
+	require.NoError(t, os.WriteFile(fpath, []byte("a,b\n1,2\n"), 0o600))
+
+	th := testh.New(t)
+	tr := testrun.New(th.Context, t, nil)
+
+	err := tr.Exec("add", fpath, "--handle", "@raw_dollar", "--skip-verify")
+	require.Error(t, err,
+		"raw '$$' path whose interpreted form doesn't exist must be rejected at add time")
+	require.Contains(t, err.Error(), "$$")
+}
+
+// TestCmdAdd_FileLocation_EscapedDollarDollar verifies that the
+// documented escaped form works end-to-end: the stored location is the
+// typed template, detection and the add-time ping interpret it, and
+// the source connects.
+func TestCmdAdd_FileLocation_EscapedDollarDollar(t *testing.T) {
+	dir := t.TempDir()
+	fpath := filepath.Join(dir, "data$$file.csv")
+	require.NoError(t, os.WriteFile(fpath, []byte("a,b\n1,2\n"), 0o600))
+
+	th := testh.New(t)
+	tr := testrun.New(th.Context, t, nil)
+
+	escaped := strings.ReplaceAll(fpath, "$", "$$")
+	require.NoError(t, tr.Exec("add", escaped, "--handle", "@esc_dollar"),
+		"escaped form must pass detection and the add-time ping")
+
+	src, err := tr.Run.Config.Collection.Get("@esc_dollar")
+	require.NoError(t, err)
+	require.Equal(t, escaped, src.Location, "the typed template form is what gets stored")
 }
 
 // newRqliteMockHandlerForCLI returns an HTTP handler that satisfies gorqlite's

--- a/cli/cmd_add_test.go
+++ b/cli/cmd_add_test.go
@@ -851,6 +851,78 @@ func TestCmdAdd_StoreKeyring_PromptsWhenNoPassword(t *testing.T) {
 	require.Equal(t, "postgres://alice:piped-password@localhost:5432/sakila", got)
 }
 
+// TestCmdAdd_InlinePassword_EscapesDollar verifies that a prompted or
+// piped password containing '$' is escaped ('$' -> '$$') when spliced
+// inline into the stored location. The stored location is a
+// placeholder template in which '$$' means a literal '$'; without
+// escaping, the connect path's unescape would corrupt the literal
+// password (e.g. 'pa$$word' -> 'pa$word').
+func TestCmdAdd_InlinePassword_EscapesDollar(t *testing.T) {
+	th := testh.New(t)
+	tr := testrun.New(th.Context, t, nil)
+
+	f, err := os.CreateTemp(t.TempDir(), "passwd")
+	require.NoError(t, err)
+	_, err = f.WriteString("pa$$word\n")
+	require.NoError(t, err)
+	_, err = f.Seek(0, 0)
+	require.NoError(t, err)
+	tr.Run.Stdin = f
+
+	const handle = "@sakila_inline_dollar"
+	err = tr.Exec("add",
+		"postgres://alice@localhost:5432/sakila",
+		"--handle", handle, "--store", "inline", "--password",
+		"--driver", "postgres", "--skip-verify")
+	require.NoError(t, err)
+
+	src, err := tr.Run.Config.Collection.Get(handle)
+	require.NoError(t, err)
+	require.Equal(t, "postgres://alice:pa$$$$word@localhost:5432/sakila", src.Location,
+		"literal password must be stored in escaped (template) form")
+
+	// Round-trip: the driver must receive the literal password. Zero
+	// refs, so no secret.Registry is needed on the context.
+	resolved, err := driver.ResolveSourceSecrets(context.Background(), src)
+	require.NoError(t, err)
+	require.Equal(t, "postgres://alice:pa$$word@localhost:5432/sakila", resolved.Location)
+}
+
+// TestCmdAdd_KeyringPassword_NotEscaped verifies that the keyring path
+// stores the literal (unescaped) DSN: keyring slots hold literal
+// values that Registry.Expand splices raw at connect time, so the
+// template escaping applied by the inline path must NOT happen here.
+func TestCmdAdd_KeyringPassword_NotEscaped(t *testing.T) {
+	gokeyring.MockInit()
+
+	th := testh.New(t)
+	tr := testrun.New(th.Context, t, nil)
+
+	f, err := os.CreateTemp(t.TempDir(), "passwd")
+	require.NoError(t, err)
+	_, err = f.WriteString("pa$$word\n")
+	require.NoError(t, err)
+	_, err = f.Seek(0, 0)
+	require.NoError(t, err)
+	tr.Run.Stdin = f
+
+	const handle = "@sakila_kr_dollar"
+	err = tr.Exec("add",
+		"postgres://alice@localhost:5432/sakila",
+		"--handle", handle, "--store", "keyring", "--password",
+		"--driver", "postgres", "--skip-verify")
+	require.NoError(t, err)
+
+	src, err := tr.Run.Config.Collection.Get(handle)
+	require.NoError(t, err)
+	id := extractKeyringID(t, src.Location)
+
+	got, err := gokeyring.Get("sq", id)
+	require.NoError(t, err)
+	require.Equal(t, "postgres://alice:pa$$word@localhost:5432/sakila", got,
+		"keyring holds the literal DSN, no template escaping")
+}
+
 // newRqliteMockHandlerForCLI returns an HTTP handler that satisfies gorqlite's
 // cluster discovery protocol, suitable for CLI-level seam tests. hostPtr is a
 // pointer to the "host:port" string of the test server resolved at request time

--- a/cli/cmd_add_test.go
+++ b/cli/cmd_add_test.go
@@ -815,20 +815,6 @@ func TestCmdAdd_Placeholder_StoreRejected(t *testing.T) {
 	}
 }
 
-// pipeStdin points tr's stdin at a temp file containing content, for
-// tests that exercise prompts or piped input. Run.Stdin wants an
-// *os.File, so a plain strings.Reader doesn't suffice.
-func pipeStdin(t *testing.T, tr *testrun.TestRun, content string) {
-	t.Helper()
-	f, err := os.CreateTemp(t.TempDir(), "stdin")
-	require.NoError(t, err)
-	_, err = f.WriteString(content)
-	require.NoError(t, err)
-	_, err = f.Seek(0, 0)
-	require.NoError(t, err)
-	tr.Run.Stdin = f
-}
-
 // TestCmdAdd_StoreKeyring_PromptsWhenNoPassword verifies that when
 // --store=keyring is set with --password, sq reads the password from
 // stdin and splices it into the URL before storing the full DSN in
@@ -838,7 +824,7 @@ func TestCmdAdd_StoreKeyring_PromptsWhenNoPassword(t *testing.T) {
 
 	th := testh.New(t)
 	tr := testrun.New(th.Context, t, nil)
-	pipeStdin(t, tr, "piped-password\n")
+	tr.PipeStdin("piped-password\n")
 
 	const handle = "@sakila_kr_prompt"
 	err := tr.Exec("add",
@@ -867,7 +853,7 @@ func TestCmdAdd_StoreKeyring_PromptsWhenNoPassword(t *testing.T) {
 func TestCmdAdd_InlinePassword_EscapesDollar(t *testing.T) {
 	th := testh.New(t)
 	tr := testrun.New(th.Context, t, nil)
-	pipeStdin(t, tr, "pa$$word\n")
+	tr.PipeStdin("pa$$word\n")
 
 	const handle = "@sakila_inline_dollar"
 	err := tr.Exec("add",
@@ -897,7 +883,7 @@ func TestCmdAdd_KeyringPassword_NotEscaped(t *testing.T) {
 
 	th := testh.New(t)
 	tr := testrun.New(th.Context, t, nil)
-	pipeStdin(t, tr, "pa$$word\n")
+	tr.PipeStdin("pa$$word\n")
 
 	const handle = "@sakila_kr_dollar"
 	err := tr.Exec("add",
@@ -914,6 +900,36 @@ func TestCmdAdd_KeyringPassword_NotEscaped(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "postgres://alice:pa$$word@localhost:5432/sakila", got,
 		"keyring holds the literal DSN, no template escaping")
+}
+
+// TestCmdAdd_KeyringInlinePassword_Unescaped verifies that the
+// keyring path converts the typed location (a placeholder template,
+// where '$$' means a literal '$') to its literal form before storing:
+// keyring slots hold literals that Registry.Expand splices raw at
+// connect, so storing the template bytes verbatim would hand the
+// driver a still-escaped credential.
+func TestCmdAdd_KeyringInlinePassword_Unescaped(t *testing.T) {
+	gokeyring.MockInit()
+
+	th := testh.New(t)
+	tr := testrun.New(th.Context, t, nil)
+
+	const handle = "@sakila_kr_inline_dollar"
+	// Typed template form: '$$' means the literal password is 'p$ss'.
+	err := tr.Exec("add",
+		"postgres://alice:p$$ss@localhost:5432/sakila",
+		"--handle", handle, "--store", "keyring",
+		"--driver", "postgres", "--skip-verify")
+	require.NoError(t, err)
+
+	src, err := tr.Run.Config.Collection.Get(handle)
+	require.NoError(t, err)
+	id := extractKeyringID(t, src.Location)
+
+	got, err := gokeyring.Get("sq", id)
+	require.NoError(t, err)
+	require.Equal(t, "postgres://alice:p$ss@localhost:5432/sakila", got,
+		"keyring must hold the literal DSN, not the template bytes")
 }
 
 // TestCmdAdd_FileLocation_RawDollarDollar verifies that adding a file
@@ -956,6 +972,51 @@ func TestCmdAdd_FileLocation_EscapedDollarDollar(t *testing.T) {
 	src, err := tr.Run.Config.Collection.Get("@esc_dollar")
 	require.NoError(t, err)
 	require.Equal(t, escaped, src.Location, "the typed template form is what gets stored")
+}
+
+// TestCmdAdd_SQLiteLocation_RawDollarDollar verifies that the '$$'
+// add-time check also covers driver-prefixed file-DB locations. This
+// matters doubly for SQLite: it CREATES missing files on open, so
+// without the check, the add-time ping would silently create and open
+// an empty DB at the interpreted path while the user's real database
+// is never touched.
+func TestCmdAdd_SQLiteLocation_RawDollarDollar(t *testing.T) {
+	dir := t.TempDir()
+	fpath := filepath.Join(dir, "my$$file.db")
+	require.NoError(t, os.WriteFile(fpath, []byte{}, 0o600))
+
+	th := testh.New(t)
+	tr := testrun.New(th.Context, t, nil)
+
+	err := tr.Exec("add", "sqlite3:"+fpath,
+		"--handle", "@sl_raw_dollar", "--driver", "sqlite3", "--skip-verify")
+	require.Error(t, err,
+		"raw '$$' sqlite path whose interpreted form doesn't exist must be rejected at add time")
+	require.Contains(t, err.Error(), "$$")
+
+	// The escaped form works end-to-end (ping included).
+	tr = testrun.New(th.Context, t, nil)
+	escaped := "sqlite3:" + strings.ReplaceAll(fpath, "$", "$$")
+	require.NoError(t, tr.Exec("add", escaped, "--handle", "@sl_esc_dollar", "--driver", "sqlite3"),
+		"escaped sqlite form must pass the check and the add-time ping")
+}
+
+// TestCmdAdd_RawDollarDollar_DetectionErrorNamesTypedForm verifies
+// that when neither the typed nor the interpreted path exists and
+// driver detection fails, the error mentions the typed form and the
+// '$$' interpretation, not just the interpreted path the user never
+// typed.
+func TestCmdAdd_RawDollarDollar_DetectionErrorNamesTypedForm(t *testing.T) {
+	th := testh.New(t)
+	tr := testrun.New(th.Context, t, nil)
+
+	// Unrecognized extension and no file at either form: detection
+	// byte-sniffs the interpreted path and fails.
+	err := tr.Exec("add", filepath.Join(t.TempDir(), "data$$file.xyz"),
+		"--handle", "@nofile_dollar", "--skip-verify")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "$$",
+		"detection failure must surface the '$$' interpretation, not only the interpreted path")
 }
 
 // newRqliteMockHandlerForCLI returns an HTTP handler that satisfies gorqlite's

--- a/cli/cmd_config_export.go
+++ b/cli/cmd_config_export.go
@@ -15,6 +15,7 @@ import (
 	"github.com/neilotoole/sq/libsq/core/errz"
 	"github.com/neilotoole/sq/libsq/core/ioz"
 	"github.com/neilotoole/sq/libsq/core/lg"
+	"github.com/neilotoole/sq/libsq/core/secret"
 )
 
 func newConfigExportCmd() *cobra.Command {
@@ -144,7 +145,13 @@ func exportExpandConfig(ctx context.Context, ru *run.Run, cfg *config.Config) (*
 		if err != nil {
 			return nil, errz.Wrapf(err, "config export: %s", src.Handle)
 		}
-		src.Location = resolved
+		// The export is itself a config, so its locations are placeholder
+		// templates. Expand's output is a literal: re-escape it ('$' ->
+		// '$$') so that the importing machine's expansion yields exactly
+		// the resolved bytes. Without this, a resolved value containing
+		// '$$' would be halved at connect time, and '${...}'-shaped text
+		// inside a secret value would be re-resolved.
+		src.Location = secret.Escape(resolved)
 	}
 
 	return clone, nil

--- a/cli/cmd_config_export.go
+++ b/cli/cmd_config_export.go
@@ -145,12 +145,9 @@ func exportExpandConfig(ctx context.Context, ru *run.Run, cfg *config.Config) (*
 		if err != nil {
 			return nil, errz.Wrapf(err, "config export: %s", src.Handle)
 		}
-		// The export is itself a config, so its locations are placeholder
-		// templates. Expand's output is a literal: re-escape it ('$' ->
-		// '$$') so that the importing machine's expansion yields exactly
-		// the resolved bytes. Without this, a resolved value containing
-		// '$$' would be halved at connect time, and '${...}'-shaped text
-		// inside a secret value would be re-resolved.
+		// The export is itself a config (a template), so re-escape the
+		// resolved literal: import then round-trips byte-identically.
+		// See the "Templates vs literals" section of package secret.
 		src.Location = secret.Escape(resolved)
 	}
 

--- a/cli/cmd_config_export_test.go
+++ b/cli/cmd_config_export_test.go
@@ -96,6 +96,37 @@ func TestCmdConfigExport_Expand_Env(t *testing.T) {
 	require.Contains(t, got, "postgres://u:envhunter@h/db")
 }
 
+// TestCmdConfigExport_Expand_EscapesDollar verifies that --expand
+// re-escapes the resolved literal before writing it: the exported
+// file is itself a config, so its locations are placeholder templates,
+// and a resolved value containing '$' must be written as '$$' or the
+// new machine's connect path would corrupt it (a second unescape of
+// '$$', or re-resolution of '${...}'-shaped text inside a secret
+// value).
+func TestCmdConfigExport_Expand_EscapesDollar(t *testing.T) {
+	gokeyring.MockInit()
+	t.Setenv("SQ_TEST_DB_PASS", "pa$$wd")
+
+	th := testh.New(t)
+	tr := testrun.New(th.Context, t, nil)
+
+	require.NoError(t, tr.Run.Config.Collection.Add(&source.Source{
+		Handle:   "@sakila",
+		Type:     drivertype.Pg,
+		Location: "postgres://u:${env:SQ_TEST_DB_PASS}@h/db",
+	}))
+
+	require.NoError(t, tr.Exec("config", "export", "--expand"))
+
+	// The literal password is 'pa$$wd'; the exported template form must
+	// double every '$', so that expanding the export yields the literal.
+	got := tr.OutString()
+	require.Contains(t, got, "postgres://u:pa$$$$wd@h/db",
+		"exported location must be the escaped template form of the resolved literal")
+	require.NotContains(t, got, "postgres://u:pa$$wd@h/db",
+		"raw literal must not appear: it would be unescaped at connect on the importing machine")
+}
+
 // TestCmdConfigExport_Expand_MissingKeyring errors clearly when a
 // placeholder cannot be resolved.
 func TestCmdConfigExport_Expand_MissingKeyring(t *testing.T) {

--- a/cli/cmd_config_keyring_migrate.go
+++ b/cli/cmd_config_keyring_migrate.go
@@ -187,7 +187,14 @@ func applyMigratePlans(ctx context.Context, ru *run.Run, plans []migratePlan) (
 			anyFailed = true
 			continue
 		}
-		if err = kr.Set(ctx, id, p.src.Location); err != nil {
+		// The stored Location is a placeholder template in which '$$'
+		// escapes a literal '$' (e.g. written by the v0.54.0 config
+		// upgrade). The keyring slot holds a literal value that
+		// Registry.Expand splices raw at connect time, so unescape
+		// here; storing the template bytes verbatim would hand the
+		// driver a wrong (still-escaped) credential. Safe because
+		// migrateSkipReason guarantees zero placeholder refs.
+		if err = kr.Set(ctx, id, secret.Unescape(p.src.Location)); err != nil {
 			rows = append(rows, output.KeyringMigrateRow{
 				Handle: p.src.Handle,
 				Status: output.KeyringMigrateStatusFailed,

--- a/cli/cmd_config_keyring_test.go
+++ b/cli/cmd_config_keyring_test.go
@@ -81,7 +81,7 @@ func TestCmdConfigKeyringCreate_PromptedFromStdin(t *testing.T) {
 	tr := testrun.New(th.Context, t, nil)
 
 	// Pipe a password through stdin.
-	pipeStdin(t, tr, "hunter2\n")
+	tr.PipeStdin("hunter2\n")
 
 	err := tr.Exec("config", "keyring", "create", "my_db_pw", "-p")
 	require.NoError(t, err)
@@ -875,7 +875,7 @@ func TestCmdConfigKeyringMigrate_JSON_SkipsPrompt(t *testing.T) {
 		Location: "postgres://alice:hunter2@db/sakila",
 	}))
 	// Pipe "n\n" so the y/N prompt — if reached — would answer "no".
-	pipeStdin(t, tr, "n\n")
+	tr.PipeStdin("n\n")
 
 	require.NoError(t, tr.Exec("config", "keyring", "migrate", "--all", "--json"))
 

--- a/cli/cmd_config_keyring_test.go
+++ b/cli/cmd_config_keyring_test.go
@@ -348,6 +348,27 @@ func TestCmdConfigKeyringMigrate_PerCase(t *testing.T) {
 			inLocation:  "postgres://alice:p%40ss%3Aword@db/sakila",
 			wantKeyring: "postgres://alice:p%40ss%3Aword@db/sakila",
 		},
+		{
+			// The stored Location is a placeholder template: '$$' means a
+			// literal '$' (e.g. written by the v0.54.0 config upgrade).
+			// The keyring slot holds a literal value that Registry.Expand
+			// splices raw at connect time, so migrate must unescape, or
+			// the driver would receive the still-escaped bytes.
+			name:        "escaped dollar unescaped before keyring store",
+			inLocation:  "postgres://alice:p$$wd@db/sakila",
+			wantKeyring: "postgres://alice:p$wd@db/sakila",
+		},
+		{
+			// An escaped placeholder ('$${env:HOME}' means the literal
+			// text '${env:HOME}') is skipped, not migrated: the braces
+			// make url.Parse reject the userinfo. The source keeps
+			// working via the connect-path unescape, so skipping is
+			// safe; migrating would have to unescape (see previous
+			// case).
+			name:           "escaped placeholder skipped as non-URL",
+			inLocation:     "postgres://alice:$${env:HOME}@db/sakila",
+			wantSkipReason: "not a URL",
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/cli/cmd_config_keyring_test.go
+++ b/cli/cmd_config_keyring_test.go
@@ -3,7 +3,6 @@ package cli_test
 import (
 	"context"
 	"encoding/json"
-	"os"
 	"strings"
 	"testing"
 
@@ -81,16 +80,10 @@ func TestCmdConfigKeyringCreate_PromptedFromStdin(t *testing.T) {
 	th := testh.New(t)
 	tr := testrun.New(th.Context, t, nil)
 
-	// Pipe a password through stdin; matches the cmd_add test pattern.
-	tmp, err := os.CreateTemp(t.TempDir(), "pw")
-	require.NoError(t, err)
-	_, err = tmp.WriteString("hunter2\n")
-	require.NoError(t, err)
-	_, err = tmp.Seek(0, 0)
-	require.NoError(t, err)
-	tr.Run.Stdin = tmp
+	// Pipe a password through stdin.
+	pipeStdin(t, tr, "hunter2\n")
 
-	err = tr.Exec("config", "keyring", "create", "my_db_pw", "-p")
+	err := tr.Exec("config", "keyring", "create", "my_db_pw", "-p")
 	require.NoError(t, err)
 
 	got, err := gokeyring.Get("sq", "my_db_pw")
@@ -882,13 +875,7 @@ func TestCmdConfigKeyringMigrate_JSON_SkipsPrompt(t *testing.T) {
 		Location: "postgres://alice:hunter2@db/sakila",
 	}))
 	// Pipe "n\n" so the y/N prompt — if reached — would answer "no".
-	tmp, err := os.CreateTemp(t.TempDir(), "stdin")
-	require.NoError(t, err)
-	_, err = tmp.WriteString("n\n")
-	require.NoError(t, err)
-	_, err = tmp.Seek(0, 0)
-	require.NoError(t, err)
-	tr.Run.Stdin = tmp
+	pipeStdin(t, tr, "n\n")
 
 	require.NoError(t, tr.Exec("config", "keyring", "migrate", "--all", "--json"))
 

--- a/cli/cmd_inspect.go
+++ b/cli/cmd_inspect.go
@@ -188,10 +188,13 @@ func execInspect(cmd *cobra.Command, args []string) error {
 	}
 
 	// Expand ${scheme:path} placeholders for display when --expand is
-	// set. Grips.Open does its own resolution for the connection, so
-	// passing an expanded Location is a no-op there; the value also
-	// flows into metadata.Location and is shown by the metadata writer.
-	src, err = maybeExpandSource(ctx, ru, cmd, src)
+	// set. The expanded clone is used only for the srcMeta.Location
+	// display override below. The connection must use the original
+	// src: Grips.doOpen resolves it internally, and resolving an
+	// already-expanded clone a second time would unescape '$$' again,
+	// corrupting literal locations (e.g. those escaped by the v0.54.0
+	// config upgrade, or a resolved secret value containing '$$').
+	displaySrc, err := maybeExpandSource(ctx, ru, cmd, src)
 	if err != nil {
 		return err
 	}
@@ -285,9 +288,9 @@ func execInspect(cmd *cobra.Command, args []string) error {
 	// without this override, sq inspect would always show the
 	// resolved value, leaking placeholder targets and ignoring the
 	// --expand flag. With this override, srcMeta.Location reflects
-	// the placeholder (default) or the explicitly-expanded value
+	// the stored template (default) or the explicitly-expanded value
 	// (when --expand is set).
-	srcMeta.Location = src.Location
+	srcMeta.Location = displaySrc.Location
 
 	// This is a bit hacky, but it works... if not "--verbose", then just zap
 	// the DBVars, as we usually don't want to see those

--- a/cli/cmd_inspect_test.go
+++ b/cli/cmd_inspect_test.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"image/png"
 	"os"
-	"path/filepath"
 	"strings"
 	"testing"
 
@@ -22,7 +21,6 @@ import (
 	"github.com/neilotoole/sq/libsq/core/ioz"
 	"github.com/neilotoole/sq/libsq/core/lg"
 	"github.com/neilotoole/sq/libsq/core/lg/lgt"
-	"github.com/neilotoole/sq/libsq/core/secret"
 	"github.com/neilotoole/sq/libsq/core/stringz"
 	"github.com/neilotoole/sq/libsq/source"
 	"github.com/neilotoole/sq/libsq/source/drivertype"
@@ -1184,19 +1182,7 @@ func TestInspect_LocationOverride_NoLeak(t *testing.T) {
 // into Grips.Open would unescape '$$' a second time, corrupting literal
 // locations the v0.54.0 upgrade escaped.
 func TestInspect_Expand_EscapedLocation(t *testing.T) {
-	dir := t.TempDir()
-	fpath := filepath.Join(dir, "data$$file.csv")
-	require.NoError(t, os.WriteFile(fpath, []byte("a,b\n1,2\n"), 0o600))
-
-	tr := testrun.New(t.Context(), t, nil)
-	require.NoError(t, tr.Run.Config.Collection.Add(&source.Source{
-		Handle: "@csv_dollar",
-		Type:   drivertype.CSV,
-		// Stored template form: '$' escaped as '$$', as the v0.54.0
-		// config upgrade writes it.
-		Location: secret.Escape(fpath),
-	}))
-
+	tr, fpath := newEscapedDollarCSVRun(t, "@csv_dollar")
 	require.NoError(t, tr.Exec("inspect", "@csv_dollar", "--overview", "--yaml", "--expand"),
 		"inspect --expand must resolve the location exactly once (double-unescape breaks the path)")
 	require.Contains(t, tr.OutString(), fpath,

--- a/cli/cmd_inspect_test.go
+++ b/cli/cmd_inspect_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"image/png"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -21,6 +22,7 @@ import (
 	"github.com/neilotoole/sq/libsq/core/ioz"
 	"github.com/neilotoole/sq/libsq/core/lg"
 	"github.com/neilotoole/sq/libsq/core/lg/lgt"
+	"github.com/neilotoole/sq/libsq/core/secret"
 	"github.com/neilotoole/sq/libsq/core/stringz"
 	"github.com/neilotoole/sq/libsq/source"
 	"github.com/neilotoole/sq/libsq/source/drivertype"
@@ -1142,6 +1144,32 @@ func TestInspect_LocationOverride_NoLeak(t *testing.T) {
 	out = tr.OutString()
 	require.Contains(t, out, dbPath,
 		"--expand must cause the resolved path to appear in inspect output")
+}
+
+// TestInspect_Expand_EscapedLocation verifies that `sq inspect --expand`
+// resolves the location template exactly once: the connection must use
+// the original stored source (Grips.doOpen resolves internally), with
+// the expanded clone used only for display. Feeding the expanded source
+// into Grips.Open would unescape '$$' a second time, corrupting literal
+// locations the v0.54.0 upgrade escaped.
+func TestInspect_Expand_EscapedLocation(t *testing.T) {
+	dir := t.TempDir()
+	fpath := filepath.Join(dir, "data$$file.csv")
+	require.NoError(t, os.WriteFile(fpath, []byte("a,b\n1,2\n"), 0o600))
+
+	tr := testrun.New(t.Context(), t, nil)
+	require.NoError(t, tr.Run.Config.Collection.Add(&source.Source{
+		Handle: "@csv_dollar",
+		Type:   drivertype.CSV,
+		// Stored template form: '$' escaped as '$$', as the v0.54.0
+		// config upgrade writes it.
+		Location: secret.Escape(fpath),
+	}))
+
+	require.NoError(t, tr.Exec("inspect", "@csv_dollar", "--overview", "--yaml", "--expand"),
+		"inspect --expand must resolve the location exactly once (double-unescape breaks the path)")
+	require.Contains(t, tr.OutString(), fpath,
+		"--expand must show the literal (expanded) path")
 }
 
 // TestInspect_DuckDB_DoesNotModifyMtime verifies that running `sq inspect`

--- a/cli/cmd_ping.go
+++ b/cli/cmd_ping.go
@@ -123,21 +123,23 @@ func execPing(cmd *cobra.Command, args []string) error {
 	lg.From(cmd).Debug("Using ping timeout", lga.Val, fmt.Sprintf("%v", timeout))
 
 	// Expand ${scheme:path} placeholders for display when --expand is
-	// set. pingSources reads src.Location from each entry and passes
-	// it to the writer alongside the ping result; expanding here makes
-	// the displayed Location reflect what was resolved. The driver
-	// itself does its own resolution inside pingSource via
-	// ResolveSourceSecrets, which is a no-op on an already-expanded
-	// Location.
+	// set. displaySrcs feeds the writer, so the displayed Location
+	// reflects what was resolved; srcs feeds the drivers untouched.
+	// The connection must use the original stored source: pingSource
+	// resolves it via ResolveSourceSecrets, and resolving an
+	// already-expanded clone a second time would unescape '$$' again,
+	// corrupting literal locations (e.g. those escaped by the v0.54.0
+	// config upgrade, or a resolved secret value containing '$$').
+	displaySrcs := make([]*source.Source, len(srcs))
 	for i, src := range srcs {
 		expanded, expandErr := maybeExpandSource(cmd.Context(), ru, cmd, src)
 		if expandErr != nil {
 			return expandErr
 		}
-		srcs[i] = expanded
+		displaySrcs[i] = expanded
 	}
 
-	err = pingSources(cmd.Context(), ru.DriverRegistry, srcs, ru.Writers.Ping, timeout)
+	err = pingSources(cmd.Context(), ru.DriverRegistry, srcs, displaySrcs, ru.Writers.Ping, timeout)
 	if errors.Is(err, context.Canceled) {
 		// It's common to cancel "sq ping". We don't want to print the cancel message.
 		return errz.ErrNoMsg
@@ -153,10 +155,10 @@ func execPing(cmd *cobra.Command, args []string) error {
 // NOTE: This ping code has an ancient lineage, in that it was
 // originally laid down before context.Context was a thing. Thus,
 // the entire thing could probably be rewritten for simplicity.
-func pingSources(ctx context.Context, dp driver.Provider, srcs []*source.Source,
+func pingSources(ctx context.Context, dp driver.Provider, srcs, displaySrcs []*source.Source,
 	w output.PingWriter, timeout time.Duration,
 ) error {
-	if err := w.Open(srcs); err != nil {
+	if err := w.Open(displaySrcs); err != nil {
 		return err
 	}
 
@@ -170,8 +172,8 @@ func pingSources(ctx context.Context, dp driver.Provider, srcs []*source.Source,
 	// is returned from this func.
 	var pingErrExists bool
 
-	for _, src := range srcs {
-		go pingSource(ctx, dp, src, timeout, resultCh)
+	for i, src := range srcs {
+		go pingSource(ctx, dp, src, displaySrcs[i], timeout, resultCh)
 	}
 
 	// This func doesn't check for context.Canceled itself; instead
@@ -211,13 +213,17 @@ func pingSources(ctx context.Context, dp driver.Provider, srcs []*source.Source,
 }
 
 // pingSource pings an individual driver.Source. It always returns a
-// result on resultCh, even when ctx is done.
-func pingSource(ctx context.Context, dp driver.Provider, src *source.Source, timeout time.Duration,
+// result on resultCh, even when ctx is done. src is the original
+// stored source, which is what the driver connects with (after
+// resolution below); displaySrc is the caller's display view of the
+// same source (identical by default, an expanded clone under
+// --expand), and is what pingResult carries to the output writers.
+func pingSource(ctx context.Context, dp driver.Provider, src, displaySrc *source.Source, timeout time.Duration,
 	resultCh chan<- pingResult,
 ) {
 	drvr, err := dp.DriverFor(src.Type)
 	if err != nil {
-		resultCh <- pingResult{src: src, err: err}
+		resultCh <- pingResult{src: displaySrc, err: err}
 		return
 	}
 
@@ -225,11 +231,12 @@ func pingSource(ctx context.Context, dp driver.Provider, src *source.Source, tim
 	// handing the source to the driver. Grips.doOpen does this for the
 	// query path; ping calls drvr.Ping directly, so we must do it here.
 	// Keep the resolved clone in a separate variable: pingResult carries
-	// the original (templated) src to output writers, which serialize
-	// src.Location verbatim — we must not leak the resolved plaintext.
+	// displaySrc to output writers, which serialize src.Location
+	// verbatim. We must not leak the resolved plaintext unless the
+	// user opted in via --expand.
 	resolved, err := driver.ResolveSourceSecrets(ctx, src)
 	if err != nil {
-		resultCh <- pingResult{src: src, err: err}
+		resultCh <- pingResult{src: displaySrc, err: err}
 		return
 	}
 
@@ -248,12 +255,12 @@ func pingSource(ctx context.Context, dp driver.Provider, src *source.Source, tim
 
 	go func() {
 		pingErr := drvr.Ping(ctx, resolved)
-		doneCh <- pingResult{src: src, duration: time.Since(start), err: pingErr}
+		doneCh <- pingResult{src: displaySrc, duration: time.Since(start), err: pingErr}
 	}()
 
 	select {
 	case <-ctx.Done():
-		resultCh <- pingResult{src: src, err: ctx.Err()}
+		resultCh <- pingResult{src: displaySrc, err: ctx.Err()}
 	case result := <-doneCh:
 		resultCh <- result
 	}

--- a/cli/cmd_ping_test.go
+++ b/cli/cmd_ping_test.go
@@ -113,6 +113,25 @@ func TestCmdPing_KeyringPlaceholder_NoLeakInJSON(t *testing.T) {
 		"password slot must be redacted in default (non-reveal) mode")
 }
 
+// newEscapedDollarCSVRun creates a CSV file whose name contains a
+// literal "$$", and returns a testrun holding a source whose stored
+// Location is the escaped template form (as the v0.54.0 config upgrade
+// writes it), plus the literal file path. Shared by the ping and
+// inspect --expand regression tests.
+func newEscapedDollarCSVRun(t *testing.T, handle string) (tr *testrun.TestRun, fpath string) {
+	t.Helper()
+	fpath = filepath.Join(t.TempDir(), "data$$file.csv")
+	require.NoError(t, os.WriteFile(fpath, []byte("a,b\n1,2\n"), 0o600))
+
+	tr = testrun.New(t.Context(), t, nil)
+	require.NoError(t, tr.Run.Config.Collection.Add(&source.Source{
+		Handle:   handle,
+		Type:     drivertype.CSV,
+		Location: secret.Escape(fpath),
+	}))
+	return tr, fpath
+}
+
 // TestCmdPing_Expand_EscapedLocation verifies that `sq ping --expand`
 // resolves the location template exactly once. The driver must connect
 // using the original stored source (resolved inside pingSource);
@@ -120,30 +139,12 @@ func TestCmdPing_KeyringPlaceholder_NoLeakInJSON(t *testing.T) {
 // ResolveSourceSecrets would unescape '$$' a second time, corrupting
 // literal locations the v0.54.0 upgrade escaped.
 func TestCmdPing_Expand_EscapedLocation(t *testing.T) {
-	dir := t.TempDir()
-	fpath := filepath.Join(dir, "data$$file.csv")
-	require.NoError(t, os.WriteFile(fpath, []byte("a,b\n1,2\n"), 0o600))
-
-	th := testh.New(t)
-	tr := testrun.New(th.Context, t, nil)
-	require.NoError(t, tr.Run.Config.Collection.Add(&source.Source{
-		Handle: "@csv_dollar",
-		Type:   drivertype.CSV,
-		// Stored template form: '$' escaped as '$$', as the v0.54.0
-		// config upgrade writes it.
-		Location: secret.Escape(fpath),
-	}))
-
+	tr, _ := newEscapedDollarCSVRun(t, "@csv_dollar")
 	require.NoError(t, tr.Exec("ping", "--expand", "@csv_dollar"),
 		"ping --expand must resolve the location exactly once (double-unescape breaks the path)")
 
 	// Sanity: plain ping (no --expand) also works.
-	tr = testrun.New(th.Context, t, nil)
-	require.NoError(t, tr.Run.Config.Collection.Add(&source.Source{
-		Handle:   "@csv_dollar",
-		Type:     drivertype.CSV,
-		Location: secret.Escape(fpath),
-	}))
+	tr, _ = newEscapedDollarCSVRun(t, "@csv_dollar")
 	require.NoError(t, tr.Exec("ping", "@csv_dollar"))
 }
 

--- a/cli/cmd_ping_test.go
+++ b/cli/cmd_ping_test.go
@@ -3,6 +3,8 @@ package cli_test
 import (
 	"context"
 	"encoding/csv"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -10,6 +12,7 @@ import (
 	gokeyring "github.com/zalando/go-keyring"
 
 	"github.com/neilotoole/sq/cli/testrun"
+	"github.com/neilotoole/sq/libsq/core/secret"
 	"github.com/neilotoole/sq/libsq/source"
 	"github.com/neilotoole/sq/libsq/source/drivertype"
 	"github.com/neilotoole/sq/testh"
@@ -108,6 +111,40 @@ func TestCmdPing_KeyringPlaceholder_NoLeakInJSON(t *testing.T) {
 		"resolved password must not leak into ping output")
 	require.Contains(t, out, "xxxxx",
 		"password slot must be redacted in default (non-reveal) mode")
+}
+
+// TestCmdPing_Expand_EscapedLocation verifies that `sq ping --expand`
+// resolves the location template exactly once. The driver must connect
+// using the original stored source (resolved inside pingSource);
+// feeding the already-expanded source back through
+// ResolveSourceSecrets would unescape '$$' a second time, corrupting
+// literal locations the v0.54.0 upgrade escaped.
+func TestCmdPing_Expand_EscapedLocation(t *testing.T) {
+	dir := t.TempDir()
+	fpath := filepath.Join(dir, "data$$file.csv")
+	require.NoError(t, os.WriteFile(fpath, []byte("a,b\n1,2\n"), 0o600))
+
+	th := testh.New(t)
+	tr := testrun.New(th.Context, t, nil)
+	require.NoError(t, tr.Run.Config.Collection.Add(&source.Source{
+		Handle: "@csv_dollar",
+		Type:   drivertype.CSV,
+		// Stored template form: '$' escaped as '$$', as the v0.54.0
+		// config upgrade writes it.
+		Location: secret.Escape(fpath),
+	}))
+
+	require.NoError(t, tr.Exec("ping", "--expand", "@csv_dollar"),
+		"ping --expand must resolve the location exactly once (double-unescape breaks the path)")
+
+	// Sanity: plain ping (no --expand) also works.
+	tr = testrun.New(th.Context, t, nil)
+	require.NoError(t, tr.Run.Config.Collection.Add(&source.Source{
+		Handle:   "@csv_dollar",
+		Type:     drivertype.CSV,
+		Location: secret.Escape(fpath),
+	}))
+	require.NoError(t, tr.Exec("ping", "@csv_dollar"))
 }
 
 // TestCmdPing_KeyringMissing_DoesNotPanic guards against the nil-panic that

--- a/cli/config/yamlstore/internal_test.go
+++ b/cli/config/yamlstore/internal_test.go
@@ -109,6 +109,44 @@ func Test_checkNeedsUpgrade_newerConfigVersion_prerelease(t *testing.T) {
 	require.Equal(t, "v99.0.0", foundVers)
 }
 
+// Test_Store_Load_NoBackupWhenNoUpgradeFuncs verifies that a routine
+// version bump with no registered upgrade funcs in range does not
+// write a pre-upgrade backup file. Due to version inflation (see the
+// IMPLEMENTATION NOTE on errConfigVersionNewerThanBuild), doUpgrade
+// runs on every sq release; the backup must be written only when an
+// upgrade func actually transforms the config, else one
+// credential-bearing backup accumulates per release.
+func Test_Store_Load_NoBackupWhenNoUpgradeFuncs(t *testing.T) {
+	setBuildVersion(t, "v0.48.0")
+
+	cfgDir := t.TempDir()
+	cfgPath := filepath.Join(cfgDir, "sq.yml")
+	err := os.WriteFile(cfgPath, []byte("config.version: v0.47.0\n"), 0o644)
+	require.NoError(t, err)
+
+	ctx := lg.NewContext(context.Background(), lgt.New(t))
+
+	store := &Store{
+		Path:            cfgPath,
+		OptionsRegistry: &options.Registry{},
+		// Non-nil but empty: the upgrade path runs, with zero funcs in
+		// range. This mirrors production for any release that doesn't
+		// change the config schema.
+		UpgradeRegistry: UpgradeRegistry{},
+	}
+
+	cfg, err := store.Load(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "v0.48.0", cfg.Version, "config.version is still stamped")
+
+	entries, err := os.ReadDir(cfgDir)
+	require.NoError(t, err)
+	for _, e := range entries {
+		require.NotContains(t, e.Name(), ".bak.",
+			"no backup file expected when no upgrade funcs ran")
+	}
+}
+
 // Test_Store_Load_newerConfigVersion verifies that Store.Load succeeds
 // (returns no error) when the config version is newer than the build version.
 // The sentinel error errConfigVersionNewerThanBuild should be handled

--- a/cli/config/yamlstore/upgrade.go
+++ b/cli/config/yamlstore/upgrade.go
@@ -3,7 +3,9 @@ package yamlstore
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"golang.org/x/mod/semver"
@@ -52,6 +54,16 @@ func (fs *Store) doUpgrade(ctx context.Context, startVersion, targetVersion stri
 		return nil, err
 	}
 
+	backupPath := backupFilePath(fs.Path, startVersion)
+	if err = ioz.WriteFileAtomic(backupPath, data, ioz.RWPerms); err != nil {
+		// Abort rather than continue without a backup: the point of the
+		// backup is guaranteed recoverability, and if a sibling file
+		// can't be written, rewriting the config itself is unlikely to
+		// go better.
+		return nil, errz.Wrapf(err, "failed to write config backup before upgrade: %s", backupPath)
+	}
+	log.Info("Wrote verbatim backup of config before upgrade", lga.Path, backupPath)
+
 	for _, fn := range upgradeFns {
 		log.Debug("Attempting config upgrade step")
 		data, err = fn(ctx, data)
@@ -80,6 +92,19 @@ func (fs *Store) doUpgrade(ctx context.Context, startVersion, targetVersion stri
 	}
 
 	return cfg, nil
+}
+
+// backupFilePath returns the path of the pre-upgrade backup file for
+// the config file at cfgPath, named for the version being upgraded
+// from: /path/to/sq.yml + v0.53.0 -> /path/to/sq.v0.53.0.bak.yml.
+// The name deliberately does not end in ".sq.yml": Store.loadExt
+// treats any such file in the config dir as ext config. A backup file
+// from a prior upgrade of the same version is overwritten; it holds
+// the same from-version content.
+func backupFilePath(cfgPath, fromVersion string) string {
+	base := filepath.Base(cfgPath)
+	base = strings.TrimSuffix(base, filepath.Ext(base))
+	return filepath.Join(filepath.Dir(cfgPath), fmt.Sprintf("%s.%s.bak.yml", base, fromVersion))
 }
 
 // getUpgradeFuncs returns the funcs required to upgrade from startingVersion

--- a/cli/config/yamlstore/upgrade.go
+++ b/cli/config/yamlstore/upgrade.go
@@ -54,15 +54,23 @@ func (fs *Store) doUpgrade(ctx context.Context, startVersion, targetVersion stri
 		return nil, err
 	}
 
-	backupPath := backupFilePath(fs.Path, startVersion)
-	if err = ioz.WriteFileAtomic(backupPath, data, ioz.RWPerms); err != nil {
-		// Abort rather than continue without a backup: the point of the
-		// backup is guaranteed recoverability, and if a sibling file
-		// can't be written, rewriting the config itself is unlikely to
-		// go better.
-		return nil, errz.Wrapf(err, "failed to write config backup before upgrade: %s", backupPath)
+	// Write the backup only when an upgrade func will actually
+	// transform the config. doUpgrade itself runs on every version
+	// bump (config.version is stamped with the binary version, so
+	// every release triggers it), and an unconditional backup would
+	// accumulate one credential-bearing copy per release for no
+	// recoverability benefit.
+	if len(upgradeFns) > 0 {
+		backupPath := backupFilePath(fs.Path, startVersion)
+		if err = ioz.WriteFileAtomic(backupPath, data, ioz.RWPerms); err != nil {
+			// Abort rather than continue without a backup: the point of
+			// the backup is guaranteed recoverability, and if a sibling
+			// file can't be written, rewriting the config itself is
+			// unlikely to go better.
+			return nil, errz.Wrapf(err, "failed to write config backup before upgrade: %s", backupPath)
+		}
+		log.Info("Wrote verbatim backup of config before upgrade", lga.Path, backupPath)
 	}
-	log.Info("Wrote verbatim backup of config before upgrade", lga.Path, backupPath)
 
 	for _, fn := range upgradeFns {
 		log.Debug("Attempting config upgrade step")

--- a/cli/config/yamlstore/upgrades/v0.54.0/testdata/sq.yml
+++ b/cli/config/yamlstore/upgrades/v0.54.0/testdata/sq.yml
@@ -22,3 +22,9 @@ collection:
     options:
       ingest.header: false
       redact: false
+  - handle: "@prod/pg2"
+    driver: postgres
+    location: postgres://sakila:p$ssW0rd@localhost/sakila
+  - handle: "@prod/pg3"
+    driver: postgres
+    location: postgres://sakila:${env:HOME}@localhost/sakila

--- a/cli/config/yamlstore/upgrades/v0.54.0/testdata/want.sq.yml
+++ b/cli/config/yamlstore/upgrades/v0.54.0/testdata/want.sq.yml
@@ -21,3 +21,9 @@ collection:
     options:
       ingest.header: false
       secrets.reveal: true
+  - handle: "@prod/pg2"
+    driver: postgres
+    location: postgres://sakila:p$ssW0rd@localhost/sakila
+  - handle: "@prod/pg3"
+    driver: postgres
+    location: postgres://sakila:$${env:HOME}@localhost/sakila

--- a/cli/config/yamlstore/upgrades/v0.54.0/upgrade.go
+++ b/cli/config/yamlstore/upgrades/v0.54.0/upgrade.go
@@ -5,11 +5,13 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"strings"
 
 	"github.com/neilotoole/sq/libsq/core/errz"
 	"github.com/neilotoole/sq/libsq/core/ioz"
 	"github.com/neilotoole/sq/libsq/core/lg"
 	"github.com/neilotoole/sq/libsq/core/lg/lga"
+	"github.com/neilotoole/sq/libsq/core/secret"
 )
 
 // Version is the target config version this upgrade produces.
@@ -18,8 +20,11 @@ const Version = "v0.54.0"
 // Upgrade renames the "redact" option to "secrets.reveal" and flips
 // polarity: secrets.reveal = !redact. The translation is applied at
 // the top-level options map and to each source's per-source options.
+// It also escapes '$' as '$$' in source locations that the new
+// placeholder-template machinery would otherwise reinterpret: see
+// escapeLocation.
 //
-// Cases:
+// Redact cases:
 //   - redact: true (the historical default): drop the key. The new
 //     option's default is secrets.reveal: false, which means the same
 //     thing (redaction on). Leaving the key absent keeps the config
@@ -66,6 +71,7 @@ func Upgrade(ctx context.Context, before []byte) (after []byte, err error) {
 				if !ok {
 					return nil, errz.Errorf("corrupt config: invalid 'collection.sources[%d]' field", i)
 				}
+				escapeLocation(log, src, i)
 				if rawSrcOpts, present := src["options"]; present {
 					srcOpts, ok := rawSrcOpts.(map[string]any)
 					if !ok {
@@ -90,6 +96,43 @@ func Upgrade(ctx context.Context, before []byte) (after []byte, err error) {
 
 	log.Info("SUCCESS: Config upgrade step completed", lga.To, Version)
 	return after, nil
+}
+
+// escapeLocation escapes '$' as '$$' in-place in src's "location"
+// field when the location would not survive v0.54.0
+// placeholder-template interpretation byte-identically. Source
+// locations predating v0.54.0 are literal strings: the placeholder
+// syntax did not exist, so any ${scheme:path}-shaped text in them is
+// accidental. Without escaping, a legacy location containing a
+// well-formed ref would be silently substituted at connect time
+// (sending wrong credentials), malformed placeholder syntax would fail
+// every connect, and a literal "$$" would be unescaped to "$"
+// (see https://github.com/neilotoole/sq/issues/782).
+//
+// Locations whose only dollars are lone '$' characters (e.g. an inline
+// password like "p$ssW0rd") already expand to themselves, and are left
+// untouched so the config bytes don't churn. The location value is
+// deliberately not logged: it may contain credentials.
+func escapeLocation(log *slog.Logger, src map[string]any, i int) {
+	loc, ok := src["location"].(string)
+	if !ok || !strings.Contains(loc, "$") {
+		return
+	}
+
+	if !strings.Contains(loc, "$$") {
+		refs, err := secret.ExtractRefs(loc)
+		if err == nil && len(refs) == 0 {
+			// Lone dollars only: expands to itself; nothing to escape.
+			return
+		}
+	}
+
+	src["location"] = secret.Escape(loc)
+	handle, _ := src["handle"].(string)
+	log.Info(
+		"config upgrade: escaped '$' as '$$' in source location so it connects byte-identically",
+		lga.Loc, fmt.Sprintf("collection.sources[%d] (%s)", i, handle),
+	)
 }
 
 // translateRedact applies the redact → secrets.reveal flip in-place

--- a/cli/config/yamlstore/upgrades/v0.54.0/upgrade.go
+++ b/cli/config/yamlstore/upgrades/v0.54.0/upgrade.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"strings"
 
 	"github.com/neilotoole/sq/libsq/core/errz"
 	"github.com/neilotoole/sq/libsq/core/ioz"
@@ -71,7 +70,9 @@ func Upgrade(ctx context.Context, before []byte) (after []byte, err error) {
 				if !ok {
 					return nil, errz.Errorf("corrupt config: invalid 'collection.sources[%d]' field", i)
 				}
-				escapeLocation(log, src, i)
+				if err = escapeLocation(log, src, i); err != nil {
+					return nil, err
+				}
 				if rawSrcOpts, present := src["options"]; present {
 					srcOpts, ok := rawSrcOpts.(map[string]any)
 					if !ok {
@@ -109,22 +110,32 @@ func Upgrade(ctx context.Context, before []byte) (after []byte, err error) {
 // every connect, and a literal "$$" would be unescaped to "$"
 // (see https://github.com/neilotoole/sq/issues/782).
 //
-// Locations whose only dollars are lone '$' characters (e.g. an inline
-// password like "p$ssW0rd") already expand to themselves, and are left
-// untouched so the config bytes don't churn. The location value is
-// deliberately not logged: it may contain credentials.
-func escapeLocation(log *slog.Logger, src map[string]any, i int) {
-	loc, ok := src["location"].(string)
-	if !ok || !strings.Contains(loc, "$") {
-		return
+// Locations that already expand to themselves byte-identically (no
+// refs, no "$$"; e.g. an inline password like "p$ssW0rd") are left
+// untouched so the config bytes don't churn. A missing or non-string
+// location is a corrupt config: neither could ever load (the typed
+// loader rejects empty locations and can't unmarshal non-string ones),
+// so erroring here aborts the upgrade before anything is written,
+// matching the corrupt-shape handling in Upgrade. The location value
+// is deliberately not logged: it may contain credentials.
+func escapeLocation(log *slog.Logger, src map[string]any, i int) error {
+	raw, present := src["location"]
+	if !present {
+		return errz.Errorf("corrupt config: missing 'collection.sources[%d].location' field", i)
+	}
+	loc, ok := raw.(string)
+	if !ok {
+		return errz.Errorf(
+			"corrupt config: invalid 'collection.sources[%d].location' field (want string, got %T)", i, raw)
 	}
 
-	if !strings.Contains(loc, "$$") {
-		refs, err := secret.ExtractRefs(loc)
-		if err == nil && len(refs) == 0 {
-			// Lone dollars only: expands to itself; nothing to escape.
-			return
-		}
+	// The skip predicate is stated in secret-package terms so it can't
+	// drift from the grammar: skip iff the location parses cleanly with
+	// zero refs AND unescaping is the identity, i.e. expansion yields
+	// exactly loc.
+	refs, err := secret.ExtractRefs(loc)
+	if err == nil && len(refs) == 0 && secret.Unescape(loc) == loc {
+		return nil
 	}
 
 	src["location"] = secret.Escape(loc)
@@ -133,6 +144,7 @@ func escapeLocation(log *slog.Logger, src map[string]any, i int) {
 		"config upgrade: escaped '$' as '$$' in source location so it connects byte-identically",
 		lga.Loc, fmt.Sprintf("collection.sources[%d] (%s)", i, handle),
 	)
+	return nil
 }
 
 // translateRedact applies the redact → secrets.reveal flip in-place

--- a/cli/config/yamlstore/upgrades/v0.54.0/upgrade.go
+++ b/cli/config/yamlstore/upgrades/v0.54.0/upgrade.go
@@ -112,12 +112,19 @@ func Upgrade(ctx context.Context, before []byte) (after []byte, err error) {
 //
 // Locations that already expand to themselves byte-identically (no
 // refs, no "$$"; e.g. an inline password like "p$ssW0rd") are left
-// untouched so the config bytes don't churn. A missing or non-string
-// location is a corrupt config: neither could ever load (the typed
-// loader rejects empty locations and can't unmarshal non-string ones),
-// so erroring here aborts the upgrade before anything is written,
-// matching the corrupt-shape handling in Upgrade. The location value
-// is deliberately not logged: it may contain credentials.
+// untouched so the config bytes don't churn.
+//
+// A missing location is a corrupt config: it could never load
+// (validSource rejects empty locations), so erroring aborts the
+// upgrade before anything is written, matching the corrupt-shape
+// handling in Upgrade. A non-string location is skipped, NOT an
+// error: the typed loader (goccy-yaml) coerces scalar values into
+// string fields, so e.g. 'location: 123' loaded fine on v0.53.0, and
+// erroring would brick a working config. Skipping it is safe for
+// escaping purposes: a YAML value that parses as non-string can't
+// contain '$' (any '$'-bearing scalar parses as a string). The
+// location value is deliberately not logged: it may contain
+// credentials.
 func escapeLocation(log *slog.Logger, src map[string]any, i int) error {
 	raw, present := src["location"]
 	if !present {
@@ -125,8 +132,7 @@ func escapeLocation(log *slog.Logger, src map[string]any, i int) error {
 	}
 	loc, ok := raw.(string)
 	if !ok {
-		return errz.Errorf(
-			"corrupt config: invalid 'collection.sources[%d].location' field (want string, got %T)", i, raw)
+		return nil
 	}
 
 	// The skip predicate is stated in secret-package terms so it can't

--- a/cli/config/yamlstore/upgrades/v0.54.0/upgrade_test.go
+++ b/cli/config/yamlstore/upgrades/v0.54.0/upgrade_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -82,6 +83,23 @@ func TestUpgrade(t *testing.T) {
 		"per-source redact:false should migrate to secrets.reveal:true")
 	require.NotContains(t, xlsxSrc.Options, "redact",
 		"per-source 'redact' should be removed on upgrade")
+
+	// Before any upgrade step runs, a verbatim backup of the
+	// pre-upgrade config must be written alongside sq.yml, named for
+	// the version the config was upgraded from. The name must not end
+	// in ".sq.yml", or ext config loading would pick it up.
+	backupRaw, err := os.ReadFile(filepath.Join(cfgDir, "sq.v0.53.0.bak.yml"))
+	require.NoError(t, err, "pre-upgrade backup file must exist")
+	origCfgRaw, err := os.ReadFile(filepath.Join("testdata", "sq.yml"))
+	require.NoError(t, err)
+	require.Equal(t, string(origCfgRaw), string(backupRaw),
+		"backup must be byte-identical to the pre-upgrade config")
+	if runtime.GOOS != "windows" {
+		fi, err := os.Stat(filepath.Join(cfgDir, "sq.v0.53.0.bak.yml"))
+		require.NoError(t, err)
+		require.Equal(t, ioz.RWPerms, fi.Mode().Perm(),
+			"backup may contain credentials; must be user-only readable")
+	}
 
 	wantCfgRaw, err := os.ReadFile(filepath.Join("testdata", "want.sq.yml"))
 	require.NoError(t, err)

--- a/cli/config/yamlstore/upgrades/v0.54.0/upgrade_test.go
+++ b/cli/config/yamlstore/upgrades/v0.54.0/upgrade_test.go
@@ -195,6 +195,52 @@ collection:
 	}
 }
 
+// TestUpgrade_CorruptLocation verifies that a missing or non-string
+// source location aborts the upgrade before anything is written.
+// Neither config could ever load (the typed loader rejects empty
+// locations and fails to unmarshal non-string ones), so erroring here
+// can't break a working config; it produces a clearer error than the
+// downstream unmarshal failure, and matches the corrupt-shape
+// precedent elsewhere in this upgrade.
+func TestUpgrade_CorruptLocation(t *testing.T) {
+	log := lgt.New(t)
+	ctx := lg.NewContext(context.Background(), log)
+
+	tests := []struct {
+		name string
+		in   string
+	}{
+		{
+			name: "missing location",
+			in: `config.version: v0.53.0
+collection:
+  sources:
+  - handle: "@src"
+    driver: postgres
+`,
+		},
+		{
+			name: "non-string location",
+			in: `config.version: v0.53.0
+collection:
+  sources:
+  - handle: "@src"
+    driver: postgres
+    location: 123
+`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := v0_54_0.Upgrade(ctx, []byte(tc.in))
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "corrupt config")
+			require.Contains(t, err.Error(), "location")
+		})
+	}
+}
+
 // TestUpgrade_NoRedactKey_IsIdempotent verifies that running Upgrade
 // against a config that has no "redact" key (whether already-migrated
 // or never had one) leaves the user-visible options untouched. Only

--- a/cli/config/yamlstore/upgrades/v0.54.0/upgrade_test.go
+++ b/cli/config/yamlstore/upgrades/v0.54.0/upgrade_test.go
@@ -96,6 +96,87 @@ func TestUpgrade(t *testing.T) {
 	require.Equal(t, wantLines, gotLines)
 }
 
+// TestUpgrade_EscapesLocationDollars verifies that the upgrade escapes
+// '$' as '$$' in any source location that would not survive v0.54.0
+// placeholder-template interpretation byte-identically: locations
+// containing a well-formed ${scheme:path} ref (would be silently
+// substituted at connect), malformed placeholder syntax (would fail
+// every connect), or a literal "$$" (would be unescaped at connect).
+// Locations whose only dollars are lone '$' characters already pass
+// through verbatim and must be left untouched. See
+// https://github.com/neilotoole/sq/issues/782.
+func TestUpgrade_EscapesLocationDollars(t *testing.T) {
+	log := lgt.New(t)
+	ctx := lg.NewContext(context.Background(), log)
+
+	tests := []struct {
+		name string
+		loc  string
+		want string
+	}{
+		{
+			name: "no dollar untouched",
+			loc:  "postgres://sakila:p_ssW0rd@localhost/sakila",
+			want: "postgres://sakila:p_ssW0rd@localhost/sakila",
+		},
+		{
+			name: "lone dollar untouched",
+			loc:  "postgres://sakila:p$ssW0rd@localhost/sakila",
+			want: "postgres://sakila:p$ssW0rd@localhost/sakila",
+		},
+		{
+			name: "malformed placeholder escaped",
+			loc:  "postgres://sakila:p${ss}W0rd@localhost/sakila",
+			want: "postgres://sakila:p$${ss}W0rd@localhost/sakila",
+		},
+		{
+			name: "well-formed placeholder escaped",
+			loc:  "postgres://sakila:${env:HOME}@localhost/sakila",
+			want: "postgres://sakila:$${env:HOME}@localhost/sakila",
+		},
+		{
+			name: "literal double dollar escaped",
+			loc:  "postgres://sakila:p$$wd@localhost/sakila",
+			want: "postgres://sakila:p$$$$wd@localhost/sakila",
+		},
+		{
+			name: "file path with lone dollar untouched",
+			loc:  "/Users/neilotoole/sq/file$.csv",
+			want: "/Users/neilotoole/sq/file$.csv",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			in := []byte(`config.version: v0.53.0
+collection:
+  sources:
+  - handle: "@src"
+    driver: postgres
+    location: ` + `"` + tc.loc + `"` + `
+`)
+
+			out, err := v0_54_0.Upgrade(ctx, in)
+			require.NoError(t, err)
+
+			var m map[string]any
+			require.NoError(t, ioz.UnmarshallYAML(out, &m))
+			src := m["collection"].(map[string]any)["sources"].([]any)[0].(map[string]any)
+			got, ok := src["location"].(string)
+			require.True(t, ok)
+			require.Equal(t, tc.want, got)
+
+			// The connect-path invariant: the stored location must parse
+			// cleanly with zero refs, and unescape to the original bytes,
+			// so the driver receives exactly what worked in v0.53.0.
+			refs, err := secret.ExtractRefs(got)
+			require.NoError(t, err)
+			require.Empty(t, refs)
+			require.Equal(t, tc.loc, secret.Unescape(got))
+		})
+	}
+}
+
 // TestUpgrade_NoRedactKey_IsIdempotent verifies that running Upgrade
 // against a config that has no "redact" key (whether already-migrated
 // or never had one) leaves the user-visible options untouched. Only

--- a/cli/config/yamlstore/upgrades/v0.54.0/upgrade_test.go
+++ b/cli/config/yamlstore/upgrades/v0.54.0/upgrade_test.go
@@ -195,50 +195,55 @@ collection:
 	}
 }
 
-// TestUpgrade_CorruptLocation verifies that a missing or non-string
-// source location aborts the upgrade before anything is written.
-// Neither config could ever load (the typed loader rejects empty
-// locations and fails to unmarshal non-string ones), so erroring here
-// can't break a working config; it produces a clearer error than the
-// downstream unmarshal failure, and matches the corrupt-shape
-// precedent elsewhere in this upgrade.
+// TestUpgrade_CorruptLocation verifies the upgrade's handling of
+// degenerate source locations.
+//
+// A missing location aborts the upgrade before anything is written:
+// such a config never loaded (validSource rejects empty locations), so
+// erroring can't break a working config, and it matches the
+// corrupt-shape precedent elsewhere in this upgrade.
+//
+// A non-string location is skipped, NOT an error: goccy-yaml coerces
+// scalar values (int/float/bool) into string fields, so 'location:
+// 123' loaded fine on v0.53.0 as "123" and erroring here would brick
+// a previously working config. Skipping is provably safe for escaping
+// purposes: a YAML scalar that parses as non-string can't contain '$'
+// (any '$'-bearing value parses as a string).
 func TestUpgrade_CorruptLocation(t *testing.T) {
 	log := lgt.New(t)
 	ctx := lg.NewContext(context.Background(), log)
 
-	tests := []struct {
-		name string
-		in   string
-	}{
-		{
-			name: "missing location",
-			in: `config.version: v0.53.0
+	t.Run("missing location errors", func(t *testing.T) {
+		in := []byte(`config.version: v0.53.0
 collection:
   sources:
   - handle: "@src"
     driver: postgres
-`,
-		},
-		{
-			name: "non-string location",
-			in: `config.version: v0.53.0
+`)
+		_, err := v0_54_0.Upgrade(ctx, in)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "corrupt config")
+		require.Contains(t, err.Error(), "location")
+	})
+
+	t.Run("non-string location skipped", func(t *testing.T) {
+		in := []byte(`config.version: v0.53.0
 collection:
   sources:
   - handle: "@src"
     driver: postgres
     location: 123
-`,
-		},
-	}
+`)
+		out, err := v0_54_0.Upgrade(ctx, in)
+		require.NoError(t, err,
+			"non-string location must not abort: it loaded fine on v0.53.0 (goccy coerces scalars)")
 
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			_, err := v0_54_0.Upgrade(ctx, []byte(tc.in))
-			require.Error(t, err)
-			require.Contains(t, err.Error(), "corrupt config")
-			require.Contains(t, err.Error(), "location")
-		})
-	}
+		var m map[string]any
+		require.NoError(t, ioz.UnmarshallYAML(out, &m))
+		require.Equal(t, v0_54_0.Version, m["config.version"])
+		src := m["collection"].(map[string]any)["sources"].([]any)[0].(map[string]any)
+		require.EqualValues(t, 123, src["location"], "non-string location value must be untouched")
+	})
 }
 
 // TestUpgrade_NoRedactKey_IsIdempotent verifies that running Upgrade

--- a/cli/expand.go
+++ b/cli/expand.go
@@ -67,6 +67,11 @@ func maybeExpandCollection(ctx context.Context, ru *run.Run, cmd *cobra.Command,
 			continue
 		}
 		src.Location = resolved
+		// Resolved bytes are literal, not a template: mark the source
+		// so a downstream ResolveSourceSecrets pass is a no-op. The
+		// lenient-failure branch above deliberately does NOT mark, as
+		// the placeholder is kept verbatim there.
+		src.SecretsResolved = true
 	}
 	return clone, nil
 }
@@ -105,5 +110,9 @@ func maybeExpandSource(ctx context.Context, ru *run.Run, cmd *cobra.Command,
 		return clone, nil
 	}
 	clone.Location = resolved
+	// Resolved bytes are literal, not a template: mark the source so a
+	// downstream ResolveSourceSecrets pass is a no-op. The lenient
+	// branch above does not mark, as the placeholder is kept verbatim.
+	clone.SecretsResolved = true
 	return clone, nil
 }

--- a/cli/expand.go
+++ b/cli/expand.go
@@ -67,10 +67,9 @@ func maybeExpandCollection(ctx context.Context, ru *run.Run, cmd *cobra.Command,
 			continue
 		}
 		src.Location = resolved
-		// Resolved bytes are literal, not a template: mark the source
-		// so a downstream ResolveSourceSecrets pass is a no-op. The
-		// lenient-failure branch above deliberately does NOT mark, as
-		// the placeholder is kept verbatim there.
+		// Resolved bytes are literal: mark so re-resolution is a no-op
+		// (the lenient branch above keeps the template, so it does not
+		// mark); see Source.SecretsResolved.
 		src.SecretsResolved = true
 	}
 	return clone, nil
@@ -110,9 +109,9 @@ func maybeExpandSource(ctx context.Context, ru *run.Run, cmd *cobra.Command,
 		return clone, nil
 	}
 	clone.Location = resolved
-	// Resolved bytes are literal, not a template: mark the source so a
-	// downstream ResolveSourceSecrets pass is a no-op. The lenient
-	// branch above does not mark, as the placeholder is kept verbatim.
+	// Resolved bytes are literal: mark so re-resolution is a no-op
+	// (the lenient branch above keeps the template, so it does not
+	// mark); see Source.SecretsResolved.
 	clone.SecretsResolved = true
 	return clone, nil
 }

--- a/cli/source.go
+++ b/cli/source.go
@@ -417,6 +417,9 @@ func checkStdinSource(ctx context.Context, ru *run.Run) (*source.Source, error) 
 		scheme = "duckdb://"
 	}
 	src.Location = scheme + tmpFile.Name()
+	// The temp path is an internally constructed literal, not a
+	// placeholder template: mark it so resolution is a no-op.
+	src.SecretsResolved = true
 	return src, nil
 }
 

--- a/cli/testrun/testrun.go
+++ b/cli/testrun/testrun.go
@@ -164,11 +164,15 @@ func (tr *TestRun) Reset() *TestRun {
 
 // PipeStdin points tr's stdin at a temp file containing content, for
 // tests that exercise prompts or piped input. Run.Stdin wants an
-// *os.File, so a plain strings.Reader doesn't suffice.
+// *os.File, so a plain strings.Reader doesn't suffice. The file is
+// closed via t.Cleanup: nothing in the Run lifecycle closes Stdin,
+// and an open handle would leak the descriptor and break TempDir
+// removal on Windows.
 func (tr *TestRun) PipeStdin(content string) *TestRun {
 	tr.T.Helper()
 	f, err := os.CreateTemp(tr.T.TempDir(), "stdin")
 	require.NoError(tr.T, err)
+	tr.T.Cleanup(func() { _ = f.Close() })
 	_, err = f.WriteString(content)
 	require.NoError(tr.T, err)
 	_, err = f.Seek(0, 0)

--- a/cli/testrun/testrun.go
+++ b/cli/testrun/testrun.go
@@ -162,6 +162,21 @@ func (tr *TestRun) Reset() *TestRun {
 	return tr
 }
 
+// PipeStdin points tr's stdin at a temp file containing content, for
+// tests that exercise prompts or piped input. Run.Stdin wants an
+// *os.File, so a plain strings.Reader doesn't suffice.
+func (tr *TestRun) PipeStdin(content string) *TestRun {
+	tr.T.Helper()
+	f, err := os.CreateTemp(tr.T.TempDir(), "stdin")
+	require.NoError(tr.T, err)
+	_, err = f.WriteString(content)
+	require.NoError(tr.T, err)
+	_, err = f.Seek(0, 0)
+	require.NoError(tr.T, err)
+	tr.Run.Stdin = f
+	return tr
+}
+
 // Add adds srcs to tr.Run.Config.Collection. If the collection
 // does not already have an active source, the first element
 // of srcs is used as the active source.

--- a/drivers/sqlite3/sqlite3.go
+++ b/drivers/sqlite3/sqlite3.go
@@ -1034,6 +1034,9 @@ func NewScratchSource(ctx context.Context, fpath string) (src *source.Source, cl
 		Type:     drivertype.SQLite,
 		Handle:   source.ScratchHandle,
 		Location: Prefix + fpath,
+		// The path is an internally constructed literal, not a
+		// placeholder template: mark it so resolution is a no-op.
+		SecretsResolved: true,
 	}
 
 	clnup = func() error {

--- a/drivers/sqlite3/sqlite3_test.go
+++ b/drivers/sqlite3/sqlite3_test.go
@@ -1093,3 +1093,28 @@ func TestSourceMetadata_LocationWithConnParams(t *testing.T) {
 	require.NotZero(t, *md.Size, "file size should be non-zero")
 	require.Equal(t, filepath.Base(dbPath), md.Name)
 }
+
+// TestNewScratchSource_SecretsResolved verifies that the scratch
+// source is marked SecretsResolved: its Location is a literal file
+// path constructed internally (never a placeholder template), so the
+// connect path's '$$' unescape must not reinterpret it. Without the
+// marker, a scratch path containing a literal '$$' (e.g. a cache dir
+// under a directory named with '$$') would be silently rewritten.
+func TestNewScratchSource_SecretsResolved(t *testing.T) {
+	ctx := testh.New(t).Context
+	fpath := filepath.Join(t.TempDir(), "scratch$$db.sqlite")
+
+	src, clnup, err := sqlite3.NewScratchSource(ctx, fpath)
+	require.NoError(t, err)
+	// The scratch DB file is only created on first open, which this
+	// test never does, so clnup's file removal may error: ignore it.
+	t.Cleanup(func() { _ = clnup() })
+
+	require.True(t, src.SecretsResolved,
+		"internally constructed literal locations must be marked resolved")
+
+	resolved, err := driver.ResolveSourceSecrets(ctx, src)
+	require.NoError(t, err)
+	require.Equal(t, src.Location, resolved.Location,
+		"resolution must not alter the literal scratch path")
+}

--- a/libsq/core/secret/escape.go
+++ b/libsq/core/secret/escape.go
@@ -1,0 +1,25 @@
+package secret
+
+import "strings"
+
+// Escape returns s with every '$' doubled to "$$", the placeholder
+// grammar's escape for a literal dollar. The result always parses
+// cleanly with zero refs (every '$' is part of a "$$" pair), and
+// expanding it yields exactly s. Use Escape to store a literal string
+// in a field that is interpreted as a placeholder template, such as
+// source locations.
+func Escape(s string) string {
+	if !strings.Contains(s, "$") {
+		return s
+	}
+	return strings.ReplaceAll(s, "$", "$$")
+}
+
+// Unescape replaces every "$$" with "$". It is the inverse of Escape
+// for strings that contain no placeholders; callers must not pass a
+// string containing well-formed ${scheme:path} refs, as the ref text
+// itself would not be protected from the replacement. Registry.Expand
+// handles unescaping for strings with refs.
+func Unescape(s string) string {
+	return unescapeDollar(s)
+}

--- a/libsq/core/secret/escape_test.go
+++ b/libsq/core/secret/escape_test.go
@@ -1,0 +1,65 @@
+package secret
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestEscape(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "empty", in: "", want: ""},
+		{name: "no dollar", in: "postgres://alice:hunter2@db/sakila", want: "postgres://alice:hunter2@db/sakila"},
+		{name: "lone dollar", in: "p$ss", want: "p$$ss"},
+		{name: "malformed placeholder", in: "p${ss}w", want: "p$${ss}w"},
+		{
+			name: "well-formed placeholder",
+			in:   "postgres://alice:${env:HOME}@db/sakila",
+			want: "postgres://alice:$${env:HOME}@db/sakila",
+		},
+		{name: "preexisting double dollar", in: "p$$wd", want: "p$$$$wd"},
+		{name: "triple dollar", in: "p$$$wd", want: "p$$$$$$wd"},
+		{name: "dollar at end", in: "pass$", want: "pass$$"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := Escape(tc.in)
+			require.Equal(t, tc.want, got)
+
+			// The escaped form must always parse cleanly with zero refs:
+			// every '$' in the output is part of a '$$' escape pair.
+			refs, err := ExtractRefs(got)
+			require.NoError(t, err)
+			require.Empty(t, refs)
+
+			// Round-trip: unescaping the escaped form yields the input.
+			require.Equal(t, tc.in, Unescape(got))
+		})
+	}
+}
+
+func TestUnescape(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "empty", in: "", want: ""},
+		{name: "no dollar", in: "hunter2", want: "hunter2"},
+		{name: "lone dollar untouched", in: "p$ss", want: "p$ss"},
+		{name: "double dollar", in: "p$$ss", want: "p$ss"},
+		{name: "escaped placeholder", in: "$${env:HOME}", want: "${env:HOME}"},
+		{name: "quadruple dollar", in: "p$$$$ss", want: "p$$ss"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, Unescape(tc.in))
+		})
+	}
+}

--- a/libsq/core/secret/secret.go
+++ b/libsq/core/secret/secret.go
@@ -21,10 +21,12 @@
 //
 // Every boundary that moves bytes between the two kinds must convert
 // exactly once: Escape converts literal -> template; Expand and Unescape
-// convert template -> literal. Storing template bytes in a literal slot
-// (or vice versa), or converting twice, mangles any '$' the value
-// contains. source.Source.SecretsResolved marks an in-memory source whose
-// Location has already been converted to literal form.
+// convert template -> literal (Unescape only for templates with no refs;
+// use Registry.Expand when refs may be present). Storing template bytes
+// in a literal slot (or vice versa), or converting twice, mangles any
+// '$' the value contains. source.Source.SecretsResolved marks an
+// in-memory source whose Location has already been converted to literal
+// form.
 package secret
 
 import (

--- a/libsq/core/secret/secret.go
+++ b/libsq/core/secret/secret.go
@@ -6,6 +6,25 @@
 // placeholder via the appropriate Resolver, and substitutes the resolved
 // values back. URL-encoding of values that land inside URL userinfo is
 // handled automatically.
+//
+// # Templates vs literals
+//
+// Two kinds of strings flow through this package, and confusing them
+// silently corrupts credentials:
+//
+//   - A template contains ${scheme:path} refs and uses "$$" to escape a
+//     literal '$'. Stored source locations (sq.yml, config exports) are
+//     templates.
+//   - A literal is raw bytes. Resolver outputs, keyring slot values, and
+//     expanded locations (e.g. from driver.ResolveSourceSecrets) are
+//     literals; they are spliced or used verbatim, never re-scanned.
+//
+// Every boundary that moves bytes between the two kinds must convert
+// exactly once: Escape converts literal -> template; Expand and Unescape
+// convert template -> literal. Storing template bytes in a literal slot
+// (or vice versa), or converting twice, mangles any '$' the value
+// contains. source.Source.SecretsResolved marks an in-memory source whose
+// Location has already been converted to literal form.
 package secret
 
 import (

--- a/libsq/driver/grips.go
+++ b/libsq/driver/grips.go
@@ -132,23 +132,22 @@ func ResolveSourceSecrets(ctx context.Context, src *source.Source) (*source.Sour
 	if err != nil {
 		return nil, errz.Wrapf(err, "parse placeholders for %s", src.Handle)
 	}
+
+	var resolved string
 	if len(refs) == 0 {
-		if unescaped := secret.Unescape(src.Location); unescaped != src.Location {
-			clone := src.Clone()
-			clone.Location = unescaped
-			clone.SecretsResolved = true
-			return clone, nil
+		if resolved = secret.Unescape(src.Location); resolved == src.Location {
+			return src, nil
 		}
-		return src, nil
+	} else {
+		reg := secret.FromContext(ctx)
+		if reg == nil {
+			return nil, errz.Errorf("resolve placeholders for %s: no secret registry bound to context", src.Handle)
+		}
+		if resolved, err = reg.Expand(ctx, src.Location); err != nil {
+			return nil, errz.Wrapf(err, "resolve secrets for %s", src.Handle)
+		}
 	}
-	reg := secret.FromContext(ctx)
-	if reg == nil {
-		return nil, errz.Errorf("resolve placeholders for %s: no secret registry bound to context", src.Handle)
-	}
-	resolved, err := reg.Expand(ctx, src.Location)
-	if err != nil {
-		return nil, errz.Wrapf(err, "resolve secrets for %s", src.Handle)
-	}
+
 	clone := src.Clone()
 	clone.Location = resolved
 	clone.SecretsResolved = true

--- a/libsq/driver/grips.go
+++ b/libsq/driver/grips.go
@@ -113,11 +113,19 @@ func (gs *Grips) IsSQLSource(src *source.Source) bool {
 // so that literal "${" sequences (e.g. an escaped "$${env:X}" or a
 // password that happens to contain "${") don't trigger resolution.
 //
+// ResolveSourceSecrets is idempotent: the returned clone is marked
+// SecretsResolved, and an already-resolved source passes through
+// unchanged, so accidental double-resolution cannot reinterpret
+// resolved literal bytes as a template.
+//
 // Exposed (rather than unexported) so callers and tests can drive the
 // resolution directly. Grips.doOpen calls it once at entry; drivers do
 // not need to call it themselves.
 func ResolveSourceSecrets(ctx context.Context, src *source.Source) (*source.Source, error) {
-	if src == nil {
+	if src == nil || src.SecretsResolved {
+		// Already-resolved Locations hold literal bytes, not template
+		// bytes; running them through resolution again would corrupt
+		// any '$' they contain.
 		return src, nil
 	}
 	refs, err := secret.ExtractRefs(src.Location)
@@ -128,6 +136,7 @@ func ResolveSourceSecrets(ctx context.Context, src *source.Source) (*source.Sour
 		if unescaped := secret.Unescape(src.Location); unescaped != src.Location {
 			clone := src.Clone()
 			clone.Location = unescaped
+			clone.SecretsResolved = true
 			return clone, nil
 		}
 		return src, nil
@@ -142,6 +151,7 @@ func ResolveSourceSecrets(ctx context.Context, src *source.Source) (*source.Sour
 	}
 	clone := src.Clone()
 	clone.Location = resolved
+	clone.SecretsResolved = true
 	return clone, nil
 }
 

--- a/libsq/driver/grips.go
+++ b/libsq/driver/grips.go
@@ -97,13 +97,17 @@ func (gs *Grips) IsSQLSource(src *source.Source) bool {
 }
 
 // ResolveSourceSecrets returns a clone of src with any ${scheme:path}
-// placeholders in src.Location resolved via the secret.Registry on ctx.
-// If src.Location contains no well-formed placeholders, src is returned
-// unchanged. If placeholders are present but no Registry is bound to
-// ctx, an error is returned: a placeholder on a source that has reached
-// this point is always meant to be resolved, and a silent passthrough
-// would surface later as a confusing "connection refused" or DSN-parse
-// error from the driver.
+// placeholders in src.Location resolved via the secret.Registry on ctx,
+// and any $$ escapes reduced to a literal $. If src.Location contains
+// no well-formed placeholders, the $$ escape is still honored (a clone
+// is returned when the location changes; no Registry is needed, since
+// nothing resolves). This is what lets a literal location be stored
+// escaped, e.g. by the v0.54.0 config upgrade, and reach the driver
+// byte-identically. If placeholders are present but no Registry is
+// bound to ctx, an error is returned: a placeholder on a source that
+// has reached this point is always meant to be resolved, and a silent
+// passthrough would surface later as a confusing "connection refused"
+// or DSN-parse error from the driver.
 //
 // Detection uses secret.ExtractRefs rather than a `${`-substring scan
 // so that literal "${" sequences (e.g. an escaped "$${env:X}" or a
@@ -121,6 +125,11 @@ func ResolveSourceSecrets(ctx context.Context, src *source.Source) (*source.Sour
 		return nil, errz.Wrapf(err, "parse placeholders for %s", src.Handle)
 	}
 	if len(refs) == 0 {
+		if unescaped := secret.Unescape(src.Location); unescaped != src.Location {
+			clone := src.Clone()
+			clone.Location = unescaped
+			return clone, nil
+		}
 		return src, nil
 	}
 	reg := secret.FromContext(ctx)

--- a/libsq/driver/grips_test.go
+++ b/libsq/driver/grips_test.go
@@ -60,7 +60,7 @@ func TestGrips_ResolveSourceSecrets_NoPlaceholder(t *testing.T) {
 // the v0.54.0 config upgrade's escaping of legacy locations (which
 // never contain intentional placeholders) connect byte-identically.
 // No secret.Registry is bound to the context: unescaping must not
-// require one, since a refless location resolves nothing.
+// require one, since a ref-free location resolves nothing.
 func TestGrips_ResolveSourceSecrets_NoRefs_Unescape(t *testing.T) {
 	tests := []struct {
 		name string

--- a/libsq/driver/grips_test.go
+++ b/libsq/driver/grips_test.go
@@ -54,6 +54,48 @@ func TestGrips_ResolveSourceSecrets_NoPlaceholder(t *testing.T) {
 	require.Same(t, src, resolved, "no placeholder => return input unchanged")
 }
 
+// TestGrips_ResolveSourceSecrets_NoRefs_Unescape verifies that the $$
+// escape is honored even when the location contains no ${scheme:path}
+// refs: the driver must receive the literal form. This is what makes
+// the v0.54.0 config upgrade's escaping of legacy locations (which
+// never contain intentional placeholders) connect byte-identically.
+// No secret.Registry is bound to the context: unescaping must not
+// require one, since a refless location resolves nothing.
+func TestGrips_ResolveSourceSecrets_NoRefs_Unescape(t *testing.T) {
+	tests := []struct {
+		name string
+		loc  string
+		want string
+	}{
+		{
+			name: "escaped dollar in password",
+			loc:  "postgres://alice:p$$ss@db/sakila",
+			want: "postgres://alice:p$ss@db/sakila",
+		},
+		{
+			name: "escaped well-formed placeholder",
+			loc:  "postgres://alice:$${env:HOME}@db/sakila",
+			want: "postgres://alice:${env:HOME}@db/sakila",
+		},
+		{
+			name: "escaped malformed placeholder",
+			loc:  "postgres://alice:p$${ss}w@db/sakila",
+			want: "postgres://alice:p${ss}w@db/sakila",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			src := &source.Source{Handle: "@sakila", Location: tc.loc}
+			resolved, err := driver.ResolveSourceSecrets(context.Background(), src)
+			require.NoError(t, err)
+			require.NotSame(t, src, resolved, "must return a clone when location changes")
+			require.Equal(t, tc.want, resolved.Location)
+			require.Equal(t, tc.loc, src.Location, "original src must be untouched")
+		})
+	}
+}
+
 func TestGrips_ResolveSourceSecrets_NoRegistry(t *testing.T) {
 	src := &source.Source{
 		Handle:   "@sakila",

--- a/libsq/driver/grips_test.go
+++ b/libsq/driver/grips_test.go
@@ -96,6 +96,51 @@ func TestGrips_ResolveSourceSecrets_NoRefs_Unescape(t *testing.T) {
 	}
 }
 
+// TestGrips_ResolveSourceSecrets_Idempotent verifies that resolving an
+// already-resolved source is a no-op. Resolution converts template
+// bytes to literal bytes; reinterpreting literal bytes as a template
+// (a second '$$' unescape, or re-resolution of '${...}'-shaped text
+// inside a resolved secret value) silently corrupts credentials. This
+// class of bug occurred three times during review (ping --expand,
+// inspect --expand, config export --expand), so the resolved clone now
+// carries a marker making double-resolution structurally harmless.
+func TestGrips_ResolveSourceSecrets_Idempotent(t *testing.T) {
+	t.Run("zero refs escaped literal", func(t *testing.T) {
+		src := &source.Source{
+			Handle:   "@sakila",
+			Location: "postgres://alice:p$$$$wd@db/sakila",
+		}
+		r1, err := driver.ResolveSourceSecrets(context.Background(), src)
+		require.NoError(t, err)
+		require.Equal(t, "postgres://alice:p$$wd@db/sakila", r1.Location)
+
+		r2, err := driver.ResolveSourceSecrets(context.Background(), r1)
+		require.NoError(t, err)
+		require.Same(t, r1, r2, "second resolution must be a no-op")
+		require.Equal(t, "postgres://alice:p$$wd@db/sakila", r2.Location)
+	})
+
+	t.Run("resolved secret value containing dollars", func(t *testing.T) {
+		reg := secret.NewRegistry()
+		reg.Register("keyring", &captureResolver{value: "p$$wd"})
+		ctx := secret.NewContext(context.Background(), reg)
+
+		src := &source.Source{
+			Handle:   "@sakila",
+			Location: "postgres://alice:${keyring:my_db_pw}@db/sakila",
+		}
+		r1, err := driver.ResolveSourceSecrets(ctx, src)
+		require.NoError(t, err)
+		require.Equal(t, "postgres://alice:p$$wd@db/sakila", r1.Location)
+
+		// Without the marker, this second pass would halve '$$' to '$'.
+		r2, err := driver.ResolveSourceSecrets(ctx, r1)
+		require.NoError(t, err)
+		require.Same(t, r1, r2, "second resolution must be a no-op")
+		require.Equal(t, "postgres://alice:p$$wd@db/sakila", r2.Location)
+	})
+}
+
 func TestGrips_ResolveSourceSecrets_NoRegistry(t *testing.T) {
 	src := &source.Source{
 		Handle:   "@sakila",

--- a/libsq/files/cache.go
+++ b/libsq/files/cache.go
@@ -209,6 +209,9 @@ func (fs *Files) cachedBackingSourceForFile(ctx context.Context, src *source.Sou
 		Handle:   src.Handle + "_cached",
 		Location: "sqlite3://" + cacheDBPath,
 		Type:     drivertype.SQLite,
+		// The cache path is an internally constructed literal, not a
+		// placeholder template: mark it so resolution is a no-op.
+		SecretsResolved: true,
 	}
 
 	lg.FromContext(ctx).Debug("Found cached backing source DB", lga.Src, src, "backing_src", backingSrc)

--- a/libsq/source/source.go
+++ b/libsq/source/source.go
@@ -65,8 +65,14 @@ type Source struct { //nolint:govet
 	// Type is the driver type, e.g. postgres.Type.
 	Type drivertype.Type `yaml:"driver" json:"driver"`
 
-	// Location is the source location, such as a DB connection URI,
-	// or a file path.
+	// Location is the source location: a DB connection URI or a file
+	// path, stored as a placeholder template. At connect time,
+	// ${scheme:path} refs are resolved via the secret registry and
+	// "$$" escapes are reduced to a literal "$"; see the
+	// libsq/core/secret package doc for the template-vs-literal rules.
+	// Code that hands the location to anything external (a driver, a
+	// subprocess, a hash) must use the resolved form from
+	// driver.ResolveSourceSecrets, not these raw template bytes.
 	Location string `yaml:"location" json:"location"`
 
 	// Catalog, when non-empty, specifies a catalog (database) name
@@ -94,6 +100,16 @@ type Source struct { //nolint:govet
 
 	// Options are additional params, typically empty.
 	Options options.Options `yaml:"options,omitempty" json:"options,omitempty"`
+
+	// SecretsResolved indicates that Location holds resolved literal
+	// bytes rather than a placeholder template: ${scheme:path} refs
+	// have been substituted and "$$" escapes reduced to "$". It is set
+	// by resolution (driver.ResolveSourceSecrets, and the CLI --expand
+	// machinery) so that feeding an already-resolved source back into
+	// resolution is a no-op, instead of a second reinterpretation of
+	// the literal bytes that would silently corrupt any '$' they
+	// contain. Never persisted or serialized.
+	SecretsResolved bool `yaml:"-" json:"-"`
 }
 
 // LogValue implements slog.LogValuer.
@@ -174,12 +190,13 @@ func (s *Source) Clone() *Source {
 	}
 
 	return &Source{
-		Handle:   s.Handle,
-		Type:     s.Type,
-		Location: s.Location,
-		Catalog:  s.Catalog,
-		Schema:   s.Schema,
-		Options:  s.Options.Clone(),
+		Handle:          s.Handle,
+		Type:            s.Type,
+		Location:        s.Location,
+		Catalog:         s.Catalog,
+		Schema:          s.Schema,
+		Options:         s.Options.Clone(),
+		SecretsResolved: s.SecretsResolved,
 	}
 }
 

--- a/site/content/en/docs/cmd/config-export.md
+++ b/site/content/en/docs/cmd/config-export.md
@@ -33,6 +33,12 @@ $ sq config export -o sq.bak.yml
 self-contained snapshot suitable for moving between machines, at the cost of writing every
 referenced secret in plaintext (which is the intent of `--expand` anyway).
 
+Because the exported file is itself a config, its locations are templates: any `$` in a
+resolved value is written as
+[`$$`](/docs/secrets#literal-dollar-signs), so that the export connects
+byte-identically when used as `sq.yml`. To see resolved values in raw literal form, use
+the display commands, e.g. `sq ls -v --expand`.
+
 ```shell
 $ sq config export --expand -o sq.bak.yml
 ```

--- a/site/content/en/docs/config/index.md
+++ b/site/content/en/docs/config/index.md
@@ -143,6 +143,21 @@ additional help for the options.
 
 ![sq config edit v](sq_config_edit_v.png)
 
+## Upgrades
+
+When a new `sq` version changes the config schema, `sq` migrates `sq.yml`
+automatically on first run. Before migrating, `sq` writes a verbatim backup of
+the config to the same dir, named for the version being upgraded from, e.g.
+`sq.v0.53.0.bak.yml`. `sq` never reads, modifies, or deletes the backup: it
+exists solely so you can restore the previous config if needed.
+
+The backup is created with user-only file permissions, but it preserves the
+old config exactly, including any inline credentials. If you later move your
+credentials out of the config (e.g. via
+[`sq config keyring migrate`](/docs/cmd/config-keyring-migrate)), remember
+that the backup still holds the plaintext values; delete it when you no
+longer need it.
+
 ## Logging
 
 By default, logging is turned off. If you need to submit a `sq`

--- a/site/content/en/docs/install.md
+++ b/site/content/en/docs/install.md
@@ -142,6 +142,13 @@ Note that `sq` is still pre-`v1.0.0`. Occasionally a release introduces a breaki
 Before upgrading, check the [CHANGELOG](https://github.com/neilotoole/sq/blob/master/CHANGELOG.md)
 or the notes for the latest [release](https://github.com/neilotoole/sq/releases).
 
+{{< alert icon="👉" >}}
+When a new version changes the config schema, `sq` migrates `sq.yml` automatically
+on first run, and first writes a verbatim backup (e.g. `sq.v0.53.0.bak.yml`) to the
+[config dir](/docs/config#location). The backup preserves the old config exactly,
+including any inline credentials: see [config upgrades](/docs/config#upgrades).
+{{< /alert >}}
+
 To upgrade, use the mechanism specific to the package manager for
 your system, e.g.:
 

--- a/site/content/en/docs/install.md
+++ b/site/content/en/docs/install.md
@@ -147,6 +147,8 @@ When a new version changes the config schema, `sq` migrates `sq.yml` automatical
 on first run, and first writes a verbatim backup (e.g. `sq.v0.53.0.bak.yml`) to the
 [config dir](/docs/config#location). The backup preserves the old config exactly,
 including any inline credentials: see [config upgrades](/docs/config#upgrades).
+`sq` never removes these backup files; it's up to you to delete them when no
+longer needed.
 {{< /alert >}}
 
 To upgrade, use the mechanism specific to the package manager for

--- a/site/content/en/docs/secrets/index.md
+++ b/site/content/en/docs/secrets/index.md
@@ -143,7 +143,8 @@ password like `p$ssw0rd`) is already literal and needs no escaping.
 
 When upgrading a config created before `v0.54.0` (which had no placeholder
 syntax), `sq` automatically escapes any source location that would otherwise
-be reinterpreted, so existing sources connect exactly as before.
+be reinterpreted, so existing sources connect exactly as before. The
+pre-upgrade config is [backed up](/docs/config#upgrades) verbatim first.
 
 ### URL encoding
 

--- a/site/content/en/docs/secrets/index.md
+++ b/site/content/en/docs/secrets/index.md
@@ -141,6 +141,11 @@ location: postgres://alice:$${env:HOME}@db/sakila
 A lone `$` that doesn't form a `${scheme:path}` placeholder (e.g. an inline
 password like `p$ssw0rd`) is already literal and needs no escaping.
 
+Escaping applies to location values you write yourself (the `sq add` location
+argument, or hand-edited config). A password supplied via
+[`sq add -p`](/docs/cmd/add) is a literal: `sq` escapes it for you before
+splicing it into the stored location.
+
 When upgrading a config created before `v0.54.0` (which had no placeholder
 syntax), `sq` automatically escapes any source location that would otherwise
 be reinterpreted, so existing sources connect exactly as before. The

--- a/site/content/en/docs/secrets/index.md
+++ b/site/content/en/docs/secrets/index.md
@@ -383,6 +383,12 @@ a self-contained snapshot suitable for moving between machines, at the cost
 of writing every referenced secret in plaintext (which is exactly the point
 of `--expand`).
 
+Because the exported file is itself a config, its locations are templates:
+any `$` in a resolved value is written as
+[`$$`](#literal-dollar-signs), so that the export connects byte-identically
+when used as `sq.yml`. To see resolved values in raw literal form, use the
+display commands, e.g. `sq ls -v --expand`.
+
 ```yaml
 # Live config: location uses a keyring placeholder
 - handle: '@sakila/pg'

--- a/site/content/en/docs/secrets/index.md
+++ b/site/content/en/docs/secrets/index.md
@@ -124,6 +124,27 @@ location: postgres://alice:${env:DB_PW}@db.acme.com/sakila
 
 `sq` ships with four schemes: `keyring`, `env`, `file`, and `op`.
 
+### Literal dollar signs
+
+The `location` value is a template: write `$$` for a literal `$`. At connect
+time, `sq` reduces each `$$` to `$` and resolves any `${scheme:path}`
+placeholders, so the driver receives the literal form.
+
+```yaml
+# Driver receives: postgres://alice:pa$$word@db/sakila
+location: postgres://alice:pa$$$$word@db/sakila
+
+# Driver receives the literal text ${env:HOME}, not the env var value
+location: postgres://alice:$${env:HOME}@db/sakila
+```
+
+A lone `$` that doesn't form a `${scheme:path}` placeholder (e.g. an inline
+password like `p$ssw0rd`) is already literal and needs no escaping.
+
+When upgrading a config created before `v0.54.0` (which had no placeholder
+syntax), `sq` automatically escapes any source location that would otherwise
+be reinterpreted, so existing sources connect exactly as before.
+
 ### URL encoding
 
 When a placeholder lands inside URL userinfo (the `user:password@host` part),


### PR DESCRIPTION
Fixes #782.

## Problem

The v0.54.0 placeholder machinery parses every source location at connect time
(`Grips.doOpen` -> `ResolveSourceSecrets` -> `secret.ExtractRefs`), but the v0.54.0 config
upgrade migrated only the `redact` option and left legacy locations untouched. For a config
that worked in v0.53.0:

- A location containing malformed placeholder syntax (e.g. an inline password with `${ss}`)
  failed every connect with a parse error.
- Worse, a location containing well-formed `${scheme:path}` text (e.g. `${env:HOME}`) was
  silently substituted, sending wrong credentials with no warning.

## Fix

Source locations are now consistently treated as placeholder templates, in which `$$`
escapes a literal `$`, with a single rule enforced at every boundary: bytes convert between
template and literal form exactly once. The rule is documented in a new "Templates vs
literals" section of the `secret` package doc, and `Source.Location`'s godoc states the
semantics. New `secret.Escape` / `secret.Unescape` helpers own the conversion.

Core changes:

- **The v0.54.0 config upgrade escapes `$` as `$$`** in any source location that would not
  survive template interpretation byte-identically: well-formed refs, malformed placeholder
  syntax, or a literal `$$`. Locations whose only dollars are lone `$` characters (e.g.
  `p$ssw0rd`) already expand to themselves and are left untouched, so config bytes don't
  churn for the common case. A missing location aborts the upgrade (such a config never
  loaded); non-string scalar locations are skipped (goccy-yaml coerces them to strings at
  load, and they can't contain `$`).
- **`ResolveSourceSecrets` honors the `$$` escape on the zero-refs path** (previously only
  `Registry.Expand` unescaped, and only when refs were present), so escaped locations reach
  the driver in their original literal form, with no secret registry needed.
- **Resolution is idempotent**: `Source` gains a `SecretsResolved` marker, set by
  `ResolveSourceSecrets` and the `--expand` machinery, so feeding an already-resolved
  source back through resolution is a no-op instead of a second, corrupting
  reinterpretation. Internally constructed literal sources (stdin temp DB, sqlite scratch,
  ingest cache backing source) are marked at construction.

Boundary fixes, each previously a path that silently corrupted `$`-bearing values:

- `sq config keyring migrate` stores the unescaped literal DSN (keyring slots hold
  literals that `Expand` splices raw).
- `sq ping --expand` and `sq inspect --expand` connect with the original stored source and
  use the expanded clone only for display.
- `sq config export --expand` re-escapes the resolved literal: the export is itself a
  config, so import round-trips byte-identically.
- `sq add -p` escapes the prompted/piped password before splicing it inline;
  `sq add --store keyring` unescapes the typed location before storing.
- `sq add` rejects a typed file path containing `$$` when the literal file exists but the
  interpreted path doesn't (covering bare paths and `sqlite3:`/`duckdb:` forms post-munge;
  SQLite would otherwise silently create an empty DB at the interpreted path), detection
  reads the template-interpreted bytes, and detection failures name the typed form.

## Pre-upgrade config backup

Since a buggy migration is otherwise one-way breakage, `yamlstore.doUpgrade` writes a
verbatim backup of the config before any upgrade func runs, named for the version being
upgraded from (e.g. `sq.v0.53.0.bak.yml`, alongside `sq.yml`), with 0600 permissions. sq
never reads, modifies, or deletes the backup; if it can't be written, the upgrade aborts.
The backup is written only when an upgrade func actually transforms the config, not on
routine version bumps. The name deliberately avoids the `.sq.yml` suffix that ext config
loading globs. Documented on the config page (including that the backup retains inline
credentials, which matters after `sq config keyring migrate`), with an alert in the
install docs' Upgrade section.

## Docs

New "Literal dollar signs" section on the secrets page (escape grammar, `add -p`
auto-escaping, upgrade behavior), an "Upgrades" section on the config page (backup), an
alert in install.md, export-docs note on escaped `--expand` output, and CHANGELOG entries
under the #728 migration item.

## Related issues

- #795 (cache dirs keyed on stored vs resolved bytes): filed during review, then closed as
  already fixed on master by #793, which is merged into this branch.
- #796: pre-existing config data-loss paths rooted in the version-stamping design
  (lossy rewrite on every version bump; downgraded-binary `Save` stripping newer-schema
  fields), out of scope here.
- #797: pre-existing edge where path absolutization splices literal cwd bytes into the
  location template.

## Testing

Everything was built test-first. Coverage includes: `secret.Escape`/`Unescape` invariants
(escaped output always parses with zero refs and round-trips); `ResolveSourceSecrets`
zero-refs unescape and idempotency (including a resolved secret value containing `$$`);
the upgrade escape matrix plus end-to-end fixtures through `yamlstore.Load`; backup
assertions (byte-identical, 0600, none written when no upgrade funcs run); regression
tests for every boundary fix (migrate, ping/inspect `--expand` on a CSV literally named
`data$$file.csv`, export `--expand`, `add -p` inline and keyring paths, raw and escaped
`$$` file and sqlite adds, detection-error wording, scratch-source marker); plus a manual
smoke of a real v0.53.0 config upgrade. Full test suite and `make lint` pass.
