### PR TITLE
completion: bound userinfo '@' search to the authority portion

### DIFF
--- a/cli/complete_location_test.go
+++ b/cli/complete_location_test.go
@@ -262,6 +262,27 @@ func TestCompleteAddLocation_Postgres(t *testing.T) {
 			wantResult: stdDirective,
 		},
 		{
+			// gh792: the '@' is part of the query value, not a
+			// credentials terminator. The typed value "me@" has no known
+			// completions, so the completer offers "&" to move to the
+			// next param; it must NOT emit authority-style garbage like
+			// "postgres://localhost/db?application_name=me@localhost/".
+			args: []string{"postgres://localhost/db?application_name=me@"},
+			want: []string{
+				"postgres://localhost/db?application_name=me@&",
+			},
+			wantResult: stdDirective,
+		},
+		{
+			// gh792: an '@' in a path segment is not a credentials
+			// terminator either.
+			args: []string{"postgres://localhost/cust@"},
+			want: []string{
+				"postgres://localhost/cust@?",
+			},
+			wantResult: stdDirective,
+		},
+		{
 			// Being that sslmode is already specified, it should not appear a
 			// second time.
 			args: []string{"postgres://alice@localhost/sakila?sslmode=disable&"},

--- a/libsq/driver/locshape.go
+++ b/libsq/driver/locshape.go
@@ -323,12 +323,24 @@ func walkSegments(shape LocationShape, m MatchedLoc, tail string) (MatchedLoc, e
 // Returns the parsed fields, the number of bytes consumed (including
 // the trailing '@' if matched), and current==true if the user is
 // still typing inside the credentials segment.
+//
+// Per RFC 3986, userinfo can only occur before the first '/' or '?',
+// so the '@' search is bounded to that authority portion (#792): an
+// '@' in the path or query string is not a credentials terminator.
+// When s has no '/' or '?' yet (the user is mid-typing), the whole of
+// s is searched, because an '@' there may genuinely terminate
+// userinfo.
 func walkCredentials(s string, optional bool) (matched MatchedLoc, advance int, current bool) {
-	atIdx := strings.IndexByte(s, '@')
+	authority := s
+	if boundary := strings.IndexAny(s, "/?"); boundary != -1 {
+		authority = s[:boundary]
+	}
+	atIdx := strings.IndexByte(authority, '@')
 	if atIdx == -1 {
-		// No '@' present.
-		if optional && strings.ContainsAny(s, "/?") {
-			// Skip-signal: user has moved past credentials.
+		// No '@' present before the authority ends.
+		if optional && len(authority) < len(s) {
+			// Skip-signal: a '/' or '?' arrived without a preceding
+			// '@', so the user has moved past credentials.
 			return MatchedLoc{}, 0, false
 		}
 		// Partial credentials being typed.

--- a/libsq/driver/locshape_test.go
+++ b/libsq/driver/locshape_test.go
@@ -292,6 +292,96 @@ func TestWalk_gh743BareHostIPv6(t *testing.T) {
 	require.True(t, got.PortSet)
 }
 
+// TestWalk_gh792AtBeyondAuthority covers issue #792: an '@' in the
+// path or query string of credential-less input must not be treated
+// as the userinfo terminator. Per RFC 3986, userinfo can only occur
+// before the first '/' or '?', so the walker bounds its '@' search to
+// that authority portion. A tail with no '/' or '?' yet (mid-typing)
+// keeps the existing behavior: an '@' there genuinely terminates
+// userinfo.
+func TestWalk_gh792AtBeyondAuthority(t *testing.T) {
+	t.Run("at_in_query_value_trailing", func(t *testing.T) {
+		// The reported repro: completing after "...application_name=me@".
+		got, err := Walk(pgShape, "postgres://localhost/db?application_name=me@")
+		require.NoError(t, err)
+		require.Equal(t, SegConnParams, got.Current)
+		require.NotContains(t, got.Done, SegCredentials)
+		require.False(t, got.HasCreds)
+		require.Empty(t, got.User)
+		require.Equal(t, "localhost", got.Hostname)
+		require.Equal(t, "db", got.PathName)
+		require.Equal(t, "application_name", got.ParamLastKey)
+		require.True(t, got.ParamAtValue)
+		require.Equal(t, "me@", got.Params.Get("application_name"))
+	})
+
+	t.Run("at_in_query_value_then_next_key", func(t *testing.T) {
+		got, err := Walk(pgShape, "postgres://localhost/db?application_name=me@example.com&ssl")
+		require.NoError(t, err)
+		require.Equal(t, SegConnParams, got.Current)
+		require.False(t, got.HasCreds)
+		require.Equal(t, "localhost", got.Hostname)
+		require.Equal(t, "me@example.com", got.Params.Get("application_name"))
+		require.Equal(t, "ssl", got.ParamLastKey)
+		require.False(t, got.ParamAtValue)
+	})
+
+	t.Run("at_in_path_segment", func(t *testing.T) {
+		got, err := Walk(pgShape, "postgres://localhost/cust@")
+		require.NoError(t, err)
+		require.Equal(t, SegPathName, got.Current)
+		require.NotContains(t, got.Done, SegCredentials)
+		require.False(t, got.HasCreds)
+		require.Equal(t, "localhost", got.Hostname)
+		require.Equal(t, "cust@", got.PathName)
+	})
+
+	t.Run("at_in_path_then_query", func(t *testing.T) {
+		got, err := Walk(pgShape, "postgres://localhost/cust@db?")
+		require.NoError(t, err)
+		require.Equal(t, SegConnParams, got.Current)
+		require.False(t, got.HasCreds)
+		require.Contains(t, got.Done, SegPathName)
+		require.Equal(t, "cust@db", got.PathName)
+	})
+
+	t.Run("at_in_query_sqlserver", func(t *testing.T) {
+		got, err := Walk(sqlserverShape, "sqlserver://localhost?database=me@x")
+		require.NoError(t, err)
+		require.Equal(t, SegConnParams, got.Current)
+		require.False(t, got.HasCreds)
+		require.Equal(t, "localhost", got.Hostname)
+		require.Equal(t, "database", got.ParamLastKey)
+		require.True(t, got.ParamAtValue)
+	})
+
+	t.Run("creds_with_at_in_query_value", func(t *testing.T) {
+		// Genuine credentials must keep working when the query also
+		// contains an '@'.
+		got, err := Walk(pgShape, "postgres://alice:hunter2@localhost/db?application_name=me@")
+		require.NoError(t, err)
+		require.True(t, got.HasCreds)
+		require.Equal(t, "alice", got.User)
+		require.Equal(t, "hunter2", got.Pass)
+		require.Equal(t, "localhost", got.Hostname)
+		require.Equal(t, "db", got.PathName)
+		require.Equal(t, SegConnParams, got.Current)
+		require.True(t, got.ParamAtValue)
+		require.Equal(t, "me@", got.Params.Get("application_name"))
+	})
+
+	t.Run("at_terminates_userinfo_when_no_boundary_yet", func(t *testing.T) {
+		// Mid-typing: no '/' or '?' yet, so the '@' is the userinfo
+		// terminator (username without password). Unchanged behavior.
+		got, err := Walk(pgShape, "postgres://bob@")
+		require.NoError(t, err)
+		require.Equal(t, []SegmentKind{SegCredentials}, got.Done)
+		require.True(t, got.HasCreds)
+		require.Equal(t, "bob", got.User)
+		require.False(t, got.PassSet)
+	})
+}
+
 func TestWalk_rqliteTLSParam(t *testing.T) {
 	got, err := Walk(rqliteShape, "rqlite://alice@h:8443?level=strong&tls=true")
 	require.NoError(t, err)


### PR DESCRIPTION
Fixes #792.

walkCredentials searched the entire post-scheme tail for '@', so an '@' in a path or query
of credential-less input (e.g. completing `postgres://localhost/db?application_name=me@`)
was taken as the userinfo terminator, corrupting the segment walk and emitting garbage
candidates. The search is now bounded to the authority portion (text before the first '/'
or '?'), per RFC 3986 userinfo rules. Mid-typing input with no boundary delimiter yet keeps
the existing behavior (an '@' there may genuinely terminate userinfo), and the existing
first-'@' convention is retained.

Testing: 7 new walker subtests (the repro, '@' in query value/path segment, sqlserver
variant, genuine credentials plus '@' in query, mid-typing case) plus two end-to-end
completion cases. All observed failing pre-fix. make lint clean; -short suites green.