### PR TITLE
rqlite: fix BOOLEAN, DATE/DATETIME, and BLOB handling on read and write

### DIFF
--- a/drivers/rqlite/nulltime.go
+++ b/drivers/rqlite/nulltime.go
@@ -17,7 +17,10 @@ var rtypeNullTime = reflect.TypeFor[nullTime]()
 // itself (verbatim from mattn/go-sqlite3.SQLiteTimestampFormats). rqlite
 // returns SQLite cells as JSON over HTTP, so date/datetime values arrive
 // here as plain strings rather than typed time.Time values, and we parse
-// them with the same set SQLite uses.
+// them with the same set SQLite uses. sqRows.Next (sqldriver.go)
+// guarantees raw string delivery by bypassing gorqlite's two-format
+// toTime pre-conversion, which would otherwise error out the whole
+// result set for most of these formats (gh775).
 var sqliteTimestampFormats = []string{
 	"2006-01-02 15:04:05.999999999-07:00",
 	"2006-01-02T15:04:05.999999999-07:00",

--- a/drivers/rqlite/sqldriver.go
+++ b/drivers/rqlite/sqldriver.go
@@ -214,7 +214,14 @@ func (r *sqRows) Next(dest []driver.Value) error {
 		// result sets.
 		return errz.New("rqlite: cannot read raw row values from gorqlite QueryResult")
 	}
-	row := r.vals[r.RowNumber()]
+	idx := r.RowNumber()
+	if idx < 0 || idx >= int64(len(r.vals)) {
+		// Same defensive posture as the valsOK guard: if gorqlite's
+		// RowNumber semantics ever change, fail loudly, never panic.
+		return errz.Errorf("rqlite: row index %d out of range (%d rows)",
+			idx, len(r.vals))
+	}
+	row := r.vals[idx]
 	if len(row) < len(dest) {
 		return errz.Errorf("rqlite: row has %d values but %d columns declared",
 			len(row), len(dest))

--- a/drivers/rqlite/sqldriver.go
+++ b/drivers/rqlite/sqldriver.go
@@ -4,25 +4,47 @@ import (
 	"context"
 	"database/sql"
 	"database/sql/driver"
+	"encoding/base64"
+	"io"
+	"reflect"
+	"strings"
+	"unsafe"
 
 	"github.com/rqlite/gorqlite"
 	"github.com/rqlite/gorqlite/stdlib"
+
+	"github.com/neilotoole/sq/libsq/core/errz"
 )
 
 // sqDBDrvrName is the registration name of sq's wrapper around
-// gorqlite's database/sql driver. The wrapper exists to expose
-// per-column type names through *sql.ColumnType.DatabaseTypeName: the
-// stock gorqlite/stdlib driver does not implement
-// driver.RowsColumnTypeDatabaseTypeName, so DatabaseTypeName always
-// returns the empty string, which downstream demotes every column
-// kind to kind.Unknown.
+// gorqlite's database/sql driver. The wrapper exists to bridge three
+// gaps between gorqlite/stdlib and what sq's record pipeline needs
+// (the latter two are gh775):
 //
-// The wrapped driver consults the gorqlite QueryResult's Types
-// (populated from the JSON "types" array on every response, including
-// empty result sets) and returns those values from
-// ColumnTypeDatabaseTypeName. That single change is enough for the
-// rest of the rqlite driver to resolve column kinds, scan-types, and
-// the float64-from-JSON to int64 coercion path through *sql.NullInt64.
+//  1. Column type names: the stock gorqlite/stdlib driver does not
+//     implement driver.RowsColumnTypeDatabaseTypeName, so
+//     DatabaseTypeName always returns the empty string, which
+//     downstream demotes every column kind to kind.Unknown. sqRows
+//     returns the gorqlite QueryResult's Types (populated from the
+//     JSON "types" array on every response, including empty result
+//     sets).
+//
+//  2. Raw row values: sqRows.Next replaces stdlib.Rows.Next, which
+//     pre-converts date/datetime columns via gorqlite's two-format
+//     toTime and errors out the entire result set on any other
+//     format (e.g. bare dates, or mattn/go-sqlite3's canonical
+//     fractional-seconds format). sqRows delivers the raw wire
+//     value instead, so the driver's own SQLite-format-complete
+//     nullTime scanner (nulltime.go) does the parsing. It also
+//     converts BOOLEAN cells that arrive as raw JSON numbers
+//     (pre-v10 rqlite servers) to bools, and base64-decodes BLOB
+//     cells, which rqlite's JSON API always returns base64-encoded.
+//
+//  3. Blob parameters: sqStmt.CheckNamedValue re-encodes []byte
+//     arguments as JSON byte arrays, rqlite's typed-blob parameter
+//     form. gorqlite marshals arguments with encoding/json, which
+//     turns []byte into a base64 string that rqlite would store as
+//     TEXT, silently corrupting binary columns.
 const sqDBDrvrName = "rqlite-sq"
 
 func init() { //nolint:gochecknoinits
@@ -91,6 +113,45 @@ func (s *sqStmt) QueryContext(ctx context.Context, args []driver.NamedValue) (dr
 	return wrapRows(r), err
 }
 
+// CheckNamedValue implements driver.NamedValueChecker. Arguments go
+// through the standard driver.DefaultParameterConverter, with one
+// rqlite-specific addition: []byte arguments are re-encoded as []int,
+// which gorqlite's json.Marshal renders as a JSON array of numbers:
+// rqlite's typed-blob parameter form (see
+// https://rqlite.io/docs/api/api/#blob-data). Without this, []byte
+// marshals to a base64 JSON string and rqlite stores it as TEXT,
+// silently corrupting every binary column on the write path (gh775).
+//
+// A nil []byte maps to SQL NULL, matching database/sql convention.
+func (s *sqStmt) CheckNamedValue(nv *driver.NamedValue) error {
+	v, err := driver.DefaultParameterConverter.ConvertValue(nv.Value)
+	if err != nil {
+		return errz.Err(err)
+	}
+	if b, ok := v.([]byte); ok {
+		if b == nil {
+			nv.Value = nil
+		} else {
+			nv.Value = blobParam(b)
+		}
+		return nil
+	}
+	nv.Value = v
+	return nil
+}
+
+// blobParam re-encodes b as []int so that gorqlite's json.Marshal
+// produces a JSON array of byte values, which rqlite accepts as a
+// typed blob parameter. An empty b yields the empty array, which
+// rqlite stores as the zero-length blob.
+func blobParam(b []byte) []int {
+	a := make([]int, len(b))
+	for i, v := range b {
+		a[i] = int(v)
+	}
+	return a
+}
+
 // wrapRows wraps a *stdlib.Rows in sqRows. nil and non-stdlib Rows
 // pass through unchanged so transient error paths don't blow up.
 func wrapRows(r driver.Rows) driver.Rows {
@@ -101,14 +162,159 @@ func wrapRows(r driver.Rows) driver.Rows {
 	if !ok {
 		return r
 	}
-	return &sqRows{Rows: sr}
+	vals, valsOK := rawValues(&sr.QueryResult)
+	return &sqRows{
+		Rows:   sr,
+		vals:   vals,
+		valsOK: valsOK,
+		convs:  wireConvsForTypes(typesOf(sr)),
+	}
 }
 
 // sqRows wraps stdlib.Rows to implement
 // driver.RowsColumnTypeDatabaseTypeName, sourcing per-column types
-// from the gorqlite QueryResult.
+// from the gorqlite QueryResult, and to replace stdlib.Rows.Next with
+// a raw-value implementation (see Next).
 type sqRows struct {
 	*stdlib.Rows
+
+	// vals is the QueryResult's raw row data (the JSON-decoded
+	// "values" array), extracted by rawValues at wrap time. valsOK
+	// records whether the extraction succeeded.
+	vals [][]any
+
+	// convs holds the per-column wire conversion derived from the
+	// response's "types" array.
+	convs []wireConv
+
+	valsOK bool
+}
+
+// Next implements driver.Rows, shadowing the embedded
+// stdlib.Rows.Next. The stdlib implementation reads each row via
+// gorqlite's QueryResult.Slice, which pre-converts any column whose
+// rqlite type is date/datetime using a two-format parser (toTime) and
+// returns an error for every other format. Because database/sql
+// surfaces that error from Rows.Next, a single bare date or
+// fractional-seconds datetime aborts the whole result set (gh775).
+//
+// This implementation reads the raw JSON-decoded values instead:
+// date/datetime cells pass through as raw strings for the driver's
+// nullTime scanner (which holds SQLite's full timestamp format list),
+// BOOLEAN cells arriving as raw JSON numbers become bools, and BLOB
+// cells are base64-decoded. See convertWireValue.
+func (r *sqRows) Next(dest []driver.Value) error {
+	if !r.QueryResult.Next() {
+		return io.EOF
+	}
+	if !r.valsOK {
+		// rawValues failed: gorqlite's internal layout has changed.
+		// Fail loudly rather than fall back to stdlib.Rows.Next, whose
+		// toTime conversion and undecoded blobs corrupt or abort
+		// result sets.
+		return errz.New("rqlite: cannot read raw row values from gorqlite QueryResult")
+	}
+	row := r.vals[r.RowNumber()]
+	if len(row) < len(dest) {
+		return errz.Errorf("rqlite: row has %d values but %d columns declared",
+			len(row), len(dest))
+	}
+	for i := range dest {
+		var conv wireConv
+		if i < len(r.convs) {
+			conv = r.convs[i]
+		}
+		dest[i] = convertWireValue(conv, row[i])
+	}
+	return nil
+}
+
+// wireConv enumerates the conversions sqRows.Next applies to raw wire
+// values, chosen per column from the response's "types" array.
+type wireConv uint8
+
+const (
+	// convNone passes the raw value through unchanged.
+	convNone wireConv = iota
+	// convBool converts raw JSON numbers to bool for BOOLEAN columns.
+	convBool
+	// convBlob base64-decodes strings for BLOB columns.
+	convBlob
+)
+
+// wireConvsForTypes derives the per-column conversion from rqlite's
+// column type names. Parameterized type names (e.g. "blob(16)") are
+// normalized first. Unrecognized and empty type names get convNone.
+func wireConvsForTypes(types []string) []wireConv {
+	convs := make([]wireConv, len(types))
+	for i, typ := range types {
+		if j := strings.IndexRune(typ, '('); j >= 0 {
+			typ = typ[:j]
+		}
+		switch strings.ToLower(strings.TrimSpace(typ)) {
+		case "boolean", "bool":
+			convs[i] = convBool
+		case "blob":
+			convs[i] = convBlob
+		}
+	}
+	return convs
+}
+
+// convertWireValue converts a raw JSON-decoded cell value per conv:
+//
+//   - convBool: raw JSON numbers become bools using SQLite truthiness
+//     (non-zero is true). Older rqlite servers deliver BOOLEAN cells
+//     as numbers; without this, sql.NullBool.Scan(float64) fails.
+//     rqlite v10+ converts server-side, so JSON bools pass through.
+//   - convBlob: strings are base64-decoded, since rqlite's JSON API
+//     returns BLOB storage base64-encoded. A string that is not valid
+//     base64 can only be TEXT stored in a BLOB-typed column, and is
+//     surfaced as its literal bytes. (A text value that happens to be
+//     valid base64 is indistinguishable from a real blob in rqlite's
+//     wire format; rqlite's ?blob_array disambiguator is not
+//     reachable through gorqlite, which hardcodes its API query
+//     strings.)
+//
+// All other values pass through unchanged.
+func convertWireValue(conv wireConv, v any) driver.Value {
+	switch conv {
+	case convNone:
+	case convBool:
+		if f, ok := v.(float64); ok {
+			return f != 0
+		}
+	case convBlob:
+		if s, ok := v.(string); ok {
+			if b, err := base64.StdEncoding.Strict().DecodeString(s); err == nil {
+				return b
+			}
+			return []byte(s)
+		}
+	}
+	return v
+}
+
+// rtypeRawValues is the expected reflect.Type of
+// gorqlite.QueryResult's values field.
+var rtypeRawValues = reflect.TypeOf([][]any(nil))
+
+// rawValues extracts the raw row data (the JSON-decoded "values"
+// array) from qr. gorqlite provides no public access to it: Map,
+// Slice, and Scan all pre-convert date/datetime columns via the
+// two-format toTime, which errors on most SQLite timestamp formats
+// and so cannot be used (gh775). The unexported field is read via
+// reflect+unsafe instead, guarded so a future gorqlite layout change
+// reports ok=false (and Test_rawValues_GorqliteLayout fails) rather
+// than panicking.
+func rawValues(qr *gorqlite.QueryResult) (vals [][]any, ok bool) {
+	f := reflect.ValueOf(qr).Elem().FieldByName("values")
+	if !f.IsValid() || f.Type() != rtypeRawValues {
+		return nil, false
+	}
+	f = reflect.NewAt(f.Type(), unsafe.Pointer(f.UnsafeAddr())).Elem()
+	vals, ok = f.Interface().([][]any)
+	return vals, ok
 }
 
 // Compile-time assertion that sqRows satisfies the optional

--- a/drivers/rqlite/sqldriver_test.go
+++ b/drivers/rqlite/sqldriver_test.go
@@ -1,0 +1,188 @@
+package rqlite
+
+import (
+	"database/sql/driver"
+	"io"
+	"reflect"
+	"testing"
+	"unsafe"
+
+	"github.com/rqlite/gorqlite"
+	"github.com/rqlite/gorqlite/stdlib"
+	"github.com/stretchr/testify/require"
+)
+
+// setQueryResultField sets an unexported field of gorqlite.QueryResult
+// so tests can fabricate wire-format results without a live server.
+// The same JSON-decoded value shapes rqlite produces over HTTP (nil,
+// bool, float64, string) are injected directly.
+func setQueryResultField(t *testing.T, qr *gorqlite.QueryResult, name string, val any) {
+	t.Helper()
+	f := reflect.ValueOf(qr).Elem().FieldByName(name)
+	require.True(t, f.IsValid(), "gorqlite.QueryResult field {%s} not found", name)
+	reflect.NewAt(f.Type(), unsafe.Pointer(f.UnsafeAddr())).Elem().Set(reflect.ValueOf(val))
+}
+
+// newTestRows fabricates a driver.Rows wrapping a gorqlite QueryResult
+// populated with the given columns, rqlite types, and raw JSON-decoded
+// values, mirroring what a server response would produce.
+func newTestRows(t *testing.T, cols, types []string, values [][]any) driver.Rows {
+	t.Helper()
+	qr := gorqlite.QueryResult{}
+	setQueryResultField(t, &qr, "columns", cols)
+	setQueryResultField(t, &qr, "types", types)
+	setQueryResultField(t, &qr, "values", values)
+	// gorqlite's parseQueryResult initializes rowNumber to -1.
+	setQueryResultField(t, &qr, "rowNumber", int64(-1))
+	return wrapRows(&stdlib.Rows{QueryResult: qr})
+}
+
+// nextRow advances rows by one and returns the row values.
+func nextRow(t *testing.T, rows driver.Rows, numCols int) []driver.Value {
+	t.Helper()
+	dest := make([]driver.Value, numCols)
+	require.NoError(t, rows.Next(dest))
+	return dest
+}
+
+// Test_sqRows_Next_BooleanWire verifies that BOOLEAN cells delivered
+// as raw JSON numbers (older rqlite servers) become bools, while JSON
+// bools (rqlite v10+ server-side conversion), strings, and NULLs pass
+// through. Without driver conversion, the float64 shape fails
+// downstream: sql.NullBool.Scan(float64) errors (gh775).
+func Test_sqRows_Next_BooleanWire(t *testing.T) {
+	rows := newTestRows(t,
+		[]string{"b"}, []string{"boolean"},
+		[][]any{
+			{float64(1)},
+			{float64(0)},
+			{float64(2)}, // SQLite truthiness: any non-zero is true.
+			{true},
+			{"true"},
+			{nil},
+		})
+
+	require.Equal(t, []driver.Value{true}, nextRow(t, rows, 1))
+	require.Equal(t, []driver.Value{false}, nextRow(t, rows, 1))
+	require.Equal(t, []driver.Value{true}, nextRow(t, rows, 1))
+	require.Equal(t, []driver.Value{true}, nextRow(t, rows, 1))
+	require.Equal(t, []driver.Value{"true"}, nextRow(t, rows, 1))
+	require.Equal(t, []driver.Value{nil}, nextRow(t, rows, 1))
+	require.ErrorIs(t, rows.Next(make([]driver.Value, 1)), io.EOF)
+}
+
+// Test_sqRows_Next_DatetimeWire verifies that DATE/DATETIME cells
+// reach the scan layer as raw values, bypassing gorqlite's toTime
+// pre-conversion. toTime knows only two layouts and errors on
+// anything else, which aborts the whole result set via Rows.Next
+// (gh775); the driver's nullTime scanner (nulltime.go) holds the full
+// SQLite format list, so the raw string must be passed through.
+func Test_sqRows_Next_DatetimeWire(t *testing.T) {
+	rows := newTestRows(t,
+		[]string{"d", "dt"}, []string{"date", "datetime"},
+		[][]any{
+			// Bare date + canonical mattn/go-sqlite3 fractional seconds:
+			// both make gorqlite's toTime error.
+			{"2024-06-01", "2024-06-01 12:00:00.123"},
+			// Formats toTime happens to know must also pass through raw.
+			{"2024-06-01 00:00:00", "2024-06-01T12:00:00Z"},
+			// REAL (e.g. Julian day) and NULL storage pass through.
+			{2460462.5, nil},
+		})
+
+	require.Equal(t,
+		[]driver.Value{"2024-06-01", "2024-06-01 12:00:00.123"},
+		nextRow(t, rows, 2))
+	require.Equal(t,
+		[]driver.Value{"2024-06-01 00:00:00", "2024-06-01T12:00:00Z"},
+		nextRow(t, rows, 2))
+	require.Equal(t,
+		[]driver.Value{2460462.5, nil},
+		nextRow(t, rows, 2))
+	require.ErrorIs(t, rows.Next(make([]driver.Value, 2)), io.EOF)
+}
+
+// Test_sqRows_Next_BlobWire verifies that BLOB cells, which rqlite's
+// JSON API returns base64-encoded, are decoded to raw bytes. A string
+// that isn't valid base64 can only be TEXT stored in a BLOB-typed
+// column, and is surfaced as its literal bytes; other storage classes
+// pass through.
+func Test_sqRows_Next_BlobWire(t *testing.T) {
+	rows := newTestRows(t,
+		[]string{"bl"}, []string{"blob"},
+		[][]any{
+			{"3q2+7w=="}, // X'DEADBEEF'
+			{""},         // X''
+			{"not base64!!"},
+			{nil},
+			{float64(42)}, // INTEGER stored in a BLOB column.
+		})
+
+	require.Equal(t, []driver.Value{[]byte{0xDE, 0xAD, 0xBE, 0xEF}}, nextRow(t, rows, 1))
+	require.Equal(t, []driver.Value{[]byte{}}, nextRow(t, rows, 1))
+	require.Equal(t, []driver.Value{[]byte("not base64!!")}, nextRow(t, rows, 1))
+	require.Equal(t, []driver.Value{nil}, nextRow(t, rows, 1))
+	require.Equal(t, []driver.Value{float64(42)}, nextRow(t, rows, 1))
+	require.ErrorIs(t, rows.Next(make([]driver.Value, 1)), io.EOF)
+}
+
+// Test_rawValues_GorqliteLayout guards the reflect+unsafe access that
+// rawValues performs on gorqlite.QueryResult's unexported values
+// field. If gorqlite renames or retypes the field, this test fails,
+// flagging that sqRows.Next can no longer read raw row values.
+func Test_rawValues_GorqliteLayout(t *testing.T) {
+	vals, ok := rawValues(&gorqlite.QueryResult{})
+	require.True(t, ok, "gorqlite.QueryResult no longer has a values [][]any field")
+	require.Nil(t, vals)
+
+	want := [][]any{{float64(1), "a"}}
+	qr := gorqlite.QueryResult{}
+	setQueryResultField(t, &qr, "values", want)
+	vals, ok = rawValues(&qr)
+	require.True(t, ok)
+	require.Equal(t, want, vals)
+}
+
+// Test_sqStmt_CheckNamedValue verifies parameter conversion,
+// especially the []byte-to-JSON-byte-array re-encoding that keeps
+// blobs from being stored as base64 TEXT (gh775).
+func Test_sqStmt_CheckNamedValue(t *testing.T) {
+	testCases := []struct {
+		in   any
+		want any
+	}{
+		{in: []byte{0xDE, 0xAD, 0xBE, 0xEF}, want: []int{222, 173, 190, 239}},
+		{in: []byte{}, want: []int{}},
+		{in: []byte(nil), want: nil},
+		{in: nil, want: nil},
+		{in: int64(7), want: int64(7)},
+		{in: "hello", want: "hello"},
+		{in: true, want: true},
+		{in: 1.5, want: 1.5},
+		// DefaultParameterConverter normalizes sub-int64 ints.
+		{in: 7, want: int64(7)},
+	}
+
+	s := &sqStmt{}
+	for _, tc := range testCases {
+		nv := &driver.NamedValue{Ordinal: 1, Value: tc.in}
+		require.NoError(t, s.CheckNamedValue(nv), "in: %#v", tc.in)
+		require.Equal(t, tc.want, nv.Value, "in: %#v", tc.in)
+	}
+}
+
+// Test_sqRows_Next_PassThrough verifies that columns outside the three
+// affected type classes are delivered unchanged, including columns with
+// parameterized type names and expression columns with no type at all.
+func Test_sqRows_Next_PassThrough(t *testing.T) {
+	rows := newTestRows(t,
+		[]string{"i", "txt", "expr"}, []string{"integer", "varchar(255)", ""},
+		[][]any{
+			{float64(7), "hello", "x"},
+			{nil, nil, nil},
+		})
+
+	require.Equal(t, []driver.Value{float64(7), "hello", "x"}, nextRow(t, rows, 3))
+	require.Equal(t, []driver.Value{nil, nil, nil}, nextRow(t, rows, 3))
+	require.ErrorIs(t, rows.Next(make([]driver.Value, 3)), io.EOF)
+}

--- a/drivers/rqlite/types_test.go
+++ b/drivers/rqlite/types_test.go
@@ -1,0 +1,214 @@
+package rqlite_test
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/neilotoole/sq/libsq/core/kind"
+	"github.com/neilotoole/sq/libsq/core/stringz"
+	"github.com/neilotoole/sq/libsq/core/tablefq"
+	"github.com/neilotoole/sq/libsq/driver"
+	"github.com/neilotoole/sq/libsq/source"
+	"github.com/neilotoole/sq/testh"
+	"github.com/neilotoole/sq/testh/sakila"
+	"github.com/neilotoole/sq/testh/tu"
+)
+
+// These tests round-trip the SQLite type classes that rqlite's JSON
+// wire format mishandles without driver-side conversion (gh775):
+// BOOLEAN, DATE/DATETIME, and BLOB. Each test writes values both via
+// raw SQL literals (covering data created by other clients, e.g. a
+// sqlite3-to-rqlite migration) and via sq's own insert path, then
+// reads them back through the record pipeline and asserts value-exact
+// results.
+
+// makeTypeTestTable creates a single-use table with the given column
+// clause, registering cleanup. It returns the table name and an open
+// helper environment.
+func makeTypeTestTable(t *testing.T, colsClause string) (th *testh.Helper, src *source.Source,
+	grip driver.Grip, tblName string,
+) {
+	t.Helper()
+	th = testh.New(t)
+	src = th.Source(sakila.Rq)
+	grip = th.Open(src)
+	db, err := grip.DB(th.Context)
+	require.NoError(t, err)
+
+	tblName = "types_" + stringz.Uniq8()
+	_, err = db.ExecContext(th.Context,
+		fmt.Sprintf("CREATE TABLE %q (%s)", tblName, colsClause))
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = grip.SQLDriver().DropTable(th.Context, db, tablefq.T{Table: tblName}, true)
+	})
+	return th, src, grip, tblName
+}
+
+// insertViaSq inserts a single record through sq's prepared-insert
+// path (the same path used by `sq tbl copy` and ingest), exercising
+// the driver's parameter encoding.
+func insertViaSq(t *testing.T, th *testh.Helper, grip driver.Grip,
+	tblName string, colNames []string, vals ...any,
+) {
+	t.Helper()
+	db, err := grip.DB(th.Context)
+	require.NoError(t, err)
+
+	// PrepareInsertStmt requires a single-conn db.
+	conn, err := db.Conn(th.Context)
+	require.NoError(t, err)
+	defer func() { _ = conn.Close() }()
+
+	execer, err := grip.SQLDriver().PrepareInsertStmt(th.Context, conn, tblName, colNames, 1)
+	require.NoError(t, err)
+	defer func() { _ = execer.Close() }()
+
+	munged := make([]any, len(vals))
+	copy(munged, vals)
+	require.NoError(t, execer.Munge(munged))
+	affected, err := execer.Exec(th.Context, munged...)
+	require.NoError(t, err)
+	require.Equal(t, int64(1), affected)
+}
+
+// TestRoundTrip_Bool verifies that BOOLEAN columns survive the wire in
+// both directions: SQLite stores booleans as integers 0/1, and rqlite's
+// JSON API delivers them back as numbers (older rqlite) or JSON booleans
+// (rqlite v10+). Both shapes must scan and surface as record bools.
+func TestRoundTrip_Bool(t *testing.T) {
+	tu.SkipShort(t, true)
+	t.Parallel()
+
+	th, src, grip, tblName := makeTypeTestTable(t, "id INTEGER, b BOOLEAN")
+	db, err := grip.DB(th.Context)
+	require.NoError(t, err)
+
+	// Rows 1-3: raw SQL literals, the gh775 repro shape.
+	_, err = db.ExecContext(th.Context, fmt.Sprintf(
+		"INSERT INTO %q (id, b) VALUES (1, 1), (2, 0), (3, NULL)", tblName))
+	require.NoError(t, err)
+
+	// Rows 4-5: sq's insert path with Go bool args.
+	insertViaSq(t, th, grip, tblName, []string{"id", "b"}, int64(4), true)
+	insertViaSq(t, th, grip, tblName, []string{"id", "b"}, int64(5), false)
+
+	sink, err := th.QuerySQL(src, nil, fmt.Sprintf(
+		"SELECT id, b FROM %q ORDER BY id", tblName))
+	require.NoError(t, err)
+	require.Len(t, sink.Recs, 5)
+	require.Equal(t, kind.Bool, sink.RecMeta[1].Kind())
+
+	require.Equal(t, true, sink.Recs[0][1])
+	require.Equal(t, false, sink.Recs[1][1])
+	require.Nil(t, sink.Recs[2][1])
+	require.Equal(t, true, sink.Recs[3][1])
+	require.Equal(t, false, sink.Recs[4][1])
+}
+
+// TestRoundTrip_Datetime verifies DATE and DATETIME columns for the
+// storage formats SQLite itself blesses, including the canonical
+// mattn/go-sqlite3 fractional-seconds format and bare dates. Older
+// rqlite servers return these strings raw; gorqlite's two-format
+// toTime conversion would abort the whole result set for them, so the
+// driver must take delivery of the raw value and parse it with the
+// full SQLite format list (drivers/rqlite/nulltime.go).
+func TestRoundTrip_Datetime(t *testing.T) {
+	tu.SkipShort(t, true)
+	t.Parallel()
+
+	th, src, grip, tblName := makeTypeTestTable(t, "id INTEGER, d DATE, dt DATETIME")
+	db, err := grip.DB(th.Context)
+	require.NoError(t, err)
+
+	// Raw SQL literals: bare date, mattn fractional seconds, minutes-only.
+	_, err = db.ExecContext(th.Context, fmt.Sprintf(`INSERT INTO %q (id, d, dt) VALUES
+(1, '2024-06-01', '2024-06-01 12:00:00.123'),
+(2, '2024-06-01', '2024-06-01 12:00'),
+(3, NULL, NULL)`, tblName))
+	require.NoError(t, err)
+
+	// sq's insert path with time.Time args.
+	wantTS := time.Date(2024, 6, 1, 12, 0, 0, 123_000_000, time.UTC)
+	wantDate := time.Date(2024, 6, 1, 0, 0, 0, 0, time.UTC)
+	insertViaSq(t, th, grip, tblName, []string{"id", "d", "dt"}, int64(4), wantDate, wantTS)
+
+	sink, err := th.QuerySQL(src, nil, fmt.Sprintf(
+		"SELECT id, d, dt FROM %q ORDER BY id", tblName))
+	require.NoError(t, err)
+	require.Len(t, sink.Recs, 4)
+	require.Equal(t, kind.Date, sink.RecMeta[1].Kind())
+	require.Equal(t, kind.Datetime, sink.RecMeta[2].Kind())
+
+	requireTimeEqual := func(want time.Time, got any) {
+		t.Helper()
+		gotTime, ok := got.(time.Time)
+		require.True(t, ok, "expected time.Time, got %T (%v)", got, got)
+		require.True(t, want.Equal(gotTime), "want %s, got %s", want, gotTime)
+	}
+
+	// Row 1: bare date + fractional seconds.
+	requireTimeEqual(wantDate, sink.Recs[0][1])
+	requireTimeEqual(wantTS, sink.Recs[0][2])
+	// Row 2: minutes-only datetime.
+	requireTimeEqual(time.Date(2024, 6, 1, 12, 0, 0, 0, time.UTC), sink.Recs[1][2])
+	// Row 3: NULLs.
+	require.Nil(t, sink.Recs[2][1])
+	require.Nil(t, sink.Recs[2][2])
+	// Row 4: written via sq's own insert path.
+	requireTimeEqual(wantDate, sink.Recs[3][1])
+	requireTimeEqual(wantTS, sink.Recs[3][2])
+}
+
+// TestRoundTrip_Blob verifies BLOB columns in both directions. rqlite's
+// JSON API returns BLOB cells base64-encoded, which the driver must
+// decode; and []byte parameters must reach rqlite as true blobs (byte
+// arrays in the JSON parameter encoding), not as base64 text.
+func TestRoundTrip_Blob(t *testing.T) {
+	tu.SkipShort(t, true)
+	t.Parallel()
+
+	th, src, grip, tblName := makeTypeTestTable(t, "id INTEGER, bl BLOB")
+	db, err := grip.DB(th.Context)
+	require.NoError(t, err)
+
+	// Rows 1-3: raw SQL literals.
+	_, err = db.ExecContext(th.Context, fmt.Sprintf(
+		"INSERT INTO %q (id, bl) VALUES (1, X'DEADBEEF'), (2, X''), (3, NULL)", tblName))
+	require.NoError(t, err)
+
+	// Rows 4-5: sq's insert path with []byte args.
+	wantBytes := []byte{0xDE, 0xAD, 0xBE, 0xEF}
+	insertViaSq(t, th, grip, tblName, []string{"id", "bl"}, int64(4), wantBytes)
+	insertViaSq(t, th, grip, tblName, []string{"id", "bl"}, int64(5), []byte{})
+
+	// The sq-written rows must be stored as genuine blobs, not as the
+	// base64 TEXT that gorqlite's default []byte JSON encoding produces.
+	rows, err := db.QueryContext(th.Context, fmt.Sprintf(
+		"SELECT id, typeof(bl) FROM %q WHERE id IN (1, 4, 5) ORDER BY id", tblName))
+	require.NoError(t, err)
+	defer func() { _ = rows.Close() }()
+	for rows.Next() {
+		var id int64
+		var typeOf string
+		require.NoError(t, rows.Scan(&id, &typeOf))
+		require.Equal(t, "blob", typeOf, "row %d: expected blob storage class", id)
+	}
+	require.NoError(t, rows.Err())
+	require.NoError(t, rows.Close())
+
+	sink, err := th.QuerySQL(src, nil, fmt.Sprintf(
+		"SELECT id, bl FROM %q ORDER BY id", tblName))
+	require.NoError(t, err)
+	require.Len(t, sink.Recs, 5)
+	require.Equal(t, kind.Bytes, sink.RecMeta[1].Kind())
+
+	require.Equal(t, wantBytes, sink.Recs[0][1], "X'DEADBEEF' literal must read back byte-exact")
+	require.Equal(t, []byte{}, sink.Recs[1][1], "X'' literal must read back as empty bytes")
+	require.Nil(t, sink.Recs[2][1])
+	require.Equal(t, wantBytes, sink.Recs[3][1], "sq-written blob must read back byte-exact")
+	require.Equal(t, []byte{}, sink.Recs[4][1], "sq-written empty blob must read back as empty bytes")
+}


### PR DESCRIPTION
Fixes #775. All three type classes were mishandled at the gorqlite wire boundary.

- **BOOLEAN:** pre-v10 servers deliver BOOLEAN cells as JSON numbers, which
  `sql.NullBool.Scan` rejects. Columns typed boolean now convert raw float64 via SQLite
  truthiness; JSON bools (v10 normalizes server-side) and strings pass through.
- **DATE/DATETIME:** gorqlite pre-converts date/datetime columns with only two layouts and
  errors on anything else (bare dates, mattn fractional seconds), aborting the whole result
  set, so data migrated from sqlite3 was unreadable. gorqlite exposes rows only through
  accessors that apply that conversion and offers no interception point, so `sqRows.Next` now
  reads the raw JSON-decoded values from the embedded `gorqlite.QueryResult` via a guarded
  reflect+unsafe accessor and routes them through the driver's existing nine-format parser.
  The accessor is read-only, fails loudly (never falls back to the corrupting path) if
  gorqlite's layout changes, and is pinned by a layout test. This also fixes gorqlite
  misreading REAL-stored (Julian day) datetimes as epoch seconds.
- **BLOB:** reads were base64 text masquerading as bytes; writes stored base64 TEXT, so
  `tbl copy` from sqlite3 silently mangled every binary column. Reads now base64-decode
  blob-typed columns; writes re-encode []byte parameters as JSON int arrays, rqlite's
  documented typed-blob parameter form (verified live: stored typeof=blob, byte-exact
  round-trip, empty slice and NULL preserved).

Testing: round-trip integration tests ran against a live sakiladb/rqlite v10.2.0 container
(raw SQL literals and sq's insert path; byte-exact blob assertions, typeof checks, bare-date /
fractional-second / NULL datetime cases). Pre-v10 wire shapes are covered by unit tests
fabricating exact gorqlite results. `make lint` clean; full `-short` suite green.

Follow-up candidates: propose a raw-values accessor (or pluggable time parsing) upstream to
gorqlite, which would remove the reflect+unsafe accessor entirely.