### PR TITLE
sqlite3/sqlparser: collapse doubled ident quotes; extract single-quoted table names

### DIFF
--- a/drivers/sqlite3/sqlite3_test.go
+++ b/drivers/sqlite3/sqlite3_test.go
@@ -499,6 +499,125 @@ func TestDriveri_AlterTableColumnKinds_QuotedIdentifier(t *testing.T) {
 	}
 }
 
+// TestDriveri_AlterTableColumnKinds_EscapedQuoteColumnName reproduces gh789
+// case 1: a column literally named my"col (declared in DDL as "my""col")
+// failed the column lookup in AlterTableColumnKinds because trimIdentQuotes
+// stripped only the outer quote pair without collapsing the doubled escape,
+// so ColDef.Name was my""col and never matched. Reachable e.g. from a CSV
+// header containing a double quote.
+func TestDriveri_AlterTableColumnKinds_EscapedQuoteColumnName(t *testing.T) {
+	testCases := []struct {
+		name    string
+		colDecl string
+		colName string
+	}{
+		{
+			name:    "double_quote_escaped",
+			colDecl: `"my""col" INTEGER NOT NULL`,
+			colName: `my"col`,
+		},
+		{
+			name:    "backtick_escaped",
+			colDecl: "`my``col` INTEGER NOT NULL",
+			colName: "my`col",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			th := testh.New(t)
+			src := &source.Source{
+				Handle:   "@test",
+				Type:     drivertype.SQLite,
+				Location: "sqlite3://" + tu.TempFile(t, "test.db"),
+			}
+
+			grip := th.Open(src)
+			db, err := grip.DB(th.Context)
+			require.NoError(t, err)
+			drvr := grip.SQLDriver()
+
+			_, err = db.ExecContext(th.Context, `CREATE TABLE example (`+tc.colDecl+`)`)
+			require.NoError(t, err)
+
+			err = drvr.AlterTableColumnKinds(th.Context, db, "example",
+				[]string{tc.colName}, []kind.Kind{kind.Text})
+			require.NoError(t, err)
+
+			md, err := grip.TableMetadata(th.Context, "example")
+			require.NoError(t, err)
+			require.Len(t, md.Columns, 1)
+			require.Equal(t, tc.colName, md.Columns[0].Name)
+			require.Equal(t, kind.Text.String(), md.Columns[0].Kind.String())
+		})
+	}
+}
+
+// TestDriveri_AlterTableColumnKinds_SingleQuotedTableName reproduces gh789
+// case 2: an externally created database whose stored DDL reads
+// CREATE TABLE 'actor' (...) (a form SQLite accepts) failed table-identifier
+// extraction because the lexer tokenizes single-quoted names as
+// STRING_LITERAL, which ExtractTableIdentFromCreateTableStmt didn't accept.
+func TestDriveri_AlterTableColumnKinds_SingleQuotedTableName(t *testing.T) {
+	th := testh.New(t)
+	src := &source.Source{
+		Handle:   "@test",
+		Type:     drivertype.SQLite,
+		Location: "sqlite3://" + tu.TempFile(t, "test.db"),
+	}
+
+	grip := th.Open(src)
+	db, err := grip.DB(th.Context)
+	require.NoError(t, err)
+	drvr := grip.SQLDriver()
+
+	// Execute exactly this SQL so sqlite_master stores the single-quoted
+	// form verbatim.
+	_, err = db.ExecContext(th.Context, `CREATE TABLE 'actor' (actor_id INTEGER NOT NULL)`)
+	require.NoError(t, err)
+
+	err = drvr.AlterTableColumnKinds(th.Context, db, "actor",
+		[]string{"actor_id"}, []kind.Kind{kind.Text})
+	require.NoError(t, err)
+
+	md, err := grip.TableMetadata(th.Context, "actor")
+	require.NoError(t, err)
+	require.Len(t, md.Columns, 1)
+	require.Equal(t, kind.Text.String(), md.Column("actor_id").Kind.String())
+}
+
+// TestDriveri_CopyTable_SingleQuotedTableName is the CopyTable counterpart
+// of gh789 case 2: copying a table whose stored DDL uses the single-quoted
+// form CREATE TABLE 'actor' (...) must succeed.
+func TestDriveri_CopyTable_SingleQuotedTableName(t *testing.T) {
+	th := testh.New(t)
+	src := &source.Source{
+		Handle:   "@test",
+		Type:     drivertype.SQLite,
+		Location: "sqlite3://" + tu.TempFile(t, "test.db"),
+	}
+
+	grip := th.Open(src)
+	db, err := grip.DB(th.Context)
+	require.NoError(t, err)
+	drvr := grip.SQLDriver()
+
+	_, err = db.ExecContext(th.Context, `CREATE TABLE 'actor' (actor_id INTEGER NOT NULL)`)
+	require.NoError(t, err)
+	_, err = db.ExecContext(th.Context, `INSERT INTO actor (actor_id) VALUES (1), (2)`)
+	require.NoError(t, err)
+
+	copied, err := drvr.CopyTable(th.Context, db,
+		tablefq.From("actor"), tablefq.From("actor_copy"), true)
+	require.NoError(t, err)
+	require.Equal(t, int64(2), copied)
+
+	md, err := grip.TableMetadata(th.Context, "actor_copy")
+	require.NoError(t, err)
+	require.Len(t, md.Columns, 1)
+	require.Equal(t, "actor_id", md.Columns[0].Name)
+}
+
 // TestDriveri_AlterTableColumnKinds_ColumnNamePrefixesType reproduces
 // gh750: a column whose name shares its declared-case prefix with the
 // type token (e.g. `text_data text`) caused the old

