### PR TITLE
Honor explicit --reveal=false / --no-redact=false over config

### DIFF
--- a/cli/cmd_ls_test.go
+++ b/cli/cmd_ls_test.go
@@ -69,6 +69,90 @@ func TestBug520_LsShowsPassword(t *testing.T) {
 	}
 }
 
+// TestRevealFlagConfigPrecedence tests
+// https://github.com/neilotoole/sq/issues/785: an explicitly set
+// --reveal or --no-redact flag overrides config secrets.reveal in both
+// directions. In particular, --reveal=false (or --no-redact=false) must
+// force redaction even when config has secrets.reveal=true.
+func TestRevealFlagConfigPrecedence(t *testing.T) {
+	t.Parallel()
+
+	const (
+		password = "p_ssW0rd"
+		loc      = "postgres://sakila:" + password + "@localhost/sakila"
+	)
+
+	testCases := []struct {
+		name         string
+		configReveal string // empty means option not set in config
+		args         []string
+		wantReveal   bool
+	}{
+		{
+			name:       "no_flag_default_config",
+			wantReveal: false,
+		},
+		{
+			name:         "no_flag_config_true",
+			configReveal: "true",
+			wantReveal:   true,
+		},
+		{
+			name:       "reveal_default_config",
+			args:       []string{"--reveal"},
+			wantReveal: true,
+		},
+		{
+			name:         "reveal_config_false",
+			configReveal: "false",
+			args:         []string{"--reveal"},
+			wantReveal:   true,
+		},
+		{
+			name:         "no_redact_config_false",
+			configReveal: "false",
+			args:         []string{"--no-redact"},
+			wantReveal:   true,
+		},
+		{
+			name:         "reveal_false_config_true",
+			configReveal: "true",
+			args:         []string{"--reveal=false"},
+			wantReveal:   false,
+		},
+		{
+			name:         "no_redact_false_config_true",
+			configReveal: "true",
+			args:         []string{"--no-redact=false"},
+			wantReveal:   false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			tr := testrun.New(t.Context(), t, nil)
+			require.NoError(t, tr.Exec("add", loc, "--skip-verify"))
+
+			if tc.configReveal != "" {
+				require.NoError(t, tr.Reset().Exec(
+					"config", "set", "secrets.reveal", tc.configReveal))
+			}
+
+			args := append([]string{"ls", "-v"}, tc.args...)
+			require.NoError(t, tr.Reset().Exec(args...))
+			if tc.wantReveal {
+				require.Contains(t, tr.OutString(), password,
+					"password should be revealed")
+			} else {
+				require.NotContains(t, tr.OutString(), password,
+					"password should be redacted")
+			}
+		})
+	}
+}
+
 // TestExpandRevealMatrix verifies the cross-product of --expand and
 // --reveal across the three placeholder shapes (whole-DSN, composition,
 // inline-plaintext) on `sq ls -v`. This is the canonical proof of the

--- a/cli/cmd_ls_test.go
+++ b/cli/cmd_ls_test.go
@@ -126,6 +126,16 @@ func TestRevealFlagConfigPrecedence(t *testing.T) {
 			args:         []string{"--no-redact=false"},
 			wantReveal:   false,
 		},
