### PR TITLE
Strip secrets from location completion candidates

### DIFF
--- a/cli/complete_location_suggestions.go
+++ b/cli/complete_location_suggestions.go
@@ -23,6 +23,11 @@ import (
 // dburl does not recognize it. The returned *dburl.URL wraps the
 // parsed URL so callers can read User/Host/Path/RawQuery uniformly.
 //
+// The location is first passed through location.StripSecrets: every
+// field parsed here can end up in shell-completion candidates echoed
+// to the terminal, which must never carry inline passwords or secret
+// query parameter values.
+//
 // On parse failure the underlying url.Parse / dburl.Parse error is
 // intentionally NOT wrapped: those errors embed the raw input
 // verbatim (e.g. `parse "postgres://alice:hunter2@host": ...`), and
@@ -30,6 +35,7 @@ import (
 // a stack-traced sentinel describing the failure category; callers
 // should log the redacted location separately.
 func parseSourceLoc(loc string, typ drivertype.Type) (*dburl.URL, error) {
+	loc = location.StripSecrets(loc)
 	if typ == drivertype.Rqlite {
 		u, err := url.Parse(loc)
 		if err != nil {
@@ -93,14 +99,23 @@ func (s *locSuggestions) Tails(kind driver.SegmentKind) []string {
 	}
 }
 
-// Locations implements driver.Suggestions.
+// Locations implements driver.Suggestions. Each location is stripped
+// of inline secrets (see location.StripSecrets) before joining the
+// candidate pool; locations that don't parse even after stripping are
+// skipped, because stripping can't be verified on a malformed input.
 func (s *locSuggestions) Locations() []string {
 	var locs []string
 	_ = s.coll.Visit(func(src *source.Source) error {
 		if src.Type != s.typ {
 			return nil
 		}
-		locs = append(locs, src.Location)
+		loc := location.StripSecrets(src.Location)
+		if _, err := parseSourceLoc(loc, s.typ); err != nil {
+			s.log.Warn("Parse source location",
+				lga.Loc, location.Redact(src.Location), lga.Err, err)
+			return nil
+		}
+		locs = append(locs, loc)
 		return nil
 	})
 	locs = lo.Uniq(locs)

--- a/cli/complete_location_suggestions.go
+++ b/cli/complete_location_suggestions.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/neilotoole/sq/libsq/core/errz"
 	"github.com/neilotoole/sq/libsq/core/lg/lga"
+	"github.com/neilotoole/sq/libsq/core/secret"
 	"github.com/neilotoole/sq/libsq/core/urlz"
 	"github.com/neilotoole/sq/libsq/driver"
 	"github.com/neilotoole/sq/libsq/source"
@@ -28,6 +29,14 @@ import (
 // to the terminal, which must never carry inline passwords or secret
 // query parameter values.
 //
+// A userinfo password surviving StripSecrets is a pure ${scheme:path}
+// placeholder, whose characters net/url rejects in userinfo. The
+// password is therefore replaced with a benign digit sentinel before
+// parsing so placeholder-password sources still contribute completion
+// suggestions (see sentinelizePlaceholderPassword). Callers must not
+// read the password from the returned URL; no completion candidate
+// carries a password, so none does.
+//
 // On parse failure the underlying url.Parse / dburl.Parse error is
 // intentionally NOT wrapped: those errors embed the raw input
 // verbatim (e.g. `parse "postgres://alice:hunter2@host": ...`), and
@@ -36,6 +45,7 @@ import (
 // should log the redacted location separately.
 func parseSourceLoc(loc string, typ drivertype.Type) (*dburl.URL, error) {
 	loc = location.StripSecrets(loc)
+	loc = sentinelizePlaceholderPassword(loc)
 	if typ == drivertype.Rqlite {
 		u, err := url.Parse(loc)
 		if err != nil {
@@ -48,6 +58,50 @@ func parseSourceLoc(loc string, typ drivertype.Type) (*dburl.URL, error) {
 		return nil, errz.New("parse location")
 	}
 	return du, nil
+}
+
+// sentinelizePlaceholderPassword replaces each ${scheme:path}
+// placeholder ref in loc's userinfo password with the digit "0".
+// net/url rejects '$', '{', and '}' in userinfo, so a placeholder
+// password such as "postgres://alice:${keyring:pg}@host/db" (which
+// location.StripSecrets keeps verbatim: placeholders are config-
+// visible text, not secrets) would otherwise fail the parse gate and
+// the source would contribute nothing to completion. The returned
+// value is parse fodder only; callers offer the original text to the
+// user. Refs outside the userinfo password (e.g. query values, which
+// parse fine; or usernames, which must keep failing the gate lest the
+// sentinel be offered as a username suggestion) are left verbatim.
+func sentinelizePlaceholderPassword(loc string) string {
+	schemeIdx := strings.Index(loc, "://")
+	if schemeIdx < 0 {
+		return loc
+	}
+	authority := loc[schemeIdx+3:]
+	if i := strings.IndexAny(authority, "/?#"); i >= 0 {
+		authority = authority[:i]
+	}
+	at := strings.LastIndexByte(authority, '@')
+	if at < 0 {
+		return loc
+	}
+	userinfo := authority[:at]
+	colon := strings.IndexByte(userinfo, ':')
+	if colon < 0 {
+		return loc
+	}
+	passwd := userinfo[colon+1:]
+	if !strings.Contains(passwd, "${") {
+		return loc
+	}
+	refs, err := secret.ExtractRefs(passwd)
+	if err != nil || len(refs) == 0 {
+		return loc
+	}
+	for _, ref := range refs {
+		passwd = strings.Replace(passwd, "${"+ref.Scheme+":"+ref.Path+"}", "0", 1)
+	}
+	i := schemeIdx + 3
+	return loc[:i+colon+1] + passwd + loc[i+at:]
 }
 
 // locSuggestions provides historical and contextual values that the
@@ -103,6 +157,10 @@ func (s *locSuggestions) Tails(kind driver.SegmentKind) []string {
 // of inline secrets (see location.StripSecrets) before joining the
 // candidate pool; locations that don't parse even after stripping are
 // skipped, because stripping can't be verified on a malformed input.
+// The parse gate tolerates a ${scheme:path} placeholder password (see
+// parseSourceLoc), so such locations join the pool with the
+// placeholder text intact: placeholders are config-visible text, not
+// secrets.
 func (s *locSuggestions) Locations() []string {
 	var locs []string
 	_ = s.coll.Visit(func(src *source.Source) error {

--- a/cli/complete_location_suggestions.go
+++ b/cli/complete_location_suggestions.go
@@ -111,8 +111,11 @@ func (s *locSuggestions) Locations() []string {
 		}
 		loc := location.StripSecrets(src.Location)
 		if _, err := parseSourceLoc(loc, s.typ); err != nil {
+			// Log the stripped value, not Redact(src.Location): Redact
+			// passes sqlite3/duckdb locations through unchanged, so a
+			// malformed location could leak secret query params here.
 			s.log.Warn("Parse source location",
-				lga.Loc, location.Redact(src.Location), lga.Err, err)
+				lga.Loc, loc, lga.Err, err)
 			return nil
 		}
 		locs = append(locs, loc)

--- a/cli/complete_location_test.go
+++ b/cli/complete_location_test.go
@@ -1766,6 +1766,84 @@ func TestCompleteAddLocation_History_SQLite3(t *testing.T) {
 	}
 }
 
+// TestCompleteAddLocation_History_SecretsStripped verifies gh784:
+// prior source locations are stripped of inline secrets (userinfo
+// passwords and secret-bearing query parameter values) before they
+// are offered as shell-completion candidates.
+func TestCompleteAddLocation_History_SecretsStripped(t *testing.T) {
+	tu.SkipIssueWindows(t, tu.GH372ShellCompletionWin)
+	wd := tu.Chdir(t, filepath.Join("testdata", "add_location"))
+	t.Logf("Working dir: %s", wd)
+
+	const (
+		userinfoSecret = "userinfoSecret77"
+		querySecret    = "querySecret88"
+	)
+
+	th := testh.New(t)
+	tr := testrun.New(th.Context, t, nil)
+	tr.Add(
+		source.Source{
+			Handle: "@pg1",
+			Type:   drivertype.Pg,
+			Location: "postgres://alice:" + userinfoSecret +
+				"@dev.acme.com:7777/sakila?sslmode=require&sslpassword=" + querySecret,
+		},
+		source.Source{
+			Handle: "@sl1",
+			Type:   drivertype.SQLite,
+			// Note that this file doesn't actually exist.
+			Location: "sqlite3:///zz_dir1/sqtest/sq/app.db?_auth_user=admin&_auth_pass=" + querySecret,
+		},
+	)
+
+	testCases := []struct {
+		args []string
+		want []string
+	}{
+		{
+			args: []string{"sqlite3:///zz_dir1/sqtest/"},
+			want: []string{
+				"sqlite3:///zz_dir1/sqtest/sq/app.db?_auth_user=admin&_auth_pass=",
+			},
+		},
+		{
+			args: []string{"postgres://"},
+			want: []string{
+				"postgres://alice",
+				"postgres://username",
+			},
+		},
+		{
+			args: []string{"postgres://alice@"},
+			want: []string{
+				"postgres://alice@localhost/",
+				"postgres://alice@localhost?",
+				"postgres://alice@localhost:5432/",
+				"postgres://alice@localhost:5432?",
+				"postgres://alice@dev.acme.com:7777/sakila?sslmode=require&sslpassword=",
+				"postgres://alice@dev.acme.com:7777/",
+				"postgres://alice@dev.acme.com:7777?",
+			},
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(tu.Name(i, strings.Join(tc.args, "_")), func(t *testing.T) {
+			args := append([]string{"add"}, tc.args...)
+			got := testComplete(t, tr, args...)
+			require.Equal(t, stdDirective, got.result, got.directives)
+			require.Equal(t, tc.want, got.values)
+			for _, v := range got.values {
+				require.NotContains(t, v, userinfoSecret,
+					"completion candidate must not contain the userinfo password")
+				require.NotContains(t, v, querySecret,
+					"completion candidate must not contain a secret query param value")
+			}
+		})
+	}
+}
+
 // TestParseLoc_stage is no more: the legacy parsedLoc / plocStage
 // parser was replaced by driver.LocationShape + driver.Walk. Stage
 // detection is now covered by TestWalk in libsq/driver.

--- a/cli/complete_location_test.go
+++ b/cli/complete_location_test.go
@@ -1790,10 +1790,26 @@ func TestCompleteAddLocation_History_SecretsStripped(t *testing.T) {
 				"@dev.acme.com:7777/sakila?sslmode=require&sslpassword=" + querySecret,
 		},
 		source.Source{
+			Handle: "@pg2",
+			Type:   drivertype.Pg,
+			// A ${scheme:path} placeholder password isn't itself a secret
+			// (it's the text stored in config). net/url rejects the
+			// placeholder characters in userinfo, but the parse gate
+			// tolerates a placeholder password, so this source must still
+			// contribute suggestions (bob, prod.acme.com:5432, the tail).
+			Location: "postgres://bob:${keyring:pg-prod}@prod.acme.com:5432/sales?sslmode=verify-full",
+		},
+		source.Source{
 			Handle: "@sl1",
 			Type:   drivertype.SQLite,
 			// Note that this file doesn't actually exist.
 			Location: "sqlite3:///zz_dir1/sqtest/sq/app.db?_auth_user=admin&_auth_pass=" + querySecret,
+		},
+		source.Source{
+			Handle: "@sl2",
+			Type:   drivertype.SQLite,
+			// Placeholder-valued secret query param: offered verbatim.
+			Location: "sqlite3:///zz_dir1/sqtest/sq/app2.db?_auth_user=admin&_auth_pass=${keyring:sl-dev}",
 		},
 	)
 
@@ -1805,12 +1821,14 @@ func TestCompleteAddLocation_History_SecretsStripped(t *testing.T) {
 			args: []string{"sqlite3:///zz_dir1/sqtest/"},
 			want: []string{
 				"sqlite3:///zz_dir1/sqtest/sq/app.db?_auth_user=admin&_auth_pass=",
+				"sqlite3:///zz_dir1/sqtest/sq/app2.db?_auth_user=admin&_auth_pass=${keyring:sl-dev}",
 			},
 		},
 		{
 			args: []string{"postgres://"},
 			want: []string{
 				"postgres://alice",
+				"postgres://bob",
 				"postgres://username",
 			},
 		},
@@ -1822,8 +1840,11 @@ func TestCompleteAddLocation_History_SecretsStripped(t *testing.T) {
 				"postgres://alice@localhost:5432/",
 				"postgres://alice@localhost:5432?",
 				"postgres://alice@dev.acme.com:7777/sakila?sslmode=require&sslpassword=",
+				"postgres://alice@prod.acme.com:5432/sales?sslmode=verify-full",
 				"postgres://alice@dev.acme.com:7777/",
 				"postgres://alice@dev.acme.com:7777?",
+				"postgres://alice@prod.acme.com:5432/",
+				"postgres://alice@prod.acme.com:5432?",
 			},
 		},
 	}

--- a/libsq/source/location/location.go
+++ b/libsq/source/location/location.go
@@ -690,6 +690,154 @@ func redactBestEffort(loc string) string {
 	return loc
 }
 
+// IsSecretQueryParam reports whether the URL query parameter key
+// conventionally carries a secret value in driver connection strings,
+// e.g. "password" (sqlserver), "sslpassword" (postgres), "_auth_pass"
+// (sqlite3). Matching is case-insensitive. Boolean toggles that merely
+// mention passwords (e.g. mysql's "allowCleartextPasswords") do not
+// match.
+func IsSecretQueryParam(key string) bool {
+	k := strings.ToLower(key)
+	switch k {
+	case "password", "passwd", "pwd", "pw", "secret", "token",
+		"apikey", "api_key", "access_token", "auth_token":
+		return true
+	default:
+		return strings.HasSuffix(k, "password") ||
+			strings.HasSuffix(k, "passwd") ||
+			strings.HasSuffix(k, "_pass") ||
+			strings.HasSuffix(k, "_secret") ||
+			strings.HasSuffix(k, "_token")
+	}
+}
+
+// StripSecrets returns loc with embedded secrets removed, for use
+// where the location must remain valid and completable but must not
+// expose secrets, e.g. shell-completion candidates. The userinfo
+// password (if any) is dropped ("scheme://alice:pw@host" becomes
+// "scheme://alice@host"), and the values of secret-bearing query
+// parameters (see IsSecretQueryParam) are emptied
+// ("?_auth_pass=hunter2" becomes "?_auth_pass="). Stripping is purely
+// textual: non-secret portions of loc, including escaping and query
+// parameter order, are preserved byte-for-byte.
+//
+// StripSecrets differs from Redact, which masks secrets with a fixed
+// "xxxxx" string for display: a masked location accepted as a
+// completion candidate would silently create a source with a bogus
+// password, so here the secret is removed instead.
+//
+// A ${scheme:path} placeholder is not itself a secret (it's the text
+// stored in config), so a password or query value consisting entirely
+// of placeholders passes through verbatim. Mixed literal/placeholder
+// values are dropped like any literal secret.
+func StripSecrets(loc string) string {
+	refs, err := secret.ExtractRefs(loc)
+	if err != nil || len(refs) == 0 {
+		return stripSecretsRaw(loc, nil)
+	}
+	sentinels, ok := pickSentinels(loc, len(refs))
+	if !ok {
+		// No non-colliding sentinels found (astronomically unlikely).
+		// Strip without placeholder preservation: placeholder-valued
+		// passwords get dropped along with literal ones, which leaks
+		// nothing.
+		return stripSecretsRaw(loc, nil)
+	}
+	placeholders := make([]string, len(refs))
+	sentinelled := loc
+	for i, ref := range refs {
+		placeholders[i] = "${" + ref.Scheme + ":" + ref.Path + "}"
+		sentinelled = strings.Replace(sentinelled, placeholders[i], sentinels[i], 1)
+	}
+	stripped := stripSecretsRaw(sentinelled, sentinels)
+	// Restore surviving sentinels. Sentinels dropped by stripping
+	// (mixed literal/placeholder secrets) are simply absent.
+	for i := range refs {
+		stripped = strings.Replace(stripped, sentinels[i], placeholders[i], 1)
+	}
+	return stripped
+}
+
+// stripSecretsRaw implements StripSecrets on a location whose
+// ${scheme:path} placeholders (if any) have been replaced with the
+// given sentinels. A password or query value composed entirely of
+// sentinels is a placeholder template, not a literal secret, and is
+// left intact.
+func stripSecretsRaw(loc string, sentinels []string) string {
+	base, query, hasQuery := strings.Cut(loc, "?")
+	base = stripUserinfoPassword(base, sentinels)
+	if !hasQuery {
+		return base
+	}
+	return base + "?" + stripSecretQueryValues(query, sentinels)
+}
+
+// stripUserinfoPassword drops the ":password" portion of base's
+// userinfo, if present. base must not contain a query string. A
+// password composed entirely of sentinels is kept.
+func stripUserinfoPassword(base string, sentinels []string) string {
+	schemeIdx := strings.Index(base, "://")
+	if schemeIdx < 0 {
+		return base
+	}
+	authority := base[schemeIdx+3:]
+	if end := strings.IndexByte(authority, '/'); end >= 0 {
+		authority = authority[:end]
+	}
+	at := strings.LastIndexByte(authority, '@')
+	if at < 0 {
+		return base
+	}
+	userinfo := authority[:at]
+	colon := strings.IndexByte(userinfo, ':')
+	if colon < 0 {
+		return base
+	}
+	if isOnlySentinels(userinfo[colon+1:], sentinels) {
+		return base
+	}
+	i := schemeIdx + 3
+	return base[:i+colon] + base[i+at:]
+}
+
+// stripSecretQueryValues empties the value of each secret-bearing
+// key=value pair (per IsSecretQueryParam) in the raw query string,
+// preserving pair order and the escaping of untouched pairs. Values
+// composed entirely of sentinels are kept.
+func stripSecretQueryValues(query string, sentinels []string) string {
+	pairs := strings.Split(query, "&")
+	for i, pair := range pairs {
+		k, v, ok := strings.Cut(pair, "=")
+		if !ok || v == "" {
+			continue
+		}
+		key, err := url.QueryUnescape(k)
+		if err != nil {
+			key = k
+		}
+		if !IsSecretQueryParam(key) {
+			continue
+		}
+		if isOnlySentinels(v, sentinels) {
+			continue
+		}
+		pairs[i] = k + "="
+	}
+	return strings.Join(pairs, "&")
+}
+
+// isOnlySentinels reports whether s is non-empty and composed entirely
+// of strings from sentinels.
+func isOnlySentinels(s string, sentinels []string) bool {
+	if s == "" || len(sentinels) == 0 {
+		return false
+	}
+	for _, sentinel := range sentinels {
+		s = strings.ReplaceAll(s, sentinel, "")
+	}
+	return s == ""
+}
+
 // MergeQuery returns loc with the given query params set, replacing
 // any existing values for the same keys. Other query params are
 // preserved. loc must be parseable by net/url and have a scheme:

--- a/libsq/source/location/location.go
+++ b/libsq/source/location/location.go
@@ -762,14 +762,21 @@ func StripSecrets(loc string) string {
 // ${scheme:path} placeholders (if any) have been replaced with the
 // given sentinels. A password or query value composed entirely of
 // sentinels is a placeholder template, not a literal secret, and is
-// left intact.
+// left intact. A URL fragment is preserved verbatim: per URL syntax
+// an unencoded '#' always starts the fragment, so it is carved off
+// before query processing lest it be swallowed by a blanked value.
 func stripSecretsRaw(loc string, sentinels []string) string {
+	loc, frag, hasFrag := strings.Cut(loc, "#")
 	base, query, hasQuery := strings.Cut(loc, "?")
 	base = stripUserinfoPassword(base, sentinels)
-	if !hasQuery {
-		return base
+	stripped := base
+	if hasQuery {
+		stripped += "?" + stripSecretQueryValues(query, sentinels)
 	}
-	return base + "?" + stripSecretQueryValues(query, sentinels)
+	if hasFrag {
+		stripped += "#" + frag
+	}
+	return stripped
 }
 
 // stripUserinfoPassword drops the ":password" portion of base's

--- a/libsq/source/location/location_test.go
+++ b/libsq/source/location/location_test.go
@@ -311,6 +311,16 @@ func TestStripSecrets(t *testing.T) {
 			want: "",
 		},
 		{
+			name: "fragment after secret query param",
+			loc:  "sqlite3:///data/app.db?_auth_pass=hunter2#frag",
+			want: "sqlite3:///data/app.db?_auth_pass=#frag",
+		},
+		{
+			name: "fragment no query",
+			loc:  "postgres://alice:pw@host/db#frag",
+			want: "postgres://alice@host/db#frag",
+		},
+		{
 			name: "no secrets",
 			loc:  "postgres://alice@localhost:5432/sakila?sslmode=require",
 			want: "postgres://alice@localhost:5432/sakila?sslmode=require",

--- a/libsq/source/location/location_test.go
+++ b/libsq/source/location/location_test.go
@@ -260,3 +260,136 @@ func TestMergeQuery(t *testing.T) {
 		})
 	}
 }
+
+func TestIsSecretQueryParam(t *testing.T) {
+	testCases := []struct {
+		key  string
+		want bool
+	}{
+		{key: "", want: false},
+		{key: "password", want: true},
+		{key: "Password", want: true},
+		{key: "passwd", want: true},
+		{key: "pwd", want: true},
+		{key: "pw", want: true},
+		{key: "secret", want: true},
+		{key: "token", want: true},
+		{key: "apikey", want: true},
+		{key: "api_key", want: true},
+		{key: "access_token", want: true},
+		{key: "auth_token", want: true},
+		{key: "sslpassword", want: true},
+		{key: "_auth_pass", want: true},
+		{key: "client_secret", want: true},
+		// Non-secrets, including near-misses.
+		{key: "user", want: false},
+		{key: "_auth_user", want: false},
+		{key: "_auth_salt", want: false},
+		{key: "database", want: false},
+		{key: "sslmode", want: false},
+		{key: "allowCleartextPasswords", want: false},
+		{key: "allowNativePasswords", want: false},
+		{key: "_foreign_keys", want: false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.key, func(t *testing.T) {
+			require.Equal(t, tc.want, location.IsSecretQueryParam(tc.key))
+		})
+	}
+}
+
+func TestStripSecrets(t *testing.T) {
+	testCases := []struct {
+		name string
+		loc  string
+		want string
+	}{
+		{
+			name: "empty",
+			loc:  "",
+			want: "",
+		},
+		{
+			name: "no secrets",
+			loc:  "postgres://alice@localhost:5432/sakila?sslmode=require",
+			want: "postgres://alice@localhost:5432/sakila?sslmode=require",
+		},
+		{
+			name: "userinfo password dropped",
+			loc:  "postgres://alice:hunter2@localhost:5432/sakila",
+			want: "postgres://alice@localhost:5432/sakila",
+		},
+		{
+			name: "userinfo password and secret query value",
+			loc:  "postgres://alice:hunter2@localhost/sakila?sslpassword=abc&sslmode=require",
+			want: "postgres://alice@localhost/sakila?sslpassword=&sslmode=require",
+		},
+		{
+			name: "sqlite auth query params",
+			loc:  "sqlite3:///data/app.db?_auth_user=admin&_auth_pass=hunter2",
+			want: "sqlite3:///data/app.db?_auth_user=admin&_auth_pass=",
+		},
+		{
+			name: "sqlserver query before path",
+			loc:  "sqlserver://alice:hunter2@server:1433?database=sakila&password=abc",
+			want: "sqlserver://alice@server:1433?database=sakila&password=",
+		},
+		{
+			name: "empty secret value unchanged",
+			loc:  "sqlite3:///data/app.db?_auth_pass=",
+			want: "sqlite3:///data/app.db?_auth_pass=",
+		},
+		{
+			name: "username only userinfo unchanged",
+			loc:  "postgres://alice@localhost/sakila",
+			want: "postgres://alice@localhost/sakila",
+		},
+		{
+			name: "empty password dropped with colon",
+			loc:  "postgres://alice:@localhost/sakila",
+			want: "postgres://alice@localhost/sakila",
+		},
+		{
+			name: "ipv6 host",
+			loc:  "postgres://alice:hunter2@[::1]:5432/sakila",
+			want: "postgres://alice@[::1]:5432/sakila",
+		},
+		{
+			name: "placeholder password kept verbatim",
+			loc:  "postgres://alice:${keyring:pg-prod}@localhost/sakila",
+			want: "postgres://alice:${keyring:pg-prod}@localhost/sakila",
+		},
+		{
+			name: "mixed literal and placeholder password dropped",
+			loc:  "postgres://alice:abc${env:PGPASS}@localhost/sakila",
+			want: "postgres://alice@localhost/sakila",
+		},
+		{
+			name: "placeholder secret query value kept verbatim",
+			loc:  "sqlite3:///data/app.db?_auth_user=admin&_auth_pass=${keyring:app-db}",
+			want: "sqlite3:///data/app.db?_auth_user=admin&_auth_pass=${keyring:app-db}",
+		},
+		{
+			name: "mixed literal and placeholder query value blanked",
+			loc:  "sqlite3:///data/app.db?_auth_pass=abc${env:DBPASS}",
+			want: "sqlite3:///data/app.db?_auth_pass=",
+		},
+		{
+			name: "placeholder in non-secret position untouched",
+			loc:  "postgres://alice@${env:PGHOST}/sakila?application_name=app1",
+			want: "postgres://alice@${env:PGHOST}/sakila?application_name=app1",
+		},
+		{
+			name: "no scheme query still scrubbed",
+			loc:  "/data/app.db?_auth_pass=hunter2",
+			want: "/data/app.db?_auth_pass=",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, location.StripSecrets(tc.loc))
+		})
+	}
+}


### PR DESCRIPTION
Fixes #784.

The location-completion redesign fed prior source locations into shell-completion candidates
verbatim: with a configured source like
`sqlite3:///data/app.db?_auth_user=admin&_auth_pass=hunter2`, typing `sq add sqlite3://<TAB>`
printed the full location including the password.

Changes:

- New `location.StripSecrets` and `location.IsSecretQueryParam` helpers. Stripping is purely
  textual (escaping and param order preserved byte-for-byte) so candidates stay
  prefix-matchable: the userinfo password is dropped (`alice:pw@host` becomes `alice@host`)
  and secret query-param values are emptied (`_auth_pass=hunter2` becomes `_auth_pass=`,
  keeping the key as a cue).
- Stripping was chosen over `Redact`-style masking because candidates are accept-and-use
  completion text: an accepted candidate containing a literal `xxxxx` password would create a
  broken source.
- `${scheme:path}` placeholder refs pass through verbatim (they are the config-visible text,
  not secrets); nothing in the completion path resolves them. Placeholder-password sources,
  previously skipped as unparseable, now contribute suggestions.
- Locations that do not parse even after stripping are excluded from the pool.

Testing: new completion test asserting no secret bytes appear in candidates for a source
carrying both a userinfo password and a secret query param; 17-case `StripSecrets` table test
(IPv6, placeholders, sqlserver query-before-path). `make lint` clean; `-short` suites green.

Follow-up candidate (not in this PR): `location.Redact` still does not mask `_auth_pass` /
`sslpassword` in sqlite3/duckdb locations on display and log surfaces; `IsSecretQueryParam`
now exists to fix that.