### PR TITLE
Restore human-readable duration strings in JSON output

### DIFF
--- a/cli/output/jsonw/configwriter.go
+++ b/cli/output/jsonw/configwriter.go
@@ -2,6 +2,7 @@ package jsonw
 
 import (
 	"io"
+	"time"
 
 	"github.com/neilotoole/sq/cli/config"
 	"github.com/neilotoole/sq/cli/output"
@@ -59,6 +60,23 @@ func (w *configWriter) Location(loc string, origin config.Origin) error {
 	return writeJSON(w.out, w.pr, c)
 }
 
+// verboseOptJSON returns vo with any time.Duration values in its Value and
+// DefaultValue fields replaced by their human-readable string form
+// (time.Duration.String, e.g. "1m30s"). Durations inside options.Options maps
+// are handled by options.Options.MarshalJSON, but VerboseOpt holds the values
+// in plain `any` fields, so they must be converted here. The conversion lives
+// in this package (not in commonw.NewVerboseOpt) because it applies only to
+// JSON output. See https://github.com/neilotoole/sq/issues/791.
+func verboseOptJSON(vo commonw.VerboseOpt) commonw.VerboseOpt {
+	if d, ok := vo.Value.(time.Duration); ok {
+		vo.Value = d.String()
+	}
+	if d, ok := vo.DefaultValue.(time.Duration); ok {
+		vo.DefaultValue = d.String()
+	}
+	return vo
+}
+
 // Opt implements output.ConfigWriter.
 func (w *configWriter) Opt(o options.Options, opt options.Opt) error {
 	if o == nil || opt == nil {
@@ -71,7 +89,7 @@ func (w *configWriter) Opt(o options.Options, opt options.Opt) error {
 		return writeJSON(w.out, w.pr, o2)
 	}
 
-	vo := commonw.NewVerboseOpt(opt, o2)
+	vo := verboseOptJSON(commonw.NewVerboseOpt(opt, o2))
 	return writeJSON(w.out, w.pr, vo)
 }
 
@@ -88,7 +106,7 @@ func (w *configWriter) Options(reg *options.Registry, o options.Options) error {
 	opts := reg.Opts()
 	m := map[string]commonw.VerboseOpt{}
 	for _, opt := range opts {
-		m[opt.Key()] = commonw.NewVerboseOpt(opt, o)
+		m[opt.Key()] = verboseOptJSON(commonw.NewVerboseOpt(opt, o))
 	}
 
 	return writeJSON(w.out, w.pr, m)
@@ -100,7 +118,7 @@ func (w *configWriter) SetOption(o options.Options, opt options.Opt) error {
 		return nil
 	}
 
-	vo := commonw.NewVerboseOpt(opt, o)
+	vo := verboseOptJSON(commonw.NewVerboseOpt(opt, o))
 	return writeJSON(w.out, w.pr, vo)
 }
 
@@ -111,6 +129,6 @@ func (w *configWriter) UnsetOption(opt options.Opt) error {
 	}
 
 	o := options.Options{opt.Key(): opt.GetAny(nil)}
-	vo := commonw.NewVerboseOpt(opt, o)
+	vo := verboseOptJSON(commonw.NewVerboseOpt(opt, o))
 	return writeJSON(w.out, w.pr, vo)
 }

--- a/cli/output/jsonw/jsonw_test.go
+++ b/cli/output/jsonw/jsonw_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/neilotoole/sq/cli/testrun"
 	"github.com/neilotoole/sq/libsq/core/errz"
 	"github.com/neilotoole/sq/libsq/core/lg/lgt"
+	"github.com/neilotoole/sq/libsq/core/options"
 	"github.com/neilotoole/sq/libsq/core/record"
 	"github.com/neilotoole/sq/libsq/source"
 	"github.com/neilotoole/sq/libsq/source/drivertype"
@@ -301,7 +302,13 @@ func TestPingWriter_Result(t *testing.T) {
 		var got map[string]any
 		require.NoError(t, json.Unmarshal(buf.Bytes(), &got))
 		require.Equal(t, true, got["pong"], "pong must be true on success")
-		require.NotNil(t, got["duration"], "duration must be present")
+		// The duration must be a human-readable string per time.Duration.String,
+		// e.g. "100ms", not bare int64 nanoseconds. See sq #791.
+		require.Equal(t, "100ms", got["duration"],
+			"duration must be a human-readable string")
+		d, err := time.ParseDuration(got["duration"].(string))
+		require.NoError(t, err, "duration must parse via time.ParseDuration")
+		require.Equal(t, 100*time.Millisecond, d)
 		require.NotContains(t, got, "error", "error key must be absent on success")
 	})
 
