### PR TITLE
sqlite3/rqlite: CopyTable copies indexes and triggers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,11 @@ Breaking changes are annotated with ☢️, and alpha/beta features with 🐥.
     that it preserves any inline credentials from the old config.
 - [#692]: [`sq inspect -f mermaid-erd`](https://sq.io/docs/inspect#mermaid-erd)
   now syntax-colors its `erDiagram` source when writing to a terminal.
+- [#758]: For SQLite (and rqlite) sources,
+  [`sq tbl copy`](https://sq.io/docs/cmd/tbl-copy) now copies the source table's
+  indexes and triggers to the destination, renamed with the destination table
+  name appended (e.g. index `idx_name` copied to table `actor2` becomes
+  `idx_name_actor2`).
 
 ### Fixed
 
@@ -1682,6 +1687,7 @@ make working with lots of sources much easier.
 [#750]: https://github.com/neilotoole/sq/issues/750
 [#752]: https://github.com/neilotoole/sq/issues/752
 [#757]: https://github.com/neilotoole/sq/issues/757
+[#758]: https://github.com/neilotoole/sq/issues/758
 [#759]: https://github.com/neilotoole/sq/issues/759
 [#782]: https://github.com/neilotoole/sq/issues/782
 [#783]: https://github.com/neilotoole/sq/issues/783

--- a/drivers/rqlite/rqlite.go
+++ b/drivers/rqlite/rqlite.go
@@ -527,9 +527,14 @@ func dsnFromLocation(loc string) (string, dsnOpts, error) {
 // against itself rather than the source (gh759). Cross-table FKs are
 // left untouched.
 //
-// Not preserved: indexes and triggers. These live as separate
-// sqlite_master rows and are out of scope for CopyTable. Matches the
-// sqlite3 driver's behavior.
+// The source table's companion objects (indexes and triggers, which
+// live as separate sqlite_master rows) are also copied (gh758), with
+// each companion renamed to "<orig-name>_<dest-table>" because index
+// and trigger names are schema-global in SQLite. The companion DDL
+// rides the same writeAtomic batch as the CREATE and INSERT, after the
+// data copy so that copied triggers don't fire on the rows being
+// copied. Matches the sqlite3 driver's behavior; see
+// copyTableCompanionDDL for the rewrite details.
 func (d *driveri) CopyTable(ctx context.Context, db sqlz.DB,
 	fromTbl, toTbl tablefq.T, copyData bool,
 ) (int64, error) {
@@ -590,23 +595,104 @@ func (d *driveri) CopyTable(ctx context.Context, db sqlz.DB,
 		return 0, errz.Wrap(err, "rqlite: copy table: failed to apply DDL rewrites")
 	}
 
-	if !copyData {
+	// Read and rewrite the companion (index and trigger) DDL up front,
+	// before any writes, so a rewrite failure aborts the copy cleanly.
+	companionStmts, err := copyTableCompanionDDL(ctx, db, fromTbl, toTbl)
+	if err != nil {
+		return 0, err
+	}
+
+	if !copyData && len(companionStmts) == 0 {
+		// Single-statement fast path: no batch needed.
 		if _, err = db.ExecContext(ctx, destDDL); err != nil {
 			return 0, errw(err)
 		}
 		return 0, nil
 	}
 
-	stmts := []gorqlite.ParameterizedStatement{
-		{Query: destDDL},
-		{Query: fmt.Sprintf(`INSERT INTO %s SELECT * FROM %s`,
-			toTbl.Render(stringz.DoubleQuote), fromTbl.Render(stringz.DoubleQuote))},
+	stmts := []gorqlite.ParameterizedStatement{{Query: destDDL}}
+	insertIdx := -1
+	if copyData {
+		insertIdx = len(stmts)
+		stmts = append(stmts, gorqlite.ParameterizedStatement{
+			Query: fmt.Sprintf(`INSERT INTO %s SELECT * FROM %s`,
+				toTbl.Render(stringz.DoubleQuote), fromTbl.Render(stringz.DoubleQuote)),
+		})
 	}
+	// Companions come after the data copy: a copied trigger must not
+	// fire on the rows being copied.
+	for _, companion := range companionStmts {
+		stmts = append(stmts, gorqlite.ParameterizedStatement{Query: companion})
+	}
+
 	results, err := writeAtomic(ctx, db, stmts...)
 	if err != nil {
 		return 0, err
 	}
-	return results[1].RowsAffected, nil
+	if insertIdx == -1 {
+		return 0, nil
+	}
+	return results[insertIdx].RowsAffected, nil
+}
+
+// copyTableCompanionDDL reads the DDL of fromTbl's companion objects
+// (indexes and triggers) from sqlite_master and returns each statement
+// rewritten to apply to toTbl. Rows with NULL sql are automatic indexes
+// (e.g. backing a UNIQUE constraint or PRIMARY KEY) that the rewritten
+// CREATE TABLE already recreates, so the query excludes them.
+//
+// Index and trigger names are schema-global in SQLite, so each
+// companion is renamed by appending the destination table name:
+// "<orig-name>_<dest-table>". A trigger's ON <table> target, and any
+// table references in its body that name the source table, are
+// rewritten to the destination; references to other tables are left
+// untouched. See sqlparser.RewriteCreateIndexStmt and
+// sqlparser.RewriteCreateTriggerStmt. Mirrors the sqlite3 driver's
+// same-named helper.
+func copyTableCompanionDDL(ctx context.Context, db sqlz.DB,
+	fromTbl, toTbl tablefq.T,
+) ([]string, error) {
+	masterTbl := tablefq.T{Schema: fromTbl.Schema, Table: "sqlite_master"}
+	q := fmt.Sprintf("SELECT name, type, sql FROM %s WHERE tbl_name = ? "+
+		"AND type IN ('index','trigger') AND sql IS NOT NULL ORDER BY name",
+		masterTbl.Render(stringz.DoubleQuote))
+	rows, err := db.QueryContext(ctx, q, fromTbl.Table)
+	if err != nil {
+		return nil, errw(err)
+	}
+	defer sqlz.CloseRows(lg.FromContext(ctx), rows)
+
+	destTblIdent := stringz.DoubleQuote(toTbl.Table)
+	var stmts []string
+	for rows.Next() {
+		var name, typ, ddl string
+		if err = rows.Scan(&name, &typ, &ddl); err != nil {
+			return nil, errw(err)
+		}
+
+		// The companion lives in the destination table's schema.
+		newIdent := tablefq.T{Schema: toTbl.Schema, Table: name + "_" + toTbl.Table}.
+			Render(stringz.DoubleQuote)
+
+		var rewritten string
+		switch typ {
+		case "index":
+			rewritten, err = sqlparser.RewriteCreateIndexStmt(ddl, newIdent, destTblIdent)
+		case "trigger":
+			rewritten, err = sqlparser.RewriteCreateTriggerStmt(ddl, newIdent, destTblIdent)
+		default:
+			// Unreachable given the query predicate.
+			continue
+		}
+		if err != nil {
+			return nil, errz.Wrapf(err, "rqlite: copy table: rewrite %s {%s}", typ, name)
+		}
+		stmts = append(stmts, rewritten)
+	}
+	if err = rows.Err(); err != nil {
+		return nil, errw(err)
+	}
+	return stmts, nil
 }
 
 // RecordMeta implements driver.SQLDriver.

--- a/drivers/rqlite/rqlite_test.go
+++ b/drivers/rqlite/rqlite_test.go
@@ -910,16 +910,20 @@ func TestWriteAtomic_PerStatementError(t *testing.T) {
 	require.NoError(t, drvr.CreateTable(th.Context, db, preDef))
 
 	// CopyTable(copyData=true) issues [CREATE dstName, INSERT INTO
-	// dstName SELECT * FROM actor] as one atomic batch. The CREATE
-	// fails because dstName already exists, and writeAtomic should
-	// surface "statement 1/2 failed" with the underlying cause.
+	// dstName SELECT * FROM actor, companion DDL...] as one atomic
+	// batch (the companion count depends on actor's indexes and
+	// triggers, so the batch size isn't asserted). The CREATE fails
+	// because dstName already exists, and writeAtomic should surface
+	// "statement 1/N failed" with the underlying cause.
 	_, err = drvr.CopyTable(th.Context, db,
 		tablefq.T{Table: sakila.TblActor},
 		tablefq.T{Table: dstName},
 		true)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "statement 1/2 failed",
+	require.Contains(t, err.Error(), "statement 1/",
 		"writeAtomic should identify which statement in the batch failed")
+	require.Contains(t, err.Error(), "already exists",
+		"the underlying cause should be preserved")
 }
 
 // TestCoerce_NumericAffinityInt verifies that NUMERIC-declared columns
@@ -1831,4 +1835,108 @@ func TestAlterTableColumnKinds_PreservesUniqueAndDefault(t *testing.T) {
 		fmt.Sprintf(`SELECT salary FROM %q WHERE id=1`, tblName)).Scan(&salary))
 	require.InDelta(t, 50000.0, salary, 0.0001,
 		"DEFAULT 50000 on salary should survive the rebuild")
+}
+
+// TestCopyTable_CopiesIndexesAndTriggers is the rqlite half of gh758:
+// CopyTable carries the source table's companion objects (indexes and
+// triggers, separate sqlite_master rows) across to the destination,
+// renamed to "<orig-name>_<dest-table>", riding the same writeAtomic
+// batch as the CREATE and INSERT. The UNIQUE constraint's automatic
+// index has NULL sql in sqlite_master and must be skipped by the
+// companion rewrite. Trigger timing is load-bearing: the copied
+// trigger must not fire on the rows being copied, only on subsequent
+// inserts into the destination. Mirrors the sqlite3 sibling test.
+func TestCopyTable_CopiesIndexesAndTriggers(t *testing.T) {
+	tu.SkipShort(t, true)
+	t.Parallel()
+
+	th := testh.New(t)
+	src := th.Source(sakila.Rq)
+	grip := th.Open(src)
+	drvr := grip.SQLDriver()
+	db, err := grip.DB(th.Context)
+	require.NoError(t, err)
+
+	uniq := stringz.Uniq8()
+	srcName := "companion_src_" + uniq
+	logName := "companion_log_" + uniq
+	dstName := "companion_dst_" + uniq
+	idxName := "idx_name_" + uniq
+	trgName := "trg_bi_" + uniq
+	t.Cleanup(func() {
+		_ = drvr.DropTable(th.Context, db, tablefq.T{Table: dstName}, true)
+		_ = drvr.DropTable(th.Context, db, tablefq.T{Table: srcName}, true)
+		_ = drvr.DropTable(th.Context, db, tablefq.T{Table: logName}, true)
+	})
+
+	for _, stmt := range []string{
+		fmt.Sprintf(`CREATE TABLE %q (id INTEGER PRIMARY KEY, name TEXT, email TEXT UNIQUE)`,
+			srcName),
+		fmt.Sprintf(`CREATE TABLE %q (id INTEGER PRIMARY KEY, msg TEXT)`, logName),
+		fmt.Sprintf(`CREATE INDEX %q ON %q (name)`, idxName, srcName),
+		fmt.Sprintf(`CREATE TRIGGER %q BEFORE INSERT ON %q BEGIN
+			INSERT INTO %q (msg) VALUES (NEW.name);
+		END`, trgName, srcName, logName),
+		fmt.Sprintf(`INSERT INTO %q (name, email) VALUES ('alice', 'a@x.com'), ('bob', 'b@x.com')`,
+			srcName),
+	} {
+		_, err = db.ExecContext(th.Context, stmt)
+		require.NoError(t, err)
+	}
+
+	copied, err := drvr.CopyTable(th.Context, db,
+		tablefq.T{Table: srcName}, tablefq.T{Table: dstName}, true)
+	require.NoError(t, err)
+	require.Equal(t, int64(2), copied)
+
+	// The copied trigger must not have fired on the copied rows: the
+	// source inserts logged 2 rows, and the copy must not add more.
+	var logCount int64
+	require.NoError(t, db.QueryRowContext(th.Context,
+		fmt.Sprintf(`SELECT count(*) FROM %q`, logName)).Scan(&logCount))
+	require.Equal(t, int64(2), logCount,
+		"copied trigger must not fire on the rows being copied")
+
+	// The explicit index is carried over, renamed, and re-targeted.
+	var idxSQL string
+	require.NoError(t, db.QueryRowContext(th.Context,
+		`SELECT sql FROM sqlite_master WHERE type='index' AND name=? AND tbl_name=?`,
+		idxName+"_"+dstName, dstName).Scan(&idxSQL))
+	require.Contains(t, idxSQL, fmt.Sprintf("%q", dstName))
+	require.NotContains(t, idxSQL, fmt.Sprintf("ON %s ", srcName))
+
+	// Exactly one explicit (non-NULL sql) index on the destination: the
+	// UNIQUE constraint's automatic index has NULL sql and must not have
+	// been duplicated by the companion copy.
+	var explicitIdxCount int64
+	require.NoError(t, db.QueryRowContext(th.Context,
+		`SELECT count(*) FROM sqlite_master WHERE type='index' AND tbl_name=?
+			AND sql IS NOT NULL`, dstName).Scan(&explicitIdxCount))
+	require.Equal(t, int64(1), explicitIdxCount)
+
+	// The trigger is carried over, renamed, and re-targeted; its body's
+	// cross-table reference (the log table) is left untouched.
+	var trgSQL string
+	require.NoError(t, db.QueryRowContext(th.Context,
+		`SELECT sql FROM sqlite_master WHERE type='trigger' AND name=? AND tbl_name=?`,
+		trgName+"_"+dstName, dstName).Scan(&trgSQL))
+	require.Contains(t, trgSQL, fmt.Sprintf(`ON %q`, dstName))
+	require.Contains(t, trgSQL, logName,
+		"cross-table body reference must be preserved")
+
+	// The copied trigger's side effect fires on insert into the destination.
+	_, err = db.ExecContext(th.Context, fmt.Sprintf(
+		`INSERT INTO %q (name, email) VALUES ('dave', 'd@x.com')`, dstName))
+	require.NoError(t, err)
+	require.NoError(t, db.QueryRowContext(th.Context,
+		fmt.Sprintf(`SELECT count(*) FROM %q WHERE msg='dave'`, logName)).Scan(&logCount))
+	require.Equal(t, int64(1), logCount,
+		"copied trigger must fire on insert into the destination")
+
+	// The source's companions are untouched: original names, original table.
+	var srcCompanionCount int64
+	require.NoError(t, db.QueryRowContext(th.Context,
+		`SELECT count(*) FROM sqlite_master WHERE tbl_name=? AND name IN (?, ?)`,
+		srcName, idxName, trgName).Scan(&srcCompanionCount))
+	require.Equal(t, int64(2), srcCompanionCount)
 }

--- a/drivers/sqlite3/sqlite3.go
+++ b/drivers/sqlite3/sqlite3.go
@@ -296,6 +296,14 @@ func (d *driveri) Renderer() *render.Renderer {
 // so the destination's FKs resolve against itself rather than the
 // source. Cross-table FKs (REFERENCES other(...) where other != src)
 // are left untouched.
+//
+// The source table's companion objects (indexes and triggers, which
+// live as separate sqlite_master rows) are also copied (gh758), with
+// each companion renamed to "<orig-name>_<dest-table>" because index
+// and trigger names are schema-global in SQLite. Companions are created
+// after the data copy so that copied triggers don't fire on (or mutate)
+// the rows being copied. See copyTableCompanionDDL for the rewrite
+// details and limitations.
 func (d *driveri) CopyTable(ctx context.Context, db sqlz.DB,
 	fromTbl, toTbl tablefq.T, copyData bool,
 ) (int64, error) {
@@ -365,22 +373,94 @@ func (d *driveri) CopyTable(ctx context.Context, db sqlz.DB,
 		return 0, errz.Wrap(err, "sqlite3: copy table: failed to apply DDL rewrites")
 	}
 
+	// Read and rewrite the companion (index and trigger) DDL up front,
+	// before any writes, so a rewrite failure aborts the copy cleanly.
+	companionStmts, err := copyTableCompanionDDL(ctx, db, fromTbl, toTbl)
+	if err != nil {
+		return 0, err
+	}
+
 	_, err = db.ExecContext(ctx, destTblCreateStmt)
 	if err != nil {
 		return 0, errw(err)
 	}
 
-	if !copyData {
-		return 0, nil
+	var affected int64
+	if copyData {
+		stmt := fmt.Sprintf("INSERT INTO %s SELECT * FROM %s", toTbl, fromTbl)
+		if affected, err = sqlz.ExecAffected(ctx, db, stmt); err != nil {
+			return 0, errw(err)
+		}
 	}
 
-	stmt := fmt.Sprintf("INSERT INTO %s SELECT * FROM %s", toTbl, fromTbl)
-	affected, err := sqlz.ExecAffected(ctx, db, stmt)
-	if err != nil {
-		return 0, errw(err)
+	// Companions are created after the data copy: a copied trigger must
+	// not fire on the rows being copied.
+	for _, stmt := range companionStmts {
+		if _, err = db.ExecContext(ctx, stmt); err != nil {
+			return 0, errw(err)
+		}
 	}
 
 	return affected, nil
+}
+
+// copyTableCompanionDDL reads the DDL of fromTbl's companion objects
+// (indexes and triggers) from sqlite_master and returns each statement
+// rewritten to apply to toTbl. Rows with NULL sql are automatic indexes
+// (e.g. backing a UNIQUE constraint or PRIMARY KEY) that the rewritten
+// CREATE TABLE already recreates, so the query excludes them.
+//
+// Index and trigger names are schema-global in SQLite, so each
+// companion is renamed by appending the destination table name:
+// "<orig-name>_<dest-table>". A trigger's ON <table> target, and any
+// table references in its body that name the source table, are
+// rewritten to the destination; references to other tables are left
+// untouched. See sqlparser.RewriteCreateIndexStmt and
+// sqlparser.RewriteCreateTriggerStmt.
+func copyTableCompanionDDL(ctx context.Context, db sqlz.DB,
+	fromTbl, toTbl tablefq.T,
+) ([]string, error) {
+	masterTbl := tablefq.T{Schema: fromTbl.Schema, Table: "sqlite_master"}
+	q := fmt.Sprintf("SELECT name, type, sql FROM %s WHERE tbl_name = ? "+
+		"AND type IN ('index','trigger') AND sql IS NOT NULL ORDER BY name",
+		masterTbl.Render(stringz.DoubleQuote))
+	rows, err := db.QueryContext(ctx, q, fromTbl.Table)
+	if err != nil {
+		return nil, errw(err)
+	}
+	defer sqlz.CloseRows(lg.FromContext(ctx), rows)
+
+	destTblIdent := stringz.DoubleQuote(toTbl.Table)
+	var stmts []string
+	for rows.Next() {
+		var name, typ, ddl string
+		if err = rows.Scan(&name, &typ, &ddl); err != nil {
+			return nil, errw(err)
+		}
+
+		// The companion lives in the destination table's schema.
+		newIdent := tablefq.T{Schema: toTbl.Schema, Table: name + "_" + toTbl.Table}.
+			Render(stringz.DoubleQuote)
+
+		var rewritten string
+		switch typ {
+		case "index":
+			rewritten, err = sqlparser.RewriteCreateIndexStmt(ddl, newIdent, destTblIdent)
+		case "trigger":
+			rewritten, err = sqlparser.RewriteCreateTriggerStmt(ddl, newIdent, destTblIdent)
+		default:
+			// Unreachable given the query predicate.
+			continue
+		}
+		if err != nil {
+			return nil, errz.Wrapf(err, "sqlite3: copy table: rewrite %s {%s}", typ, name)
+		}
+		stmts = append(stmts, rewritten)
+	}
+	if err = rows.Err(); err != nil {
+		return nil, errw(err)
+	}
+	return stmts, nil
 }
 
 // RecordMeta implements driver.SQLDriver.

--- a/drivers/sqlite3/sqlite3_test.go
+++ b/drivers/sqlite3/sqlite3_test.go
@@ -1277,3 +1277,186 @@ func TestNewScratchSource_SecretsResolved(t *testing.T) {
 	require.Equal(t, src.Location, resolved.Location,
 		"resolution must not alter the literal scratch path")
 }
+
+// TestDriveri_CopyTable_CopiesIndexesAndTriggers verifies gh758:
+// CopyTable carries the source table's companion objects (indexes and
+// triggers, separate sqlite_master rows) across to the destination,
+// renamed to "<orig-name>_<dest-table>". The UNIQUE constraint's
+// automatic index has NULL sql in sqlite_master and must be skipped by
+// the companion rewrite (the rewritten CREATE TABLE recreates it).
+// Trigger timing is also load-bearing: the copied trigger must not fire
+// on the rows being copied, only on subsequent inserts into the
+// destination.
+func TestDriveri_CopyTable_CopiesIndexesAndTriggers(t *testing.T) {
+	th := testh.New(t)
+	src := &source.Source{
+		Handle:   "@test",
+		Type:     drivertype.SQLite,
+		Location: "sqlite3://" + tu.TempFile(t, "test.db"),
+	}
+
+	grip := th.Open(src)
+	db, err := grip.DB(th.Context)
+	require.NoError(t, err)
+	drvr := grip.SQLDriver()
+
+	for _, stmt := range []string{
+		`CREATE TABLE src (id INTEGER PRIMARY KEY, name TEXT, email TEXT UNIQUE)`,
+		`CREATE TABLE src_log (id INTEGER PRIMARY KEY, msg TEXT)`,
+		`CREATE INDEX idx_src_name ON src (name)`,
+		`CREATE TRIGGER trg_src_bi BEFORE INSERT ON src BEGIN
+			INSERT INTO src_log (msg) VALUES (NEW.name);
+		END`,
+		`INSERT INTO src (name, email) VALUES ('alice', 'a@x.com'), ('bob', 'b@x.com')`,
+	} {
+		_, err = db.ExecContext(th.Context, stmt)
+		require.NoError(t, err)
+	}
+
+	copied, err := drvr.CopyTable(th.Context, db,
+		tablefq.From("src"), tablefq.From("dst"), true)
+	require.NoError(t, err)
+	require.Equal(t, int64(2), copied)
+
+	// The copied trigger must not have fired on the copied rows: the
+	// source inserts logged 2 rows, and the copy must not add more.
+	var logCount int64
+	require.NoError(t, db.QueryRowContext(th.Context,
+		`SELECT count(*) FROM src_log`).Scan(&logCount))
+	require.Equal(t, int64(2), logCount,
+		"copied trigger must not fire on the rows being copied")
+
+	// The explicit index is carried over, renamed, and re-targeted.
+	var idxSQL string
+	require.NoError(t, db.QueryRowContext(th.Context,
+		`SELECT sql FROM sqlite_master WHERE type='index' AND name='idx_src_name_dst'
+			AND tbl_name='dst'`).Scan(&idxSQL))
+	require.Contains(t, idxSQL, `"dst"`)
+	require.NotContains(t, idxSQL, `ON src`)
+
+	// Exactly one explicit (non-NULL sql) index on the destination: the
+	// UNIQUE constraint's automatic index has NULL sql and must not have
+	// been duplicated by the companion copy.
+	var explicitIdxCount int64
+	require.NoError(t, db.QueryRowContext(th.Context,
+		`SELECT count(*) FROM sqlite_master WHERE type='index' AND tbl_name='dst'
+			AND sql IS NOT NULL`).Scan(&explicitIdxCount))
+	require.Equal(t, int64(1), explicitIdxCount)
+
+	// The UNIQUE constraint itself survives via the CREATE TABLE rewrite.
+	_, err = db.ExecContext(th.Context,
+		`INSERT INTO dst (name, email) VALUES ('carol', 'a@x.com')`)
+	require.Error(t, err, "UNIQUE(email) must be enforced on the destination")
+
+	// The trigger is carried over, renamed, and re-targeted; its body's
+	// cross-table reference (src_log) is left untouched.
+	var trgSQL string
+	require.NoError(t, db.QueryRowContext(th.Context,
+		`SELECT sql FROM sqlite_master WHERE type='trigger' AND name='trg_src_bi_dst'
+			AND tbl_name='dst'`).Scan(&trgSQL))
+	require.Contains(t, trgSQL, `ON "dst"`)
+	require.Contains(t, trgSQL, "src_log",
+		"cross-table body reference must be preserved")
+
+	// The copied trigger's side effect fires on insert into the destination.
+	_, err = db.ExecContext(th.Context,
+		`INSERT INTO dst (name, email) VALUES ('dave', 'd@x.com')`)
+	require.NoError(t, err)
+	require.NoError(t, db.QueryRowContext(th.Context,
+		`SELECT count(*) FROM src_log WHERE msg='dave'`).Scan(&logCount))
+	require.Equal(t, int64(1), logCount,
+		"copied trigger must fire on insert into the destination")
+
+	// The source's companions are untouched: original names, original table.
+	var srcCompanionCount int64
+	require.NoError(t, db.QueryRowContext(th.Context,
+		`SELECT count(*) FROM sqlite_master WHERE tbl_name='src'
+			AND name IN ('idx_src_name', 'trg_src_bi')`).Scan(&srcCompanionCount))
+	require.Equal(t, int64(2), srcCompanionCount)
+}
+
+// TestDriveri_CopyTable_TriggerBodySelfRef verifies that a trigger body
+// reference to the trigger's own table is rewritten to the destination,
+// mirroring CopyTable's self-FK rewrite semantics: the copied trigger
+// operates on the copied table, not the source.
+func TestDriveri_CopyTable_TriggerBodySelfRef(t *testing.T) {
+	th := testh.New(t)
+	src := &source.Source{
+		Handle:   "@test",
+		Type:     drivertype.SQLite,
+		Location: "sqlite3://" + tu.TempFile(t, "test.db"),
+	}
+
+	grip := th.Open(src)
+	db, err := grip.DB(th.Context)
+	require.NoError(t, err)
+	drvr := grip.SQLDriver()
+
+	for _, stmt := range []string{
+		`CREATE TABLE src (id INTEGER PRIMARY KEY, name TEXT)`,
+		`CREATE TRIGGER trg_upper AFTER INSERT ON src BEGIN
+			UPDATE src SET name = upper(NEW.name) WHERE id = NEW.id;
+		END`,
+		`INSERT INTO src (name) VALUES ('alice')`,
+	} {
+		_, err = db.ExecContext(th.Context, stmt)
+		require.NoError(t, err)
+	}
+
+	_, err = drvr.CopyTable(th.Context, db,
+		tablefq.From("src"), tablefq.From("dst"), true)
+	require.NoError(t, err)
+
+	var trgSQL string
+	require.NoError(t, db.QueryRowContext(th.Context,
+		`SELECT sql FROM sqlite_master WHERE type='trigger'
+			AND name='trg_upper_dst'`).Scan(&trgSQL))
+	require.Contains(t, trgSQL, `UPDATE "dst"`,
+		"trigger body self-reference must be rewritten to the destination")
+
+	// The copied trigger acts on the destination only.
+	_, err = db.ExecContext(th.Context, `INSERT INTO dst (name) VALUES ('bob')`)
+	require.NoError(t, err)
+
+	var gotName string
+	require.NoError(t, db.QueryRowContext(th.Context,
+		`SELECT name FROM dst WHERE name='BOB'`).Scan(&gotName))
+	require.Equal(t, "BOB", gotName)
+
+	var srcCount int64
+	require.NoError(t, db.QueryRowContext(th.Context,
+		`SELECT count(*) FROM src`).Scan(&srcCount))
+	require.Equal(t, int64(1), srcCount, "source table must be unaffected")
+}
+
+// TestDriveri_CopyTable_NoCompanions_StructureOnly is the regression
+// guard for the no-companion path: a plain table with copyData=false
+// still copies cleanly after the gh758 companion logic landed.
+func TestDriveri_CopyTable_NoCompanions_StructureOnly(t *testing.T) {
+	th := testh.New(t)
+	src := &source.Source{
+		Handle:   "@test",
+		Type:     drivertype.SQLite,
+		Location: "sqlite3://" + tu.TempFile(t, "test.db"),
+	}
+
+	grip := th.Open(src)
+	db, err := grip.DB(th.Context)
+	require.NoError(t, err)
+	drvr := grip.SQLDriver()
+
+	_, err = db.ExecContext(th.Context,
+		`CREATE TABLE src (id INTEGER PRIMARY KEY, name TEXT)`)
+	require.NoError(t, err)
+
+	copied, err := drvr.CopyTable(th.Context, db,
+		tablefq.From("src"), tablefq.From("dst"), false)
+	require.NoError(t, err)
+	require.Equal(t, int64(0), copied)
+
+	var companionCount int64
+	require.NoError(t, db.QueryRowContext(th.Context,
+		`SELECT count(*) FROM sqlite_master WHERE tbl_name='dst'
+			AND type IN ('index','trigger')`).Scan(&companionCount))
+	require.Equal(t, int64(0), companionCount)
+}

--- a/drivers/sqlite3/sqlparser/companion.go
+++ b/drivers/sqlite3/sqlparser/companion.go
@@ -1,0 +1,194 @@
+package sqlparser
+
+import (
+	"strings"
+
+	antlr "github.com/antlr4-go/antlr/v4"
+
+	"github.com/neilotoole/sq/drivers/sqlite3/sqlparser/sqlite"
+	"github.com/neilotoole/sq/libsq/ast/antlrz"
+	"github.com/neilotoole/sq/libsq/core/errz"
+)
+
+// This file implements DDL rewrites for a table's companion objects:
+// the indexes and triggers that accompany a table as separate
+// sqlite_master rows. When a table is copied, its companion DDL must be
+// re-targeted at the copy: the companion's own name must change (index
+// and trigger names are schema-global in SQLite) and its table
+// references must point at the destination table.
+
+func parseCreateIndexStmt(input string) (*sqlite.Create_index_stmtContext, error) {
+	lex := sqlite.NewSQLiteLexer(antlr.NewInputStream(input))
+	lex.RemoveErrorListeners() // the generated lexer has default listeners we don't want
+	lexErrs := &antlrErrorListener{name: "lexer"}
+	lex.AddErrorListener(lexErrs)
+
+	p := sqlite.NewSQLiteParser(antlr.NewCommonTokenStream(lex, 0))
+	p.RemoveErrorListeners() // the generated parser has default listeners we don't want
+	parseErrs := &antlrErrorListener{name: "parser"}
+	p.AddErrorListener(parseErrs)
+
+	qCtx := p.Create_index_stmt()
+
+	if err := lexErrs.error(); err != nil {
+		return nil, errz.Err(err)
+	}
+
+	if err := parseErrs.error(); err != nil {
+		return nil, errz.Err(err)
+	}
+
+	return qCtx.(*sqlite.Create_index_stmtContext), nil
+}
+
+func parseCreateTriggerStmt(input string) (*sqlite.Create_trigger_stmtContext, error) {
+	lex := sqlite.NewSQLiteLexer(antlr.NewInputStream(input))
+	lex.RemoveErrorListeners() // the generated lexer has default listeners we don't want
+	lexErrs := &antlrErrorListener{name: "lexer"}
+	lex.AddErrorListener(lexErrs)
+
+	p := sqlite.NewSQLiteParser(antlr.NewCommonTokenStream(lex, 0))
+	p.RemoveErrorListeners() // the generated parser has default listeners we don't want
+	parseErrs := &antlrErrorListener{name: "parser"}
+	p.AddErrorListener(parseErrs)
+
+	qCtx := p.Create_trigger_stmt()
+
+	if err := lexErrs.error(); err != nil {
+		return nil, errz.Err(err)
+	}
+
+	if err := parseErrs.error(); err != nil {
+		return nil, errz.Err(err)
+	}
+
+	return qCtx.(*sqlite.Create_trigger_stmtContext), nil
+}
+
+// RewriteCreateIndexStmt rewrites a CREATE INDEX statement (as read from
+// sqlite_master) so that it applies to a different table. The index's own
+// identifier, including any schema qualifier, is replaced with
+// newIndexIdent, and the ON <table> target is replaced with
+// newTableIdent.
+//
+// Both replacement arguments must be pre-rendered SQL identifier text
+// (i.e. already quoted as needed). newIndexIdent may carry a schema
+// qualifier (`"sch"."idx_copy"`); newTableIdent must be a bare table
+// identifier because SQLite's CREATE INDEX ... ON clause does not accept
+// a schema qualifier (the table is resolved in the index's own schema).
+//
+// Column references in the indexed-column list and in a partial index's
+// WHERE clause are left untouched: SQLite does not permit table-qualified
+// references there, so they cannot name the source table.
+func RewriteCreateIndexStmt(stmt, newIndexIdent, newTableIdent string) (string, error) {
+	stmtCtx, err := parseCreateIndexStmt(stmt)
+	if err != nil {
+		return "", err
+	}
+
+	tokx := antlrz.NewTokenExtractor(stmt)
+
+	nameCtx, ok := stmtCtx.Index_name().(*sqlite.Index_nameContext)
+	if !ok || !anyNameIsExtractable(nameCtx.Any_name()) {
+		return "", errz.Errorf("failed to extract index name from CREATE INDEX statement")
+	}
+	nameOffset, _ := tokx.Offset(nameCtx)
+	nameEnd := nameOffset + len(tokx.Extract(nameCtx))
+	nameStart := nameOffset
+	if sn, snOK := stmtCtx.Schema_name().(*sqlite.Schema_nameContext); snOK && anyNameIsExtractable(sn.Any_name()) {
+		nameStart, _ = tokx.Offset(sn)
+	}
+
+	tblCtx, ok := stmtCtx.Table_name().(*sqlite.Table_nameContext)
+	if !ok || !anyNameIsExtractable(tblCtx.Any_name()) {
+		return "", errz.Errorf("failed to extract table name from CREATE INDEX statement")
+	}
+	tblOffset, _ := tokx.Offset(tblCtx)
+	tblRaw := tokx.Extract(tblCtx)
+
+	edits := []Edit{
+		{Start: nameStart, End: nameEnd, Replacement: newIndexIdent},
+		{Start: tblOffset, End: tblOffset + len(tblRaw), Replacement: newTableIdent},
+	}
+	return ApplyEdits(stmt, edits)
+}
+
+// RewriteCreateTriggerStmt rewrites a CREATE TRIGGER statement (as read
+// from sqlite_master) so that it applies to a different table. The
+// trigger's own identifier, including any schema qualifier, is replaced
+// with newTriggerIdent. The ON <table> target, and every table-name
+// position in the trigger body that names the same table
+// (case-insensitively), are replaced with newTableIdent; body references
+// to other tables are left untouched. This mirrors the self-FK rewrite
+// semantics of CopyTable: the copied trigger operates on the copied
+// table, while cross-table references (e.g. inserts into an audit table)
+// continue to point at their original targets.
+//
+// Both replacement arguments must be pre-rendered SQL identifier text
+// (i.e. already quoted as needed). newTriggerIdent may carry a schema
+// qualifier (`"sch"."trg_copy"`); newTableIdent must be a bare table
+// identifier because SQLite's CREATE TRIGGER ... ON clause does not
+// accept a schema qualifier (the table is resolved in the trigger's own
+// schema).
+func RewriteCreateTriggerStmt(stmt, newTriggerIdent, newTableIdent string) (string, error) {
+	stmtCtx, err := parseCreateTriggerStmt(stmt)
+	if err != nil {
+		return "", err
+	}
+
+	tokx := antlrz.NewTokenExtractor(stmt)
+
+	nameCtx, ok := stmtCtx.Trigger_name().(*sqlite.Trigger_nameContext)
+	if !ok || !anyNameIsExtractable(nameCtx.Any_name()) {
+		return "", errz.Errorf("failed to extract trigger name from CREATE TRIGGER statement")
+	}
+	nameOffset, _ := tokx.Offset(nameCtx)
+	nameEnd := nameOffset + len(tokx.Extract(nameCtx))
+	nameStart := nameOffset
+	if sn, snOK := stmtCtx.Schema_name().(*sqlite.Schema_nameContext); snOK && anyNameIsExtractable(sn.Any_name()) {
+		nameStart, _ = tokx.Offset(sn)
+	}
+
+	// The grammar's create_trigger_stmt rule has exactly one direct
+	// table_name child: the ON <table> target. Body table references are
+	// nested inside the body's update/insert/delete/select statements.
+	onTblCtx, ok := stmtCtx.Table_name().(*sqlite.Table_nameContext)
+	if !ok || !anyNameIsExtractable(onTblCtx.Any_name()) {
+		return "", errz.Errorf("failed to extract table name from CREATE TRIGGER statement")
+	}
+	srcTable := trimIdentQuotes(tokx.Extract(onTblCtx))
+
+	edits := []Edit{{Start: nameStart, End: nameEnd, Replacement: newTriggerIdent}}
+
+	// Walk the whole statement (the ON target included) and rewrite every
+	// table-name position matching the trigger's own table.
+	collectMatchingTableNameEdits(stmtCtx, tokx, srcTable, newTableIdent, &edits)
+
+	return ApplyEdits(stmt, edits)
+}
+
+// collectMatchingTableNameEdits descends node depth-first, appending one
+// Edit per Table_nameContext whose unquoted text equals match
+// (case-insensitively, consistent with SQLite's identifier resolution).
+// The walk does not descend into a matched Table_nameContext: its only
+// child is the name's any_name, and re-entering would risk a
+// double-record.
+func collectMatchingTableNameEdits(node antlr.Tree, tokx *antlrz.TokenExtractor,
+	match, replacement string, edits *[]Edit,
+) {
+	if tn, ok := node.(*sqlite.Table_nameContext); ok {
+		raw := tokx.Extract(tn)
+		if strings.EqualFold(trimIdentQuotes(raw), match) {
+			offset, _ := tokx.Offset(tn)
+			*edits = append(*edits, Edit{
+				Start:       offset,
+				End:         offset + len(raw),
+				Replacement: replacement,
+			})
+		}
+		return
+	}
+	for _, child := range node.GetChildren() {
+		collectMatchingTableNameEdits(child, tokx, match, replacement, edits)
+	}
+}

--- a/drivers/sqlite3/sqlparser/companion_test.go
+++ b/drivers/sqlite3/sqlparser/companion_test.go
@@ -1,0 +1,200 @@
+package sqlparser_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/neilotoole/sq/drivers/sqlite3/sqlparser"
+)
+
+func TestRewriteCreateIndexStmt(t *testing.T) {
+	testCases := []struct {
+		name    string
+		in      string
+		newIdx  string
+		newTbl  string
+		want    string
+		wantErr bool
+	}{
+		{
+			name:   "basic",
+			in:     `CREATE INDEX idx_actor_name ON actor (first_name)`,
+			newIdx: `"idx_actor_name_actor2"`,
+			newTbl: `"actor2"`,
+			want:   `CREATE INDEX "idx_actor_name_actor2" ON "actor2" (first_name)`,
+		},
+		{
+			name:   "unique_quoted",
+			in:     `CREATE UNIQUE INDEX "idx_actor_name" ON "actor" ("first_name", "last_name")`,
+			newIdx: `"idx2"`,
+			newTbl: `"actor2"`,
+			want:   `CREATE UNIQUE INDEX "idx2" ON "actor2" ("first_name", "last_name")`,
+		},
+		{
+			name:   "schema_qualified_index_name",
+			in:     `CREATE INDEX main.idx_actor_name ON actor (first_name)`,
+			newIdx: `"idx2"`,
+			newTbl: `"actor2"`,
+			want:   `CREATE INDEX "idx2" ON "actor2" (first_name)`,
+		},
+		{
+			name:   "dest_schema_qualifier",
+			in:     `CREATE INDEX idx_actor_name ON actor (first_name)`,
+			newIdx: `"aux"."idx2"`,
+			newTbl: `"actor2"`,
+			want:   `CREATE INDEX "aux"."idx2" ON "actor2" (first_name)`,
+		},
+		{
+			name:   "partial_index_where_untouched",
+			in:     `CREATE INDEX idx_p ON actor (first_name) WHERE first_name IS NOT NULL`,
+			newIdx: `"idx_p2"`,
+			newTbl: `"actor2"`,
+			want:   `CREATE INDEX "idx_p2" ON "actor2" (first_name) WHERE first_name IS NOT NULL`,
+		},
+		{
+			name:   "expression_index",
+			in:     "CREATE INDEX idx_e ON actor (lower(first_name))",
+			newIdx: `"idx_e2"`,
+			newTbl: `"actor2"`,
+			want:   `CREATE INDEX "idx_e2" ON "actor2" (lower(first_name))`,
+		},
+		{
+			name:   "if_not_exists",
+			in:     "CREATE INDEX IF NOT EXISTS idx_n ON actor (first_name)",
+			newIdx: `"idx_n2"`,
+			newTbl: `"actor2"`,
+			want:   `CREATE INDEX IF NOT EXISTS "idx_n2" ON "actor2" (first_name)`,
+		},
+		{
+			name:   "bracket_quoted",
+			in:     "CREATE INDEX [idx one] ON [my table] ([first name])",
+			newIdx: `"idx two"`,
+			newTbl: `"other table"`,
+			want:   `CREATE INDEX "idx two" ON "other table" ([first name])`,
+		},
+		{
+			name:    "not_an_index_stmt",
+			in:      `CREATE TABLE actor (id INTEGER)`,
+			newIdx:  `"x"`,
+			newTbl:  `"y"`,
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := sqlparser.RewriteCreateIndexStmt(tc.in, tc.newIdx, tc.newTbl)
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestRewriteCreateTriggerStmt(t *testing.T) {
+	testCases := []struct {
+		name    string
+		in      string
+		newTrg  string
+		newTbl  string
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "before_insert_cross_table_body",
+			in: `CREATE TRIGGER trg_bi BEFORE INSERT ON actor BEGIN ` +
+				`INSERT INTO actor_log (msg) VALUES (NEW.first_name); END`,
+			newTrg: `"trg_bi_actor2"`,
+			newTbl: `"actor2"`,
+			// The body's actor_log reference is a different table: untouched.
+			want: `CREATE TRIGGER "trg_bi_actor2" BEFORE INSERT ON "actor2" BEGIN ` +
+				`INSERT INTO actor_log (msg) VALUES (NEW.first_name); END`,
+		},
+		{
+			name: "body_self_reference_rewritten",
+			in: `CREATE TRIGGER trg_ai AFTER INSERT ON actor BEGIN ` +
+				`UPDATE actor SET first_name = upper(NEW.first_name) WHERE id = NEW.id; END`,
+			newTrg: `"trg_ai_actor2"`,
+			newTbl: `"actor2"`,
+			want: `CREATE TRIGGER "trg_ai_actor2" AFTER INSERT ON "actor2" BEGIN ` +
+				`UPDATE "actor2" SET first_name = upper(NEW.first_name) WHERE id = NEW.id; END`,
+		},
+		{
+			name: "body_self_reference_case_insensitive",
+			in: `CREATE TRIGGER trg AFTER DELETE ON "Actor" BEGIN ` +
+				`DELETE FROM ACTOR WHERE id = OLD.id; END`,
+			newTrg: `"trg2"`,
+			newTbl: `"actor2"`,
+			want: `CREATE TRIGGER "trg2" AFTER DELETE ON "actor2" BEGIN ` +
+				`DELETE FROM "actor2" WHERE id = OLD.id; END`,
+		},
+		{
+			name: "qualified_column_ref_in_body_rewritten",
+			in: `CREATE TRIGGER trg AFTER INSERT ON actor BEGIN ` +
+				`INSERT INTO log (n) SELECT count(*) FROM actor WHERE actor.id > 0; END`,
+			newTrg: `"trg2"`,
+			newTbl: `"actor2"`,
+			want: `CREATE TRIGGER "trg2" AFTER INSERT ON "actor2" BEGIN ` +
+				`INSERT INTO log (n) SELECT count(*) FROM "actor2" WHERE "actor2".id > 0; END`,
+		},
+		{
+			name: "update_of_columns",
+			in: `CREATE TRIGGER trg AFTER UPDATE OF first_name, last_name ON actor BEGIN ` +
+				`INSERT INTO log (msg) VALUES ('x'); END`,
+			newTrg: `"trg2"`,
+			newTbl: `"actor2"`,
+			want: `CREATE TRIGGER "trg2" AFTER UPDATE OF first_name, last_name ON "actor2" BEGIN ` +
+				`INSERT INTO log (msg) VALUES ('x'); END`,
+		},
+		{
+			name: "when_clause_and_for_each_row",
+			in: `CREATE TRIGGER trg BEFORE INSERT ON actor FOR EACH ROW WHEN NEW.id > 0 BEGIN ` +
+				`SELECT RAISE(ABORT, 'no'); END`,
+			newTrg: `"trg2"`,
+			newTbl: `"actor2"`,
+			want: `CREATE TRIGGER "trg2" BEFORE INSERT ON "actor2" FOR EACH ROW WHEN NEW.id > 0 BEGIN ` +
+				`SELECT RAISE(ABORT, 'no'); END`,
+		},
+		{
+			name: "schema_qualified_trigger_name",
+			in: `CREATE TRIGGER main.trg BEFORE INSERT ON actor BEGIN ` +
+				`INSERT INTO log (msg) VALUES ('x'); END`,
+			newTrg: `"trg2"`,
+			newTbl: `"actor2"`,
+			want: `CREATE TRIGGER "trg2" BEFORE INSERT ON "actor2" BEGIN ` +
+				`INSERT INTO log (msg) VALUES ('x'); END`,
+		},
+		{
+			name: "trigger_name_same_as_table_untouched",
+			in: `CREATE TRIGGER actor BEFORE INSERT ON actor BEGIN ` +
+				`INSERT INTO log (msg) VALUES ('x'); END`,
+			newTrg: `"actor_trg2"`,
+			newTbl: `"actor2"`,
+			want: `CREATE TRIGGER "actor_trg2" BEFORE INSERT ON "actor2" BEGIN ` +
+				`INSERT INTO log (msg) VALUES ('x'); END`,
+		},
+		{
+			name:    "not_a_trigger_stmt",
+			in:      `CREATE INDEX idx ON actor (first_name)`,
+			newTrg:  `"x"`,
+			newTbl:  `"y"`,
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := sqlparser.RewriteCreateTriggerStmt(tc.in, tc.newTrg, tc.newTbl)
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}


### PR DESCRIPTION
Fixes #758.

## The problem

`sq tbl copy` (and the CopyTable driver method behind it) rebuilds the destination from the
source table's CREATE TABLE row in `sqlite_master`. That faithful-DDL rewrite (landed in
#748 for both sqlite3 and rqlite) deliberately handled only `type='table'` rows, and the
godoc on both drivers documented the gap: indexes and triggers live as separate
`sqlite_master` rows referencing the table by name, so they were silently absent from the
copy. For real-world tables that means the destination loses its covering indexes (queries
work but crawl) and its business-rule triggers (writes succeed that the source would have
rejected or augmented) with no warning at all: the copy looks complete because the rows and
schema are there.

## What this PR does

After the destination table is created and the data copied, companion rows are fetched:

```sql
SELECT sql, type, name FROM sqlite_master
WHERE tbl_name = ? AND type IN ('index','trigger') AND sql IS NOT NULL
```

(`sql IS NULL` rows are the automatic indexes backing UNIQUE/PK constraints; the rewritten
CREATE TABLE recreates those itself, so they are excluded rather than redundantly copied.)
Each companion's DDL is rewritten for the destination and executed: sqlite3 inside the
existing transaction, rqlite appended to the existing `writeAtomic` batch, so in both
drivers the table, its data, and its companions land (or fail) together. Companions execute
AFTER the data copy deliberately: a copied BEFORE INSERT trigger must not fire on the rows
being copied.

## How the DDL rewrite works, and why it's parser-backed

Naive string replacement on trigger DDL is exactly the class of bug the gh750-gh759 parser
work eliminated, so the rewrites reuse that machinery (offset-tracked edits via
`ApplyEdits`), in a new `sqlparser/companion.go`:

- **CREATE INDEX**: the parse identifies the index-identifier span (including any schema
  qualifier) and the `ON <table>` token; both are replaced. Indexed-column lists and
  partial-index WHERE clauses are untouched, which is provably safe: SQLite forbids
  table-qualified column references there, so the source table's name cannot appear.
- **CREATE TRIGGER**: the parse replaces the trigger identifier, then walks the full tree
  rewriting every `table_name` position whose unquoted text case-insensitively equals the
  trigger's ON-table. That covers not just the ON clause but trigger-body self-references:
  `UPDATE src SET ...`, `src.col` qualifiers, schema-qualified `main.src`. Cross-table body
  references (e.g. an audit-log INSERT into a different table) are left intact, which is
  the correct semantics: the copied trigger should still log to the same audit table.

A limitation paragraph was budgeted for trigger bodies and turned out to be unnecessary:
the grammar funnels every body table reference (insert/update/delete/select, qualified
refs in expressions) through `Table_nameContext`, so the walk is complete. `NEW`/`OLD`
parse as table names but can never equal the source table's name, so they pass through
untouched.

## Decisions on the issue's open questions

- **Default-on, no flag.** The issue weighed default-on vs opt-in. Default-on matches what
  `sq tbl copy` users plainly expect (a copy that behaves like the original); a
  structural-only opt-out can be added later if a use case (e.g. trigger-free backup
  destinations) materializes. Shipping the flag speculatively would be API surface without
  a customer.
- **Companion naming**: `<orig-name>_<dest-table>` (e.g. `idx_actor_name` copied to
  `actor2` becomes `idx_actor_name_actor2`), deterministic and schema-qualified for the
  destination's schema. Index and trigger names share one namespace per schema with tables,
  so collisions are possible if an object with the derived name already exists; in that
  case SQLite's own error fails the copy. On rqlite the whole batch rolls back; on sqlite3
  outside a caller transaction the table and data may remain, the same partial-failure
  exposure the pre-existing CREATE+INSERT sequence already had.
- **Out of scope** (per the issue): FTS5/r-tree shadow objects and WITHOUT ROWID specials.
  Views are irrelevant to the `tbl copy` context.

## Testing

- 17 parser-level rewrite cases (schema qualifiers, quoting styles, partial indexes,
  trigger-body self-references and cross-references).
- Per-driver end-to-end tests following the issue's spec: source table with a named index,
  a UNIQUE constraint (whose NULL-sql auto-index must be skipped), and a BEFORE INSERT
  trigger; copy with data; assert the index exists under the rewritten name, the trigger
  exists, and the trigger's side effect fires on an insert into the destination.
- A trigger-body self-reference end-to-end case, and a no-companion regression case
  (single-statement fast path for copyData=false is preserved).
- sqlite3 verified locally (no Docker); rqlite verified against the live container.
  `TestWriteAtomic_PerStatementError` was updated because companions legitimately grow the
  batch its statement-index assertion hardcoded.

CHANGELOG: this is the batch's one user-visible behavior change vs v0.53.0 (`sq tbl copy`
now carries indexes and triggers), so it has an Unreleased entry.