### PR TITLE
duckdb: --readonly overrides access_mode=AUTOMATIC; exempt empty-path in-memory

### DIFF
--- a/cli/cmd_sql.go
+++ b/cli/cmd_sql.go
@@ -96,6 +96,9 @@ func execSQL(cmd *cobra.Command, args []string) error {
 	if readOnlySrc {
 		if peek := peekActiveSrc(cmd, ru.Config.Collection); peek != nil &&
 			peek.Type == drivertype.DuckDB {
+			// Only READ_WRITE is a hard conflict. access_mode=AUTOMATIC is
+			// overridden to READ_ONLY by the driver (see
+			// duckdb.ApplyReadOnlyToLocation), and READ_ONLY already agrees.
 			if mode, ok := duckdb.ExplicitAccessMode(peek.Location); ok &&
 				strings.EqualFold(mode, "READ_WRITE") {
 				return errz.Errorf(
@@ -104,7 +107,7 @@ func execSQL(cmd *cobra.Command, args []string) error {
 			}
 		}
 		if !cmdFlagChanged(cmd, flag.Insert) {
-			ctx = driver.WithReadOnly(ctx)
+			ctx = driver.WithReadOnlyExplicit(ctx)
 			cmd.SetContext(ctx)
 		}
 	}
@@ -222,9 +225,10 @@ func execSQLInsert(ctx context.Context, ru *run.Run,
 	}
 
 	// Now mark the ctx read-only for the source-side open. Skips the
-	// rewrite if the user didn't pass --readonly.
+	// rewrite if the user didn't pass --readonly. Explicit, because
+	// readOnlySrc is only true when the user passed --readonly.
 	if readOnlySrc {
-		ctx = driver.WithReadOnly(ctx)
+		ctx = driver.WithReadOnlyExplicit(ctx)
 	}
 
 	fromGrip, err := grips.Open(ctx, fromSrc)

--- a/cli/cmd_sql_test.go
+++ b/cli/cmd_sql_test.go
@@ -884,6 +884,48 @@ func TestSQL_ReadOnly_RejectsWrites(t *testing.T) {
 		"unexpected error: %s", msg)
 }
 
+// TestSQL_ReadOnly_OverridesAutomatic is the gh788 repro: a location
+// carrying access_mode=AUTOMATIC (which defaults to READ_WRITE for a local
+// file) must not silently defeat --readonly. The explicit flag overrides
+// AUTOMATIC to READ_ONLY, so the write must fail and the file stay intact.
+func TestSQL_ReadOnly_OverridesAutomatic(t *testing.T) {
+	t.Parallel()
+	th := testh.New(t)
+
+	srcPath := proj.Abs("drivers/duckdb/testdata/sakila.duckdb")
+	dstPath := filepath.Join(t.TempDir(), "sakila.duckdb")
+	in, err := os.Open(srcPath)
+	require.NoError(t, err)
+	defer in.Close()
+	out, err := os.Create(dstPath)
+	require.NoError(t, err)
+	_, err = io.Copy(out, in)
+	require.NoError(t, err)
+	require.NoError(t, out.Close())
+
+	src := &source.Source{
+		Handle:   "@sakila_duck_auto",
+		Type:     drivertype.DuckDB,
+		Location: "duckdb://" + dstPath + "?access_mode=AUTOMATIC",
+	}
+
+	tr := testrun.New(th.Context, t, nil).Add(*src)
+	err = tr.Exec("sql", "--src", src.Handle, "--readonly",
+		"INSERT INTO actor (first_name, last_name) VALUES ('X', 'Y')")
+	require.Error(t, err,
+		"--readonly must override access_mode=AUTOMATIC, rejecting the INSERT")
+	msg := err.Error()
+	require.True(t,
+		strings.Contains(msg, "read-only") || strings.Contains(msg, "Cannot execute"),
+		"unexpected error: %s", msg)
+
+	// The actor table must be untouched.
+	tr = testrun.New(th.Context, t, nil).Add(*src)
+	require.NoError(t, tr.Exec("sql", "--src", src.Handle,
+		"SELECT count(*) AS n FROM actor"))
+	require.Contains(t, tr.Out.String(), "200")
+}
+
 // TestSQL_ReadOnly_SrcSchema_DoesNotModifyMtime mirrors the SLQ regression
 // test: --src.schema triggers verifySourceCatalogSchema, which pre-opens
 // the source via Grips.Open. Without hoisting the RO ctx flip ahead of

--- a/drivers/duckdb/access_mode.go
+++ b/drivers/duckdb/access_mode.go
@@ -8,28 +8,41 @@ import (
 // accessModeKey is the DuckDB DSN query-string key controlling open mode.
 const accessModeKey = "access_mode"
 
-// ApplyReadOnlyToLocation returns loc with access_mode=READ_ONLY appended
-// to its query string, plus a flag reporting whether the rewrite happened.
+// ApplyReadOnlyToLocation returns loc rewritten so that DuckDB opens it
+// READ_ONLY, plus a flag reporting whether the rewrite happened. The
+// explicit arg distinguishes explicit user intent (the --readonly flag)
+// from the implicit read-only hint that non-writing commands (sq, inspect,
+// diff, ping) set.
 //
-// The rewrite is skipped (loc returned unchanged, changed=false) when:
+// The access_mode policy matrix (values compared case-insensitively):
+//   - no access_mode in loc: READ_ONLY appended (implicit and explicit).
+//   - access_mode=AUTOMATIC: overridden to READ_ONLY when explicit
+//     (AUTOMATIC expresses no strong preference, while --readonly does);
+//     unchanged when implicit.
+//   - access_mode=READ_ONLY: unchanged (already read-only).
+//   - access_mode=READ_WRITE: unchanged. The user's explicit choice wins;
+//     for the explicit --readonly flag, the CLI surfaces the conflict as
+//     an error before the driver is reached.
+//
+// The rewrite is also skipped (loc returned unchanged, changed=false) when:
 //   - loc does not start with the duckdb:// scheme. This is defensive:
 //     the only caller is the DuckDB driver's own doOpen, which always
 //     passes a duckdb-scheme location, but the helper is total.
-//   - loc's path component is the in-memory sentinel ":memory:" (an empty
-//     in-memory DB can't usefully be opened READ_ONLY),
-//   - loc already specifies access_mode (the user's explicit choice wins),
+//   - loc's path component is the in-memory sentinel ":memory:" or is
+//     empty: go-duckdb treats both as in-memory (see dsnFromLocation),
+//     and an empty in-memory DB can't usefully be opened READ_ONLY.
 //   - loc is empty.
 //
 // The helper is intentionally tolerant: if anything is malformed it returns
 // the input unchanged. The driver's existing dsnFromLocation will surface
 // the real parsing error downstream.
-func ApplyReadOnlyToLocation(loc string) (out string, changed bool) {
+func ApplyReadOnlyToLocation(loc string, explicit bool) (out string, changed bool) {
 	if !strings.HasPrefix(loc, Prefix) {
 		return loc, false
 	}
 	bare := loc[len(Prefix):]
 	pathPart, queryPart, hasQuery := strings.Cut(bare, "?")
-	if pathPart == ":memory:" {
+	if pathPart == ":memory:" || pathPart == "" {
 		return loc, false
 	}
 	if hasQuery {
@@ -38,6 +51,13 @@ func ApplyReadOnlyToLocation(loc string) (out string, changed bool) {
 			return loc, false
 		}
 		if vals.Has(accessModeKey) {
+			if explicit && strings.EqualFold(vals.Get(accessModeKey), "AUTOMATIC") {
+				// AUTOMATIC defaults to READ_WRITE for a local file, which
+				// would silently defeat --readonly: override it. Re-encoding
+				// may reorder params, but only on this rare override path.
+				vals.Set(accessModeKey, "READ_ONLY")
+				return Prefix + pathPart + "?" + vals.Encode(), true
+			}
 			return loc, false
 		}
 		// Append; preserve existing query string verbatim to avoid

--- a/drivers/duckdb/access_mode.go
+++ b/drivers/duckdb/access_mode.go
@@ -11,8 +11,8 @@ const accessModeKey = "access_mode"
 // ApplyReadOnlyToLocation returns loc rewritten so that DuckDB opens it
 // READ_ONLY, plus a flag reporting whether the rewrite happened. The
 // explicit arg distinguishes explicit user intent (the --readonly flag)
-// from the implicit read-only hint that non-writing commands (sq, inspect,
-// diff, ping) set.
+// from the implicit read-only hint that non-writing code paths set (e.g.
+// sq, inspect, diff, ping, or source validation at add time).
 //
 // The access_mode policy matrix (values compared case-insensitively):
 //   - no access_mode in loc: READ_ONLY appended (implicit and explicit).

--- a/drivers/duckdb/access_mode_test.go
+++ b/drivers/duckdb/access_mode_test.go
@@ -17,24 +17,73 @@ func TestApplyReadOnlyToLocation(t *testing.T) {
 	testCases := []struct {
 		name        string
 		in          string
+		explicit    bool
 		wantOut     string
 		wantChanged bool
 	}{
 		{
-			name:        "no_query",
+			name:        "no_query_implicit",
 			in:          "duckdb:///path/to/f.duckdb",
 			wantOut:     "duckdb:///path/to/f.duckdb?access_mode=READ_ONLY",
 			wantChanged: true,
 		},
 		{
-			name:        "other_param",
+			name:        "no_query_explicit",
+			in:          "duckdb:///path/to/f.duckdb",
+			explicit:    true,
+			wantOut:     "duckdb:///path/to/f.duckdb?access_mode=READ_ONLY",
+			wantChanged: true,
+		},
+		{
+			name:        "other_param_implicit",
 			in:          "duckdb:///path/to/f.duckdb?threads=4",
 			wantOut:     "duckdb:///path/to/f.duckdb?threads=4&access_mode=READ_ONLY",
 			wantChanged: true,
 		},
 		{
-			name:        "user_read_write_wins",
+			name:        "other_param_explicit",
+			in:          "duckdb:///path/to/f.duckdb?threads=4",
+			explicit:    true,
+			wantOut:     "duckdb:///path/to/f.duckdb?threads=4&access_mode=READ_ONLY",
+			wantChanged: true,
+		},
+		{
+			name:        "automatic_implicit_unchanged",
+			in:          "duckdb:///path/to/f.duckdb?access_mode=AUTOMATIC",
+			wantOut:     "duckdb:///path/to/f.duckdb?access_mode=AUTOMATIC",
+			wantChanged: false,
+		},
+		{
+			name:        "automatic_explicit_overridden",
+			in:          "duckdb:///path/to/f.duckdb?access_mode=AUTOMATIC",
+			explicit:    true,
+			wantOut:     "duckdb:///path/to/f.duckdb?access_mode=READ_ONLY",
+			wantChanged: true,
+		},
+		{
+			name:        "automatic_lowercase_explicit_overridden",
+			in:          "duckdb:///path/to/f.duckdb?access_mode=automatic",
+			explicit:    true,
+			wantOut:     "duckdb:///path/to/f.duckdb?access_mode=READ_ONLY",
+			wantChanged: true,
+		},
+		{
+			name:        "automatic_explicit_other_params_preserved",
+			in:          "duckdb:///path/to/f.duckdb?threads=4&access_mode=AUTOMATIC",
+			explicit:    true,
+			wantOut:     "duckdb:///path/to/f.duckdb?access_mode=READ_ONLY&threads=4",
+			wantChanged: true,
+		},
+		{
+			name:        "user_read_write_wins_implicit",
 			in:          "duckdb:///path/to/f.duckdb?access_mode=READ_WRITE",
+			wantOut:     "duckdb:///path/to/f.duckdb?access_mode=READ_WRITE",
+			wantChanged: false,
+		},
+		{
+			name:        "user_read_write_wins_explicit",
+			in:          "duckdb:///path/to/f.duckdb?access_mode=READ_WRITE",
+			explicit:    true,
 			wantOut:     "duckdb:///path/to/f.duckdb?access_mode=READ_WRITE",
 			wantChanged: false,
 		},
@@ -45,8 +94,22 @@ func TestApplyReadOnlyToLocation(t *testing.T) {
 			wantChanged: false,
 		},
 		{
+			name:        "user_read_only_lowercase_already_set_explicit",
+			in:          "duckdb:///path/to/f.duckdb?access_mode=read_only",
+			explicit:    true,
+			wantOut:     "duckdb:///path/to/f.duckdb?access_mode=read_only",
+			wantChanged: false,
+		},
+		{
 			name:        "memory_skipped",
 			in:          "duckdb://:memory:",
+			wantOut:     "duckdb://:memory:",
+			wantChanged: false,
+		},
+		{
+			name:        "memory_skipped_explicit",
+			in:          "duckdb://:memory:",
+			explicit:    true,
 			wantOut:     "duckdb://:memory:",
 			wantChanged: false,
 		},
@@ -54,6 +117,25 @@ func TestApplyReadOnlyToLocation(t *testing.T) {
 			name:        "memory_with_query_skipped",
 			in:          "duckdb://:memory:?threads=4",
 			wantOut:     "duckdb://:memory:?threads=4",
+			wantChanged: false,
+		},
+		{
+			name:        "empty_path_memory_skipped",
+			in:          "duckdb://",
+			wantOut:     "duckdb://",
+			wantChanged: false,
+		},
+		{
+			name:        "empty_path_memory_skipped_explicit",
+			in:          "duckdb://",
+			explicit:    true,
+			wantOut:     "duckdb://",
+			wantChanged: false,
+		},
+		{
+			name:        "empty_path_memory_with_query_skipped",
+			in:          "duckdb://?threads=4",
+			wantOut:     "duckdb://?threads=4",
 			wantChanged: false,
 		},
 		{
@@ -72,7 +154,7 @@ func TestApplyReadOnlyToLocation(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			gotOut, gotChanged := duckdb.ApplyReadOnlyToLocation(tc.in)
+			gotOut, gotChanged := duckdb.ApplyReadOnlyToLocation(tc.in, tc.explicit)
 			require.Equal(t, tc.wantOut, gotOut)
 			require.Equal(t, tc.wantChanged, gotChanged)
 		})

--- a/drivers/duckdb/duckdb.go
+++ b/drivers/duckdb/duckdb.go
@@ -116,7 +116,8 @@ func (d *driveri) doOpen(ctx context.Context, src *source.Source) (*sql.DB, erro
 	loc := src.Location
 	if driver.IsReadOnly(ctx) {
 		var changed bool
-		if loc, changed = ApplyReadOnlyToLocation(loc); changed {
+		loc, changed = ApplyReadOnlyToLocation(loc, driver.IsReadOnlyExplicit(ctx))
+		if changed {
 			lg.FromContext(ctx).Debug("DuckDB source opened READ_ONLY",
 				lga.Src, src)
 		}

--- a/libsq/driver/readonly.go
+++ b/libsq/driver/readonly.go
@@ -5,7 +5,8 @@ import "context"
 // readOnlyCtxKey is the (unexported) context key carrying the read-only hint.
 // The stored bool reports whether the hint is explicit: true when the user
 // asked for read-only directly (e.g. sq sql --readonly), false when a
-// non-writing command (sq, inspect, diff, ping) set the hint implicitly.
+// non-writing code path (e.g. sq, inspect, diff, ping, or source validation
+// at add time) set the hint implicitly.
 type readOnlyCtxKey struct{}
 
 // WithReadOnly returns a derived context that signals to driver.Driver

--- a/libsq/driver/readonly.go
+++ b/libsq/driver/readonly.go
@@ -3,6 +3,9 @@ package driver
 import "context"
 
 // readOnlyCtxKey is the (unexported) context key carrying the read-only hint.
+// The stored bool reports whether the hint is explicit: true when the user
+// asked for read-only directly (e.g. sq sql --readonly), false when a
+// non-writing command (sq, inspect, diff, ping) set the hint implicitly.
 type readOnlyCtxKey struct{}
 
 // WithReadOnly returns a derived context that signals to driver.Driver
@@ -11,13 +14,36 @@ type readOnlyCtxKey struct{}
 // read-only mode; drivers that cannot must ignore it.
 //
 // The hint is advisory. A driver that ignores it MUST still produce a
-// working connection.
+// working connection. The hint is implicit: it never overrides an access
+// mode the user set on the source location. For explicit user intent
+// (the --readonly flag), use WithReadOnlyExplicit. If ctx already carries
+// an explicit marker, WithReadOnly preserves it.
 func WithReadOnly(ctx context.Context) context.Context {
+	if IsReadOnlyExplicit(ctx) {
+		return ctx
+	}
+	return context.WithValue(ctx, readOnlyCtxKey{}, false)
+}
+
+// WithReadOnlyExplicit is like WithReadOnly, but additionally marks the
+// hint as explicit user intent (e.g. sq sql --readonly). Drivers may treat
+// an explicit hint more forcefully, e.g. overriding access_mode=AUTOMATIC
+// on a DuckDB location.
+func WithReadOnlyExplicit(ctx context.Context) context.Context {
 	return context.WithValue(ctx, readOnlyCtxKey{}, true)
 }
 
-// IsReadOnly reports whether ctx was marked read-only via WithReadOnly.
+// IsReadOnly reports whether ctx was marked read-only via WithReadOnly or
+// WithReadOnlyExplicit.
 func IsReadOnly(ctx context.Context) bool {
+	_, ok := ctx.Value(readOnlyCtxKey{}).(bool)
+	return ok
+}
+
+// IsReadOnlyExplicit reports whether ctx was marked read-only via
+// WithReadOnlyExplicit, i.e. the read-only request is explicit user intent
+// rather than an implicit hint from a non-writing command.
+func IsReadOnlyExplicit(ctx context.Context) bool {
 	v, _ := ctx.Value(readOnlyCtxKey{}).(bool)
 	return v
 }

--- a/libsq/driver/readonly_test.go
+++ b/libsq/driver/readonly_test.go
@@ -30,3 +30,36 @@ func TestWithReadOnly_Idempotent(t *testing.T) {
 	ctx := driver.WithReadOnly(driver.WithReadOnly(context.Background()))
 	require.True(t, driver.IsReadOnly(ctx))
 }
+
+func TestIsReadOnlyExplicit_BareContext(t *testing.T) {
+	require.False(t, driver.IsReadOnlyExplicit(context.Background()))
+}
+
+func TestWithReadOnly_NotExplicit(t *testing.T) {
+	ctx := driver.WithReadOnly(context.Background())
+	require.True(t, driver.IsReadOnly(ctx))
+	require.False(t, driver.IsReadOnlyExplicit(ctx),
+		"implicit hint must not register as explicit")
+}
+
+func TestWithReadOnlyExplicit_RoundTrip(t *testing.T) {
+	ctx := driver.WithReadOnlyExplicit(context.Background())
+	require.True(t, driver.IsReadOnly(ctx),
+		"explicit read-only implies read-only")
+	require.True(t, driver.IsReadOnlyExplicit(ctx))
+}
+
+func TestWithReadOnly_DoesNotDowngradeExplicit(t *testing.T) {
+	ctx := driver.WithReadOnly(driver.WithReadOnlyExplicit(context.Background()))
+	require.True(t, driver.IsReadOnly(ctx))
+	require.True(t, driver.IsReadOnlyExplicit(ctx),
+		"an implicit hint must not weaken an existing explicit marker")
+}
+
+func TestWithReadOnlyExplicit_SurvivesChildContext(t *testing.T) {
+	ctx := driver.WithReadOnlyExplicit(context.Background())
+	child, cancel := context.WithCancel(ctx)
+	defer cancel()
+	require.True(t, driver.IsReadOnlyExplicit(child),
+		"explicit read-only flag must propagate through derived contexts")
+}


### PR DESCRIPTION
Fixes #788. Two gaps in the DuckDB read-only handling from #610.

**`--readonly` silently ignored with `access_mode=AUTOMATIC`.** The preflight conflict check
errored only on explicit `READ_WRITE`, and `ApplyReadOnlyToLocation` returned the location
unchanged whenever any `access_mode` key was present, so
`sq sql --readonly 'DELETE FROM t'` against `duckdb:///data.db?access_mode=AUTOMATIC` opened
read-write and executed the DELETE with no error.

**Empty-path in-memory form got `READ_ONLY` appended.** The in-memory exemption matched only
the `:memory:` sentinel, but go-duckdb treats an empty path the same way, so `duckdb://`
failed to open ("cannot launch in-memory database in read-only mode").

Policy now implemented in `ApplyReadOnlyToLocation` (values compared case-insensitively):

| URL access_mode | Implicit read-only (sq, inspect, diff, ping) | Explicit `--readonly` |
|---|---|---|
| absent | append READ_ONLY | append READ_ONLY |
| AUTOMATIC | unchanged | overridden to READ_ONLY |
| READ_ONLY | unchanged | unchanged |
| READ_WRITE | unchanged (URL wins) | CLI preflight errors |
| `:memory:` or empty path | exempt | exempt |

Distinguishing implicit hint from explicit flag required a new `driver.WithReadOnlyExplicit`
/ `IsReadOnlyExplicit` context marker (`WithReadOnly` never downgrades an existing explicit
marker) and an `explicit` param on `ApplyReadOnlyToLocation`. The driver owns the policy;
`cmd_sql.go` keeps only the user-facing READ_WRITE conflict error.

Testing: 19-case matrix test for `ApplyReadOnlyToLocation`, explicit-marker semantics tests,
and an end-to-end repro (`AUTOMATIC` + `--readonly` rejects an INSERT), written first and
observed failing. Mutation check confirmed the e2e test exercises the override. `make lint`
clean; `-short` suites green.

Note: the AUTOMATIC-override path re-encodes the query string via `url.Values.Encode()`
(params may be re-ordered); the common no-`access_mode` append path preserves the query
verbatim.