### PR TITLE
Munge resolved placeholder locations for file-based drivers

### DIFF
--- a/cli/cmd_add.go
+++ b/cli/cmd_add.go
@@ -483,23 +483,18 @@ func applyPassword(ctx context.Context, cmd *cobra.Command, ru *run.Run, loc str
 
 // mungeLocationForType applies driver-specific location munging for
 // the file-based DB types (SQLite, DuckDB); other types pass through
-// unchanged. Only meaningful for non-placeholder locations.
+// unchanged. Only meaningful for non-placeholder locations: a
+// placeholder location is opaque at add time, and gets the same
+// munging at connect time via driver.ResolveSourceSecrets.
 func mungeLocationForType(ctx context.Context, typ drivertype.Type, loc string) (string, error) {
-	locBefore := loc
-	var err error
-	if typ == drivertype.SQLite {
-		if loc, err = sqlite3.MungeLocation(loc); err != nil {
-			return "", err
-		}
-		lg.FromContext(ctx).Debug("Munged sqlite loc", lga.Before, locBefore, lga.After, loc)
+	munged, err := location.MungeForDriver(typ, loc)
+	if err != nil {
+		return "", err
 	}
-	if typ == drivertype.DuckDB {
-		if loc, err = duckdb.MungeLocation(loc); err != nil {
-			return "", err
-		}
-		lg.FromContext(ctx).Debug("Munged duckdb loc", lga.Before, locBefore, lga.After, loc)
+	if munged != loc {
+		lg.FromContext(ctx).Debug("Munged location", lga.Before, loc, lga.After, munged)
 	}
-	return loc, nil
+	return munged, nil
 }
 
 // checkFileLocationEscape rejects a typed file location whose '$$'

--- a/drivers/duckdb/duckdb.go
+++ b/drivers/duckdb/duckdb.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"log/slog"
 	"math/big"
-	"path/filepath"
 	"strings"
 	"sync"
 	"time"
@@ -27,6 +26,7 @@ import (
 	"github.com/neilotoole/sq/libsq/driver"
 	"github.com/neilotoole/sq/libsq/source"
 	"github.com/neilotoole/sq/libsq/source/drivertype"
+	"github.com/neilotoole/sq/libsq/source/location"
 	"github.com/neilotoole/sq/libsq/source/metadata"
 )
 
@@ -207,34 +207,12 @@ func PathFromLocation(src *source.Source) (string, error) {
 // But that input location gets mangled on non-Windows OSes. This probably
 // isn't a problem in practice, but longer-term it may make sense to rewrite
 // MungeLocation to be OS-independent.
+//
+// MungeLocation is idempotent, and is a thin wrapper around
+// location.MungeForDriver, which also munges locations resolved from
+// secret placeholders at connect time (driver.ResolveSourceSecrets).
 func MungeLocation(loc string) (string, error) {
-	loc2 := strings.TrimSpace(loc)
-	if loc2 == "" {
-		return "", errz.New("location must not be empty")
-	}
-
-	// Detect the :memory: sentinel, optionally preceded by the duckdb scheme
-	// and optionally followed by a "?key=val&..." query suffix.
-	bare := strings.TrimPrefix(loc2, Prefix)
-	bare = strings.TrimPrefix(bare, "duckdb:")
-	pathPart, queryPart, hasQuery := strings.Cut(bare, "?")
-	if pathPart == ":memory:" {
-		if hasQuery {
-			return Prefix + ":memory:?" + queryPart, nil
-		}
-		return Prefix + ":memory:", nil
-	}
-
-	fp, err := filepath.Abs(pathPart)
-	if err != nil {
-		return "", errz.Wrapf(err, "invalid location: %s", loc)
-	}
-
-	fp = filepath.ToSlash(fp)
-	if hasQuery {
-		return Prefix + fp + "?" + queryPart, nil
-	}
-	return Prefix + fp, nil
+	return location.MungeForDriver(drivertype.DuckDB, loc)
 }
 
 // Ping implements driver.Driver.

--- a/drivers/duckdb/internal_test.go
+++ b/drivers/duckdb/internal_test.go
@@ -103,6 +103,13 @@ func TestMungeLocation(t *testing.T) {
 
 			require.NoError(t, err)
 			require.Equal(t, tc.want, got)
+
+			// MungeLocation must be idempotent: connect-time resolution
+			// (driver.ResolveSourceSecrets) munges resolved placeholder
+			// locations that may already be in canonical form (gh #798).
+			again, err := MungeLocation(got)
+			require.NoError(t, err)
+			require.Equal(t, got, again, "MungeLocation must be idempotent")
 		})
 	}
 }

--- a/drivers/sqlite3/sqlite3.go
+++ b/drivers/sqlite3/sqlite3.go
@@ -37,6 +37,7 @@ import (
 	"github.com/neilotoole/sq/libsq/driver/dialect"
 	"github.com/neilotoole/sq/libsq/source"
 	"github.com/neilotoole/sq/libsq/source/drivertype"
+	"github.com/neilotoole/sq/libsq/source/location"
 	"github.com/neilotoole/sq/libsq/source/metadata"
 )
 
@@ -1134,27 +1135,10 @@ func filePathFromLocation(loc string) string {
 // But that input location gets mangled on non-Windows OSes. This probably
 // isn't a problem in practice, but longer-term it may make sense to rewrite
 // MungeLocation to be OS-independent.
+//
+// MungeLocation is idempotent, and is a thin wrapper around
+// location.MungeForDriver, which also munges locations resolved from
+// secret placeholders at connect time (driver.ResolveSourceSecrets).
 func MungeLocation(loc string) (string, error) {
-	loc2 := strings.TrimSpace(loc)
-	if loc2 == "" {
-		return "", errz.New("location must not be empty")
-	}
-
-	loc2 = strings.TrimPrefix(loc2, "sqlite3://")
-	loc2 = strings.TrimPrefix(loc2, "sqlite3:")
-
-	pathPart, queryPart, hasQuery := strings.Cut(loc2, "?")
-
-	fp, err := filepath.Abs(pathPart)
-	if err != nil {
-		// Use pathPart, not loc: the original may contain secret
-		// connection params (e.g. _auth_pass) in the query suffix.
-		return "", errz.Wrapf(errw(err), "invalid location: %s", pathPart)
-	}
-
-	fp = filepath.ToSlash(fp)
-	if hasQuery {
-		return "sqlite3://" + fp + "?" + queryPart, nil
-	}
-	return "sqlite3://" + fp, nil
+	return location.MungeForDriver(drivertype.SQLite, loc)
 }

--- a/drivers/sqlite3/sqlite3_test.go
+++ b/drivers/sqlite3/sqlite3_test.go
@@ -16,6 +16,8 @@ import (
 	"github.com/neilotoole/sq/drivers/sqlite3/sqlparser"
 	"github.com/neilotoole/sq/libsq/core/kind"
 	"github.com/neilotoole/sq/libsq/core/schema"
+	"github.com/neilotoole/sq/libsq/core/secret"
+	"github.com/neilotoole/sq/libsq/core/secret/env"
 	"github.com/neilotoole/sq/libsq/core/sqlz"
 	"github.com/neilotoole/sq/libsq/core/stringz"
 	"github.com/neilotoole/sq/libsq/core/tablefq"
@@ -330,8 +332,46 @@ func TestMungeLocation(t *testing.T) {
 
 			require.NoError(t, err)
 			require.Equal(t, tc.want, got)
+
+			// MungeLocation must be idempotent: connect-time resolution
+			// (driver.ResolveSourceSecrets) munges resolved placeholder
+			// locations that may already be in canonical form (gh #798).
+			again, err := sqlite3.MungeLocation(got)
+			require.NoError(t, err)
+			require.Equal(t, got, again, "MungeLocation must be idempotent")
 		})
 	}
+}
+
+// TestPlaceholderLocation_Connect verifies end-to-end that a source
+// whose stored location is a placeholder resolving to a bare file path
+// connects successfully (gh #798). Before the fix, resolution spliced
+// the secret value without munging, and the driver rejected the bare
+// path with: invalid sqlite3 location: missing "sqlite3://" prefix.
+func TestPlaceholderLocation_Connect(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "gh798.db")
+	t.Setenv("SQ_TEST_GH798_DB_PATH", dbPath)
+
+	reg := secret.NewRegistry()
+	reg.Register("env", env.NewResolver())
+
+	th := testh.New(t)
+	ctx := secret.NewContext(th.Context, reg)
+
+	src := &source.Source{
+		Handle:   "@gh798",
+		Type:     drivertype.SQLite,
+		Location: "${env:SQ_TEST_GH798_DB_PATH}",
+	}
+
+	resolved, err := driver.ResolveSourceSecrets(ctx, src)
+	require.NoError(t, err)
+	require.Equal(t, "sqlite3://"+filepath.ToSlash(dbPath), resolved.Location)
+
+	// SQLite creates the file on open, so Ping succeeds iff the
+	// resolved location is in canonical driver form.
+	drvr := th.DriverFor(resolved)
+	require.NoError(t, drvr.Ping(ctx, resolved))
 }
 
 func TestSQLQuery_Whitespace(t *testing.T) {

--- a/libsq/driver/grips.go
+++ b/libsq/driver/grips.go
@@ -22,6 +22,7 @@ import (
 	"github.com/neilotoole/sq/libsq/files"
 	"github.com/neilotoole/sq/libsq/source"
 	"github.com/neilotoole/sq/libsq/source/drivertype"
+	"github.com/neilotoole/sq/libsq/source/location"
 )
 
 // ScratchSrcFunc is a function that returns a scratch source.
@@ -113,6 +114,15 @@ func (gs *Grips) IsSQLSource(src *source.Source) bool {
 // so that literal "${" sequences (e.g. an escaped "$${env:X}" or a
 // password that happens to contain "${") don't trigger resolution.
 //
+// When the location changes, the resolved value also receives the
+// driver-specific canonicalization (location.MungeForDriver) that
+// "sq add" applies to literal locations: a ${env:DB_PATH} placeholder
+// resolving to a bare file path like /data/sakila.db becomes
+// sqlite3:///data/sakila.db, which is the form the file-based drivers
+// require. Munging is idempotent, so a secret value already in
+// canonical form passes through unchanged. The munged form exists
+// only on the returned clone; the stored template is never modified.
+//
 // ResolveSourceSecrets is idempotent: the returned clone is marked
 // SecretsResolved, and an already-resolved source passes through
 // unchanged, so accidental double-resolution cannot reinterpret
@@ -146,6 +156,21 @@ func ResolveSourceSecrets(ctx context.Context, src *source.Source) (*source.Sour
 		if resolved, err = reg.Expand(ctx, src.Location); err != nil {
 			return nil, errz.Wrapf(err, "resolve secrets for %s", src.Handle)
 		}
+	}
+
+	// At add time, a literal file-DB location gets driver-specific
+	// munging (e.g. /data/sakila.db -> sqlite3:///data/sakila.db), but
+	// a placeholder location is opaque then, so it's stored unmunged.
+	// Apply the same munging to the resolved value here, on the clone
+	// only: the stored template must remain untouched. MungeForDriver
+	// is idempotent and a passthrough for non-file driver types, so an
+	// already-canonical location is unaffected.
+	if resolved, err = location.MungeForDriver(src.Type, resolved); err != nil {
+		// Don't echo the resolved location: it is secret material.
+		if len(refs) > 0 {
+			return nil, errz.Wrapf(err, "source %s: invalid location after resolving placeholders", src.Handle)
+		}
+		return nil, errz.Wrapf(err, "source %s: invalid location", src.Handle)
 	}
 
 	clone := src.Clone()

--- a/libsq/driver/grips.go
+++ b/libsq/driver/grips.go
@@ -164,13 +164,19 @@ func ResolveSourceSecrets(ctx context.Context, src *source.Source) (*source.Sour
 	// Apply the same munging to the resolved value here, on the clone
 	// only: the stored template must remain untouched. MungeForDriver
 	// is idempotent and a passthrough for non-file driver types, so an
-	// already-canonical location is unaffected.
-	if resolved, err = location.MungeForDriver(src.Type, resolved); err != nil {
-		// Don't echo the resolved location: it is secret material.
-		if len(refs) > 0 {
-			return nil, errz.Wrapf(err, "source %s: invalid location after resolving placeholders", src.Handle)
+	// already-canonical location is unaffected. Munging is gated on
+	// resolution actually changing the bytes: if expansion is a no-op
+	// (a secret value byte-identical to its own placeholder), the
+	// still-placeholder-shaped string must not be reinterpreted as a
+	// file path; it passes through for the driver to reject.
+	if resolved != src.Location {
+		if resolved, err = location.MungeForDriver(src.Type, resolved); err != nil {
+			// Don't echo the resolved location: it is secret material.
+			if len(refs) > 0 {
+				return nil, errz.Wrapf(err, "source %s: invalid location after resolving placeholders", src.Handle)
+			}
+			return nil, errz.Wrapf(err, "source %s: invalid location", src.Handle)
 		}
-		return nil, errz.Wrapf(err, "source %s: invalid location", src.Handle)
 	}
 
 	clone := src.Clone()

--- a/libsq/driver/grips_test.go
+++ b/libsq/driver/grips_test.go
@@ -2,13 +2,16 @@ package driver_test
 
 import (
 	"context"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/neilotoole/sq/libsq/core/secret"
+	"github.com/neilotoole/sq/libsq/core/secret/env"
 	"github.com/neilotoole/sq/libsq/driver"
 	"github.com/neilotoole/sq/libsq/source"
+	"github.com/neilotoole/sq/libsq/source/drivertype"
 )
 
 type captureResolver struct {
@@ -139,6 +142,116 @@ func TestGrips_ResolveSourceSecrets_Idempotent(t *testing.T) {
 		require.Same(t, r1, r2, "second resolution must be a no-op")
 		require.Equal(t, "postgres://alice:p$$wd@db/sakila", r2.Location)
 	})
+}
+
+// TestGrips_ResolveSourceSecrets_MungeFileDB verifies that the
+// driver-specific location munging that "sq add" applies to literal
+// file-DB locations is also applied to a location resolved from
+// placeholders (gh #798). A stored "${env:DB_PATH}" with
+// DB_PATH=/data/sakila.db must resolve to "sqlite3:///data/sakila.db";
+// the bare path would be rejected by the sqlite3 driver at connect
+// time ("invalid sqlite3 location: missing \"sqlite3://\" prefix").
+// The stored template must remain untouched: only the resolved clone
+// carries the munged form.
+func TestGrips_ResolveSourceSecrets_MungeFileDB(t *testing.T) {
+	relPath, err := filepath.Abs("data/sakila.db")
+	require.NoError(t, err)
+
+	testCases := []struct {
+		name    string
+		typ     drivertype.Type
+		envVal  string
+		want    string
+		wantErr bool
+	}{
+		{
+			name:   "sqlite bare absolute path",
+			typ:    drivertype.SQLite,
+			envVal: "/data/sakila.db",
+			want:   "sqlite3:///data/sakila.db",
+		},
+		{
+			name:   "sqlite bare relative path",
+			typ:    drivertype.SQLite,
+			envVal: "data/sakila.db",
+			want:   "sqlite3://" + filepath.ToSlash(relPath),
+		},
+		{
+			name:   "sqlite already munged",
+			typ:    drivertype.SQLite,
+			envVal: "sqlite3:///data/sakila.db",
+			want:   "sqlite3:///data/sakila.db",
+		},
+		{
+			name:   "sqlite munged with query suffix",
+			typ:    drivertype.SQLite,
+			envVal: "sqlite3:///data/sakila.db?mode=ro",
+			want:   "sqlite3:///data/sakila.db?mode=ro",
+		},
+		{
+			name:   "duckdb bare absolute path",
+			typ:    drivertype.DuckDB,
+			envVal: "/data/sakila.duckdb",
+			want:   "duckdb:///data/sakila.duckdb",
+		},
+		{
+			name:   "duckdb memory",
+			typ:    drivertype.DuckDB,
+			envVal: ":memory:",
+			want:   "duckdb://:memory:",
+		},
+		{
+			name:    "sqlite empty resolved value",
+			typ:     drivertype.SQLite,
+			envVal:  "",
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("SQ_TEST_GH798_DB_PATH", tc.envVal)
+			reg := secret.NewRegistry()
+			reg.Register("env", env.NewResolver())
+			ctx := secret.NewContext(context.Background(), reg)
+
+			src := &source.Source{
+				Handle:   "@gh798",
+				Type:     tc.typ,
+				Location: "${env:SQ_TEST_GH798_DB_PATH}",
+			}
+
+			resolved, err := driver.ResolveSourceSecrets(ctx, src)
+			if tc.wantErr {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "@gh798")
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.want, resolved.Location)
+			require.Equal(t, "${env:SQ_TEST_GH798_DB_PATH}", src.Location,
+				"stored template must remain untouched")
+		})
+	}
+}
+
+// TestGrips_ResolveSourceSecrets_MungeFileDB_NonFileDriver verifies
+// that munging at the resolution boundary leaves non-file driver
+// locations untouched.
+func TestGrips_ResolveSourceSecrets_MungeFileDB_NonFileDriver(t *testing.T) {
+	reg := secret.NewRegistry()
+	reg.Register("keyring", &captureResolver{value: "hunter2"})
+	ctx := secret.NewContext(context.Background(), reg)
+
+	src := &source.Source{
+		Handle:   "@sakila",
+		Type:     drivertype.Pg,
+		Location: "postgres://alice:${keyring:my_db_pw}@db/sakila",
+	}
+
+	resolved, err := driver.ResolveSourceSecrets(ctx, src)
+	require.NoError(t, err)
+	require.Equal(t, "postgres://alice:hunter2@db/sakila", resolved.Location)
 }
 
 func TestGrips_ResolveSourceSecrets_NoRegistry(t *testing.T) {

--- a/libsq/driver/grips_test.go
+++ b/libsq/driver/grips_test.go
@@ -157,6 +157,18 @@ func TestGrips_ResolveSourceSecrets_MungeFileDB(t *testing.T) {
 	relPath, err := filepath.Abs("data/sakila.db")
 	require.NoError(t, err)
 
+	// Volume-qualify the absolute test paths so the expectations hold on
+	// Windows too: there, filepath.Abs("/data/sakila.db") resolves the
+	// rooted-but-driveless path against the current drive, yielding e.g.
+	// "C:\data\sakila.db", which munges to "sqlite3://C:/data/sakila.db".
+	// On POSIX, Abs is the identity here and the canonical slash form is
+	// "sqlite3:///data/sakila.db".
+	absSakilaDB, err := filepath.Abs("/data/sakila.db")
+	require.NoError(t, err)
+	absSakilaDBSlash := filepath.ToSlash(absSakilaDB)
+	absSakilaDuck, err := filepath.Abs("/data/sakila.duckdb")
+	require.NoError(t, err)
+
 	testCases := []struct {
 		name    string
 		typ     drivertype.Type
@@ -167,8 +179,8 @@ func TestGrips_ResolveSourceSecrets_MungeFileDB(t *testing.T) {
 		{
 			name:   "sqlite bare absolute path",
 			typ:    drivertype.SQLite,
-			envVal: "/data/sakila.db",
-			want:   "sqlite3:///data/sakila.db",
+			envVal: absSakilaDB,
+			want:   "sqlite3://" + absSakilaDBSlash,
 		},
 		{
 			name:   "sqlite bare relative path",
@@ -179,20 +191,20 @@ func TestGrips_ResolveSourceSecrets_MungeFileDB(t *testing.T) {
 		{
 			name:   "sqlite already munged",
 			typ:    drivertype.SQLite,
-			envVal: "sqlite3:///data/sakila.db",
-			want:   "sqlite3:///data/sakila.db",
+			envVal: "sqlite3://" + absSakilaDBSlash,
+			want:   "sqlite3://" + absSakilaDBSlash,
 		},
 		{
 			name:   "sqlite munged with query suffix",
 			typ:    drivertype.SQLite,
-			envVal: "sqlite3:///data/sakila.db?mode=ro",
-			want:   "sqlite3:///data/sakila.db?mode=ro",
+			envVal: "sqlite3://" + absSakilaDBSlash + "?mode=ro",
+			want:   "sqlite3://" + absSakilaDBSlash + "?mode=ro",
 		},
 		{
 			name:   "duckdb bare absolute path",
 			typ:    drivertype.DuckDB,
-			envVal: "/data/sakila.duckdb",
-			want:   "duckdb:///data/sakila.duckdb",
+			envVal: absSakilaDuck,
+			want:   "duckdb://" + filepath.ToSlash(absSakilaDuck),
 		},
 		{
 			name:   "duckdb memory",
@@ -233,6 +245,50 @@ func TestGrips_ResolveSourceSecrets_MungeFileDB(t *testing.T) {
 				"stored template must remain untouched")
 		})
 	}
+}
+
+// TestGrips_ResolveSourceSecrets_MungeFileDB_NoChange verifies that
+// connect-time munging is gated on resolution actually changing the
+// location bytes. A literal file-DB location with no placeholders or
+// escapes was already munged by "sq add" (or deliberately left
+// non-canonical by the user); ResolveSourceSecrets must pass it
+// through untouched, preserving pre-resolution behavior. Likewise, if
+// expansion is a byte-level no-op (a secret value that is literally
+// its own placeholder text), the still-placeholder-shaped string must
+// not be reinterpreted as a file path in the cwd; it passes through
+// for the driver to reject.
+func TestGrips_ResolveSourceSecrets_MungeFileDB_NoChange(t *testing.T) {
+	t.Run("literal non-canonical location", func(t *testing.T) {
+		src := &source.Source{
+			Handle:   "@gh798",
+			Type:     drivertype.SQLite,
+			Location: "/data/sakila.db",
+		}
+		resolved, err := driver.ResolveSourceSecrets(context.Background(), src)
+		require.NoError(t, err)
+		require.Same(t, src, resolved, "no change => return input unchanged")
+		require.Equal(t, "/data/sakila.db", resolved.Location,
+			"location must not be munged")
+	})
+
+	t.Run("expansion is byte-level no-op", func(t *testing.T) {
+		const tmpl = "${env:SQ_TEST_GH798_DB_PATH}"
+		t.Setenv("SQ_TEST_GH798_DB_PATH", tmpl)
+		reg := secret.NewRegistry()
+		reg.Register("env", env.NewResolver())
+		ctx := secret.NewContext(context.Background(), reg)
+
+		src := &source.Source{
+			Handle:   "@gh798",
+			Type:     drivertype.SQLite,
+			Location: tmpl,
+		}
+		resolved, err := driver.ResolveSourceSecrets(ctx, src)
+		require.NoError(t, err)
+		require.Equal(t, tmpl, resolved.Location,
+			"placeholder-shaped resolved value must not be munged into a file path")
+		require.True(t, resolved.SecretsResolved)
+	})
 }
 
 // TestGrips_ResolveSourceSecrets_MungeFileDB_NonFileDriver verifies

--- a/libsq/source/location/munge.go
+++ b/libsq/source/location/munge.go
@@ -1,0 +1,93 @@
+package location
+
+import (
+	"path/filepath"
+	"strings"
+
+	"github.com/neilotoole/sq/libsq/core/errz"
+	"github.com/neilotoole/sq/libsq/source/drivertype"
+)
+
+// MungeForDriver applies driver-specific location canonicalization for
+// the file-based DB types (SQLite, DuckDB); other driver types pass
+// through unchanged. For SQLite, each of these forms is allowed:
+//
+//	sqlite3:///path/to/sakila.db  --> sqlite3:///path/to/sakila.db
+//	sqlite3:sakila.db             --> sqlite3:///current/working/dir/sakila.db
+//	sqlite3:/sakila.db            --> sqlite3:///sakila.db
+//	sqlite3:./sakila.db           --> sqlite3:///current/working/dir/sakila.db
+//	sakila.db                     --> sqlite3:///current/working/dir/sakila.db
+//	/path/to/sakila.db            --> sqlite3:///path/to/sakila.db
+//
+// DuckDB accepts the same forms with the "duckdb:" scheme, plus the
+// ":memory:" sentinel (optionally scheme-prefixed), which passes
+// through as "duckdb://:memory:".
+//
+// An optional "?key=val[&...]" connection-string suffix is preserved
+// verbatim. The first '?' is always treated as the path/query
+// separator, so paths whose POSIX filename legally contains '?' are
+// not supported.
+//
+// MungeForDriver is idempotent: an already-canonical location is
+// returned unchanged. This matters because it runs both at add time
+// (on the literal location the user typed) and at connect time (on a
+// location resolved from secret placeholders, which may already be in
+// canonical form); see driver.ResolveSourceSecrets.
+//
+// Errors returned by MungeForDriver do not echo the location: at
+// connect time the location bytes are resolved secret material.
+//
+// Note that this function is OS-dependent, due to the use of pkg
+// filepath. Thus, on Windows, this is seen:
+//
+//	C:/Users/sq/sakila.db  --> sqlite3://C:/Users/sq/sakila.db
+//
+// But that input location gets mangled on non-Windows OSes. This
+// probably isn't a problem in practice, but longer-term it may make
+// sense to rewrite the munging to be OS-independent.
+func MungeForDriver(typ drivertype.Type, loc string) (string, error) {
+	switch typ { //nolint:exhaustive // all other driver types pass through via default
+	case drivertype.SQLite:
+		return mungeFileDBLocation("sqlite3://", loc, false)
+	case drivertype.DuckDB:
+		return mungeFileDBLocation("duckdb://", loc, true)
+	default:
+		return loc, nil
+	}
+}
+
+// mungeFileDBLocation canonicalizes a file-based DB location per
+// MungeForDriver. Arg prefix is the canonical location prefix, e.g.
+// "sqlite3://". If allowMemory is true, the ":memory:" path sentinel
+// is preserved instead of being treated as a file path.
+func mungeFileDBLocation(prefix, loc string, allowMemory bool) (string, error) {
+	loc2 := strings.TrimSpace(loc)
+	if loc2 == "" {
+		return "", errz.New("location must not be empty")
+	}
+
+	loc2 = strings.TrimPrefix(loc2, prefix)
+	// Also trim the bare scheme form, e.g. "sqlite3:sakila.db".
+	loc2 = strings.TrimPrefix(loc2, strings.TrimSuffix(prefix, "//"))
+
+	pathPart, queryPart, hasQuery := strings.Cut(loc2, "?")
+	if allowMemory && pathPart == ":memory:" {
+		if hasQuery {
+			return prefix + ":memory:?" + queryPart, nil
+		}
+		return prefix + ":memory:", nil
+	}
+
+	fp, err := filepath.Abs(pathPart)
+	if err != nil {
+		// Don't echo the path: it may be resolved secret material, or
+		// carry secret connection params in a "?key=val" suffix.
+		return "", errz.Wrap(err, "invalid location")
+	}
+
+	fp = filepath.ToSlash(fp)
+	if hasQuery {
+		return prefix + fp + "?" + queryPart, nil
+	}
+	return prefix + fp, nil
+}

--- a/libsq/source/location/munge.go
+++ b/libsq/source/location/munge.go
@@ -71,6 +71,13 @@ func mungeFileDBLocation(prefix, loc string, allowMemory bool) (string, error) {
 	loc2 = strings.TrimPrefix(loc2, strings.TrimSuffix(prefix, "//"))
 
 	pathPart, queryPart, hasQuery := strings.Cut(loc2, "?")
+	if pathPart == "" {
+		// Reject explicitly: filepath.Abs("") would resolve to the
+		// current working directory, silently canonicalizing a prefix-only
+		// location (or an empty resolved placeholder value) to a DB
+		// location pointing at the cwd.
+		return "", errz.New("location path must not be empty")
+	}
 	if allowMemory && pathPart == ":memory:" {
 		if hasQuery {
 			return prefix + ":memory:?" + queryPart, nil

--- a/libsq/source/location/munge_test.go
+++ b/libsq/source/location/munge_test.go
@@ -1,0 +1,38 @@
+package location_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/neilotoole/sq/libsq/source/drivertype"
+	"github.com/neilotoole/sq/libsq/source/location"
+)
+
+func TestMungeForDriver_EmptyPath(t *testing.T) {
+	testCases := []struct {
+		name string
+		typ  drivertype.Type
+		loc  string
+	}{
+		{name: "sqlite3 prefix only", typ: drivertype.SQLite, loc: "sqlite3://"},
+		{name: "sqlite3 bare scheme only", typ: drivertype.SQLite, loc: "sqlite3:"},
+		{name: "sqlite3 empty path with query", typ: drivertype.SQLite, loc: "sqlite3://?mode=ro"},
+		{name: "duckdb prefix only", typ: drivertype.DuckDB, loc: "duckdb://"},
+		{name: "duckdb empty path with query", typ: drivertype.DuckDB, loc: "duckdb://?access_mode=READ_ONLY"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := location.MungeForDriver(tc.typ, tc.loc)
+			require.Error(t, err)
+			require.NotContains(t, err.Error(), tc.loc,
+				"error must not echo the location")
+		})
+	}
+
+	// The :memory: sentinel is not an empty path.
+	got, err := location.MungeForDriver(drivertype.DuckDB, "duckdb://:memory:")
+	require.NoError(t, err)
+	require.Equal(t, "duckdb://:memory:", got)
+}


### PR DESCRIPTION
Fixes #798.

Location munging for file-based DBs (sqlite3, duckdb) ran only at add time, in `cmd_add`'s
non-placeholder branch. A placeholder location is opaque at add time, so it was stored
unmunged, and connect-time resolution spliced the secret value (a bare file path) without
munging: `sq add '${env:DB_PATH}'` with `DB_PATH=/data/sakila.db` added fine but every
connect failed with `invalid sqlite3 location: missing "sqlite3://" prefix`.

Changes:

- New `location.MungeForDriver(typ, loc)` in `libsq/source/location/munge.go` is the single
  munge dispatch shared by add-time and connect-time paths. The sqlite3 and duckdb
  `MungeLocation` funcs and `cmd_add.mungeLocationForType` now delegate to it.
- `driver.ResolveSourceSecrets` applies the munge to the resolved location when the resolved
  bytes differ from the stored bytes. Only the resolved clone is touched; the stored
  placeholder template is never modified, so cache keying (#795) is unaffected.
- Munging is idempotent (asserted by tests), so already-canonical secret values like
  `sqlite3:///path?mode=ro` pass through byte-identically.
- On munge failure during resolution, the error names the handle and notes the location was
  invalid after resolving placeholders, without echoing the resolved bytes.

Testing: new table test for `ResolveSourceSecrets` munging via `${env:...}` placeholders;
end-to-end sqlite3 test (placeholder, resolve, ping); idempotency assertions for both
drivers. `make lint` clean; `-short` suites green.