+		{
+			// Both flags explicitly set with conflicting values: true wins,
+			// preserving union composition (a script that bakes in
+			// --no-redact composed with a user-added --reveal=false, or
+			// vice versa).
+			name:         "conflicting_flags_true_wins",
+			configReveal: "false",
+			args:         []string{"--reveal=false", "--no-redact"},
+			wantReveal:   true,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/cli/cmd_root.go
+++ b/cli/cmd_root.go
@@ -111,12 +111,10 @@ See docs and more: https://sq.io`,
 	// --reveal is the canonical disclosure flag; --no-redact is its
 	// deprecated alias. Neither is bound directly to OptSecretsReveal.
 	// Both are free-standing pflags whose presence is detected in
-	// getOptionsFromFlags and unioned into secrets.reveal=true.
-	// Explicit false (--reveal=false, --no-redact=false) is a no-op:
-	// the flags are positive opt-ins to disclosure, and a leftover
-	// config or default value wins. To force redaction when
-	// secrets.reveal is true in config, override it via
-	// 'sq config set secrets.reveal false'.
+	// getOptionsFromFlags and mapped onto secrets.reveal. An explicitly
+	// set flag wins over config in both directions (see #785): explicit
+	// false (--reveal=false, --no-redact=false) forces redaction even
+	// when config has secrets.reveal=true.
 	cmd.PersistentFlags().Bool(flag.Reveal, false, flag.RevealUsage)
 	cmd.PersistentFlags().Bool(flag.NoRedact, false, flag.NoRedactUsage)
 	// --expand resolves ${scheme:path} placeholders against the

--- a/cli/options.go
+++ b/cli/options.go
@@ -73,16 +73,14 @@ func getOptionsFromFlags(flags *pflag.FlagSet, reg *options.Registry) (options.O
 
 	// --reveal is the canonical disclosure flag; --no-redact is its
 	// deprecated alias (see #717). Both are free-standing pflags,
-	// detected here and unioned into secrets.reveal=true. Treating
-	// them as a union (not as conflicting inputs) lets a script
-	// baking in --no-redact compose with an ad-hoc --reveal on top.
-	//
-	// Explicit false (--reveal=false, --no-redact=false) is a no-op:
-	// the flags are positive opt-ins, and the config or default value
-	// wins. This differs from the pre-v0.54 --no-redact, which via
-	// its Invert binding would explicitly set redact=true. To force
-	// redaction when secrets.reveal is true in config, override it
-	// via 'sq config set secrets.reveal false'.
+	// detected here and mapped onto secrets.reveal. An explicitly set
+	// flag always wins over config, in both directions (see #785):
+	// --reveal and --no-redact set secrets.reveal=true, while
+	// --reveal=false and --no-redact=false force secrets.reveal=false
+	// even when config has secrets.reveal=true. If both flags are set
+	// with conflicting values, true wins, so a script baking in
+	// --no-redact composes with an ad-hoc --reveal on top.
+	var revealChanged, reveal bool
 	for _, flagName := range []string{flag.Reveal, flag.NoRedact} {
 		fl := flags.Lookup(flagName)
 		if fl == nil || !fl.Changed {
@@ -92,9 +90,11 @@ func getOptionsFromFlags(flags *pflag.FlagSet, reg *options.Registry) (options.O
 		if getBoolErr != nil {
 			return nil, errz.Err(getBoolErr)
 		}
-		if b {
-			o[secret.OptSecretsReveal.Key()] = true
-		}
+		revealChanged = true
+		reveal = reveal || b
+	}
+	if revealChanged {
+		o[secret.OptSecretsReveal.Key()] = reveal
 	}
 
 	o, err = reg.Process(o)

--- a/cli/run.go
+++ b/cli/run.go
@@ -205,12 +205,11 @@ func preRun(cmd *cobra.Command, ru *run.Run) error {
 	}
 
 	// --no-redact is deprecated in favor of --reveal (see #717). Warn
-	// only when the user actually opted into the deprecated behavior
-	// (--no-redact or --no-redact=true). --no-redact=false is a no-op
-	// in the new positive-opt-in semantics, so warning on it would be
-	// noise. No stderr nudge, so existing scripts stay quiet on the
-	// user-facing side.
-	if cmdFlagIsSetTrue(ru.Cmd, flag.NoRedact) {
+	// whenever the user explicitly sets the deprecated flag: both
+	// --no-redact and --no-redact=false are meaningful (the latter
+	// forces redaction over config; see #785). No stderr nudge, so
+	// existing scripts stay quiet on the user-facing side.
+	if cmdFlagChanged(ru.Cmd, flag.NoRedact) {
 		lg.FromContext(ctx).Warn(
 			"--no-redact is deprecated; use --reveal instead",
 			lga.Cmd, ru.Cmd.CommandPath())


### PR DESCRIPTION
Fixes #785.

The reveal/no-redact flag-union logic in `cli/options.go` only acted when the flag value was
true, so an explicit `--reveal=false` (or deprecated `--no-redact=false`) was a no-op and a
config-level `secrets.reveal: true` won, printing plaintext passwords. In v0.53.0 the
inverted `--no-redact` binding honored explicit false and forced masking.

Changes:

- The union loop now records whether either flag was explicitly set (`fl.Changed`) and maps
  the value onto `secrets.reveal` in both directions, so an explicitly set flag always wins
  over config. If both flags are set with conflicting values, true wins, preserving the
  documented union composition (a script that bakes in `--no-redact` plus a user-added
  `--reveal`).
- Replaced the stale comment documenting explicit-false as a deliberate no-op.
- The `--no-redact` deprecation warning now fires on any explicit use, since
  `--no-redact=false` is meaningful again.

Scope audit: only `--reveal` and `--no-redact` flow through the union logic, and both default
false, so no default-true flag changes behavior. `--expand` has no config counterpart and is
untouched; other opt-bound boolean flags already honor `Changed` in the generic loop.

Testing: new `TestRevealFlagConfigPrecedence` with 7 subtests covering both directions plus
no-flag config-wins cases; observed failing on the two explicit-false cases before the fix.
`make lint` clean; `-short` suites green.