### PR TITLE
secret: error on unbalanced '}' after a placeholder; pin $$ path agreement

### DIFF
--- a/cli/cmd_config_export_test.go
+++ b/cli/cmd_config_export_test.go
@@ -127,6 +127,35 @@ func TestCmdConfigExport_Expand_EscapesDollar(t *testing.T) {
 		"raw literal must not appear: it would be unescaped at connect on the importing machine")
 }
 
+// TestCmdConfigExport_Expand_ZeroRefs_DollarRoundTrip verifies that
+// --expand and the connect path agree for a location with no
+// placeholders (gh #787): a stored template "pa$$wd" connects as the
+// literal "pa$wd", and --expand must export the same template form
+// "pa$$wd" (Expand unescapes to the literal, then export re-escapes),
+// so the restored backup connects with an identical password.
+// Historically the export wrote the half-unescaped "pa$wd", silently
+// corrupting the password on restore.
+func TestCmdConfigExport_Expand_ZeroRefs_DollarRoundTrip(t *testing.T) {
+	gokeyring.MockInit()
+
+	th := testh.New(t)
+	tr := testrun.New(th.Context, t, nil)
+
+	require.NoError(t, tr.Run.Config.Collection.Add(&source.Source{
+		Handle:   "@sakila",
+		Type:     drivertype.Pg,
+		Location: "postgres://u:pa$$wd@h/db",
+	}))
+
+	require.NoError(t, tr.Exec("config", "export", "--expand"))
+
+	got := tr.OutString()
+	require.Contains(t, got, "postgres://u:pa$$wd@h/db",
+		"exported template must be byte-identical to the stored template")
+	require.NotContains(t, got, "postgres://u:pa$wd@h/db",
+		"the unescaped literal must not leak into the export")
+}
+
 // TestCmdConfigExport_Expand_MissingKeyring errors clearly when a
 // placeholder cannot be resolved.
 func TestCmdConfigExport_Expand_MissingKeyring(t *testing.T) {

--- a/cli/expand_test.go
+++ b/cli/expand_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/neilotoole/sq/cli/run"
 	"github.com/neilotoole/sq/libsq/core/lg"
 	"github.com/neilotoole/sq/libsq/core/secret"
+	"github.com/neilotoole/sq/libsq/driver"
 	"github.com/neilotoole/sq/libsq/source"
 	"github.com/neilotoole/sq/libsq/source/drivertype"
 )