@@ -318,7 +325,122 @@ func TestPingWriter_Result(t *testing.T) {
 		var got map[string]any
 		require.NoError(t, json.Unmarshal(buf.Bytes(), &got))
 		require.Equal(t, false, got["pong"], "pong must be false on failure")
+		require.Equal(t, "100ms", got["duration"],
+			"duration must be a human-readable string")
 		require.Equal(t, "connection refused", got["error"])
+	})
+}
+
+// TestConfigWriter_DurationOpt verifies that time.Duration option values are
+// encoded as human-readable quoted strings (e.g. "1m40s"), not bare int64
+// nanoseconds. The string form is the contract from sq v0.53.0 and earlier;
+// the jsoncolor swap regressed it. See sq #791.
+func TestConfigWriter_DurationOpt(t *testing.T) {
+	opt := options.NewDuration("conn.open-timeout", nil, 10*time.Second, "usage", "help")
+	o := options.Options{opt.Key(): 100 * time.Second}
+
+	t.Run("opt", func(t *testing.T) {
+		var buf bytes.Buffer
+		pr := output.NewPrinting()
+		pr.EnableColor(false)
+
+		cw := jsonw.NewConfigWriter(&buf, pr)
+		require.NoError(t, cw.Opt(o, opt))
+
+		var got map[string]any
+		require.NoError(t, json.Unmarshal(buf.Bytes(), &got))
+		require.Equal(t, "1m40s", got[opt.Key()],
+			"duration option value must be a human-readable string")
+	})
+
+	t.Run("opt_verbose", func(t *testing.T) {
+		var buf bytes.Buffer
+		pr := output.NewPrinting()
+		pr.EnableColor(false)
+		pr.Verbose = true
+
+		cw := jsonw.NewConfigWriter(&buf, pr)
+		require.NoError(t, cw.Opt(o, opt))
+
+		var got map[string]any
+		require.NoError(t, json.Unmarshal(buf.Bytes(), &got))
+		require.Equal(t, "1m40s", got["value"],
+			"verbose opt value must be a human-readable string")
+		require.Equal(t, "10s", got["default_value"],
+			"verbose opt default_value must be a human-readable string")
+	})
+
+	t.Run("options_verbose", func(t *testing.T) {
+		reg := &options.Registry{}
+		reg.Add(opt)
+
+		var buf bytes.Buffer
+		pr := output.NewPrinting()
+		pr.EnableColor(false)
+		pr.Verbose = true
+
+		cw := jsonw.NewConfigWriter(&buf, pr)
+		require.NoError(t, cw.Options(reg, o))
+
+		var got map[string]map[string]any
+		require.NoError(t, json.Unmarshal(buf.Bytes(), &got))
+		require.Equal(t, "1m40s", got[opt.Key()]["value"])
+		require.Equal(t, "10s", got[opt.Key()]["default_value"])
+	})
+
+	t.Run("set_option_verbose", func(t *testing.T) {
+		var buf bytes.Buffer
+		pr := output.NewPrinting()
+		pr.EnableColor(false)
+		pr.Verbose = true
+
+		cw := jsonw.NewConfigWriter(&buf, pr)
+		require.NoError(t, cw.SetOption(o, opt))
+
+		var got map[string]any
+		require.NoError(t, json.Unmarshal(buf.Bytes(), &got))
+		require.Equal(t, "1m40s", got["value"])
+	})
+
+	t.Run("source_options", func(t *testing.T) {
+		// Source.Options is serialized by sourcewriter, pingwriter, and
+		// metadatawriter; duration values there must take the string form too.
+		src := &source.Source{
+			Handle:   "@duration_test",
+			Type:     drivertype.SQLite,
+			Location: "test://",
+			Options:  o,
+		}
+
+		var buf bytes.Buffer
+		pr := output.NewPrinting()
+		pr.EnableColor(false)
+
+		require.NoError(t, jsonw.WriteJSON(&buf, pr, src))
+
+		var got map[string]any
+		require.NoError(t, json.Unmarshal(buf.Bytes(), &got))
+		srcOpts, ok := got["options"].(map[string]any)
+		require.True(t, ok, "options must be a JSON object")
+		require.Equal(t, "1m40s", srcOpts[opt.Key()])
+	})
+
+	t.Run("colorized", func(t *testing.T) {
+		// The duration string must survive the colorized encoder path, which
+		// re-tokenizes json.Marshaler output.
+		var buf bytes.Buffer
+		pr := output.NewPrinting()
+		pr.EnableColor(true)
+
+		require.NoError(t, jsonw.WriteJSON(&buf, pr, o))
+
+		out := buf.String()
+		require.Contains(t, out, "\x1b[", "expected ANSI escape in color output")
+
+		plain := reANSI.ReplaceAllString(out, "")
+		var got map[string]any
+		require.NoError(t, json.Unmarshal([]byte(plain), &got))
+		require.Equal(t, "1m40s", got[opt.Key()])
 	})
 }
 

--- a/cli/output/jsonw/pingwriter.go
+++ b/cli/output/jsonw/pingwriter.go
@@ -40,15 +40,18 @@ func (p pingWriter) Result(src *source.Source, d time.Duration, err error) error
 		src.Location = src.RedactedLocation()
 	}
 