--- a/drivers/sqlite3/sqlparser/create_table.go
+++ b/drivers/sqlite3/sqlparser/create_table.go
@@ -83,7 +83,7 @@ func ExtractTableIdentFromCreateTableStmt(stmt string) (*TableIdent, error) {
 	ident := &TableIdent{SchemaOffset: -1}
 
 	if n, ok := stmtCtx.Schema_name().(*sqlite.Schema_nameContext); ok {
-		if n.Any_name() != nil && !n.Any_name().IsEmpty() && n.Any_name().IDENTIFIER() != nil {
+		if anyNameIsExtractable(n.Any_name()) {
 			ident.RawSchema = tokx.Extract(n)
 			ident.Schema = trimIdentQuotes(ident.RawSchema)
 			ident.SchemaOffset, _ = tokx.Offset(n)
@@ -91,7 +91,7 @@ func ExtractTableIdentFromCreateTableStmt(stmt string) (*TableIdent, error) {
 	}
 
 	if x, ok := stmtCtx.Table_name().(*sqlite.Table_nameContext); ok {
-		if x.Any_name() != nil && !x.Any_name().IsEmpty() && x.Any_name().IDENTIFIER() != nil {
+		if anyNameIsExtractable(x.Any_name()) {
 			ident.RawTable = tokx.Extract(x)
 			ident.Table = trimIdentQuotes(ident.RawTable)
 			ident.TableOffset, _ = tokx.Offset(x)
@@ -103,6 +103,18 @@ func ExtractTableIdentFromCreateTableStmt(stmt string) (*TableIdent, error) {
 	}
 
 	return ident, nil
+}
+
+// anyNameIsExtractable reports whether n matches a directly extractable
+// alternative of the any_name grammar rule: IDENTIFIER (bare, double-quoted,
+// backtick-quoted, or bracket-quoted), STRING_LITERAL (single-quoted; the
+// lexer tokenizes 'actor' as STRING_LITERAL, not IDENTIFIER, but SQLite
+// accepts the form in DDL), or a bare keyword. The remaining alternative,
+// a parenthesized any_name, is a grammar artifact that SQLite itself does
+// not accept in a CREATE TABLE name position, so it is not accepted here.
+func anyNameIsExtractable(n sqlite.IAny_nameContext) bool {
+	return n != nil && !n.IsEmpty() &&
+		(n.IDENTIFIER() != nil || n.STRING_LITERAL() != nil || n.Keyword() != nil)
 }
 
 // ForeignTableRef describes a single REFERENCES <table> occurrence inside a

--- a/drivers/sqlite3/sqlparser/sqlparser.go
+++ b/drivers/sqlite3/sqlparser/sqlparser.go
@@ -18,16 +18,27 @@ import (
 //	`actor` -> actor
 //	'actor' -> actor
 //
+// Within a quoted identifier, SQLite escapes the quote character by
+// doubling it, and trimIdentQuotes collapses the escape:
+//
+//	"my""col" -> my"col
+//	'my''col' -> my'col
+//	`my``col` -> my`col
+//
+// Square brackets have no escape mechanism in SQLite (a ] cannot appear
+// inside [..]), so bracket content is returned verbatim.
+//
 // If s is empty, unquoted, or is malformed, it is returned unchanged.
 func trimIdentQuotes(s string) string {
 	if len(s) < 2 {
 		return s
 	}
 
-	switch s[0] {
+	switch q := s[0]; q {
 	case '"', '`', '\'':
-		if s[len(s)-1] == s[0] {
-			return s[1 : len(s)-1]
+		if s[len(s)-1] == q {
+			body := s[1 : len(s)-1]
+			return strings.ReplaceAll(body, string([]byte{q, q}), string(q))
 		}
 	case '[':
 		if s[len(s)-1] == ']' {

--- a/drivers/sqlite3/sqlparser/sqlparser_internal_test.go
+++ b/drivers/sqlite3/sqlparser/sqlparser_internal_test.go
@@ -1,0 +1,64 @@
+package sqlparser
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/neilotoole/sq/testh/tu"
+)
+
+// TestTrimIdentQuotes verifies that trimIdentQuotes strips each of SQLite's
+// four legal identifier-quote styles and collapses the doubled escape
+// sequence for the three styles that have one: a doubled quote character
+// inside double quotes, single quotes, or backticks denotes a literal
+// occurrence of that character. Square brackets have no escape mechanism
+// in SQLite (a ] cannot appear inside [..]), so bracket content is
+// returned verbatim. See issue #789.
+func TestTrimIdentQuotes(t *testing.T) {
+	testCases := []struct {
+		in   string
+		want string
+	}{
+		// Unquoted and degenerate inputs pass through unchanged.
+		{in: "", want: ""},
+		{in: "a", want: "a"},
+		{in: "actor", want: "actor"},
+		{in: `"`, want: `"`},
+		{in: `"actor`, want: `"actor`},
+		{in: `actor"`, want: `actor"`},
+		{in: `[actor`, want: `[actor`},
+
+		// Plain quoted forms.
+		{in: `"actor"`, want: "actor"},
+		{in: `'actor'`, want: "actor"},
+		{in: "`actor`", want: "actor"},
+		{in: `[actor]`, want: "actor"},
+
+		// Doubled-escape collapse per quote style.
+		{in: `"my""col"`, want: `my"col`},
+		{in: `'my''col'`, want: `my'col`},
+		{in: "`my``col`", want: "my`col"},
+		{in: `"a""b""c"`, want: `a"b"c`},
+		{in: `""""`, want: `"`},
+		{in: `''''`, want: `'`},
+
+		// The empty quoted identifier.
+		{in: `""`, want: ""},
+		{in: `''`, want: ""},
+		{in: "``", want: ""},
+		{in: `[]`, want: ""},
+
+		// A quote char of a different style inside the quoted body is
+		// literal, not an escape.
+		{in: `"it's"`, want: "it's"},
+		{in: `'he said "hi"'`, want: `he said "hi"`},
+		{in: `[my"col]`, want: `my"col`},
+	}
+
+	for i, tc := range testCases {
+		t.Run(tu.Name(i, tc.in), func(t *testing.T) {
+			require.Equal(t, tc.want, trimIdentQuotes(tc.in))
+		})
+	}
+}

--- a/drivers/sqlite3/sqlparser/sqlparser_test.go
+++ b/drivers/sqlite3/sqlparser/sqlparser_test.go
@@ -49,6 +49,45 @@ func TestExtractTableIdentFromCreateTableStmt(t *testing.T) {
 			wantRawSchema: `"sak ila"`,
 			wantRawTable:  `"actor"`,
 		},
+		{
+			// Single-quoted table name: the lexer tokenizes 'actor' as
+			// STRING_LITERAL, not IDENTIFIER, but SQLite accepts this
+			// form in DDL. See issue #789.
+			in:           `CREATE TABLE 'actor' ( actor_id INTEGER NOT NULL)`,
+			wantTable:    "actor",
+			wantRawTable: `'actor'`,
+		},
+		{
+			in:            `CREATE TABLE 'main'.'actor' ( actor_id INTEGER NOT NULL)`,
+			wantSchema:    "main",
+			wantTable:     "actor",
+			wantRawSchema: `'main'`,
+			wantRawTable:  `'actor'`,
+		},
+		{
+			in:           "CREATE TABLE `actor` ( actor_id INTEGER NOT NULL)",
+			wantTable:    "actor",
+			wantRawTable: "`actor`",
+		},
+		{
+			// A bare keyword lexes as its keyword token, not IDENTIFIER,
+			// and reaches table_name via any_name's keyword alternative.
+			in:           `CREATE TABLE replace ( actor_id INTEGER NOT NULL)`,
+			wantTable:    "replace",
+			wantRawTable: "replace",
+		},
+		{
+			// Doubled escape quotes must collapse: DDL "my""tbl" denotes
+			// a table literally named my"tbl. See issue #789.
+			in:           `CREATE TABLE "my""tbl" ( actor_id INTEGER NOT NULL)`,
+			wantTable:    `my"tbl`,
+			wantRawTable: `"my""tbl"`,
+		},
+		{
+			in:           `CREATE TABLE 'my''tbl' ( actor_id INTEGER NOT NULL)`,
+			wantTable:    `my'tbl`,
+			wantRawTable: `'my''tbl'`,
+		},
 	}
 
 	for i, tc := range testCases {
@@ -171,6 +210,55 @@ func TestExtractCreateTableStmtColDefs_QuotedIdentifiers(t *testing.T) {
 			require.Len(t, colDefs, 1)
 			require.Equal(t, tc.wantRawName, colDefs[0].RawName)
 			require.Equal(t, "age", colDefs[0].Name)
+		})
+	}
+}
+
+// TestExtractCreateTableStmtColDefs_EscapedQuotes verifies that ColDef.Name
+// collapses doubled escape quotes inside quoted column names: DDL "my""col"
+// denotes a column literally named my"col, and similarly for single quotes
+// and backticks. Square brackets have no escape mechanism in SQLite, so
+// bracket content is taken verbatim. See issue #789.
+func TestExtractCreateTableStmtColDefs_EscapedQuotes(t *testing.T) {
+	testCases := []struct {
+		name        string
+		stmt        string
+		wantRawName string
+		wantName    string
+	}{
+		{
+			name:        "double_quote_escaped",
+			stmt:        `CREATE TABLE t ("my""col" INTEGER NOT NULL)`,
+			wantRawName: `"my""col"`,
+			wantName:    `my"col`,
+		},
+		{
+			name:        "single_quote_escaped",
+			stmt:        `CREATE TABLE t ('my''col' INTEGER NOT NULL)`,
+			wantRawName: `'my''col'`,
+			wantName:    `my'col`,
+		},
+		{
+			name:        "backtick_escaped",
+			stmt:        "CREATE TABLE t (`my``col` INTEGER NOT NULL)",
+			wantRawName: "`my``col`",
+			wantName:    "my`col",
+		},
+		{
+			name:        "bracket_content_verbatim",
+			stmt:        `CREATE TABLE t ([my"col] INTEGER NOT NULL)`,
+			wantRawName: `[my"col]`,
+			wantName:    `my"col`,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			colDefs, err := sqlparser.ExtractCreateTableStmtColDefs(tc.stmt)
+			require.NoError(t, err)
+			require.Len(t, colDefs, 1)
+			require.Equal(t, tc.wantRawName, colDefs[0].RawName)
+			require.Equal(t, tc.wantName, colDefs[0].Name)
 		})
 	}
 }


### PR DESCRIPTION
Fixes #789. Two identifier-quoting edges in the sqlparser package; rqlite inherits both fixes
since it shares the parser.

- **Doubled escape quotes now collapse.** `trimIdentQuotes` stripped only the outer pair, so a
  column literally named `my"col` (DDL `"my""col"`) yielded `ColDef.Name` of `my""col` and
  `AlterTableColumnKinds` failed with "column not found" even though the column exists
  (reachable from a CSV header containing a double quote). Escapes now collapse per SQLite's
  actual rules: `""`, `''`, and doubled backtick; brackets deliberately have no escape (a `]`
  cannot appear inside, per the lexer rule), so bracket content stays verbatim.
- **Single-quoted and keyword table names now extract.** The lexer tokenizes `'actor'` as
  STRING_LITERAL, but `ExtractTableIdentFromCreateTableStmt` only accepted IDENTIFIER tokens,
  so an externally created database whose stored DDL reads `CREATE TABLE 'actor' (...)` failed
  table-ident extraction, aborting `tbl copy` and column-kind alteration. The STRING_LITERAL
  and keyword alternatives of `any_name` are now accepted (for both schema and table) and
  routed through `trimIdentQuotes`. Column-name and FK-ref extraction never had the gating bug
  and get the escape-collapse fix automatically.

Testing: 27-case `trimIdentQuotes` table test, new ExtractTableIdent cases (single-quote,
schema-qualified, backtick, keyword, doubled escapes), and end-to-end
`AlterTableColumnKinds` / `CopyTable` tests against real SQLite files using the affected DDL
forms. Generated ANTLR files untouched. `make lint` clean; full `-short` suite green.