### PR TITLE
keyring migrate: derive JSON mode from resolved output format

### DIFF
--- a/cli/cmd_config_keyring_migrate.go
+++ b/cli/cmd_config_keyring_migrate.go
@@ -12,6 +12,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/neilotoole/sq/cli/output"
+	"github.com/neilotoole/sq/cli/output/format"
 	"github.com/neilotoole/sq/cli/run"
 	"github.com/neilotoole/sq/libsq/core/errz"
 	"github.com/neilotoole/sq/libsq/core/lg"
@@ -89,7 +90,7 @@ func execConfigKeyringMigrate(cmd *cobra.Command, args []string) error {
 	// Non-dry-run: print the plan in text mode so the user can see what
 	// will happen before the prompt. In JSON mode, skip the pre-prompt
 	// preview — the consumer reads a single envelope after apply.
-	if outputFormatIsJSON(cmd) {
+	if outputFormatIsJSON(ru) {
 		// JSON: skip preview, skip confirmation prompt, apply directly.
 		// JSON callers are non-interactive; --yes is implied.
 		rows, err := applyMigratePlans(ctx, ru, plans)
@@ -235,13 +236,16 @@ func applyMigratePlans(ctx context.Context, ru *run.Run, plans []migratePlan) (
 	return rows, nil
 }
 
-// outputFormatIsJSON reports whether the caller selected JSON output via
-// --json (or --format=json once we surface that flag).
-func outputFormatIsJSON(cmd *cobra.Command) bool {
-	if cmd == nil {
+// outputFormatIsJSON reports whether the resolved output format is JSON,
+// whether selected via the --json flag or the config "format" option. It
+// must agree with the writer selection in newWriters, which keys off the
+// same resolved format (see getFormat): whenever the JSON keyring writer
+// is in play, the command must behave non-interactively.
+func outputFormatIsJSON(ru *run.Run) bool {
+	if ru == nil || ru.Config == nil {
 		return false
 	}
-	return cmdFlagIsSetTrue(cmd, "json")
+	return getFormat(ru.Cmd, ru.Config.Options) == format.JSON
 }
 
 // migrateSkipReason inspects loc and returns a non-empty reason string

--- a/cli/cmd_config_keyring_test.go
+++ b/cli/cmd_config_keyring_test.go
@@ -893,6 +893,53 @@ func TestCmdConfigKeyringMigrate_JSON_SkipsPrompt(t *testing.T) {
 	require.Contains(t, src.Location, "${keyring:")
 }
 
+// TestCmdConfigKeyringMigrate_ConfigFormatJSON_SkipsPrompt verifies
+// that JSON output selected via the config "format" option behaves
+// exactly like the --json flag: no preview envelope, no y/N prompt,
+// a single valid JSON document on stdout. Regression test for #790,
+// where outputFormatIsJSON checked only the --json flag while writer
+// selection used the resolved format, so `sq config set format json`
+// produced two concatenated JSON envelopes with a blocking prompt in
+// between.
+func TestCmdConfigKeyringMigrate_ConfigFormatJSON_SkipsPrompt(t *testing.T) {
+	gokeyring.MockInit()
+	th := testh.New(t)
+	tr := testrun.New(th.Context, t, nil)
+
+	// Persist format=json to config, then start a fresh run that loads
+	// it, mirroring `sq config set format json` followed by a separate
+	// `sq config keyring migrate` invocation.
+	require.NoError(t, tr.Exec("config", "set", "format", "json"))
+	tr = testrun.New(th.Context, t, tr)
+
+	require.NoError(t, tr.Run.Config.Collection.Add(&source.Source{
+		Handle:   "@cfg_json",
+		Type:     "postgres",
+		Location: "postgres://alice:hunter2@db/sakila",
+	}))
+	// Pipe "n\n" so the y/N prompt (if reached) would answer "no".
+	tr.PipeStdin("n\n")
+
+	// No --json flag and no --yes: JSON-ness must come from config.
+	require.NoError(t, tr.Exec("config", "keyring", "migrate", "--all"))
+
+	// Unmarshaling the entire stdout buffer fails if the output is two
+	// concatenated documents or contains prompt text, so this asserts
+	// "exactly one valid JSON document" as well as the envelope shape.
+	var env migrateJSONEnvelope
+	require.NoError(t, json.Unmarshal(tr.Out.Bytes(), &env),
+		"stdout must be a single valid JSON document; got: %s", tr.Out.String())
+	require.False(t, env.DryRun)
+	require.Len(t, env.Rows, 1)
+	require.Equal(t, "migrated", env.Rows[0].Status,
+		"config format=json must bypass the y/N prompt; got status %q", env.Rows[0].Status)
+
+	// Sanity: source's Location is now a placeholder.
+	src, err := tr.Run.Config.Collection.Get("@cfg_json")
+	require.NoError(t, err)
+	require.Contains(t, src.Location, "${keyring:")
+}
+
 // TestCmdConfigKeyringRm_Completion_TolerantOfMalformedSource verifies
 // that shell completion doesn't crash or short-circuit when one of the
 // sources in the active collection has a malformed placeholder in its


### PR DESCRIPTION
Fixes #790.

`outputFormatIsJSON` checked only the `--json` flag, while writer selection uses
`getFormat()`, which falls back to the config `format` option. With `format: json` in config,
`sq config keyring migrate --all` selected the JSON writer but took the interactive text-mode
flow: JSON preview envelope, a blocking `Proceed with migration? [y/N]` prompt (hanging
non-interactive pipelines), then a second envelope — two concatenated JSON documents.

`outputFormatIsJSON` now derives from the resolved format (the same `getFormat()` call as
writer selection, matching the precedent in cmd_slq.go), so config-format json behaves
identically to `--json`: no preview, no prompt (the JSON path implies `--yes`, its existing
documented behavior), one valid JSON document. The predicate is equality with `format.JSON`
specifically, agreeing with the writer wiring (JSONL/JSONA/YAML keep the text keyring writer).

The sibling keyring commands (create, get, ls, rm, update) call the format-resolved writer
directly and don't branch on output format; no other instance of the bug.

Testing: new regression test persists `format=json` via config, pipes `n` to stdin (would
abort if the prompt fired), runs `migrate --all` with neither `--json` nor `--yes`, and
asserts the entire stdout unmarshals as a single JSON envelope with status=migrated. Observed
failing pre-fix with exactly the reported symptom. `make lint` clean; `-short` suites green.