### PR TITLE
rqlite: FK pragma outside the rebuild transaction; parameterize metadata SQL

### DIFF
--- a/drivers/rqlite/internal_test.go
+++ b/drivers/rqlite/internal_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	_ "github.com/mattn/go-sqlite3" // For TestWriteAtomic_DBTypeCheck.
+	"github.com/rqlite/gorqlite"
 	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/require"
 
@@ -17,6 +18,7 @@ import (
 	"github.com/neilotoole/sq/libsq/core/kind"
 	"github.com/neilotoole/sq/libsq/core/record"
 	"github.com/neilotoole/sq/libsq/core/schema"
+	"github.com/neilotoole/sq/libsq/core/sqlz"
 	"github.com/neilotoole/sq/libsq/driver"
 	"github.com/neilotoole/sq/libsq/source"
 	"github.com/neilotoole/sq/libsq/source/drivertype"
@@ -28,6 +30,15 @@ var (
 	KindFromDBTypeName = kindFromDBTypeName
 	RTypeNullTime      = rtypeNullTime
 )
+
+// ExecNonTx executes query as a single non-transactional request via
+// writeNonTx. Exported for external_test consumers that need to toggle
+// connection-level pragmas such as foreign_keys, which are no-ops when
+// executed through the regular transaction-wrapped write path (gh776).
+func ExecNonTx(ctx context.Context, db sqlz.DB, query string) error {
+	_, err := writeNonTx(ctx, db, gorqlite.ParameterizedStatement{Query: query})
+	return err
+}
 
 func TestPlaceholders(t *testing.T) {
 	testCases := []struct {

--- a/drivers/rqlite/metadata.go
+++ b/drivers/rqlite/metadata.go
@@ -487,8 +487,10 @@ func getTableMetadata(ctx context.Context, db sqlz.DB, tblName string) (*metadat
 
 	tblMeta.FQName = schemaName + "." + tblName
 
-	query = "PRAGMA TABLE_INFO(" + stringz.DoubleQuote(tblMeta.Name) + ")"
-	rows, err := db.QueryContext(ctx, query)
+	// The table-valued pragma function takes the table name as a bound
+	// parameter, eliminating an interpolated quoting site (gh777).
+	query = `SELECT cid, name, type, "notnull", dflt_value, pk FROM pragma_table_info(?)`
+	rows, err := db.QueryContext(ctx, query, tblMeta.Name)
 	if err != nil {
 		return nil, errw(err)
 	}

--- a/drivers/rqlite/metadata.go
+++ b/drivers/rqlite/metadata.go
@@ -452,10 +452,14 @@ func getTableMetadata(ctx context.Context, db sqlz.DB, tblName string) (*metadat
 	// SQLite rejects (gh777). In identifier position (FROM),
 	// stringz.DoubleQuote applies proper SQLite quoting, doubling any
 	// embedded double quote.
+	// The type filter matters: a trigger (or index) may share a table's
+	// name in sqlite_master, and without the filter the first matching
+	// row could misreport the table's type.
 	const tpl = `SELECT
 (SELECT COUNT(*) FROM %s),
-(SELECT type FROM sqlite_master WHERE name = ? LIMIT 1),
-(SELECT 1 FROM sqlite_master WHERE name = ? AND substr("sql",0,21) == 'CREATE VIRTUAL TABLE') AS is_virtual,
+(SELECT type FROM sqlite_master WHERE name = ? AND type IN ('table','view') LIMIT 1),
+(SELECT 1 FROM sqlite_master WHERE name = ?
+ AND type = 'table' AND substr("sql",0,21) == 'CREATE VIRTUAL TABLE') AS is_virtual,
 (SELECT name FROM pragma_database_list ORDER BY seq LIMIT 1)`
 
 	var schemaName string

--- a/drivers/rqlite/metadata.go
+++ b/drivers/rqlite/metadata.go
@@ -444,10 +444,18 @@ func getTableMetadata(ctx context.Context, db sqlz.DB, tblName string) (*metadat
 	log := lg.FromContext(ctx)
 	tblMeta := &metadata.Table{Name: tblName}
 
+	// The table name is bound as a query parameter where it appears in
+	// string-literal position: interpolating it with Go's %q resolved a
+	// double-quoted token as an identifier first, so a table named after
+	// a sqlite_master column (name, type, sql) produced a tautology, and
+	// a name containing a double quote got Go backslash escaping, which
+	// SQLite rejects (gh777). In identifier position (FROM),
+	// stringz.DoubleQuote applies proper SQLite quoting, doubling any
+	// embedded double quote.
 	const tpl = `SELECT
-(SELECT COUNT(*) FROM %q),
-(SELECT type FROM sqlite_master WHERE name = %q LIMIT 1),
-(SELECT 1 FROM sqlite_master WHERE name = %q AND substr("sql",0,21) == 'CREATE VIRTUAL TABLE') AS is_virtual,
+(SELECT COUNT(*) FROM %s),
+(SELECT type FROM sqlite_master WHERE name = ? LIMIT 1),
+(SELECT 1 FROM sqlite_master WHERE name = ? AND substr("sql",0,21) == 'CREATE VIRTUAL TABLE') AS is_virtual,
 (SELECT name FROM pragma_database_list ORDER BY seq LIMIT 1)`
 
 	var schemaName string
@@ -456,8 +464,8 @@ func getTableMetadata(ctx context.Context, db sqlz.DB, tblName string) (*metadat
 	// sql.NullBool. NULL means not a virtual table; any non-zero
 	// value means virtual.
 	var isVirtualTbl sql.NullFloat64
-	query := fmt.Sprintf(tpl, tblMeta.Name, tblMeta.Name, tblMeta.Name)
-	err := db.QueryRowContext(ctx, query).Scan(
+	query := fmt.Sprintf(tpl, stringz.DoubleQuote(tblMeta.Name))
+	err := db.QueryRowContext(ctx, query, tblMeta.Name, tblMeta.Name).Scan(
 		&tblMeta.RowCount, &tblMeta.DBTableType, &isVirtualTbl, &schemaName)
 	if err != nil {
 		return nil, errw(err)
@@ -475,7 +483,7 @@ func getTableMetadata(ctx context.Context, db sqlz.DB, tblName string) (*metadat
 
 	tblMeta.FQName = schemaName + "." + tblName
 
-	query = fmt.Sprintf("PRAGMA TABLE_INFO('%s')", tblMeta.Name)
+	query = "PRAGMA TABLE_INFO(" + stringz.DoubleQuote(tblMeta.Name) + ")"
 	rows, err := db.QueryContext(ctx, query)
 	if err != nil {
 		return nil, errw(err)

--- a/drivers/rqlite/rqlite.go
+++ b/drivers/rqlite/rqlite.go
@@ -944,20 +944,46 @@ func (d *driveri) AlterTableRenameColumn(ctx context.Context, db sqlz.DB, tbl, c
 // SQLite has no ALTER COLUMN TYPE, so the implementation rebuilds the
 // table via an atomic batch through writeAtomic:
 //
-//	PRAGMA foreign_keys=off
 //	CREATE TABLE <tmp> (... new kinds, original constraints ...)
 //	INSERT INTO <tmp> SELECT * FROM <original>
 //	DROP TABLE <original>
 //	ALTER TABLE <tmp> RENAME TO <original>
 //	(restore sqlite_sequence row, if the original table had one)
-//	PRAGMA foreign_keys=<prev>
 //
-// All statements ride one /db/execute HTTP call and are atomic
-// at rqlite. The prior foreign_keys value is read outside the batch
-// (rqlite has no interactive transactions) and inlined as the final
-// statement, restoring the session state rather than blindly forcing
-// it on. This mirrors the sqlite3 driver's pragmaDisableForeignKeys
-// restore pattern (drivers/sqlite3/alter.go).
+// All batch statements ride one /db/execute HTTP call and are atomic
+// at rqlite. Foreign-key enforcement is disabled around the batch via
+// separate NON-transactional requests (writeNonTx): the pragma cannot
+// ride inside the batch, because gorqlite unconditionally appends
+// &transaction to /db/execute, rqlite then wraps the batch in
+// BEGIN/COMMIT, and SQLite specifies PRAGMA foreign_keys as a no-op
+// while a transaction is pending. The in-batch pragma therefore never
+// disabled enforcement, and on a node running -fk the DROP TABLE step
+// failed with "FOREIGN KEY constraint failed" for tables referenced
+// by another table's FK (gh776). This mirrors the semantics of the
+// sqlite3 driver's pragmaDisableForeignKeys/deferred-restore pattern
+// (drivers/sqlite3/alter.go), where the pragma likewise executes
+// outside any transaction.
+//
+// Atomicity tradeoff: the pragma-off request, the rebuild batch, and
+// the pragma-restore request are three requests, not one atom. The
+// rebuild batch itself remains atomic, but the pragma applies to the
+// node's shared write connection, so between off and restore, FK
+// enforcement is suspended for ALL writes on the node (the pragma
+// statements replicate through the Raft log, so the same holds on
+// every node of a cluster). The restore is deferred, and runs on a
+// non-cancelable context, so it executes even when the batch fails;
+// but if the process dies first, enforcement stays off until an
+// operator resets it or the node restarts.
+//
+// The restore target is the foreign_keys value read via /db/query,
+// which is served by the node's read-only connection pool and thus
+// reports the node's boot-time -fk default rather than the write
+// connection's live pragma state (which the HTTP API cannot read).
+// Restoring the configured default is the sanest available choice,
+// and also repairs a write connection left foreign_keys=off by an
+// earlier crash. For the same reason the pragma-off is issued
+// unconditionally rather than skipped when the read reports
+// enforcement already off.
 //
 // The new CREATE TABLE is built by reading the original DDL from
 // sqlite_master, patching the column type tokens for the requested
@@ -1040,13 +1066,10 @@ func (d *driveri) AlterTableColumnKinds(ctx context.Context, db sqlz.DB,
 		return errz.Wrap(err, "rqlite: alter table: failed to apply DDL rewrites")
 	}
 
-	// Read the prior foreign_keys pragma so we can restore it at the
-	// end of the atomic batch rather than blindly forcing it on.
-	// Matches the sqlite3 driver's pragmaDisableForeignKeys/restore
-	// pattern in drivers/sqlite3/alter.go, adapted for rqlite's
-	// no-interactive-transactions model: the restore value is inlined
-	// as the last statement of the batch rather than captured in a
-	// defer.
+	// Read the foreign_keys value to restore after the rebuild. This
+	// query is served by the node's read-only connection pool, so it
+	// reports the boot-time -fk default, not the write connection's
+	// live pragma state; see the function doc comment.
 	var fkPrev int64
 	if err = db.QueryRowContext(ctx, "PRAGMA foreign_keys").Scan(&fkPrev); err != nil {
 		return errz.Wrapf(errw(err), "rqlite: alter table: failed to read foreign_keys pragma")
@@ -1062,7 +1085,6 @@ func (d *driveri) AlterTableColumnKinds(ctx context.Context, db sqlz.DB,
 	}
 
 	stmts := []gorqlite.ParameterizedStatement{
-		{Query: "PRAGMA foreign_keys=off"},
 		{Query: nuDDL},
 		{Query: fmt.Sprintf(`INSERT INTO %s SELECT * FROM %s`,
 			stringz.DoubleQuote(tmpName), stringz.DoubleQuote(tbl))},
@@ -1095,9 +1117,28 @@ func (d *driveri) AlterTableColumnKinds(ctx context.Context, db sqlz.DB,
 		)
 	}
 
-	stmts = append(stmts, gorqlite.ParameterizedStatement{
-		Query: fmt.Sprintf("PRAGMA foreign_keys=%d", fkPrev),
-	})
+	// Disable FK enforcement around the rebuild via separate
+	// non-transactional requests; an in-batch pragma is a no-op inside
+	// rqlite's transaction wrapper (gh776). See the function doc
+	// comment for the atomicity tradeoff.
+	if _, err = writeNonTx(ctx, db, gorqlite.ParameterizedStatement{
+		Query: "PRAGMA foreign_keys=off",
+	}); err != nil {
+		return errz.Wrap(err, "rqlite: alter table: failed to disable foreign_keys pragma")
+	}
+	defer func() {
+		// Restore on a non-cancelable context: leaving the node's write
+		// connection with FK enforcement off is worse than the cost of
+		// one more request after cancellation.
+		if _, restoreErr := writeNonTx(context.WithoutCancel(ctx),
+			db, gorqlite.ParameterizedStatement{
+				Query: fmt.Sprintf("PRAGMA foreign_keys=%d", fkPrev),
+			}); restoreErr != nil {
+			lg.FromContext(ctx).Error(
+				"rqlite: alter table: failed to restore foreign_keys pragma",
+				lga.Err, restoreErr)
+		}
+	}()
 
 	_, err = writeAtomic(ctx, db, stmts...)
 	return err

--- a/drivers/rqlite/rqlite.go
+++ b/drivers/rqlite/rqlite.go
@@ -1141,6 +1141,11 @@ func (d *driveri) AlterTableColumnKinds(ctx context.Context, db sqlz.DB,
 	// returned error: reporting success while the node is left with
 	// enforcement off would be worse than reporting a failed alter.
 	defer func() {
+		if fkPrev == 0 {
+			// The pragma-off below already set the value the restore
+			// would write: skip the redundant Raft-replicated request.
+			return
+		}
 		if _, restoreErr := writeNonTx(context.WithoutCancel(ctx),
 			db, gorqlite.ParameterizedStatement{
 				Query: fmt.Sprintf("PRAGMA foreign_keys=%d", fkPrev),

--- a/drivers/rqlite/rqlite.go
+++ b/drivers/rqlite/rqlite.go
@@ -975,6 +975,17 @@ func (d *driveri) AlterTableRenameColumn(ctx context.Context, db sqlz.DB, tbl, c
 // but if the process dies first, enforcement stays off until an
 // operator resets it or the node restarts.
 //
+// Two further consequences of the pragma riding node-global state:
+// concurrent rebuilds (from any client) interleave their windows, so
+// one caller's restore can re-enable enforcement inside another
+// caller's window and fail its DROP; nothing client-side can
+// serialize that. And because pragma state is connection state, not
+// database state, it is not captured in Raft snapshots: a snapshot
+// boundary falling between the pragma-off entry and the batch entry
+// means a node restoring (or joining) from that snapshot replays the
+// batch on a fresh connection at the -fk boot default, where the
+// DROP can fail, leaving that node without the alter.
+//
 // The restore target is the foreign_keys value read via /db/query,
 // which is served by the node's read-only connection pool and thus
 // reports the node's boot-time -fk default rather than the write
@@ -1005,7 +1016,7 @@ func (d *driveri) AlterTableRenameColumn(ctx context.Context, db sqlz.DB, tbl, c
 // against writes that race the batch.
 func (d *driveri) AlterTableColumnKinds(ctx context.Context, db sqlz.DB,
 	tbl string, colNames []string, kinds []kind.Kind,
-) error {
+) (retErr error) {
 	if len(colNames) != len(kinds) {
 		return errz.New("rqlite: alter table: mismatched count of columns and kinds")
 	}
@@ -1121,24 +1132,33 @@ func (d *driveri) AlterTableColumnKinds(ctx context.Context, db sqlz.DB,
 	// non-transactional requests; an in-batch pragma is a no-op inside
 	// rqlite's transaction wrapper (gh776). See the function doc
 	// comment for the atomicity tradeoff.
+	// The restore is registered BEFORE the pragma-off is issued: the off
+	// request can fail client-side after the server has already applied
+	// it (e.g. the response is lost), and the restore must run in that
+	// case too. It runs on a non-cancelable context: leaving the node's
+	// write connection with FK enforcement off is worse than the cost of
+	// one more request after cancellation. A restore failure joins the
+	// returned error: reporting success while the node is left with
+	// enforcement off would be worse than reporting a failed alter.
+	defer func() {
+		if _, restoreErr := writeNonTx(context.WithoutCancel(ctx),
+			db, gorqlite.ParameterizedStatement{
+				Query: fmt.Sprintf("PRAGMA foreign_keys=%d", fkPrev),
+			}); restoreErr != nil {
+			restoreErr = errz.Wrap(restoreErr,
+				"rqlite: alter table: failed to restore foreign_keys pragma")
+			lg.FromContext(ctx).Error(
+				"rqlite: alter table: failed to restore foreign_keys pragma",
+				lga.Err, restoreErr)
+			retErr = errz.Append(retErr, restoreErr)
+		}
+	}()
+
 	if _, err = writeNonTx(ctx, db, gorqlite.ParameterizedStatement{
 		Query: "PRAGMA foreign_keys=off",
 	}); err != nil {
 		return errz.Wrap(err, "rqlite: alter table: failed to disable foreign_keys pragma")
 	}
-	defer func() {
-		// Restore on a non-cancelable context: leaving the node's write
-		// connection with FK enforcement off is worse than the cost of
-		// one more request after cancellation.
-		if _, restoreErr := writeNonTx(context.WithoutCancel(ctx),
-			db, gorqlite.ParameterizedStatement{
-				Query: fmt.Sprintf("PRAGMA foreign_keys=%d", fkPrev),
-			}); restoreErr != nil {
-			lg.FromContext(ctx).Error(
-				"rqlite: alter table: failed to restore foreign_keys pragma",
-				lga.Err, restoreErr)
-		}
-	}()
 
 	_, err = writeAtomic(ctx, db, stmts...)
 	return err

--- a/drivers/rqlite/rqlite_test.go
+++ b/drivers/rqlite/rqlite_test.go
@@ -1854,13 +1854,25 @@ func TestTableMetadata_ProblematicTableNames(t *testing.T) {
 	db, err := grip.DB(th.Context)
 	require.NoError(t, err)
 
-	tblNames := []string{"name", "type", "sql", `we"ird`}
+	tblNames := []string{"name", "type", "sql", `we"ird`, "shadowed"}
 	t.Cleanup(func() {
+		_, _ = db.ExecContext(th.Context, `DROP TRIGGER IF EXISTS "shadowed"`)
+		_, _ = db.ExecContext(th.Context, `DROP TABLE IF EXISTS aab_other`)
 		for _, tblName := range tblNames {
 			_, _ = db.ExecContext(th.Context,
 				"DROP TABLE IF EXISTS "+stringz.DoubleQuote(tblName))
 		}
 	})
+
+	// A trigger may share a table's name in sqlite_master. Create the
+	// trigger before the same-named table so the trigger row precedes the
+	// table row: without the type filter in the metadata query, the
+	// trigger row shadowed the table and the metadata was misreported.
+	_, err = db.ExecContext(th.Context, `CREATE TABLE aab_other (x INTEGER)`)
+	require.NoError(t, err)
+	_, err = db.ExecContext(th.Context,
+		`CREATE TRIGGER "shadowed" AFTER INSERT ON aab_other BEGIN SELECT 1; END`)
+	require.NoError(t, err)
 
 	for _, tblName := range tblNames {
 		quoted := stringz.DoubleQuote(tblName)

--- a/drivers/rqlite/rqlite_test.go
+++ b/drivers/rqlite/rqlite_test.go
@@ -1841,9 +1841,12 @@ func TestAlterTableColumnKinds_PreservesUniqueAndDefault(t *testing.T) {
 // column (name, type, sql) turned WHERE name = "name" into a tautology,
 // and a table name containing a double quote was emitted with Go backslash
 // escaping, which SQLite rejects outright. Mirrors the sqlite3 driver test.
+//
+// Deliberately NOT parallel: the test creates tables with fixed names
+// (name, type, sql, we"ird) in the shared Sakila rqlite database, so it
+// can't safely interleave with other tests touching the same server.
 func TestTableMetadata_ProblematicTableNames(t *testing.T) {
 	tu.SkipShort(t, true)
-	t.Parallel()
 
 	th := testh.New(t)
 	src := th.Source(sakila.Rq)
@@ -1871,8 +1874,6 @@ func TestTableMetadata_ProblematicTableNames(t *testing.T) {
 
 	for _, tblName := range tblNames {
 		t.Run(tu.Name(tblName), func(t *testing.T) {
-			t.Parallel()
-
 			md, err := grip.TableMetadata(th.Context, tblName)
 			require.NoError(t, err)
 			require.Equal(t, tblName, md.Name)

--- a/drivers/rqlite/rqlite_test.go
+++ b/drivers/rqlite/rqlite_test.go
@@ -1851,18 +1851,23 @@ func TestTableMetadata_ProblematicTableNames(t *testing.T) {
 	th := testh.New(t)
 	src := th.Source(sakila.Rq)
 	grip := th.Open(src)
+	drvr := grip.SQLDriver()
 	db, err := grip.DB(th.Context)
 	require.NoError(t, err)
 
 	tblNames := []string{"name", "type", "sql", `we"ird`, "shadowed"}
-	t.Cleanup(func() {
+	// The fixed-name tables live in the shared database, so drop any
+	// leftovers from an aborted earlier run before creating: the test
+	// must be self-healing.
+	dropAll := func() {
 		_, _ = db.ExecContext(th.Context, `DROP TRIGGER IF EXISTS "shadowed"`)
-		_, _ = db.ExecContext(th.Context, `DROP TABLE IF EXISTS aab_other`)
+		_ = drvr.DropTable(th.Context, db, tablefq.T{Table: "aab_other"}, true)
 		for _, tblName := range tblNames {
-			_, _ = db.ExecContext(th.Context,
-				"DROP TABLE IF EXISTS "+stringz.DoubleQuote(tblName))
+			_ = drvr.DropTable(th.Context, db, tablefq.T{Table: tblName}, true)
 		}
-	})
+	}
+	dropAll()
+	t.Cleanup(dropAll)
 
 	// A trigger may share a table's name in sqlite_master. Create the
 	// trigger before the same-named table so the trigger row precedes the
@@ -1930,10 +1935,8 @@ func TestAlterTableColumnKinds_ForeignKeyEnforcement(t *testing.T) {
 		// Restore the node default (the test server runs without -fk),
 		// then drop child before parent.
 		_ = rqlite.ExecNonTx(th.Context, db, "PRAGMA foreign_keys=off")
-		_, _ = db.ExecContext(th.Context,
-			"DROP TABLE IF EXISTS "+stringz.DoubleQuote(childTbl))
-		_, _ = db.ExecContext(th.Context,
-			"DROP TABLE IF EXISTS "+stringz.DoubleQuote(parentTbl))
+		_ = drvr.DropTable(th.Context, db, tablefq.T{Table: childTbl}, true)
+		_ = drvr.DropTable(th.Context, db, tablefq.T{Table: parentTbl}, true)
 	})
 
 	_, err = db.ExecContext(th.Context, fmt.Sprintf(

--- a/drivers/rqlite/rqlite_test.go
+++ b/drivers/rqlite/rqlite_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/neilotoole/sq/libsq/core/kind"
 	"github.com/neilotoole/sq/libsq/core/lg"
 	"github.com/neilotoole/sq/libsq/core/schema"
+	"github.com/neilotoole/sq/libsq/core/sqlz"
 	"github.com/neilotoole/sq/libsq/core/stringz"
 	"github.com/neilotoole/sq/libsq/core/tablefq"
 	"github.com/neilotoole/sq/libsq/source"
@@ -1831,4 +1832,166 @@ func TestAlterTableColumnKinds_PreservesUniqueAndDefault(t *testing.T) {
 		fmt.Sprintf(`SELECT salary FROM %q WHERE id=1`, tblName)).Scan(&salary))
 	require.InDelta(t, 50000.0, salary, 0.0001,
 		"DEFAULT 50000 on salary should survive the rebuild")
+}
+
+// TestTableMetadata_ProblematicTableNames reproduces gh777 for the rqlite
+// driver: getTableMetadata interpolated the table name with Go's %q,
+// including into string-literal position. SQLite resolves a double-quoted
+// token as an identifier first, so a table named after a sqlite_master
+// column (name, type, sql) turned WHERE name = "name" into a tautology,
+// and a table name containing a double quote was emitted with Go backslash
+// escaping, which SQLite rejects outright. Mirrors the sqlite3 driver test.
+func TestTableMetadata_ProblematicTableNames(t *testing.T) {
+	tu.SkipShort(t, true)
+	t.Parallel()
+
+	th := testh.New(t)
+	src := th.Source(sakila.Rq)
+	grip := th.Open(src)
+	db, err := grip.DB(th.Context)
+	require.NoError(t, err)
+
+	tblNames := []string{"name", "type", "sql", `we"ird`}
+	t.Cleanup(func() {
+		for _, tblName := range tblNames {
+			_, _ = db.ExecContext(th.Context,
+				"DROP TABLE IF EXISTS "+stringz.DoubleQuote(tblName))
+		}
+	})
+
+	for _, tblName := range tblNames {
+		quoted := stringz.DoubleQuote(tblName)
+		_, err = db.ExecContext(th.Context, fmt.Sprintf(
+			"CREATE TABLE %s (id INTEGER PRIMARY KEY, val TEXT)", quoted))
+		require.NoError(t, err)
+		_, err = db.ExecContext(th.Context, fmt.Sprintf(
+			"INSERT INTO %s (val) VALUES ('a'), ('b')", quoted))
+		require.NoError(t, err)
+	}
+
+	for _, tblName := range tblNames {
+		t.Run(tu.Name(tblName), func(t *testing.T) {
+			t.Parallel()
+
+			md, err := grip.TableMetadata(th.Context, tblName)
+			require.NoError(t, err)
+			require.Equal(t, tblName, md.Name)
+			require.Equal(t, int64(2), md.RowCount)
+			require.Equal(t, sqlz.TableTypeTable, md.TableType)
+			require.Len(t, md.Columns, 2)
+			require.Equal(t, "id", md.Columns[0].Name)
+			require.Equal(t, "val", md.Columns[1].Name)
+		})
+	}
+}
+
+// TestAlterTableColumnKinds_ForeignKeyEnforcement reproduces gh776: the
+// table-rebuild dance in AlterTableColumnKinds carried PRAGMA
+// foreign_keys=off inside its transaction-wrapped batch, where SQLite
+// specifies the pragma is a no-op. On a node enforcing foreign keys, the
+// rebuild's DROP TABLE step failed with "FOREIGN KEY constraint failed"
+// whenever the altered table was referenced by another table's FK. The
+// fix issues the pragma off/restore as separate non-transactional
+// requests around the (still atomic) rebuild batch.
+//
+// The standard test server runs without -fk, so the test enables
+// enforcement on the node's write connection via a non-transactional
+// pragma, exactly as a -fk node would have it at boot.
+//
+// Deliberately NOT parallel: the foreign_keys pragma applies to the
+// node's shared write connection, so toggling it would affect writes
+// from concurrently running tests.
+func TestAlterTableColumnKinds_ForeignKeyEnforcement(t *testing.T) {
+	tu.SkipShort(t, true)
+
+	th := testh.New(t)
+	src := th.Source(sakila.Rq)
+	grip := th.Open(src)
+	drvr := grip.SQLDriver()
+	db, err := grip.DB(th.Context)
+	require.NoError(t, err)
+
+	parentTbl := "fkparent_" + stringz.Uniq8()
+	childTbl := "fkchild_" + stringz.Uniq8()
+	t.Cleanup(func() {
+		// Restore the node default (the test server runs without -fk),
+		// then drop child before parent.
+		_ = rqlite.ExecNonTx(th.Context, db, "PRAGMA foreign_keys=off")
+		_, _ = db.ExecContext(th.Context,
+			"DROP TABLE IF EXISTS "+stringz.DoubleQuote(childTbl))
+		_, _ = db.ExecContext(th.Context,
+			"DROP TABLE IF EXISTS "+stringz.DoubleQuote(parentTbl))
+	})
+
+	_, err = db.ExecContext(th.Context, fmt.Sprintf(
+		"CREATE TABLE %s (id INTEGER PRIMARY KEY, val INTEGER NOT NULL)",
+		stringz.DoubleQuote(parentTbl)))
+	require.NoError(t, err)
+	_, err = db.ExecContext(th.Context, fmt.Sprintf(
+		"CREATE TABLE %s (id INTEGER PRIMARY KEY, pid INTEGER NOT NULL REFERENCES %s(id))",
+		stringz.DoubleQuote(childTbl), stringz.DoubleQuote(parentTbl)))
+	require.NoError(t, err)
+	_, err = db.ExecContext(th.Context, fmt.Sprintf(
+		"INSERT INTO %s (id, val) VALUES (1, 42)", stringz.DoubleQuote(parentTbl)))
+	require.NoError(t, err)
+	_, err = db.ExecContext(th.Context, fmt.Sprintf(
+		"INSERT INTO %s (id, pid) VALUES (1, 1)", stringz.DoubleQuote(childTbl)))
+	require.NoError(t, err)
+
+	// Enable FK enforcement on the node's write connection. This must go
+	// through the non-transactional path: a pragma in a
+	// transaction-wrapped request is a no-op.
+	require.NoError(t, rqlite.ExecNonTx(th.Context, db, "PRAGMA foreign_keys=on"))
+
+	// Sanity check: enforcement is live, so a dangling child insert fails.
+	_, err = db.ExecContext(th.Context, fmt.Sprintf(
+		"INSERT INTO %s (id, pid) VALUES (99, 999)", stringz.DoubleQuote(childTbl)))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "FOREIGN KEY constraint failed")
+
+	// The rebuild. Pre-fix, this failed at the DROP TABLE step with
+	// "FOREIGN KEY constraint failed" because the in-batch pragma never
+	// disabled enforcement.
+	require.NoError(t, drvr.AlterTableColumnKinds(th.Context, db, parentTbl,
+		[]string{"val"}, []kind.Kind{kind.Text}))
+
+	// Kind changed, and data in both tables survived the rebuild.
+	md, err := grip.TableMetadata(th.Context, parentTbl)
+	require.NoError(t, err)
+	require.Equal(t, kind.Text, md.Column("val").Kind)
+
+	var parentVal string
+	require.NoError(t, db.QueryRowContext(th.Context,
+		"SELECT val FROM "+stringz.DoubleQuote(parentTbl)+" WHERE id = 1").
+		Scan(&parentVal))
+	require.Equal(t, "42", parentVal)
+	var childCount int64
+	require.NoError(t, db.QueryRowContext(th.Context,
+		"SELECT COUNT(*) FROM "+stringz.DoubleQuote(childTbl)).Scan(&childCount))
+	require.Equal(t, int64(1), childCount)
+
+	// AlterTableColumnKinds restores the foreign_keys pragma to the
+	// node's configured default: the write connection's live pragma
+	// state is not readable over the HTTP API (PRAGMA foreign_keys via
+	// /db/query is served by the read-only pool), so the boot default is
+	// the restore target. This test server's default is off, so a
+	// dangling insert succeeding here proves the restore ran. On a node
+	// actually running -fk, the same restore re-enables enforcement.
+	_, err = db.ExecContext(th.Context, fmt.Sprintf(
+		"INSERT INTO %s (id, pid) VALUES (100, 999)", stringz.DoubleQuote(childTbl)))
+	require.NoError(t, err)
+	_, err = db.ExecContext(th.Context, fmt.Sprintf(
+		"DELETE FROM %s WHERE id = 100", stringz.DoubleQuote(childTbl)))
+	require.NoError(t, err)
+
+	// Re-enable enforcement: the child's FK must still be wired to the
+	// rebuilt parent (the DROP/RENAME preserved the relationship).
+	require.NoError(t, rqlite.ExecNonTx(th.Context, db, "PRAGMA foreign_keys=on"))
+	_, err = db.ExecContext(th.Context, fmt.Sprintf(
+		"INSERT INTO %s (id, pid) VALUES (101, 999)", stringz.DoubleQuote(childTbl)))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "FOREIGN KEY constraint failed")
+	_, err = db.ExecContext(th.Context, fmt.Sprintf(
+		"INSERT INTO %s (id, pid) VALUES (2, 1)", stringz.DoubleQuote(childTbl)))
+	require.NoError(t, err)
 }

--- a/drivers/rqlite/write.go
+++ b/drivers/rqlite/write.go
@@ -80,6 +80,25 @@ func writeNonTx(ctx context.Context, db sqlz.DB,
 // request rides rqlite's transaction wrapper (gorqlite's default);
 // otherwise the connection's transaction flag is cleared around the
 // request and restored afterward.
+//
+// Flag invariant: every pooled connection has gorqlite's
+// wantsTransactions flag set true except within this function's
+// non-tx window. The restore below hardcodes true (rather than
+// saving the prior value) because that invariant makes the prior
+// value always true, and gorqlite exposes no getter to save it; any
+// future code that legitimately holds a flag-false connection
+// breaks this assumption and must revisit the restore.
+//
+// Why the toggle is safe: the flag is a per-Connection, mutex-guarded
+// field consumed at request-assembly time, each pooled driver conn
+// wraps its own gorqlite.Connection, and conn.Raw pins the conn
+// exclusively for the closure's duration, so the toggle cannot be
+// observed by, or leak to, any other connection or goroutine.
+// SetExecutionWithTransaction errors only on a closed connection,
+// and database/sql never returns a closed conn to the pool, so a
+// failed restore (log-only below) cannot poison a pooled conn: any
+// later use of a closed conn fails loudly with ErrClosed rather than
+// running non-transactionally.
 func write(ctx context.Context, db sqlz.DB, withTx bool,
 	stmts []gorqlite.ParameterizedStatement,
 ) (results []gorqlite.WriteResult, err error) {

--- a/drivers/rqlite/write.go
+++ b/drivers/rqlite/write.go
@@ -67,12 +67,13 @@ func writeAtomic(ctx context.Context, db sqlz.DB,
 // This exists for statements that are no-ops inside a transaction:
 // SQLite specifies that PRAGMA foreign_keys does nothing while a
 // transaction is pending, so toggling it requires a non-transactional
-// request (gh776). Multi-statement batches passed here are NOT atomic;
-// use writeAtomic for anything that must roll back together.
+// request (gh776). It takes exactly one statement: a non-transactional
+// multi-statement batch would not be atomic, so anything that must
+// roll back together belongs in writeAtomic.
 func writeNonTx(ctx context.Context, db sqlz.DB,
-	stmts ...gorqlite.ParameterizedStatement,
+	stmt gorqlite.ParameterizedStatement,
 ) ([]gorqlite.WriteResult, error) {
-	return write(ctx, db, false, stmts)
+	return write(ctx, db, false, []gorqlite.ParameterizedStatement{stmt})
 }
 
 // write implements writeAtomic and writeNonTx. If withTx is true, the
@@ -95,8 +96,8 @@ func write(ctx context.Context, db sqlz.DB, withTx bool,
 	case *sql.Conn:
 		conn = v
 	case *sql.Tx:
-		return nil, errz.New("rqlite: write batch cannot run inside *sql.Tx; " +
-			"gorqlite's tx is a no-op so atomicity would be silently lost")
+		return nil, errz.New("rqlite: write cannot run inside *sql.Tx: " +
+			"gorqlite's transaction support is a no-op")
 	default:
 		return nil, errz.Errorf("rqlite: write batch: unsupported db type %T", v)
 	}

--- a/drivers/rqlite/write.go
+++ b/drivers/rqlite/write.go
@@ -14,7 +14,7 @@ import (
 )
 
 // gorqliteWriter is the structural interface satisfied by gorqlite/stdlib's
-// *Conn (whose embedded *gorqlite.Connection provides the method).
+// *Conn (whose embedded *gorqlite.Connection provides the methods).
 // Asserting against this method-shape interface lets us reach the
 // atomic-batch primitive without importing gorqlite/stdlib directly;
 // the coupling shifts from a package import to a method-shape match
@@ -25,6 +25,7 @@ import (
 type gorqliteWriter interface {
 	WriteParameterizedContext(context.Context,
 		[]gorqlite.ParameterizedStatement) ([]gorqlite.WriteResult, error)
+	SetExecutionWithTransaction(bool) error
 }
 
 // Compile-time check that *gorqlite.Connection satisfies gorqliteWriter.
@@ -52,6 +53,34 @@ var _ gorqliteWriter = (*gorqlite.Connection)(nil)
 // may be partial or empty and should not be inspected for counts.
 func writeAtomic(ctx context.Context, db sqlz.DB,
 	stmts ...gorqlite.ParameterizedStatement,
+) ([]gorqlite.WriteResult, error) {
+	return write(ctx, db, true, stmts)
+}
+
+// writeNonTx executes stmts as a single /db/execute request WITHOUT
+// rqlite's transaction wrapper, by clearing gorqlite's per-connection
+// transaction flag for the duration of the request (gorqlite otherwise
+// unconditionally appends &transaction, and rqlite then wraps the
+// request in BEGIN/COMMIT). The flag is restored before the connection
+// returns to the pool.
+//
+// This exists for statements that are no-ops inside a transaction:
+// SQLite specifies that PRAGMA foreign_keys does nothing while a
+// transaction is pending, so toggling it requires a non-transactional
+// request (gh776). Multi-statement batches passed here are NOT atomic;
+// use writeAtomic for anything that must roll back together.
+func writeNonTx(ctx context.Context, db sqlz.DB,
+	stmts ...gorqlite.ParameterizedStatement,
+) ([]gorqlite.WriteResult, error) {
+	return write(ctx, db, false, stmts)
+}
+
+// write implements writeAtomic and writeNonTx. If withTx is true, the
+// request rides rqlite's transaction wrapper (gorqlite's default);
+// otherwise the connection's transaction flag is cleared around the
+// request and restored afterward.
+func write(ctx context.Context, db sqlz.DB, withTx bool,
+	stmts []gorqlite.ParameterizedStatement,
 ) (results []gorqlite.WriteResult, err error) {
 	log := lg.FromContext(ctx)
 
@@ -66,10 +95,10 @@ func writeAtomic(ctx context.Context, db sqlz.DB,
 	case *sql.Conn:
 		conn = v
 	case *sql.Tx:
-		return nil, errz.New("rqlite: writeAtomic cannot run inside *sql.Tx; " +
+		return nil, errz.New("rqlite: write batch cannot run inside *sql.Tx; " +
 			"gorqlite's tx is a no-op so atomicity would be silently lost")
 	default:
-		return nil, errz.Errorf("rqlite: writeAtomic: unsupported db type %T", v)
+		return nil, errz.Errorf("rqlite: write batch: unsupported db type %T", v)
 	}
 
 	rawErr := conn.Raw(func(raw any) error {
@@ -77,6 +106,21 @@ func writeAtomic(ctx context.Context, db sqlz.DB,
 		if !ok {
 			return errz.Errorf("rqlite: driver conn is %T, "+
 				"expected gorqlite-backed", raw)
+		}
+		if !withTx {
+			if txErr := gc.SetExecutionWithTransaction(false); txErr != nil {
+				return errz.Wrap(txErr,
+					"rqlite: failed to clear connection transaction flag")
+			}
+			// Restore gorqlite's default (transactions on) before the
+			// connection goes back to the pool, whether or not the
+			// write succeeded.
+			defer func() {
+				if txErr := gc.SetExecutionWithTransaction(true); txErr != nil {
+					log.Error("rqlite: failed to restore connection transaction flag",
+						lga.Err, txErr)
+				}
+			}()
 		}
 		var wErr error
 		results, wErr = gc.WriteParameterizedContext(ctx, stmts)
@@ -96,12 +140,12 @@ func writeAtomic(ctx context.Context, db sqlz.DB,
 		}
 	}
 	if rawErr != nil {
-		log.Debug("rqlite: writeAtomic raw error", lga.Err, rawErr)
+		log.Debug("rqlite: write batch raw error", lga.Err, rawErr)
 		return results, errw(rawErr)
 	}
 	if len(results) != len(stmts) {
 		return results, errz.Errorf(
-			"rqlite: writeAtomic: expected %d results but got %d",
+			"rqlite: write batch: expected %d results but got %d",
 			len(stmts), len(results))
 	}
 	return results, nil

--- a/drivers/sqlite3/metadata.go
+++ b/drivers/sqlite3/metadata.go
@@ -280,10 +280,14 @@ func getTableMetadata(ctx context.Context, db sqlz.DB, tblName string) (*metadat
 	// SQLite rejects (gh777). In identifier position (FROM),
 	// stringz.DoubleQuote applies proper SQLite quoting, doubling any
 	// embedded double quote.
+	// The type filter matters: a trigger (or index) may share a table's
+	// name in sqlite_master, and without the filter the first matching
+	// row could misreport the table's type.
 	const tpl = `SELECT
 (SELECT COUNT(*) FROM %s),
-(SELECT type FROM sqlite_master WHERE name = ? LIMIT 1),
-(SELECT 1 FROM sqlite_master WHERE name = ? AND substr("sql",0,21) == 'CREATE VIRTUAL TABLE') AS is_virtual,
+(SELECT type FROM sqlite_master WHERE name = ? AND type IN ('table','view') LIMIT 1),
+(SELECT 1 FROM sqlite_master WHERE name = ?
+ AND type = 'table' AND substr("sql",0,21) == 'CREATE VIRTUAL TABLE') AS is_virtual,
 (SELECT name FROM pragma_database_list ORDER BY seq LIMIT 1)`
 
 	var schema string

--- a/drivers/sqlite3/metadata.go
+++ b/drivers/sqlite3/metadata.go
@@ -271,17 +271,26 @@ func getTableMetadata(ctx context.Context, db sqlz.DB, tblName string) (*metadat
 	// Note that there's no easy way of getting the physical size of
 	// a table, so tblMeta.Size remains nil.
 
-	// But we can get the row count and table type ("table" or "view")
+	// But we can get the row count and table type ("table" or "view").
+	// The table name is bound as a query parameter where it appears in
+	// string-literal position: interpolating it with Go's %q resolved a
+	// double-quoted token as an identifier first, so a table named after
+	// a sqlite_master column (name, type, sql) produced a tautology, and
+	// a name containing a double quote got Go backslash escaping, which
+	// SQLite rejects (gh777). In identifier position (FROM),
+	// stringz.DoubleQuote applies proper SQLite quoting, doubling any
+	// embedded double quote.
 	const tpl = `SELECT
-(SELECT COUNT(*) FROM %q),
-(SELECT type FROM sqlite_master WHERE name = %q LIMIT 1),
-(SELECT 1 FROM sqlite_master WHERE name = %q AND substr("sql",0,21) == 'CREATE VIRTUAL TABLE') AS is_virtual,
+(SELECT COUNT(*) FROM %s),
+(SELECT type FROM sqlite_master WHERE name = ? LIMIT 1),
+(SELECT 1 FROM sqlite_master WHERE name = ? AND substr("sql",0,21) == 'CREATE VIRTUAL TABLE') AS is_virtual,
 (SELECT name FROM pragma_database_list ORDER BY seq LIMIT 1)`
 
 	var schema string
 	var isVirtualTbl sql.NullBool
-	query := fmt.Sprintf(tpl, tblMeta.Name, tblMeta.Name, tblMeta.Name)
-	err := db.QueryRowContext(ctx, query).Scan(&tblMeta.RowCount, &tblMeta.DBTableType, &isVirtualTbl, &schema)
+	query := fmt.Sprintf(tpl, stringz.DoubleQuote(tblMeta.Name))
+	err := db.QueryRowContext(ctx, query, tblMeta.Name, tblMeta.Name).
+		Scan(&tblMeta.RowCount, &tblMeta.DBTableType, &isVirtualTbl, &schema)
 	if err != nil {
 		return nil, errw(err)
 	}
@@ -303,7 +312,7 @@ func getTableMetadata(ctx context.Context, db sqlz.DB, tblName string) (*metadat
 	// 0	actor_id	INT			1		<null>		1
 	// 1	film_id		INT			1		<null>		2
 	// 2	last_update	TIMESTAMP	1		<null>		0
-	query = fmt.Sprintf("PRAGMA TABLE_INFO('%s')", tblMeta.Name)
+	query = "PRAGMA TABLE_INFO(" + stringz.DoubleQuote(tblMeta.Name) + ")"
 	rows, err := db.QueryContext(ctx, query)
 	if err != nil {
 		return nil, errw(err)
@@ -814,7 +823,7 @@ func getTblRowCounts(ctx context.Context, db sqlz.DB, tblNames []string) ([]int6
 		if terms > 0 {
 			sb.WriteString(" UNION ALL ")
 		}
-		sb.WriteString(fmt.Sprintf("SELECT COUNT(*) FROM %q", tblNames[i]))
+		sb.WriteString("SELECT COUNT(*) FROM " + stringz.DoubleQuote(tblNames[i]))
 		terms++
 
 		if terms != maxCompoundSelect && i != len(tblNames)-1 {

--- a/drivers/sqlite3/metadata.go
+++ b/drivers/sqlite3/metadata.go
@@ -316,8 +316,10 @@ func getTableMetadata(ctx context.Context, db sqlz.DB, tblName string) (*metadat
 	// 0	actor_id	INT			1		<null>		1
 	// 1	film_id		INT			1		<null>		2
 	// 2	last_update	TIMESTAMP	1		<null>		0
-	query = "PRAGMA TABLE_INFO(" + stringz.DoubleQuote(tblMeta.Name) + ")"
-	rows, err := db.QueryContext(ctx, query)
+	// The table-valued pragma function takes the table name as a bound
+	// parameter, eliminating an interpolated quoting site (gh777).
+	query = `SELECT cid, name, type, "notnull", dflt_value, pk FROM pragma_table_info(?)`
+	rows, err := db.QueryContext(ctx, query, tblMeta.Name)
 	if err != nil {
 		return nil, errw(err)
 	}

--- a/drivers/sqlite3/metadata_test.go
+++ b/drivers/sqlite3/metadata_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/neilotoole/sq/libsq/core/lg"
 	"github.com/neilotoole/sq/libsq/core/lg/lgt"
 	"github.com/neilotoole/sq/libsq/core/sqlz"
+	"github.com/neilotoole/sq/libsq/core/stringz"
 	"github.com/neilotoole/sq/libsq/core/tablefq"
 	"github.com/neilotoole/sq/libsq/source"
 	"github.com/neilotoole/sq/libsq/source/drivertype"
@@ -503,4 +504,60 @@ func TestIndexes_ExpressionArity(t *testing.T) {
 		"the lower(b) key position must be the empty-string sentinel")
 	require.NotContains(t, idxByName, "ix_allexpr",
 		"an all-expression index must be omitted")
+}
+
+// TestTableMetadata_ProblematicTableNames reproduces gh777: getTableMetadata
+// interpolated the table name with Go's %q, including into string-literal
+// position. SQLite resolves a double-quoted token as an identifier first, so
+// a table named after a sqlite_master column (name, type, sql) turned
+// WHERE name = "name" into a tautology that matched the first sqlite_master
+// row, and a table name containing a double quote was emitted with Go
+// backslash escaping, which SQLite rejects outright.
+func TestTableMetadata_ProblematicTableNames(t *testing.T) {
+	t.Parallel()
+
+	th := testh.New(t)
+	src := &source.Source{
+		Handle:   "@tblnames_sl3",
+		Type:     drivertype.SQLite,
+		Location: "sqlite3://" + tu.TempFile(t, "tblnames.db"),
+	}
+	th.Add(src)
+	grip := th.Open(src)
+	db, err := grip.DB(th.Context)
+	require.NoError(t, err)
+
+	// Create a view first so it occupies the first sqlite_master row. The
+	// pre-fix tautology (WHERE name = "name") matched the first row of
+	// sqlite_master, which would coincidentally report "table" if a table
+	// happened to come first; a leading view makes the bug observable for
+	// the "name" case too.
+	_, err = db.ExecContext(th.Context, `CREATE VIEW aaa_view AS SELECT 1 AS x`)
+	require.NoError(t, err)
+
+	tblNames := []string{"name", "type", "sql", `we"ird`}
+	for _, tblName := range tblNames {
+		quoted := stringz.DoubleQuote(tblName)
+		_, err = db.ExecContext(th.Context, fmt.Sprintf(
+			"CREATE TABLE %s (id INTEGER PRIMARY KEY, val TEXT)", quoted))
+		require.NoError(t, err)
+		_, err = db.ExecContext(th.Context, fmt.Sprintf(
+			"INSERT INTO %s (val) VALUES ('a'), ('b')", quoted))
+		require.NoError(t, err)
+	}
+
+	for _, tblName := range tblNames {
+		t.Run(tu.Name(tblName), func(t *testing.T) {
+			t.Parallel()
+
+			md, err := grip.TableMetadata(th.Context, tblName)
+			require.NoError(t, err)
+			require.Equal(t, tblName, md.Name)
+			require.Equal(t, int64(2), md.RowCount)
+			require.Equal(t, sqlz.TableTypeTable, md.TableType)
+			require.Len(t, md.Columns, 2)
+			require.Equal(t, "id", md.Columns[0].Name)
+			require.Equal(t, "val", md.Columns[1].Name)
+		})
+	}
 }

--- a/drivers/sqlite3/metadata_test.go
+++ b/drivers/sqlite3/metadata_test.go
@@ -535,7 +535,17 @@ func TestTableMetadata_ProblematicTableNames(t *testing.T) {
 	_, err = db.ExecContext(th.Context, `CREATE VIEW aaa_view AS SELECT 1 AS x`)
 	require.NoError(t, err)
 
-	tblNames := []string{"name", "type", "sql", `we"ird`}
+	// A trigger may share a table's name in sqlite_master. Create the
+	// trigger before the same-named table so the trigger row precedes the
+	// table row: without the type filter in the metadata query, the
+	// trigger row shadowed the table and the metadata was misreported.
+	_, err = db.ExecContext(th.Context, `CREATE TABLE aab_other (x INTEGER)`)
+	require.NoError(t, err)
+	_, err = db.ExecContext(th.Context,
+		`CREATE TRIGGER "shadowed" AFTER INSERT ON aab_other BEGIN SELECT 1; END`)
+	require.NoError(t, err)
+
+	tblNames := []string{"name", "type", "sql", `we"ird`, "shadowed"}
 	for _, tblName := range tblNames {
 		quoted := stringz.DoubleQuote(tblName)
 		_, err = db.ExecContext(th.Context, fmt.Sprintf(


### PR DESCRIPTION
Fixes #776, fixes #777.

Two correctness fixes in the rqlite driver's table-alteration and metadata paths. They share
a theme: code mirrored from the sqlite3 driver behaved differently (or was already wrong)
once rqlite's HTTP/JSON wire model and gorqlite's connection handling entered the picture.

## #776: `PRAGMA foreign_keys=off` was a silent no-op during table rebuilds

### The problem

`AlterTableColumnKinds` rebuilds a table the SQLite way: create the new table, copy data,
drop the old, rename. Rebuilding a table that other tables reference by foreign key requires
disabling FK enforcement around the drop, so the statement batch included
`PRAGMA foreign_keys=off` at the top and the restore at the bottom, mirroring the sqlite3
driver.

That never worked, due to a three-layer interaction:

1. gorqlite sets `wantsTransactions=true` unconditionally and appends `&transaction` to
   every `/db/execute` batch.
2. rqlite therefore wraps the batch in BEGIN/COMMIT.
3. SQLite documents `PRAGMA foreign_keys` as a no-op while a transaction is pending.

So FK enforcement was never actually disabled; the pragma just sat inertly at the top of the
batch. On a node running with enforcement enabled (`-fk`), altering a referenced table (e.g.
sakila's `actor`, referenced by `film_actor`) failed at the DROP TABLE step with
`FOREIGN KEY constraint failed`. Nothing in the test fleet enabled `-fk`, so the path was
green in CI while broken in exactly the deployments that care about referential integrity.

### The investigation that drove the design

The issue offered two fix directions: execute the pragma in separate non-transactional
requests around the batch, or restructure the rebuild to not need the pragma at all. The
choice hinged on an empirical question: **does a connection-level pragma issued in one HTTP
request still apply to a later request?** If every rqlite HTTP request got a fresh SQLite
connection, the separate-requests approach would only appear to work.

Verified against a live rqlite v10.2.0 node (curl first, then Go tests), in both
directions: a non-transactional `PRAGMA foreign_keys=on` made a later request's dangling
insert fail, and a non-transactional `off` allowed a subsequent transactional rebuild batch
to succeed. The reason it holds: gorqlite's write path is a single long-lived connection,
and pragma statements replicate through the Raft log like any other write. That assumption
(single write connection) is recorded in the code comment, with the explicit note that a
future gorqlite that pools write connections would invalidate it.

One quirk surfaced and is documented: reading `PRAGMA foreign_keys` back via `/db/query` is
served by rqlite's read-only connection pool, so it reports the node's boot-time `-fk`
default, never the write connection's live state. Two consequences baked into the design:
the pragma-off is issued unconditionally (skipping based on that unreliable read would break
exactly the FK-enforcing case), and the restore targets the configured default.

### The fix

A new `writeNonTx` helper (sharing its body with `writeAtomic`) clears gorqlite's
per-connection transaction flag around the write and restores it before the connection
returns to the pool. The rebuild is now three requests:

1. non-transactional `PRAGMA foreign_keys=off`
2. the rebuild batch, unchanged: still one atomic transactional `/db/execute`
3. deferred non-transactional restore, on `context.WithoutCancel` so caller cancellation
   cannot skip it

The tradeoff is explicit and documented on the function: the pragma window is node-wide (FK
enforcement is suspended for all writers on the node during the alter), and a crash between
steps 1 and 3 leaves enforcement off until the node restarts. That matches the sqlite3
driver's semantics (same pragma scope, same crash exposure) and was judged acceptable
against the alternative of restructuring the rebuild, which would have diverged the two
drivers' alter implementations right before #778 plans to unify them.

### Testing it without a `-fk` cluster

Rather than adding a special FK-enforcing test cluster, the new
`TestAlterTableColumnKinds_ForeignKeyEnforcement` enables enforcement on the live node's
write connection via the same non-transactional path (state-equivalent to booting with
`-fk`), so it runs under the standard `SQ_TEST_SRC__SAKILA_RQ` gate. It is deliberately
serial (the pragma is node-global) and asserts the full arc: enforcement demonstrably live
before the alter, rebuild succeeds (it failed with the exact reported error against the
unfixed code), data intact, restore ran, and the child table's FK still binds to the
rebuilt parent.

## #777: `%q` is not SQL quoting

### The problem

`getTableMetadata` built SQL by interpolating table names with Go's `%q` verb, including
into a string-literal position:

```sql
(SELECT type FROM sqlite_master WHERE name = %q LIMIT 1)
```

Two distinct failure classes:

- **Identifier/literal confusion.** SQLite resolves a double-quoted token as an identifier
  first, and `name`, `type`, and `sql` are all `sqlite_master` columns. A table literally
  named `name` produced `WHERE name = name`, a tautology matching an arbitrary row, so the
  reported table type could come from an unrelated index or trigger. Tables named `type` or
  `sql` compared the wrong columns entirely.
- **Go escaping is not SQL escaping.** A table name containing a double quote is emitted by
  `%q` with backslash escaping (`\"`), which SQLite rejects as malformed. The `FROM %q`
  row-count subquery had the same flaw.

Is this a code smell? Yes: reaching for a Go string-formatting verb to do SQL quoting
conflates two quoting systems that merely look similar. `%q` answers "how would this string
look in Go source"; SQL needs either a bound parameter (value position) or
identifier quoting with embedded-quote doubling (identifier position), and those two
positions need different treatment, which a single format verb can't express. The smell had
also already propagated: the pattern was copied from `drivers/sqlite3/metadata.go`, which
carried the identical weakness.

### The fix

In both drivers (rqlite and sqlite3): table names are bound as query parameters wherever
they appear as values, and quoted with the existing `stringz.DoubleQuote` helper (doubles
embedded `"`) wherever they appear as identifiers, covering the COUNT subquery, the
`PRAGMA TABLE_INFO` call (previously raw single-quote interpolation), and sqlite3's bulk
row-count query, which had the same flaw.

`TestTableMetadata_ProblematicTableNames` exercises tables named `name`, `type`, `sql`, and
`we"ird` in both drivers. Pre-fix, all four subtests failed on sqlite3 and three failed on
rqlite (the `name` tautology coincidentally matched a table row there, which is itself a
demonstration of why the bug is insidious). The sqlite3 variant creates a leading view so
the tautology's wrong answer is observable rather than accidentally correct. The test runs
serially on rqlite, since the fixed-name tables live in the shared test database.

## Verification

- Full rqlite suite against the live sakiladb/rqlite v10.2.0 container: pass.
- sqlite3 suite (no Docker): pass. make lint: 0 issues.
- No CHANGELOG entry: the rqlite driver is unreleased, and the sqlite3 metadata fix restores
  correct behavior with no user-visible surface change.