@@ -181,6 +182,31 @@ func TestMaybeExpandSource_FlagSet_Expands(t *testing.T) {
 	require.NotSame(t, src, got, "must clone")
 	require.Equal(t, "postgres://alice:hunter2@db/sakila", got.Location)
 	require.Equal(t, "${keyring:abc}", src.Location, "input must not be mutated")
+}
+
+// TestMaybeExpandSource_ZeroRefs_AgreesWithConnect verifies that the
+// --expand display path agrees with connect-time resolution for a
+// template with no placeholders (gh #787): "$$" is unescaped to the
+// literal form on both paths, so the displayed location is exactly
+// what the driver connects with.
+func TestMaybeExpandSource_ZeroRefs_AgreesWithConnect(t *testing.T) {
+	ru := newTestRun(t, nil)
+	cmd := newCmdWithExpand(t, true)
+
+	src := &source.Source{
+		Handle:   "@a",
+		Type:     drivertype.Pg,
+		Location: "postgres://alice:pa$$wd@db/sakila",
+	}
+
+	got, err := maybeExpandSource(context.Background(), ru, cmd, src)
+	require.NoError(t, err)
+	require.Equal(t, "postgres://alice:pa$wd@db/sakila", got.Location)
+
+	resolved, err := driver.ResolveSourceSecrets(context.Background(), src)
+	require.NoError(t, err)
+	require.Equal(t, resolved.Location, got.Location,
+		"display expansion and connect-time resolution must agree")
 }
 
 func TestMaybeExpandSource_FlagSet_LenientOnResolverError(t *testing.T) {

--- a/libsq/core/secret/parse.go
+++ b/libsq/core/secret/parse.go
@@ -17,7 +17,9 @@ type placeholder struct {
 
 // findPlaceholders returns every ${scheme:path} placeholder in s, in order.
 // $$ is treated as an escape for a literal '$' and does not start a
-// placeholder. Returns an error if any placeholder is malformed.
+// placeholder. Returns an error if any placeholder is malformed, or if
+// the literal text following a placeholder contains an unbalanced '}'
+// (see checkUnbalancedClose).
 func findPlaceholders(s string) ([]placeholder, error) {
 	var out []placeholder
 	for i := 0; i < len(s); i++ {
@@ -54,7 +56,65 @@ func findPlaceholders(s string) ([]placeholder, error) {
 		})
 		i = end // skip past the placeholder
 	}
+	if err := checkUnbalancedClose(s, out); err != nil {
+		return nil, err
+	}
 	return out, nil
+}
+
+// checkUnbalancedClose scans the literal text of s (the regions outside
+// the placeholders in phs) for a '}' that most likely marks a truncated
+// placeholder path, and returns a parse error when one is found. The
+// grammar terminates a placeholder path at the first '}', so a path
+// containing '}' cannot be expressed: without this check, a template
+// like "${file:/run/sec}rets/pw}" silently parses as path "/run/sec"
+// with "rets/pw}" spliced into the location as literal text (gh #787).
+//
+// The rules, chosen so that well-formed existing templates keep parsing
+// unchanged:
+//
+//   - Literal text before the first placeholder is never checked: a '}'
+//     there cannot be a truncation artifact.
+//   - A run of '}' immediately following a placeholder is literal, so
+//     "${env:X}}" stays a placeholder followed by a literal '}'.
+//   - Any other '}' in literal text after a placeholder must be
+//     balanced by an earlier unmatched literal '{'; an unbalanced '}'
+//     is an error naming its byte offset.
+func checkUnbalancedClose(s string, phs []placeholder) error {
+	if len(phs) == 0 {
+		return nil
+	}
+	var depth int // unmatched literal '{' count
+	next := 0     // index into phs of the next placeholder
+	last := -1    // index into phs of the most recent placeholder
+	for i := 0; i < len(s); i++ {
+		if next < len(phs) && i == phs[next].start {
+			last = next
+			next++
+			i = phs[last].end - 1 // loop increment moves past the closing '}'
+			// A run of '}' immediately following the placeholder is
+			// literal; skip it without affecting depth.
+			for i+1 < len(s) && s[i+1] == '}' {
+				i++
+			}
+			continue
+		}
+		switch s[i] {
+		case '{':
+			depth++
+		case '}':
+			if depth > 0 {
+				depth--
+				continue
+			}
+			if last >= 0 {
+				return errz.Errorf("unbalanced '}' at offset %d after placeholder ${%s:%s}",
+					i, phs[last].scheme, phs[last].path)
+			}
+			// Before the first placeholder: literal; depth stays 0.
+		}
+	}
+	return nil
 }
 
 // validateScheme returns nil if scheme matches [a-z][a-z0-9]*.

--- a/libsq/core/secret/parse_test.go
+++ b/libsq/core/secret/parse_test.go
@@ -81,6 +81,64 @@ func TestFindPlaceholders(t *testing.T) {
 				start: 0, end: 24, scheme: "keyring", path: "@grp/sub/name",
 			}},
 		},
+		{
+			// gh #787: a path containing '}' truncates at the first '}',
+			// leaving "rets/pw}" as literal text. The stray '}' must be a
+			// parse error, not a silent misparse.
+			name:    "truncated path with unbalanced brace",
+			in:      "postgres://alice:${file:/run/sec}rets/pw}@db/sakila",
+			wantErr: "unbalanced '}' at offset 40",
+		},
+		{
+			// gh #787 regression guard: a '}' immediately following a
+			// placeholder is literal text and must keep parsing as today.
+			name: "placeholder then literal close brace",
+			in:   "${env:X}}",
+			want: []placeholder{{
+				start: 0, end: 8, scheme: "env", path: "X",
+			}},
+		},
+		{
+			name: "placeholder then run of literal close braces",
+			in:   "${env:X}}}",
+			want: []placeholder{{
+				start: 0, end: 8, scheme: "env", path: "X",
+			}},
+		},
+		{
+			name: "balanced braces after placeholder",
+			in:   "${env:X}-{a}-b",
+			want: []placeholder{{
+				start: 0, end: 8, scheme: "env", path: "X",
+			}},
+		},
+		{
+			name: "placeholder wrapped in literal braces",
+			in:   "{${env:X}}",
+			want: []placeholder{{
+				start: 1, end: 9, scheme: "env", path: "X",
+			}},
+		},
+		{
+			name:    "unbalanced brace between placeholders",
+			in:      "${env:A}x}${env:B}",
+			wantErr: "unbalanced '}' at offset 9",
+		},
+		{
+			// A '}' before the first placeholder cannot be a truncation
+			// artifact: it stays literal.
+			name: "brace before first placeholder is literal",
+			in:   "we}ird-${env:X}",
+			want: []placeholder{{
+				start: 7, end: 15, scheme: "env", path: "X",
+			}},
+		},
+		{
+			// With no placeholders at all, braces are always literal.
+			name: "literal braces without placeholders",
+			in:   "postgres://alice:hu}nter2@db/sakila",
+			want: nil,
+		},
 	}
 
 	for _, tc := range tests {

--- a/libsq/core/secret/secret.go
+++ b/libsq/core/secret/secret.go
@@ -7,6 +7,19 @@
 // values back. URL-encoding of values that land inside URL userinfo is
 // handled automatically.
 //
+// # Grammar
+//
+// A placeholder is ${scheme:path}, where scheme matches [a-z][a-z0-9]*
+// and path is any non-empty text up to the first '}'. In literal text,
+// "$$" escapes a literal '$'. Because the path ends at the first '}', a
+// path containing '}' cannot be expressed. To prevent such a path from
+// silently truncating, a '}' in literal text is constrained: before the
+// first placeholder it is always literal; immediately after a
+// placeholder it is literal (so "${env:X}}" is the placeholder followed
+// by '}'); anywhere else after a placeholder it must be balanced by an
+// earlier unmatched literal '{', or parsing fails with an unbalanced-'}'
+// error.
+//
 // # Templates vs literals
 //
 // Two kinds of strings flow through this package, and confusing them

--- a/libsq/driver/grips_test.go
+++ b/libsq/driver/grips_test.go
@@ -99,6 +99,58 @@ func TestGrips_ResolveSourceSecrets_NoRefs_Unescape(t *testing.T) {
 	}
 }
 