+	// Duration is a string in time.Duration.String form (e.g. "105.4ms"),
+	// not bare int64 nanoseconds: that's the shape sq has always emitted,
+	// and consumers parse it. See https://github.com/neilotoole/sq/issues/791.
 	r := struct { //nolint:govet // field alignment
 		*source.Source
-		Pong     bool          `json:"pong"`
-		Duration time.Duration `json:"duration"`
-		Error    string        `json:"error,omitempty"`
+		Pong     bool   `json:"pong"`
+		Duration string `json:"duration"`
+		Error    string `json:"error,omitempty"`
 	}{
 		Source:   src,
 		Pong:     err == nil,
-		Duration: d,
+		Duration: d.String(),
 	}
 
 	if err != nil {

--- a/libsq/core/options/options.go
+++ b/libsq/core/options/options.go
@@ -14,6 +14,7 @@ package options
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log/slog"
 	"maps"
@@ -22,6 +23,8 @@ import (
 	"time"
 
 	"github.com/samber/lo"
+
+	"github.com/neilotoole/sq/libsq/core/errz"
 )
 
 type contextKey struct{}
@@ -160,6 +163,25 @@ func (r *Registry) Process(o Options) (Options, error) {
 
 // Options is a map of Opt.Key to a value.
 type Options map[string]any
+
+// MarshalJSON implements json.Marshaler. It encodes time.Duration values in
+// their human-readable time.Duration.String form, e.g. "1m30s", not the
+// stdlib's bare int64 nanosecond count. The string form matches how durations
+// appear in sq's config file, and is the JSON shape that sq has always
+// emitted: see https://github.com/neilotoole/sq/issues/791.
+func (o Options) MarshalJSON() ([]byte, error) {
+	m := make(map[string]any, len(o))
+	for k, v := range o {
+		if d, ok := v.(time.Duration); ok {
+			m[k] = d.String()
+			continue
+		}
+		m[k] = v
+	}
+
+	b, err := json.Marshal(m)
+	return b, errz.Err(err)
+}
 
 // Clone clones o.
 func (o Options) Clone() Options {

--- a/libsq/core/options/options.go
+++ b/libsq/core/options/options.go
@@ -170,6 +170,11 @@ type Options map[string]any
 // appear in sq's config file, and is the JSON shape that sq has always
 // emitted: see https://github.com/neilotoole/sq/issues/791.
 func (o Options) MarshalJSON() ([]byte, error) {
+	if o == nil {
+		// Match stdlib behavior for a nil map.
+		return []byte("null"), nil
+	}
+
 	m := make(map[string]any, len(o))
 	for k, v := range o {
 		if d, ok := v.(time.Duration); ok {

--- a/libsq/core/options/options_test.go
+++ b/libsq/core/options/options_test.go
@@ -2,6 +2,7 @@ package options_test
 
 import (
 	"context"
+	"encoding/json"
 	"os"
 	"testing"
 	"time"
@@ -144,6 +145,21 @@ func TestMerge(t *testing.T) {
 	got = options.Merge(o1, o2, o3)
 	require.NotEqual(t, o1, got)
 	require.Equal(t, got, options.Options{"a": 1, "b": 2, "c": 3})
+}
+
+func TestOptions_MarshalJSON(t *testing.T) {
+	var nilOpts options.Options
+	got, err := json.Marshal(nilOpts)
+	require.NoError(t, err)
+	require.Equal(t, "null", string(got), "nil Options must marshal as null, matching stdlib")
+
+	got, err = json.Marshal(options.Options{})
+	require.NoError(t, err)
+	require.Equal(t, "{}", string(got))
+
+	got, err = json.Marshal(options.Options{"conn.open-timeout": time.Second * 100, "b": true})
+	require.NoError(t, err)
+	require.JSONEq(t, `{"conn.open-timeout": "1m40s", "b": true}`, string(got))
 }
 
 func TestOptions_LogValue(t *testing.T) {


### PR DESCRIPTION
Fixes #791.

Replacing the in-tree jcolorenc fork with github.com/neilotoole/jsoncolor silently changed
`time.Duration` JSON encoding from a quoted human string to bare int64 nanoseconds:
`sq ping --json` emitted `"duration": 105400000` instead of `"duration": "105.4ms"`, and
duration-typed options in `sq config get --json` / `sq config ls -jv` changed shape the same
way. Consumers parsing the string form broke, and the in-range test only asserted key
presence, so it shipped silently.

This restores the v0.53.0 quoted-string form. jsoncolor v0.9.1 exposes no encoder option for
duration encoding, so the conversion happens in sq:

- `options.Options` implements `json.Marshaler`, encoding duration values via `d.String()`.
  This covers all map-based surfaces, and jsoncolor re-tokenizes marshaler output so
  colorization is preserved.
- `jsonw/pingwriter` emits `Duration` as a formatted string field.
- `jsonw/configwriter` converts `time.Duration` in `VerboseOpt.Value` / `.DefaultValue`
  locally, keeping the shared `commonw.VerboseOpt` untouched for yamlw.

YAML output is unaffected: sq never enables goccy's `UseJSONMarshaler`, verified empirically
(`config get -y` still emits `1m40s`).

Testing: shape-asserting tests for ping (success and failure) and config duration options,
written first and observed failing with bare nanoseconds; end-to-end checks with the built
binary. The textual JSON is byte-identical to v0.53.0. `make lint` clean; `-short` suites
green.