### PR TITLE
keyring get --json: represent empty revealed secret distinctly

### DIFF
--- a/cli/cmd_config_keyring_test.go
+++ b/cli/cmd_config_keyring_test.go
@@ -678,6 +678,43 @@ func TestCmdConfigKeyringGet_JSON_WithReveal(t *testing.T) {
 	require.Equal(t, "hunter2", got["value"])
 }
 
+// TestCmdConfigKeyringGet_JSON_WithReveal_EmptyValue: an empty stored
+// secret must still emit the "value" key (as "") with --reveal, so a
+// consumer can distinguish "empty secret, revealed" from "redacted".
+func TestCmdConfigKeyringGet_JSON_WithReveal_EmptyValue(t *testing.T) {
+	gokeyring.MockInit()
+	require.NoError(t, gokeyring.Set("sq", "abc_get_js_empty", ""))
+	th := testh.New(t)
+	tr := testrun.New(th.Context, t, nil)
+	require.NoError(t, tr.Exec("config", "keyring", "get", "abc_get_js_empty", "--reveal", "--json"))
+
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(tr.Out.Bytes(), &got))
+	require.Equal(t, "abc_get_js_empty", got["path"])
+	require.Equal(t, true, got["exists"])
+	v, hasValue := got["value"]
+	require.True(t, hasValue, "value must be present with --reveal, even when empty")
+	require.Equal(t, "", v)
+}
+
+// TestCmdConfigKeyringGet_JSON_WithoutReveal_EmptyValue: without
+// --reveal, an empty stored secret emits no "value" key, same as any
+// other redacted secret.
+func TestCmdConfigKeyringGet_JSON_WithoutReveal_EmptyValue(t *testing.T) {
+	gokeyring.MockInit()
+	require.NoError(t, gokeyring.Set("sq", "abc_get_js_empty2", ""))
+	th := testh.New(t)
+	tr := testrun.New(th.Context, t, nil)
+	require.NoError(t, tr.Exec("config", "keyring", "get", "abc_get_js_empty2", "--json"))
+
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(tr.Out.Bytes(), &got))
+	require.Equal(t, "abc_get_js_empty2", got["path"])
+	require.Equal(t, true, got["exists"])
+	_, hasValue := got["value"]
+	require.False(t, hasValue, "value must be absent without --reveal")
+}
+
 // TestCmdConfigKeyringCreate_JSON: explicit create with --json emits a
 // confirmation object with "created": true.
 func TestCmdConfigKeyringCreate_JSON(t *testing.T) {

--- a/cli/output/jsonw/keyringwriter.go
+++ b/cli/output/jsonw/keyringwriter.go
@@ -29,16 +29,20 @@ func (w *keyringWriter) List(refs []output.KeyringRef) error {
 	return writeJSON(w.out, w.pr, refs)
 }
 
-// Get implements output.KeyringWriter.
+// Get implements output.KeyringWriter. The "value" field's presence
+// carries the revealed/redacted distinction: it is emitted whenever
+// revealed is true, even for an empty stored value (hence the pointer;
+// a plain string with omitempty would drop the field for ""), and
+// omitted otherwise.
 func (w *keyringWriter) Get(path, value string, revealed bool) error {
 	type record struct {
-		Path   string `json:"path"`
-		Value  string `json:"value,omitempty"`
-		Exists bool   `json:"exists"`
+		Value  *string `json:"value,omitempty"`
+		Path   string  `json:"path"`
+		Exists bool    `json:"exists"`
 	}
 	r := record{Path: path, Exists: true}
 	if revealed {
-		r.Value = value
+		r.Value = &value
 	}
 	return writeJSON(w.out, w.pr, r)
 }


### PR DESCRIPTION
Fixes #786.

The JSON keyring writer marshaled the revealed value with `json:"value,omitempty"` on a plain
string, so a secret whose stored value is empty (storable: the VALUE arg accepts an empty
string) serialized identically to the redacted case, and `--reveal --json | jq .value`
returned null either way.

The field is now `*string`: nil when redacted (field absent), set when revealed, so field
presence carries the revealed/redacted distinction exactly and an empty revealed secret emits
`"value": ""`. Cosmetic side effect: fieldalignment puts the pointer field first, so JSON key
order is now value, path, exists.

The text writer was audited and is not ambiguous (revealed prints the raw value, redacted
prints `secret exists: PATH`); there is no YAML keyring writer; the other JSON methods have no
value-presence ambiguity; site docs show no JSON value example needing updates.

Testing: new tests store an empty secret via the keyring mock and assert `"value": ""` is
present with `--reveal` and absent without it; observed failing pre-fix. `make lint` clean;
`-short` suites green.