+// TestGrips_ResolveSourceSecrets_AgreesWithExpand verifies that
+// connect-time resolution and Registry.Expand produce identical bytes
+// for the same template (gh #787). Historically the two diverged on the
+// zero-refs path: Expand unescaped "$$" while ResolveSourceSecrets
+// returned the location verbatim, so a no-placeholder password like
+// "pa$$wd" connected as "pa$$wd" but displayed and exported as "pa$wd",
+// silently corrupting restored backups.
+func TestGrips_ResolveSourceSecrets_AgreesWithExpand(t *testing.T) {
+	reg := secret.NewRegistry()
+	reg.Register("keyring", &captureResolver{value: "hunter2"})
+	ctx := secret.NewContext(context.Background(), reg)
+
+	tests := []struct {
+		name string
+		loc  string
+	}{
+		{
+			name: "zero refs with dollar escape",
+			loc:  "postgres://alice:pa$$wd@db/sakila",
+		},
+		{
+			name: "zero refs no dollar",
+			loc:  "postgres://alice:pw@db/sakila",
+		},
+		{
+			name: "refs with dollar escape outside placeholder",
+			loc:  "postgres://ali$$ce:${keyring:my_db_pw}@db/sakila",
+		},
+		{
+			name: "refs only",
+			loc:  "postgres://alice:${keyring:my_db_pw}@db/sakila",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			expanded, err := reg.Expand(ctx, tc.loc)
+			require.NoError(t, err)
+
+			src := &source.Source{
+				Handle:   "@sakila",
+				Type:     drivertype.Pg,
+				Location: tc.loc,
+			}
+			resolved, err := driver.ResolveSourceSecrets(ctx, src)
+			require.NoError(t, err)
+			require.Equal(t, expanded, resolved.Location,
+				"connect-time bytes must equal Expand output")
+		})
+	}
+}
+
 // TestGrips_ResolveSourceSecrets_Idempotent verifies that resolving an
 // already-resolved source is a no-op. Resolution converts template
 // bytes to literal bytes; reinterpreting literal bytes as a template


### PR DESCRIPTION
Fixes #787.

**Unbalanced `}` now errors instead of silently misparsing.** A placeholder path containing
`}` (e.g. `${file:/run/sec}rets/pw}`) used to truncate at the first `}` and splice the
remainder into the location as literal text, surfacing later as a confusing resolver or
connection failure. Escape grammars were evaluated and rejected: `}}` or `$}` inside the body
would each re-interpret some currently-valid template (notably `${env:X}}`, placeholder
followed by a literal `}`, which keeps parsing as today and now has a regression test).
Instead, `findPlaceholders` rejects an unmatched `}` appearing after a placeholder unless it
closes an earlier literal `{`, with an error naming the offset. The rule is documented in a
new Grammar section of the package godoc. `$$` escape round-tripping (the #782/#794 upgrade
path) is unaffected.

A consequence: paths containing `}` remain inexpressible in placeholder syntax; a literal
unbalanced `}` after a placeholder can be percent-encoded (`%7D`) in URL locations.

**The `$$` expansion/connect divergence reported in the issue is already fixed** on master by
the #793/#794/#799 work: the zero-refs connect path applies the same unescape as `Expand`, and
`config export --expand` re-escapes literals. This PR adds regression tests pinning the
agreement across connect, `--expand` display, and export round-trip, so the divergence cannot
silently return.

Testing: new parse-error and backward-compat cases in the secret package; agreement tests in
libsq/driver and cli. `make lint` clean; `-short` suites green.