### PR TITLE
cli: centralize --expand and the --readonly conflict check

### DIFF
--- a/cli/cmd_add.go
+++ b/cli/cmd_add.go
@@ -402,10 +402,6 @@ func execSrcAdd(cmd *cobra.Command, args []string) (err error) {
 		return err
 	}
 
-	if src, err = maybeExpandSource(ctx, ru, cmd, src); err != nil {
-		return err
-	}
-
 	return ru.Writers.Source.Added(ru.Config.Collection, src)
 }
 

--- a/cli/cmd_config_export.go
+++ b/cli/cmd_config_export.go
@@ -128,6 +128,13 @@ func execConfigExport(cmd *cobra.Command, _ []string) error {
 // Collection sources are mutated). The input cfg is not mutated.
 // Resolution errors are wrapped with the source handle so the user knows
 // which source's placeholder failed.
+//
+// This is the second --expand implementation, deliberately separate from
+// the writer-layer expansion in expand.go/expand_writer.go: config export
+// serializes a config template (so it re-escapes the resolved literal for
+// byte-identical round-trip) and is strict on resolver error, whereas the
+// display path is lenient (keeps the placeholder verbatim). Keep the two
+// in sync where they should agree (the underlying SecretRegistry.Expand).
 func exportExpandConfig(ctx context.Context, ru *run.Run, cfg *config.Config) (*config.Config, error) {
 	clone := &config.Config{
 		Version:    cfg.Version,

--- a/cli/cmd_inspect.go
+++ b/cli/cmd_inspect.go
@@ -279,7 +279,11 @@ func execInspect(cmd *cobra.Command, args []string) error {
 	// expand decorator (see expand_writer.go) then applies --expand
 	// expansion centrally, so the displayed value is the stored
 	// template by default, or the expanded value when --expand is set.
+	// SecretsResolved is carried so the decorator skips re-expanding an
+	// already-resolved location (e.g. a stdin source), matching the
+	// guard on the source/group/collection expand paths.
 	srcMeta.Location = src.Location
+	srcMeta.SecretsResolved = src.SecretsResolved
 
 	// This is a bit hacky, but it works... if not "--verbose", then just zap
 	// the DBVars, as we usually don't want to see those

--- a/cli/cmd_inspect.go
+++ b/cli/cmd_inspect.go
@@ -188,18 +188,6 @@ func execInspect(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	// Expand ${scheme:path} placeholders for display when --expand is
-	// set. The expanded clone is used only for the srcMeta.Location
-	// display override below. The connection must use the original
-	// src: Grips.doOpen resolves it internally, and resolving an
-	// already-expanded clone a second time would unescape '$$' again,
-	// corrupting literal locations (e.g. those escaped by the v0.54.0
-	// config upgrade, or a resolved secret value containing '$$').
-	displaySrc, err := maybeExpandSource(ctx, ru, cmd, src)
-	if err != nil {
-		return err
-	}
-
 	grip, err := ru.Grips.Open(ctx, src, driver.ModeReadOnly)
 	if err != nil {
 		return errz.Wrapf(err, "failed to inspect %s", src.Handle)
@@ -283,15 +271,15 @@ func execInspect(cmd *cobra.Command, args []string) error {
 		return errz.Wrapf(err, "failed to read %s source metadata", src.Handle)
 	}
 
-	// Use the inspect handler's view of src.Location for display.
-	// Drivers populate srcMeta.Location from the grip's stored src,
-	// which doOpen always replaces with the resolver-expanded clone;
-	// without this override, sq inspect would always show the
-	// resolved value, leaking placeholder targets and ignoring the
-	// --expand flag. With this override, srcMeta.Location reflects
-	// the stored template (default) or the explicitly-expanded value
-	// (when --expand is set).
-	srcMeta.Location = displaySrc.Location
+	// Reset srcMeta.Location to the stored (template) location for
+	// display. Drivers populate srcMeta.Location from the grip's stored
+	// src, which doOpen always replaces with the resolver-expanded
+	// clone; without this override, sq inspect would always show the
+	// resolved value, leaking placeholder targets. The writer layer's
+	// expand decorator (see expand_writer.go) then applies --expand
+	// expansion centrally, so the displayed value is the stored
+	// template by default, or the expanded value when --expand is set.
+	srcMeta.Location = src.Location
 
 	// This is a bit hacky, but it works... if not "--verbose", then just zap
 	// the DBVars, as we usually don't want to see those

--- a/cli/cmd_inspect_test.go
+++ b/cli/cmd_inspect_test.go
@@ -1158,10 +1158,10 @@ func TestInspect_LocationOverride_NoLeak(t *testing.T) {
 		"default inspect must NOT leak the resolved path "+
 			"(regression guard for the srcMeta.Location override in execInspect)")
 
-	// With --expand: maybeExpandSource resolves the placeholder before
-	// execInspect runs, so src.Location is already the resolved sqlite3
-	// URL when srcMeta.Location = src.Location is executed. The output
-	// must therefore show the resolved path.
+	// With --expand: the writer layer's expand decorator (see
+	// expand_writer.go) resolves the placeholder in srcMeta.Location
+	// before the metadata writer renders it. The output must therefore
+	// show the resolved path.
 	tr = testrun.New(t.Context(), t, nil)
 	require.NoError(t, tr.Run.Config.Collection.Add(&source.Source{
 		Handle:   "@leak",

--- a/cli/cmd_ls.go
+++ b/cli/cmd_ls.go
@@ -90,10 +90,5 @@ func execList(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	coll, err := maybeExpandCollection(cmd.Context(), ru, cmd, coll)
-	if err != nil {
-		return err
-	}
-
 	return ru.Writers.Source.Collection(coll)
 }

--- a/cli/cmd_ls_test.go
+++ b/cli/cmd_ls_test.go
@@ -332,10 +332,10 @@ func TestExpandLenient_PartialFailure(t *testing.T) {
 }
 
 // TestExpand_PerCommandWiring is a smoke test for the --expand flag across
-// the display commands that are supposed to call maybeExpandSource or
-// maybeExpandCollection. If a future refactor drops that call from one
-// handler, this test catches it even though the expand unit tests would
-// still pass.
+// the display commands. Expansion is applied centrally by the writer-layer
+// expand decorators (see expand_writer.go); this test catches a future
+// refactor that breaks the wiring for one of these commands, even though
+// the expand unit tests would still pass.
 //
 // Shape A (whole-DSN keyring placeholder) is used because it produces the
 // most visible difference: without --expand the verbatim placeholder string
@@ -472,6 +472,59 @@ func TestRedactFlags_Union(t *testing.T) {
 			} else {
 				require.NotContains(t, tr.OutString(), password,
 					"%s must redact by default", tc.name)
+			}
+		})
+	}
+}
+
+// TestExpandCentral_GroupCmd verifies that --expand is honored through
+// the central writer-layer decorator (see expand_writer.go) by a
+// command that has no expansion code of its own: sq group (gh780).
+// Before centralization, only commands that explicitly called
+// maybeExpandSource / maybeExpandCollection honored --expand; sq group
+// accepted the flag and silently ignored it.
+func TestExpandCentral_GroupCmd(t *testing.T) {
+	// Not parallel: uses t.Setenv.
+	const (
+		envVar  = "SQ_TEST_GROUP_EXPAND_PW"
+		envPass = "grouphunter"
+	)
+	t.Setenv(envVar, envPass)
+	loc := "postgres://alice:${env:" + envVar + "}@db/sakila"
+
+	testCases := []struct {
+		name    string
+		args    []string
+		want    string
+		wantNot string
+	}{
+		{
+			name: "expand_reveal_shows_resolved",
+			args: []string{"group", "--json", "--expand", "--reveal"},
+			want: envPass,
+		},
+		{
+			name:    "reveal_only_shows_placeholder",
+			args:    []string{"group", "--json", "--reveal"},
+			want:    "${env:" + envVar + "}",
+			wantNot: envPass,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			tr := testrun.New(t.Context(), t, nil)
+			require.NoError(t, tr.Run.Config.Collection.Add(&source.Source{
+				Handle:   "@group_expand",
+				Type:     drivertype.Pg,
+				Location: loc,
+			}))
+
+			require.NoError(t, tr.Exec(tc.args...))
+			got := tr.OutString()
+			require.Contains(t, got, tc.want)
+			if tc.wantNot != "" {
+				require.NotContains(t, got, tc.wantNot)
 			}
 		})
 	}

--- a/cli/cmd_ls_test.go
+++ b/cli/cmd_ls_test.go
@@ -420,6 +420,39 @@ func TestExpand_PerCommandWiring(t *testing.T) {
 		require.NotContains(t, out, "hunter2",
 			"sq ping --json --expand must not leak the plaintext secret")
 	})
+
+	t.Run("sq_rm_json", func(t *testing.T) {
+		// rm reloads config from the store, so the source must be
+		// persisted (TestRun.Add saves), not just added in-memory.
+		tr := testrun.New(t.Context(), t, nil).Add(*makeSrc())
+
+		// rm's --json output for removed sources is verbose-gated.
+		require.NoError(t, tr.Exec("rm", "@h", "--json", "-v", "--expand"),
+			"sq rm --json -v --expand must succeed")
+		out := tr.OutString()
+		require.Contains(t, out, "postgres://alice:"+redactedPass+"@db.example.com/sakila",
+			"sq rm --json --expand must show the resolved, redacted DSN")
+		require.NotContains(t, out, placeholder,
+			"sq rm --json --expand must not show the verbatim placeholder")
+		require.NotContains(t, out, "hunter2",
+			"sq rm --json --expand must not leak the plaintext secret")
+	})
+
+	t.Run("sq_mv_json", func(t *testing.T) {
+		// mv reloads config from the store, so the source must be
+		// persisted (TestRun.Add saves), not just added in-memory.
+		tr := testrun.New(t.Context(), t, nil).Add(*makeSrc())
+
+		require.NoError(t, tr.Exec("mv", "@h", "@h2", "--json", "--expand"),
+			"sq mv --json --expand must succeed")
+		out := tr.OutString()
+		require.Contains(t, out, "postgres://alice:"+redactedPass+"@db.example.com/sakila",
+			"sq mv --json --expand must show the resolved, redacted DSN for the moved source")
+		require.NotContains(t, out, placeholder,
+			"sq mv --json --expand must not show the verbatim placeholder")
+		require.NotContains(t, out, "hunter2",
+			"sq mv --json --expand must not leak the plaintext secret")
+	})
 }
 
 // TestExpand_NoOp_OnNonDisplayCommand verifies that --expand is

--- a/cli/cmd_mv.go
+++ b/cli/cmd_mv.go
@@ -156,10 +156,6 @@ func execMoveHandleToGroup(cmd *cobra.Command, oldHandle, newGroup string) error
 		return err
 	}
 
-	if newSrc, err = maybeExpandSource(cmd.Context(), ru, cmd, newSrc); err != nil {
-		return err
-	}
-
 	return ru.Writers.Source.Moved(ru.Config.Collection, oldSrc, newSrc)
 }
 
@@ -187,10 +183,6 @@ func execMoveRenameHandle(cmd *cobra.Command, oldHandle, newHandle string) error
 	}
 
 	if err = ru.ConfigStore.Save(cmd.Context(), ru.Config); err != nil {
-		return err
-	}
-
-	if newSrc, err = maybeExpandSource(cmd.Context(), ru, cmd, newSrc); err != nil {
 		return err
 	}
 

--- a/cli/cmd_ping.go
+++ b/cli/cmd_ping.go
@@ -237,7 +237,10 @@ func pingSource(ctx context.Context, dp driver.Provider, src *source.Source, tim
 		defer cancelFn()
 	}
 
-	doneCh := make(chan pingResult)
+	// Buffered (size 1) so the goroutine's send always completes even when
+	// the select below returns on ctx.Done() first; an unbuffered channel
+	// would leak the goroutine (blocked on send) on the timeout/cancel path.
+	doneCh := make(chan pingResult, 1)
 	start := time.Now()
 
 	go func() {

--- a/cli/cmd_ping.go
+++ b/cli/cmd_ping.go
@@ -122,24 +122,15 @@ func execPing(cmd *cobra.Command, args []string) error {
 
 	lg.From(cmd).Debug("Using ping timeout", lga.Val, fmt.Sprintf("%v", timeout))
 
-	// Expand ${scheme:path} placeholders for display when --expand is
-	// set. displaySrcs feeds the writer, so the displayed Location
-	// reflects what was resolved; srcs feeds the drivers untouched.
-	// The connection must use the original stored source: pingSource
+	// Note: the writer layer's expand decorator (see expand_writer.go)
+	// applies --expand expansion to the displayed locations; the
+	// original stored sources feed the drivers untouched. The
+	// connection must use the original stored source: pingSource
 	// resolves it via ResolveSourceSecrets, and resolving an
 	// already-expanded clone a second time would unescape '$$' again,
 	// corrupting literal locations (e.g. those escaped by the v0.54.0
 	// config upgrade, or a resolved secret value containing '$$').
-	displaySrcs := make([]*source.Source, len(srcs))
-	for i, src := range srcs {
-		expanded, expandErr := maybeExpandSource(cmd.Context(), ru, cmd, src)
-		if expandErr != nil {
-			return expandErr
-		}
-		displaySrcs[i] = expanded
-	}
-
-	err = pingSources(cmd.Context(), ru.DriverRegistry, srcs, displaySrcs, ru.Writers.Ping, timeout)
+	err = pingSources(cmd.Context(), ru.DriverRegistry, srcs, ru.Writers.Ping, timeout)
 	if errors.Is(err, context.Canceled) {
 		// It's common to cancel "sq ping". We don't want to print the cancel message.
 		return errz.ErrNoMsg
@@ -155,10 +146,10 @@ func execPing(cmd *cobra.Command, args []string) error {
 // NOTE: This ping code has an ancient lineage, in that it was
 // originally laid down before context.Context was a thing. Thus,
 // the entire thing could probably be rewritten for simplicity.
-func pingSources(ctx context.Context, dp driver.Provider, srcs, displaySrcs []*source.Source,
+func pingSources(ctx context.Context, dp driver.Provider, srcs []*source.Source,
 	w output.PingWriter, timeout time.Duration,
 ) error {
-	if err := w.Open(displaySrcs); err != nil {
+	if err := w.Open(srcs); err != nil {
 		return err
 	}
 
@@ -172,8 +163,8 @@ func pingSources(ctx context.Context, dp driver.Provider, srcs, displaySrcs []*s
 	// is returned from this func.
 	var pingErrExists bool
 
-	for i, src := range srcs {
-		go pingSource(ctx, dp, src, displaySrcs[i], timeout, resultCh)
+	for _, src := range srcs {
+		go pingSource(ctx, dp, src, timeout, resultCh)
 	}
 
 	// This func doesn't check for context.Canceled itself; instead
@@ -215,15 +206,15 @@ func pingSources(ctx context.Context, dp driver.Provider, srcs, displaySrcs []*s
 // pingSource pings an individual driver.Source. It always returns a
 // result on resultCh, even when ctx is done. src is the original
 // stored source, which is what the driver connects with (after
-// resolution below); displaySrc is the caller's display view of the
-// same source (identical by default, an expanded clone under
-// --expand), and is what pingResult carries to the output writers.
-func pingSource(ctx context.Context, dp driver.Provider, src, displaySrc *source.Source, timeout time.Duration,
+// resolution below), and what pingResult carries to the output
+// writers; the writer layer's expand decorator handles the --expand
+// display view.
+func pingSource(ctx context.Context, dp driver.Provider, src *source.Source, timeout time.Duration,
 	resultCh chan<- pingResult,
 ) {
 	drvr, err := dp.DriverFor(src.Type)
 	if err != nil {
-		resultCh <- pingResult{src: displaySrc, err: err}
+		resultCh <- pingResult{src: src, err: err}
 		return
 	}
 
@@ -231,12 +222,12 @@ func pingSource(ctx context.Context, dp driver.Provider, src, displaySrc *source
 	// handing the source to the driver. Grips.doOpen does this for the
 	// query path; ping calls drvr.Ping directly, so we must do it here.
 	// Keep the resolved clone in a separate variable: pingResult carries
-	// displaySrc to output writers, which serialize src.Location
+	// the stored src to output writers, which serialize src.Location
 	// verbatim. We must not leak the resolved plaintext unless the
 	// user opted in via --expand.
 	resolved, err := driver.ResolveSourceSecrets(ctx, src)
 	if err != nil {
-		resultCh <- pingResult{src: displaySrc, err: err}
+		resultCh <- pingResult{src: src, err: err}
 		return
 	}
 
@@ -254,12 +245,12 @@ func pingSource(ctx context.Context, dp driver.Provider, src, displaySrc *source
 		// It calls drvr.Ping directly (bypassing Grips), passing the mode
 		// as an explicit argument.
 		pingErr := drvr.Ping(ctx, resolved, driver.ModeReadOnly)
-		doneCh <- pingResult{src: displaySrc, duration: time.Since(start), err: pingErr}
+		doneCh <- pingResult{src: src, duration: time.Since(start), err: pingErr}
 	}()
 
 	select {
 	case <-ctx.Done():
-		resultCh <- pingResult{src: displaySrc, err: ctx.Err()}
+		resultCh <- pingResult{src: src, err: ctx.Err()}
 	case result := <-doneCh:
 		resultCh <- result
 	}

--- a/cli/cmd_ping_internal_test.go
+++ b/cli/cmd_ping_internal_test.go
@@ -1,0 +1,81 @@
+package cli
+
+import (
+	"context"
+	"runtime"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/neilotoole/sq/libsq/driver"
+	"github.com/neilotoole/sq/libsq/source"
+	"github.com/neilotoole/sq/libsq/source/drivertype"
+)
+
+// fakePingProvider returns drvr for any source type.
+type fakePingProvider struct{ drvr driver.Driver }
+
+func (p fakePingProvider) DriverFor(drivertype.Type) (driver.Driver, error) {
+	return p.drvr, nil
+}
+
+// fakePingDriver implements driver.Driver but overrides only Ping;
+// pingSource calls nothing else on the driver. Other methods panic via
+// the embedded nil interface if ever reached.
+type fakePingDriver struct {
+	driver.Driver
+	pingFn func(ctx context.Context, src *source.Source, mode driver.AccessMode) error
+}
+
+func (d *fakePingDriver) Ping(ctx context.Context, src *source.Source, mode driver.AccessMode) error {
+	return d.pingFn(ctx, src, mode)
+}
+
+// TestPingSource_TimeoutDoesNotLeakGoroutine pins the buffered-doneCh
+// fix: when a ping times out, pingSource returns via ctx.Done() with no
+// receiver left for doneCh, so the ping goroutine must still be able to
+// complete its send (doneCh is buffered, size 1) and exit. An unbuffered
+// doneCh would block that send forever, leaking the goroutine.
+func TestPingSource_TimeoutDoesNotLeakGoroutine(t *testing.T) {
+	// Not parallel: this test counts goroutines, so it must not race
+	// other tests' goroutine churn.
+	release := make(chan struct{})
+	var once sync.Once
+	releaseFn := func() { once.Do(func() { close(release) }) }
+	t.Cleanup(releaseFn) // Unblock Ping even if an assertion fails early.
+
+	drvr := &fakePingDriver{
+		pingFn: func(_ context.Context, _ *source.Source, _ driver.AccessMode) error {
+			<-release // Block well past the ping timeout.
+			return nil
+		},
+	}
+	dp := fakePingProvider{drvr: drvr}
+	src := &source.Source{
+		Handle:   "@p",
+		Type:     drivertype.SQLite,
+		Location: "sqlite3:///tmp/sq_ping_leak_test.db", // No placeholders: ResolveSourceSecrets is a no-op.
+	}
+	resultCh := make(chan pingResult, 1)
+
+	n0 := runtime.NumGoroutine()
+	pingSource(context.Background(), dp, src, 20*time.Millisecond, resultCh)
+
+	res := <-resultCh
+	require.ErrorIs(t, res.err, context.DeadlineExceeded,
+		"timeout path must return a deadline error")
+
+	// The ping goroutine is still blocked in Ping. Release it; with a
+	// buffered doneCh its send completes and it exits. Poll with a bare
+	// sleep loop rather than require.Eventually, which spawns its own
+	// goroutines and would inflate the count we're measuring.
+	releaseFn()
+	deadline := time.Now().Add(3 * time.Second)
+	for runtime.NumGoroutine() > n0 && time.Now().Before(deadline) {
+		time.Sleep(10 * time.Millisecond)
+	}
+	require.LessOrEqual(t, runtime.NumGoroutine(), n0,
+		"ping goroutine must exit after Ping returns; if it doesn't, doneCh blocked the send (leak)")
+}

--- a/cli/cmd_ping_internal_test.go
+++ b/cli/cmd_ping_internal_test.go
@@ -22,9 +22,17 @@ import (
 // tests' background goroutines would make flaky. The "pingSource.func"
 // marker matches only the spawned closure, not this helper's own frame.
 func pingGoroutineLives() bool {
-	buf := make([]byte, 1<<20)
-	n := runtime.Stack(buf, true)
-	return bytes.Contains(buf[:n], []byte("pingSource.func"))
+	// Grow the buffer until the full dump fits: runtime.Stack truncates
+	// silently at len(buf), and a truncated tail could drop the frame we
+	// look for (a false negative that would mask a real leak).
+	buf := make([]byte, 1<<16)
+	for {
+		n := runtime.Stack(buf, true)
+		if n < len(buf) {
+			return bytes.Contains(buf[:n], []byte("pingSource.func"))
+		}
+		buf = make([]byte, 2*len(buf))
+	}
 }
 
 // fakePingProvider returns drvr for any source type.

--- a/cli/cmd_ping_internal_test.go
+++ b/cli/cmd_ping_internal_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"bytes"
 	"context"
 	"runtime"
 	"sync"
@@ -13,6 +14,18 @@ import (
 	"github.com/neilotoole/sq/libsq/source"
 	"github.com/neilotoole/sq/libsq/source/drivertype"
 )
+
+// pingGoroutineLives reports whether pingSource's spawned send goroutine
+// is currently alive, by scanning a full stack dump for its closure frame
+// ("pingSource.func"). This targets that specific goroutine rather than
+// comparing runtime.NumGoroutine to a baseline, which other parallel
+// tests' background goroutines would make flaky. The "pingSource.func"
+// marker matches only the spawned closure, not this helper's own frame.
+func pingGoroutineLives() bool {
+	buf := make([]byte, 1<<20)
+	n := runtime.Stack(buf, true)
+	return bytes.Contains(buf[:n], []byte("pingSource.func"))
+}
 
 // fakePingProvider returns drvr for any source type.
 type fakePingProvider struct{ drvr driver.Driver }
@@ -39,8 +52,6 @@ func (d *fakePingDriver) Ping(ctx context.Context, src *source.Source, mode driv
 // complete its send (doneCh is buffered, size 1) and exit. An unbuffered
 // doneCh would block that send forever, leaking the goroutine.
 func TestPingSource_TimeoutDoesNotLeakGoroutine(t *testing.T) {
-	// Not parallel: this test counts goroutines, so it must not race
-	// other tests' goroutine churn.
 	release := make(chan struct{})
 	var once sync.Once
 	releaseFn := func() { once.Do(func() { close(release) }) }
@@ -60,22 +71,23 @@ func TestPingSource_TimeoutDoesNotLeakGoroutine(t *testing.T) {
 	}
 	resultCh := make(chan pingResult, 1)
 
-	n0 := runtime.NumGoroutine()
 	pingSource(context.Background(), dp, src, 20*time.Millisecond, resultCh)
 
 	res := <-resultCh
 	require.ErrorIs(t, res.err, context.DeadlineExceeded,
 		"timeout path must return a deadline error")
+	require.True(t, pingGoroutineLives(),
+		"ping goroutine should still be blocked in Ping at this point")
 
-	// The ping goroutine is still blocked in Ping. Release it; with a
-	// buffered doneCh its send completes and it exits. Poll with a bare
-	// sleep loop rather than require.Eventually, which spawns its own
-	// goroutines and would inflate the count we're measuring.
+	// Release Ping; with a buffered doneCh its send completes and the
+	// goroutine exits. Poll a stack dump for that specific goroutine
+	// (bare sleep loop, not require.Eventually, which spawns its own
+	// goroutines).
 	releaseFn()
 	deadline := time.Now().Add(3 * time.Second)
-	for runtime.NumGoroutine() > n0 && time.Now().Before(deadline) {
+	for pingGoroutineLives() && time.Now().Before(deadline) {
 		time.Sleep(10 * time.Millisecond)
 	}
-	require.LessOrEqual(t, runtime.NumGoroutine(), n0,
+	require.False(t, pingGoroutineLives(),
 		"ping goroutine must exit after Ping returns; if it doesn't, doneCh blocked the send (leak)")
 }

--- a/cli/cmd_sql.go
+++ b/cli/cmd_sql.go
@@ -81,12 +81,13 @@ func execSQL(cmd *cobra.Command, args []string) error {
 
 	// --readonly / --ro: opt the raw-SQL command into read-only mode for
 	// the source. When set, peek at the would-be active source and surface
-	// the URL-conflict error preemptively. Doing this after determineSources
-	// would let verifySourceCatalogSchema briefly open the file READ_WRITE
-	// (the URL wins over the RO request) before the error fires, defeating
-	// the whole point of the conflict surfacing. The check is generic: any
-	// driver implementing driver.ReadOnlyConflictDetector (currently only
-	// DuckDB) gets consulted, rather than hardcoding a driver type here.
+	// the URL-conflict error preemptively, before determineSources does any
+	// validation pre-open or secret resolution. The driver also refuses an
+	// explicit read-only open against access_mode=READ_WRITE (see duckdb
+	// doOpen), so the conflict can't slip through; surfacing it here just
+	// fails fast, before that work. The check is generic: any driver
+	// implementing driver.ReadOnlyConflictDetector (currently only DuckDB)
+	// gets consulted, rather than hardcoding a driver type here.
 	readOnlySrc := cmdFlagIsSetTrue(cmd, flag.SQLReadOnly) ||
 		cmdFlagIsSetTrue(cmd, flag.SQLReadOnlyAlias)
 	if readOnlySrc {

--- a/cli/cmd_sql.go
+++ b/cli/cmd_sql.go
@@ -10,7 +10,6 @@ import (
 	"github.com/neilotoole/sq/cli/flag"
 	"github.com/neilotoole/sq/cli/output"
 	"github.com/neilotoole/sq/cli/run"
-	"github.com/neilotoole/sq/drivers/duckdb"
 	"github.com/neilotoole/sq/libsq"
 	"github.com/neilotoole/sq/libsq/core/errz"
 	"github.com/neilotoole/sq/libsq/core/lg"
@@ -19,7 +18,6 @@ import (
 	"github.com/neilotoole/sq/libsq/driver"
 	"github.com/neilotoole/sq/libsq/driver/dialect"
 	"github.com/neilotoole/sq/libsq/source"
-	"github.com/neilotoole/sq/libsq/source/drivertype"
 )
 
 func newSQLCmd() *cobra.Command {
@@ -86,20 +84,23 @@ func execSQL(cmd *cobra.Command, args []string) error {
 	// the URL-conflict error preemptively. Doing this after determineSources
 	// would let verifySourceCatalogSchema briefly open the file READ_WRITE
 	// (the URL wins over the RO request) before the error fires, defeating
-	// the whole point of the conflict surfacing.
+	// the whole point of the conflict surfacing. The check is generic: any
+	// driver implementing driver.ReadOnlyConflictDetector (currently only
+	// DuckDB) gets consulted, rather than hardcoding a driver type here.
 	readOnlySrc := cmdFlagIsSetTrue(cmd, flag.SQLReadOnly) ||
 		cmdFlagIsSetTrue(cmd, flag.SQLReadOnlyAlias)
 	if readOnlySrc {
-		if peek := peekActiveSrc(cmd, ru.Config.Collection); peek != nil &&
-			peek.Type == drivertype.DuckDB {
-			// Only READ_WRITE is a hard conflict. access_mode=AUTOMATIC is
-			// overridden to READ_ONLY by the driver (see
-			// duckdb.ApplyReadOnlyToLocation), and READ_ONLY already agrees.
-			if mode, ok := duckdb.ExplicitAccessMode(peek.Location); ok &&
-				strings.EqualFold(mode, "READ_WRITE") {
-				return errz.Errorf(
-					"sql: --%s conflicts with access_mode=READ_WRITE in %s",
-					flag.SQLReadOnly, peek.Handle)
+		if peek := peekActiveSrc(cmd, ru.Config.Collection); peek != nil {
+			// A DriverFor error is deliberately not surfaced here: the peek
+			// is a best-effort early check, and an unknown driver type gets
+			// a proper error from determineSources below.
+			if drvr, drvrErr := ru.DriverRegistry.DriverFor(peek.Type); drvrErr == nil {
+				if detector, ok := drvr.(driver.ReadOnlyConflictDetector); ok {
+					if conflict, has := detector.DetectReadOnlyConflict(peek.Location); has {
+						return errz.Errorf("sql: --%s conflicts with %s in %s",
+							flag.SQLReadOnly, conflict, peek.Handle)
+					}
+				}
 			}
 		}
 	}

--- a/cli/cmd_src.go
+++ b/cli/cmd_src.go
@@ -43,11 +43,6 @@ func execSrc(cmd *cobra.Command, args []string) error {
 			return nil
 		}
 
-		src, err := maybeExpandSource(ctx, ru, cmd, src)
-		if err != nil {
-			return err
-		}
-
 		return ru.Writers.Source.Source(cfg.Collection, src)
 	}
 
@@ -57,11 +52,6 @@ func execSrc(cmd *cobra.Command, args []string) error {
 	}
 
 	if err = ru.ConfigStore.Save(ctx, cfg); err != nil {
-		return err
-	}
-
-	src, err = maybeExpandSource(ctx, ru, cmd, src)
-	if err != nil {
 		return err
 	}
 

--- a/cli/expand.go
+++ b/cli/expand.go
@@ -15,22 +15,62 @@ import (
 	"github.com/neilotoole/sq/libsq/source"
 )
 
-// maybeExpandCollection returns coll unchanged when --expand is not set
-// on cmd. Otherwise it returns a deep clone whose source Locations have
-// each been passed through ru.SecretRegistry.Expand, with lenient
-// fallback: any per-source resolver error is swallowed and the
-// original Location is preserved verbatim. ctx is used for the
-// resolver call; context.Canceled / context.DeadlineExceeded propagate
-// as errors (a partial expansion under user-driven cancellation is not
-// a "this source's keyring is offline" situation).
-//
-// Called by every command that prints a source location: sq src,
-// sq ls, sq inspect, sq add and sq mv (post-action echo), and
-// sq ping in JSON/YAML output. Each handler invokes this once
-// before passing data to the writer. The writer's existing redact
-// step runs on whatever Location it sees, so the matrix is:
+// This file implements the --expand flag's location expansion. The
+// expansion is applied centrally in the writer layer: newWriters wraps
+// the writers that print source locations (Source, Ping, Metadata) in
+// the expand decorators from expand_writer.go, so any command that
+// prints a location honors --expand without per-command code. The
+// matrix is:
 //
 //	raw -> [expand?] -> [redact?] -> displayed
+//
+// where the redact step is the writer impls' pr.Redact handling.
+
+// expandLocation returns loc with ${scheme:path} placeholders expanded
+// via ru.SecretRegistry, with lenient fallback: a resolver error is
+// swallowed (logged at debug level) and loc is returned verbatim with
+// resolved=false. Context cancellation propagates as an error (a
+// partial expansion under user-driven cancellation is not a "this
+// source's keyring is offline" situation), as does a placeholder parse
+// error: parse errors are user config bugs (e.g. "${env}" missing the
+// colon) and must surface so the user can fix them; swallowing them
+// silently would hide a config break behind the lenient-resolver
+// fallback. The handle arg is used only for error and log context.
+func expandLocation(ctx context.Context, ru *run.Run, handle, loc string,
+) (expanded string, resolved bool, err error) {
+	if _, parseErr := secret.ExtractRefs(loc); parseErr != nil {
+		return "", false, errz.Wrapf(parseErr, "expand %s", handle)
+	}
+
+	expanded, expandErr := ru.SecretRegistry.Expand(ctx, loc)
+	if expandErr != nil {
+		if errors.Is(expandErr, context.Canceled) || errors.Is(expandErr, context.DeadlineExceeded) {
+			return "", false, errz.Err(expandErr)
+		}
+		// Lenient resolver failure: keep the placeholder verbatim and
+		// log at debug level. The verbatim placeholder may itself be
+		// hidden downstream (e.g. a placeholder inside a URL password
+		// slot is masked by the redact filter when --reveal is off),
+		// so the debug log is the reliable signal for operators
+		// running with SQ_LOG=debug.
+		lg.FromContext(ctx).Debug("expand: leaving placeholder verbatim",
+			lga.Src, handle,
+			lga.Err, expandErr)
+		return loc, false, nil
+	}
+	return expanded, true, nil
+}
+
+// maybeExpandCollection returns coll unchanged when --expand is not set
+// on cmd. Otherwise it returns a deep clone whose source Locations have
+// each been passed through expandLocation (lenient on resolver error,
+// strict on parse error and context cancellation; see expandLocation).
+//
+// Sources already carrying resolved literal locations
+// (Source.SecretsResolved) are skipped: re-resolving a literal would
+// unescape '$$' a second time, corrupting locations (e.g. those escaped
+// by the v0.54.0 config upgrade, or a resolved secret value containing
+// '$$').
 //
 // See also: maybeExpandSource for the single-source variant.
 func maybeExpandCollection(ctx context.Context, ru *run.Run, cmd *cobra.Command,
@@ -42,76 +82,82 @@ func maybeExpandCollection(ctx context.Context, ru *run.Run, cmd *cobra.Command,
 
 	clone := coll.Clone()
 	for _, src := range clone.Sources() {
-		// Validate placeholder syntax upfront. Parse errors are user config
-		// bugs (e.g. "${env}" missing the colon) and must surface so the
-		// user can fix them; swallowing them silently would hide a config
-		// break behind the lenient-resolver fallback below. cmd_add does the
-		// same dance for added sources.
-		if _, parseErr := secret.ExtractRefs(src.Location); parseErr != nil {
-			return nil, errz.Wrapf(parseErr, "expand %s", src.Handle)
-		}
-		resolved, err := ru.SecretRegistry.Expand(ctx, src.Location)
-		if err != nil {
-			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-				return nil, errz.Err(err)
-			}
-			// Lenient resolver failure: keep the placeholder verbatim and
-			// log at debug level. The verbatim placeholder may itself be
-			// hidden downstream (e.g. a placeholder inside a URL password
-			// slot is masked by the redact filter when --reveal is off),
-			// so the debug log is the reliable signal for operators
-			// running with SQ_LOG=debug.
-			lg.FromContext(ctx).Debug("expand: leaving placeholder verbatim",
-				lga.Src, src.Handle,
-				lga.Err, err)
+		if src.SecretsResolved {
+			// Location is already literal: nothing to expand, and
+			// re-resolution would double-unescape '$$'.
 			continue
 		}
-		src.Location = resolved
+		loc, resolved, err := expandLocation(ctx, ru, src.Handle, src.Location)
+		if err != nil {
+			return nil, err
+		}
+		src.Location = loc
 		// Resolved bytes are literal: mark so re-resolution is a no-op
-		// (the lenient branch above keeps the template, so it does not
-		// mark); see Source.SecretsResolved.
-		src.SecretsResolved = true
+		// (the lenient branch keeps the template, so resolved is false
+		// and the marker stays unset); see Source.SecretsResolved.
+		src.SecretsResolved = resolved
 	}
 	return clone, nil
 }
 
 // maybeExpandSource is the single-source variant of
 // maybeExpandCollection. Same semantics: --expand unset returns input
-// verbatim; --expand set returns a cloned source with Expand applied,
-// lenient on resolver error, propagates context cancellation.
+// verbatim; --expand set returns a cloned source with the location
+// expanded, lenient on resolver error, propagating parse errors and
+// context cancellation. A source already carrying a resolved literal
+// location (Source.SecretsResolved) is returned unchanged.
 func maybeExpandSource(ctx context.Context, ru *run.Run, cmd *cobra.Command,
 	src *source.Source,
 ) (*source.Source, error) {
-	if !cmdFlagIsSetTrue(cmd, flag.Expand) || src == nil {
+	if !cmdFlagIsSetTrue(cmd, flag.Expand) || src == nil || src.SecretsResolved {
 		return src, nil
 	}
 
-	// Validate placeholder syntax upfront. Parse errors are user config
-	// bugs (e.g. "${env}" missing the colon) and must surface so the
-	// user can fix them; swallowing them silently would hide a config
-	// break behind the lenient-resolver fallback below.
-	if _, parseErr := secret.ExtractRefs(src.Location); parseErr != nil {
-		return nil, errz.Wrapf(parseErr, "expand %s", src.Handle)
-	}
 	clone := src.Clone()
-	resolved, err := ru.SecretRegistry.Expand(ctx, clone.Location)
+	loc, resolved, err := expandLocation(ctx, ru, src.Handle, src.Location)
 	if err != nil {
-		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-			return nil, errz.Err(err)
-		}
-		// Lenient resolver failure: keep the placeholder verbatim and
-		// log at debug level. The verbatim value is the user-visible
-		// signal in default output; the debug log is for operators
-		// running with SQ_LOG=debug.
-		lg.FromContext(ctx).Debug("expand: leaving placeholder verbatim",
-			lga.Src, src.Handle,
-			lga.Err, err)
-		return clone, nil
+		return nil, err
 	}
-	clone.Location = resolved
+	clone.Location = loc
 	// Resolved bytes are literal: mark so re-resolution is a no-op
-	// (the lenient branch above keeps the template, so it does not
-	// mark); see Source.SecretsResolved.
-	clone.SecretsResolved = true
+	// (the lenient branch keeps the template, so resolved is false and
+	// the marker stays unset); see Source.SecretsResolved.
+	clone.SecretsResolved = resolved
+	return clone, nil
+}
+
+// maybeExpandGroup is the source.Group variant of maybeExpandSource.
+// When --expand is set on cmd, it returns a clone of g whose sources
+// (recursively, including subgroups) have been expanded via
+// maybeExpandSource. Mirrors source.RedactGroup, which performs the
+// same walk for the redaction step.
+func maybeExpandGroup(ctx context.Context, ru *run.Run, cmd *cobra.Command,
+	g *source.Group,
+) (*source.Group, error) {
+	if !cmdFlagIsSetTrue(cmd, flag.Expand) || g == nil {
+		return g, nil
+	}
+
+	clone := &source.Group{Name: g.Name, Active: g.Active}
+	if g.Sources != nil {
+		clone.Sources = make([]*source.Source, len(g.Sources))
+		for i, src := range g.Sources {
+			expanded, err := maybeExpandSource(ctx, ru, cmd, src)
+			if err != nil {
+				return nil, err
+			}
+			clone.Sources[i] = expanded
+		}
+	}
+	if g.Groups != nil {
+		clone.Groups = make([]*source.Group, len(g.Groups))
+		for i, sub := range g.Groups {
+			expanded, err := maybeExpandGroup(ctx, ru, cmd, sub)
+			if err != nil {
+				return nil, err
+			}
+			clone.Groups[i] = expanded
+		}
+	}
 	return clone, nil
 }

--- a/cli/expand.go
+++ b/cli/expand.go
@@ -38,6 +38,12 @@ import (
 // fallback. The handle arg is used only for error and log context.
 func expandLocation(ctx context.Context, ru *run.Run, handle, loc string,
 ) (expanded string, resolved bool, err error) {
+	// ExtractRefs is what classifies a parse error (strict) from a
+	// resolver error (lenient): Registry.Expand below collapses both
+	// into an undifferentiated error, so the placeholder syntax is
+	// parsed here first to surface parse errors before the lenient
+	// resolver branch can swallow them. The re-parse inside Expand is
+	// the accepted cost of that classification; do not drop this call.
 	if _, parseErr := secret.ExtractRefs(loc); parseErr != nil {
 		return "", false, errz.Wrapf(parseErr, "expand %s", handle)
 	}
@@ -61,16 +67,35 @@ func expandLocation(ctx context.Context, ru *run.Run, handle, loc string,
 	return expanded, true, nil
 }
 
+// expandSourceLocation expands src.Location in place via expandLocation,
+// unless src is already a resolved literal (Source.SecretsResolved), in
+// which case it is left unchanged: re-resolving a literal would unescape
+// '$$' a second time, corrupting locations (e.g. those escaped by the
+// v0.54.0 config upgrade, or a resolved secret value containing '$$').
+// It does NOT check the --expand flag; callers gate on that. This is the
+// single skip+expand site shared by maybeExpandSource and
+// maybeExpandCollection (and, via the former, maybeExpandGroup).
+func expandSourceLocation(ctx context.Context, ru *run.Run, src *source.Source) error {
+	if src == nil || src.SecretsResolved {
+		return nil
+	}
+	loc, resolved, err := expandLocation(ctx, ru, src.Handle, src.Location)
+	if err != nil {
+		return err
+	}
+	src.Location = loc
+	// Resolved bytes are literal: mark so re-resolution is a no-op (the
+	// lenient branch keeps the template, so resolved is false and the
+	// marker stays unset); see Source.SecretsResolved.
+	src.SecretsResolved = resolved
+	return nil
+}
+
 // maybeExpandCollection returns coll unchanged when --expand is not set
 // on cmd. Otherwise it returns a deep clone whose source Locations have
-// each been passed through expandLocation (lenient on resolver error,
-// strict on parse error and context cancellation; see expandLocation).
-//
-// Sources already carrying resolved literal locations
-// (Source.SecretsResolved) are skipped: re-resolving a literal would
-// unescape '$$' a second time, corrupting locations (e.g. those escaped
-// by the v0.54.0 config upgrade, or a resolved secret value containing
-// '$$').
+// each been passed through expandSourceLocation (lenient on resolver
+// error, strict on parse error and context cancellation; see
+// expandLocation). Already-resolved sources are skipped.
 //
 // See also: maybeExpandSource for the single-source variant.
 func maybeExpandCollection(ctx context.Context, ru *run.Run, cmd *cobra.Command,
@@ -82,20 +107,9 @@ func maybeExpandCollection(ctx context.Context, ru *run.Run, cmd *cobra.Command,
 
 	clone := coll.Clone()
 	for _, src := range clone.Sources() {
-		if src.SecretsResolved {
-			// Location is already literal: nothing to expand, and
-			// re-resolution would double-unescape '$$'.
-			continue
-		}
-		loc, resolved, err := expandLocation(ctx, ru, src.Handle, src.Location)
-		if err != nil {
+		if err := expandSourceLocation(ctx, ru, src); err != nil {
 			return nil, err
 		}
-		src.Location = loc
-		// Resolved bytes are literal: mark so re-resolution is a no-op
-		// (the lenient branch keeps the template, so resolved is false
-		// and the marker stays unset); see Source.SecretsResolved.
-		src.SecretsResolved = resolved
 	}
 	return clone, nil
 }
@@ -114,15 +128,9 @@ func maybeExpandSource(ctx context.Context, ru *run.Run, cmd *cobra.Command,
 	}
 
 	clone := src.Clone()
-	loc, resolved, err := expandLocation(ctx, ru, src.Handle, src.Location)
-	if err != nil {
+	if err := expandSourceLocation(ctx, ru, clone); err != nil {
 		return nil, err
 	}
-	clone.Location = loc
-	// Resolved bytes are literal: mark so re-resolution is a no-op
-	// (the lenient branch keeps the template, so resolved is false and
-	// the marker stays unset); see Source.SecretsResolved.
-	clone.SecretsResolved = resolved
 	return clone, nil
 }
 

--- a/cli/expand_test.go
+++ b/cli/expand_test.go
@@ -258,6 +258,58 @@ func TestMaybeExpandSource_ParseErrorPropagates(t *testing.T) {
 		"error message must include the source handle")
 }
 
+// TestMaybeExpandSource_SecretsResolved_Skipped verifies that a source
+// already carrying a resolved literal location is returned unchanged,
+// so a literal '$$' is not unescaped a second time.
+func TestMaybeExpandSource_SecretsResolved_Skipped(t *testing.T) {
+	ru := newTestRun(t, nil)
+	cmd := newCmdWithExpand(t, true)
+
+	src := &source.Source{
+		Handle:          "@a",
+		Type:            drivertype.Pg,
+		Location:        "postgres://alice:pa$$wd@db/sakila",
+		SecretsResolved: true,
+	}
+
+	got, err := maybeExpandSource(context.Background(), ru, cmd, src)
+	require.NoError(t, err)
+	require.Same(t, src, got, "an already-resolved source must be returned unchanged")
+	require.Equal(t, "postgres://alice:pa$$wd@db/sakila", got.Location,
+		"resolved literal must not be re-unescaped")
+}
+
+// TestMaybeExpandCollection_SecretsResolved_Skipped verifies that an
+// already-resolved source in a collection is left untouched by --expand
+// while other sources still expand.
+func TestMaybeExpandCollection_SecretsResolved_Skipped(t *testing.T) {
+	ru := newTestRun(t, map[string]string{
+		"abc": "postgres://alice:hunter2@db/sakila",
+	})
+	cmd := newCmdWithExpand(t, true)
+
+	coll := &source.Collection{}
+	require.NoError(t, coll.Add(&source.Source{
+		Handle:          "@resolved",
+		Type:            drivertype.Pg,
+		Location:        "postgres://b:pa$$wd@h/db",
+		SecretsResolved: true,
+	}))
+	require.NoError(t, coll.Add(&source.Source{
+		Handle:   "@template",
+		Type:     drivertype.Pg,
+		Location: "${keyring:abc}",
+	}))
+
+	got, err := maybeExpandCollection(context.Background(), ru, cmd, coll)
+	require.NoError(t, err)
+	srcs := got.Sources()
+	require.Equal(t, "postgres://b:pa$$wd@h/db", srcs[0].Location,
+		"already-resolved source must not be re-unescaped")
+	require.Equal(t, "postgres://alice:hunter2@db/sakila", srcs[1].Location,
+		"template source must still expand")
+}
+
 // captureHandler is a minimal slog.Handler that records log entries for
 // test assertions. It captures all levels.
 type captureHandler struct {

--- a/cli/expand_writer.go
+++ b/cli/expand_writer.go
@@ -212,8 +212,8 @@ func (ew *expandPingWriter) Open(srcs []*source.Source) error {
 	if err != nil {
 		return err
 	}
-	// Reset any prior cache so a reused writer (or an inactive re-Open)
-	// can't serve stale expanded sources from a previous call.
+	// Reset before (maybe) repopulating, so an inactive Open can't leave
+	// a stale cache behind.
 	ew.cache = nil
 	if ew.active() {
 		// Cache input->expanded so the per-source Result calls don't
@@ -242,8 +242,7 @@ func (ew *expandPingWriter) Result(src *source.Source, d time.Duration, err erro
 
 // Close implements output.PingWriter.
 func (ew *expandPingWriter) Close() error {
-	// Drop the cache so resolved (potentially plaintext) locations aren't
-	// retained past the ping run.
+	// Drop the cache once the run is done.
 	ew.cache = nil
 	return ew.w.Close()
 }
@@ -285,10 +284,9 @@ func (ew *expandMetadataWriter) SourceMetadata(srcMeta *metadata.Source, showSch
 		}
 		clone := *srcMeta
 		clone.Location = loc
-		// Mark the clone resolved when expansion produced a literal, so a
-		// downstream consumer (or a repeat call) sees a consistent marker
-		// and won't re-expand. The lenient branch keeps the template and
-		// leaves resolved false; see expandLocation.
+		// Keep the clone self-consistent: a resolved literal location gets
+		// the resolved marker (the lenient branch keeps the template and
+		// leaves resolved false; see expandLocation).
 		clone.SecretsResolved = resolved
 		srcMeta = &clone
 	}

--- a/cli/expand_writer.go
+++ b/cli/expand_writer.go
@@ -42,24 +42,24 @@ import (
 // context updates made by the command (e.g. cmd.SetContext) are
 // honored.
 
-// expander is the shared core of the expand decorators.
+// expander is the shared core of the expand decorators. The run is
+// injected at construction (newWriters), where it's always in hand; the
+// context is read fresh from cmd at write time so cmd.SetContext updates
+// (e.g. timeouts) are honored when the resolver runs.
 type expander struct {
 	cmd *cobra.Command
+	ru  *run.Run
 }
 
-// runCtx returns the command's current context and run. The returned
-// run is nil in degenerate cases (e.g. a test harness without a run on
-// the context, or before the secret registry is installed); callers
-// must treat nil as "don't expand". FromContextOrNil is used (not
-// FromContext) precisely so the no-run case returns nil rather than
-// panicking.
+// runCtx returns the command's current context and run. The returned run
+// is nil when expansion can't run (no secret registry yet); callers must
+// treat nil as "don't expand".
 func (e expander) runCtx() (context.Context, *run.Run) {
 	ctx := e.cmd.Context()
-	ru := run.FromContextOrNil(ctx)
-	if ru == nil || ru.SecretRegistry == nil {
+	if e.ru == nil || e.ru.SecretRegistry == nil {
 		return ctx, nil
 	}
-	return ctx, ru
+	return ctx, e.ru
 }
 
 // active reports whether expansion should be attempted at all.

--- a/cli/expand_writer.go
+++ b/cli/expand_writer.go
@@ -48,11 +48,14 @@ type expander struct {
 }
 
 // runCtx returns the command's current context and run. The returned
-// run may be nil in degenerate cases (e.g. a test harness without a
-// run on the context); callers must treat nil as "don't expand".
+// run is nil in degenerate cases (e.g. a test harness without a run on
+// the context, or before the secret registry is installed); callers
+// must treat nil as "don't expand". FromContextOrNil is used (not
+// FromContext) precisely so the no-run case returns nil rather than
+// panicking.
 func (e expander) runCtx() (context.Context, *run.Run) {
 	ctx := e.cmd.Context()
-	ru := run.FromContext(ctx)
+	ru := run.FromContextOrNil(ctx)
 	if ru == nil || ru.SecretRegistry == nil {
 		return ctx, nil
 	}
@@ -142,13 +145,13 @@ func (ew *expandSourceWriter) Removed(srcs ...*source.Source) error {
 	return ew.w.Removed(srcs...)
 }
 
-// Moved implements output.SourceWriter.
+// Moved implements output.SourceWriter. Only nu is expanded: every
+// underlying Moved impl displays the destination source and discards
+// old, so expanding old would be wasted resolver I/O on a value no
+// writer prints.
 func (ew *expandSourceWriter) Moved(coll *source.Collection, old, nu *source.Source) error {
-	old, err := ew.src(old)
+	nu, err := ew.src(nu)
 	if err != nil {
-		return err
-	}
-	if nu, err = ew.src(nu); err != nil {
 		return err
 	}
 	return ew.w.Moved(coll, old, nu)
@@ -244,17 +247,21 @@ func (ew *expandPingWriter) Close() error {
 // delegating. The other MetadataWriter methods carry no source
 // location and delegate unchanged.
 //
-// CALLER CONTRACT: srcMeta.Location must be the stored (template)
-// location, not an already-resolved literal. Unlike the source/group
-// expand paths, which skip Source.SecretsResolved sources to avoid
-// re-resolving a literal (which would unescape '$$' a second time and
-// corrupt it; see maybeExpandSource), metadata.Source carries no
-// SecretsResolved bit, so this decorator cannot detect an
-// already-resolved location and would double-unescape it. Drivers
-// populate srcMeta.Location from the grip's resolved source;
-// execInspect resets it to the stored template before writing
-// (cmd_inspect.go), satisfying the contract. Any future caller of
-// SourceMetadata must do the same.
+// Like the source/group expand paths, an already-resolved location is
+// skipped (re-resolving a literal would unescape '$$' a second time and
+// corrupt it; see maybeExpandSource). metadata.Source.SecretsResolved
+// carries that bit: drivers populate srcMeta.Location from the grip's
+// resolved source but leave SecretsResolved false; execInspect resets
+// the location to the stored template and sets SecretsResolved from the
+// source (cmd_inspect.go). Any future SourceMetadata caller that passes
+// an already-resolved location must set srcMeta.SecretsResolved so this
+// decorator skips it.
+//
+// Note: because expansion happens at write time, a malformed ${...}
+// placeholder under --expand surfaces here (after the source has been
+// opened and metadata read) rather than fail-fast before the open. That
+// is the accepted cost of lazy, writer-layer expansion; the parse error
+// still surfaces.
 type expandMetadataWriter struct {
 	w output.MetadataWriter
 	expander
@@ -264,7 +271,7 @@ var _ output.MetadataWriter = (*expandMetadataWriter)(nil)
 
 // SourceMetadata implements output.MetadataWriter.
 func (ew *expandMetadataWriter) SourceMetadata(srcMeta *metadata.Source, showSchema bool) error {
-	if srcMeta != nil && ew.active() {
+	if srcMeta != nil && !srcMeta.SecretsResolved && ew.active() {
 		ctx, ru := ew.runCtx()
 		loc, _, err := expandLocation(ctx, ru, srcMeta.Handle, srcMeta.Location)
 		if err != nil {

--- a/cli/expand_writer.go
+++ b/cli/expand_writer.go
@@ -37,10 +37,11 @@ import (
 // (e.g. stdin sources). Lazily expanding cloned values at write time
 // has neither problem.
 //
-// The decorators hold the cobra command and derive the context, run
-// (and thus the secret registry), and flag state at write time, so
-// context updates made by the command (e.g. cmd.SetContext) are
-// honored.
+// The decorators hold the cobra command and the run (injected at
+// construction by newWriters, which carries the secret registry). The
+// context and --expand flag state are read from the command fresh at
+// write time, so context updates made by the command (e.g. cmd.SetContext
+// timeouts) are honored when the resolver runs.
 
 // expander is the shared core of the expand decorators. The run is
 // injected at construction (newWriters), where it's always in hand; the

--- a/cli/expand_writer.go
+++ b/cli/expand_writer.go
@@ -51,24 +51,19 @@ type expander struct {
 	ru  *run.Run
 }
 
-// runCtx returns the command's current context and run. The returned run
-// is nil when expansion can't run (no secret registry yet); callers must
-// treat nil as "don't expand".
+// runCtx returns the command's current context (read fresh so
+// cmd.SetContext updates such as timeouts are honored when the resolver
+// runs) and the injected run.
 func (e expander) runCtx() (context.Context, *run.Run) {
-	ctx := e.cmd.Context()
-	if e.ru == nil || e.ru.SecretRegistry == nil {
-		return ctx, nil
-	}
-	return ctx, e.ru
+	return e.cmd.Context(), e.ru
 }
 
-// active reports whether expansion should be attempted at all.
+// active reports whether expansion should be attempted (the --expand flag
+// is set). The run and its secret registry are injected at construction
+// and always present by the time a decorator runs, so there's nothing
+// else to gate on.
 func (e expander) active() bool {
-	if !cmdFlagIsSetTrue(e.cmd, flag.Expand) {
-		return false
-	}
-	_, ru := e.runCtx()
-	return ru != nil
+	return cmdFlagIsSetTrue(e.cmd, flag.Expand)
 }
 
 // src returns the expanded clone of s per maybeExpandSource.

--- a/cli/expand_writer.go
+++ b/cli/expand_writer.go
@@ -1,0 +1,303 @@
+package cli
+
+import (
+	"context"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/neilotoole/sq/cli/flag"
+	"github.com/neilotoole/sq/cli/output"
+	"github.com/neilotoole/sq/cli/run"
+	"github.com/neilotoole/sq/libsq/driver"
+	"github.com/neilotoole/sq/libsq/source"
+	"github.com/neilotoole/sq/libsq/source/metadata"
+)
+
+// This file contains decorators that apply --expand location expansion
+// in the writer layer, mirroring how redaction is enforced once via
+// Printing.Redact rather than per command. newWriters wraps the writer
+// interfaces that print source locations (SourceWriter, PingWriter,
+// MetadataWriter) so that ANY command printing a location honors
+// --expand, including future commands that don't know the flag exists.
+//
+// Why decorators in cli, not an Expand field on output.Printing
+// consumed by each writer impl? Unlike redaction, expansion performs
+// fallible I/O (keyring, 1Password CLI, file, env resolvers). Pushing
+// that into every format writer (tablew, jsonw, yamlw, ...) would
+// duplicate the I/O and error plumbing across implementations; a
+// single decorator runs the expansion exactly once per write and
+// propagates failures through the writer methods' existing error
+// returns, so there's no silent partial expansion beyond the
+// deliberate lenient-resolver fallback (see expandLocation).
+//
+// Why not expand eagerly in preRun? Expanding ru.Config.Collection in
+// place would risk persisting resolved secrets when a command saves
+// config (add, mv, src), and would miss sources created after preRun
+// (e.g. stdin sources). Lazily expanding cloned values at write time
+// has neither problem.
+//
+// The decorators hold the cobra command and derive the context, run
+// (and thus the secret registry), and flag state at write time, so
+// context updates made by the command (e.g. cmd.SetContext) are
+// honored.
+
+// expander is the shared core of the expand decorators.
+type expander struct {
+	cmd *cobra.Command
+}
+
+// runCtx returns the command's current context and run. The returned
+// run may be nil in degenerate cases (e.g. a test harness without a
+// run on the context); callers must treat nil as "don't expand".
+func (e expander) runCtx() (context.Context, *run.Run) {
+	ctx := e.cmd.Context()
+	ru := run.FromContext(ctx)
+	if ru == nil || ru.SecretRegistry == nil {
+		return ctx, nil
+	}
+	return ctx, ru
+}
+
+// active reports whether expansion should be attempted at all.
+func (e expander) active() bool {
+	if !cmdFlagIsSetTrue(e.cmd, flag.Expand) {
+		return false
+	}
+	_, ru := e.runCtx()
+	return ru != nil
+}
+
+// src returns the expanded clone of s per maybeExpandSource.
+func (e expander) src(s *source.Source) (*source.Source, error) {
+	if !e.active() {
+		return s, nil
+	}
+	ctx, ru := e.runCtx()
+	return maybeExpandSource(ctx, ru, e.cmd, s)
+}
+
+// srcs returns expanded clones of each element of in per src. When
+// expansion is inactive, in is returned unchanged.
+func (e expander) srcs(in []*source.Source) ([]*source.Source, error) {
+	if !e.active() {
+		return in, nil
+	}
+	out := make([]*source.Source, len(in))
+	for i, s := range in {
+		exp, err := e.src(s)
+		if err != nil {
+			return nil, err
+		}
+		out[i] = exp
+	}
+	return out, nil
+}
+
+// expandSourceWriter decorates an output.SourceWriter, expanding
+// source locations per the --expand flag before delegating.
+type expandSourceWriter struct {
+	w output.SourceWriter
+	expander
+}
+
+var _ output.SourceWriter = (*expandSourceWriter)(nil)
+
+// Collection implements output.SourceWriter.
+func (ew *expandSourceWriter) Collection(coll *source.Collection) error {
+	if ew.active() {
+		ctx, ru := ew.runCtx()
+		var err error
+		if coll, err = maybeExpandCollection(ctx, ru, ew.cmd, coll); err != nil {
+			return err
+		}
+	}
+	return ew.w.Collection(coll)
+}
+
+// Source implements output.SourceWriter.
+func (ew *expandSourceWriter) Source(coll *source.Collection, src *source.Source) error {
+	src, err := ew.src(src)
+	if err != nil {
+		return err
+	}
+	return ew.w.Source(coll, src)
+}
+
+// Added implements output.SourceWriter.
+func (ew *expandSourceWriter) Added(coll *source.Collection, src *source.Source) error {
+	src, err := ew.src(src)
+	if err != nil {
+		return err
+	}
+	return ew.w.Added(coll, src)
+}
+
+// Removed implements output.SourceWriter.
+func (ew *expandSourceWriter) Removed(srcs ...*source.Source) error {
+	srcs, err := ew.srcs(srcs)
+	if err != nil {
+		return err
+	}
+	return ew.w.Removed(srcs...)
+}
+
+// Moved implements output.SourceWriter.
+func (ew *expandSourceWriter) Moved(coll *source.Collection, old, nu *source.Source) error {
+	old, err := ew.src(old)
+	if err != nil {
+		return err
+	}
+	if nu, err = ew.src(nu); err != nil {
+		return err
+	}
+	return ew.w.Moved(coll, old, nu)
+}
+
+// Group implements output.SourceWriter.
+func (ew *expandSourceWriter) Group(group *source.Group) error {
+	group, err := ew.group(group)
+	if err != nil {
+		return err
+	}
+	return ew.w.Group(group)
+}
+
+// SetActiveGroup implements output.SourceWriter.
+func (ew *expandSourceWriter) SetActiveGroup(group *source.Group) error {
+	group, err := ew.group(group)
+	if err != nil {
+		return err
+	}
+	return ew.w.SetActiveGroup(group)
+}
+
+// Groups implements output.SourceWriter.
+func (ew *expandSourceWriter) Groups(tree *source.Group) error {
+	tree, err := ew.group(tree)
+	if err != nil {
+		return err
+	}
+	return ew.w.Groups(tree)
+}
+
+func (ew *expandSourceWriter) group(g *source.Group) (*source.Group, error) {
+	if !ew.active() {
+		return g, nil
+	}
+	ctx, ru := ew.runCtx()
+	return maybeExpandGroup(ctx, ru, ew.cmd, g)
+}
+
+// expandPingWriter decorates an output.PingWriter, expanding source
+// locations per the --expand flag before delegating. Open expands each
+// source once and caches the result (keyed by the input pointer), so
+// the subsequent per-source Result calls don't repeat resolver I/O.
+// PingWriter is invoked sequentially (Open, then Results from a single
+// loop; see pingSources), so the cache needs no locking.
+type expandPingWriter struct {
+	w     output.PingWriter
+	cache map[*source.Source]*source.Source
+	expander
+}
+
+var _ output.PingWriter = (*expandPingWriter)(nil)
+
+// Open implements output.PingWriter.
+func (ew *expandPingWriter) Open(srcs []*source.Source) error {
+	expanded, err := ew.srcs(srcs)
+	if err != nil {
+		return err
+	}
+	if ew.active() {
+		// Cache input->expanded so the per-source Result calls don't
+		// repeat resolver I/O (see expandPingWriter doc).
+		ew.cache = make(map[*source.Source]*source.Source, len(srcs))
+		for i, src := range srcs {
+			ew.cache[src] = expanded[i]
+		}
+	}
+	return ew.w.Open(expanded)
+}
+
+// Result implements output.PingWriter.
+func (ew *expandPingWriter) Result(src *source.Source, d time.Duration, err error) error {
+	if exp, ok := ew.cache[src]; ok {
+		src = exp
+	} else {
+		// Defensive: a src that didn't pass through Open.
+		var expandErr error
+		if src, expandErr = ew.src(src); expandErr != nil {
+			return expandErr
+		}
+	}
+	return ew.w.Result(src, d, err)
+}
+
+// Close implements output.PingWriter.
+func (ew *expandPingWriter) Close() error {
+	return ew.w.Close()
+}
+
+// expandMetadataWriter decorates an output.MetadataWriter, expanding
+// the location in SourceMetadata per the --expand flag before
+// delegating. The other MetadataWriter methods carry no source
+// location and delegate unchanged.
+//
+// CALLER CONTRACT: srcMeta.Location must be the stored (template)
+// location, not an already-resolved literal. Unlike the source/group
+// expand paths, which skip Source.SecretsResolved sources to avoid
+// re-resolving a literal (which would unescape '$$' a second time and
+// corrupt it; see maybeExpandSource), metadata.Source carries no
+// SecretsResolved bit, so this decorator cannot detect an
+// already-resolved location and would double-unescape it. Drivers
+// populate srcMeta.Location from the grip's resolved source;
+// execInspect resets it to the stored template before writing
+// (cmd_inspect.go), satisfying the contract. Any future caller of
+// SourceMetadata must do the same.
+type expandMetadataWriter struct {
+	w output.MetadataWriter
+	expander
+}
+
+var _ output.MetadataWriter = (*expandMetadataWriter)(nil)
+
+// SourceMetadata implements output.MetadataWriter.
+func (ew *expandMetadataWriter) SourceMetadata(srcMeta *metadata.Source, showSchema bool) error {
+	if srcMeta != nil && ew.active() {
+		ctx, ru := ew.runCtx()
+		loc, _, err := expandLocation(ctx, ru, srcMeta.Handle, srcMeta.Location)
+		if err != nil {
+			return err
+		}
+		clone := *srcMeta
+		clone.Location = loc
+		srcMeta = &clone
+	}
+	return ew.w.SourceMetadata(srcMeta, showSchema)
+}
+
+// TableMetadata implements output.MetadataWriter.
+func (ew *expandMetadataWriter) TableMetadata(tblMeta *metadata.Table) error {
+	return ew.w.TableMetadata(tblMeta)
+}
+
+// DBProperties implements output.MetadataWriter.
+func (ew *expandMetadataWriter) DBProperties(props map[string]any) error {
+	return ew.w.DBProperties(props)
+}
+
+// DriverMetadata implements output.MetadataWriter.
+func (ew *expandMetadataWriter) DriverMetadata(drvrs []driver.Metadata) error {
+	return ew.w.DriverMetadata(drvrs)
+}
+
+// Catalogs implements output.MetadataWriter.
+func (ew *expandMetadataWriter) Catalogs(currentCatalog string, catalogs []string) error {
+	return ew.w.Catalogs(currentCatalog, catalogs)
+}
+
+// Schemata implements output.MetadataWriter.
+func (ew *expandMetadataWriter) Schemata(currentSchema string, schemas []*metadata.Schema) error {
+	return ew.w.Schemata(currentSchema, schemas)
+}

--- a/cli/expand_writer.go
+++ b/cli/expand_writer.go
@@ -212,6 +212,9 @@ func (ew *expandPingWriter) Open(srcs []*source.Source) error {
 	if err != nil {
 		return err
 	}
+	// Reset any prior cache so a reused writer (or an inactive re-Open)
+	// can't serve stale expanded sources from a previous call.
+	ew.cache = nil
 	if ew.active() {
 		// Cache input->expanded so the per-source Result calls don't
 		// repeat resolver I/O (see expandPingWriter doc).
@@ -239,6 +242,9 @@ func (ew *expandPingWriter) Result(src *source.Source, d time.Duration, err erro
 
 // Close implements output.PingWriter.
 func (ew *expandPingWriter) Close() error {
+	// Drop the cache so resolved (potentially plaintext) locations aren't
+	// retained past the ping run.
+	ew.cache = nil
 	return ew.w.Close()
 }
 
@@ -273,12 +279,17 @@ var _ output.MetadataWriter = (*expandMetadataWriter)(nil)
 func (ew *expandMetadataWriter) SourceMetadata(srcMeta *metadata.Source, showSchema bool) error {
 	if srcMeta != nil && !srcMeta.SecretsResolved && ew.active() {
 		ctx, ru := ew.runCtx()
-		loc, _, err := expandLocation(ctx, ru, srcMeta.Handle, srcMeta.Location)
+		loc, resolved, err := expandLocation(ctx, ru, srcMeta.Handle, srcMeta.Location)
 		if err != nil {
 			return err
 		}
 		clone := *srcMeta
 		clone.Location = loc
+		// Mark the clone resolved when expansion produced a literal, so a
+		// downstream consumer (or a repeat call) sees a consistent marker
+		// and won't re-expand. The lenient branch keeps the template and
+		// leaves resolved false; see expandLocation.
+		clone.SecretsResolved = resolved
 		srcMeta = &clone
 	}
 	return ew.w.SourceMetadata(srcMeta, showSchema)

--- a/cli/expand_writer_test.go
+++ b/cli/expand_writer_test.go
@@ -302,3 +302,41 @@ func TestExpandMetadataWriter_SourceMetadata_Expands(t *testing.T) {
 	require.Equal(t, "${keyring:abc}", srcMeta.Location,
 		"input must not be mutated")
 }
+
+// TestExpandMetadataWriter_SecretsResolved_Skipped verifies the metadata
+// decorator skips expansion for an already-resolved location, matching
+// the source/group/collection paths, so a literal '$$' is not
+// double-unescaped.
+func TestExpandMetadataWriter_SecretsResolved_Skipped(t *testing.T) {
+	cmd := newExpanderCmd(t, true, nil)
+
+	rec := &recordingMetadataWriter{}
+	ew := &expandMetadataWriter{w: rec, expander: expander{cmd: cmd}}
+
+	srcMeta := &metadata.Source{
+		Handle:          "@a",
+		Location:        "postgres://b:pa$$wd@h/db",
+		SecretsResolved: true,
+	}
+	require.NoError(t, ew.SourceMetadata(srcMeta, true))
+	require.NotNil(t, rec.gotSrcMeta)
+	require.Equal(t, "postgres://b:pa$$wd@h/db", rec.gotSrcMeta.Location,
+		"already-resolved location must not be re-unescaped")
+}
+
+// TestExpander_NoRunOnContext_NoPanic verifies that an expand decorator
+// over a command whose context carries no run does not panic when
+// --expand is set: active() returns false and the source passes through
+// unchanged. Guards the runCtx -> run.FromContextOrNil contract.
+func TestExpander_NoRunOnContext_NoPanic(t *testing.T) {
+	cmd := newCmdWithExpand(t, true)
+	cmd.SetContext(context.Background()) // no run installed
+
+	e := expander{cmd: cmd}
+	require.False(t, e.active(), "active must be false when no run is on the context")
+
+	src := &source.Source{Handle: "@a", Location: "${keyring:abc}"}
+	got, err := e.src(src)
+	require.NoError(t, err)
+	require.Same(t, src, got, "no run -> pass through unchanged, no panic")
+}

--- a/cli/expand_writer_test.go
+++ b/cli/expand_writer_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/require"
 
-	"github.com/neilotoole/sq/cli/flag"
 	"github.com/neilotoole/sq/cli/output"
 	"github.com/neilotoole/sq/cli/run"
 	"github.com/neilotoole/sq/libsq/core/secret"
@@ -123,25 +122,25 @@ func (w *recordingMetadataWriter) Schemata(string, []*metadata.Schema) error {
 	return nil
 }
 
-// newExpanderCmd returns a cmd suitable for the expand decorators: the
-// --expand flag is registered (and set per the set arg), and the cmd's
-// context carries a run.Run whose SecretRegistry "keyring" scheme is
-// backed by values.
-func newExpanderCmd(t *testing.T, set bool, values map[string]string) *cobra.Command {
+// newExpanderCmd returns a cmd and run suitable for the expand
+// decorators: the --expand flag is registered (and set per the set arg),
+// and the run's SecretRegistry "keyring" scheme is backed by values. The
+// run is injected into the expander by the caller; the cmd carries a
+// plain context (the decorators read it only for the resolver ctx).
+func newExpanderCmd(t *testing.T, set bool, values map[string]string) (*cobra.Command, *run.Run) {
 	t.Helper()
 	cmd := newCmdWithExpand(t, set)
-	ru := newTestRun(t, values)
-	cmd.SetContext(run.NewContext(context.Background(), ru))
-	return cmd
+	cmd.SetContext(context.Background())
+	return cmd, newTestRun(t, values)
 }
 
 func TestExpandSourceWriter_Source_FlagSet_Expands(t *testing.T) {
-	cmd := newExpanderCmd(t, true, map[string]string{
+	cmd, ru := newExpanderCmd(t, true, map[string]string{
 		"abc": "postgres://alice:hunter2@db/sakila",
 	})
 
 	rec := &recordingSourceWriter{}
-	ew := &expandSourceWriter{w: rec, expander: expander{cmd: cmd}}
+	ew := &expandSourceWriter{w: rec, expander: expander{cmd: cmd, ru: ru}}
 
 	src := &source.Source{
 		Handle:   "@a",
@@ -155,10 +154,10 @@ func TestExpandSourceWriter_Source_FlagSet_Expands(t *testing.T) {
 }
 
 func TestExpandSourceWriter_Source_FlagUnset_PassThrough(t *testing.T) {
-	cmd := newExpanderCmd(t, false, nil)
+	cmd, ru := newExpanderCmd(t, false, nil)
 
 	rec := &recordingSourceWriter{}
-	ew := &expandSourceWriter{w: rec, expander: expander{cmd: cmd}}
+	ew := &expandSourceWriter{w: rec, expander: expander{cmd: cmd, ru: ru}}
 
 	src := &source.Source{
 		Handle:   "@a",
@@ -172,10 +171,10 @@ func TestExpandSourceWriter_Source_FlagUnset_PassThrough(t *testing.T) {
 }
 
 func TestExpandSourceWriter_ParseErrorPropagates(t *testing.T) {
-	cmd := newExpanderCmd(t, true, nil)
+	cmd, ru := newExpanderCmd(t, true, nil)
 
 	rec := &recordingSourceWriter{}
-	ew := &expandSourceWriter{w: rec, expander: expander{cmd: cmd}}
+	ew := &expandSourceWriter{w: rec, expander: expander{cmd: cmd, ru: ru}}
 
 	src := &source.Source{
 		Handle:   "@bad",
@@ -189,12 +188,12 @@ func TestExpandSourceWriter_ParseErrorPropagates(t *testing.T) {
 }
 
 func TestExpandSourceWriter_Collection_Expands(t *testing.T) {
-	cmd := newExpanderCmd(t, true, map[string]string{
+	cmd, ru := newExpanderCmd(t, true, map[string]string{
 		"abc": "postgres://alice:hunter2@db/sakila",
 	})
 
 	rec := &recordingSourceWriter{}
-	ew := &expandSourceWriter{w: rec, expander: expander{cmd: cmd}}
+	ew := &expandSourceWriter{w: rec, expander: expander{cmd: cmd, ru: ru}}
 
 	coll := &source.Collection{}
 	require.NoError(t, coll.Add(&source.Source{
@@ -213,13 +212,13 @@ func TestExpandSourceWriter_Collection_Expands(t *testing.T) {
 }
 
 func TestExpandSourceWriter_Group_ExpandsNestedSources(t *testing.T) {
-	cmd := newExpanderCmd(t, true, map[string]string{
+	cmd, ru := newExpanderCmd(t, true, map[string]string{
 		"abc": "postgres://alice:hunter2@db/sakila",
 		"def": "mysql://bob:opensesame@db/sakila",
 	})
 
 	rec := &recordingSourceWriter{}
-	ew := &expandSourceWriter{w: rec, expander: expander{cmd: cmd}}
+	ew := &expandSourceWriter{w: rec, expander: expander{cmd: cmd, ru: ru}}
 
 	group := &source.Group{
 		Name: "/",
@@ -262,10 +261,10 @@ func TestExpandPingWriter_OpenCachesForResult(t *testing.T) {
 	reg.Register("keyring", counting)
 	ru := &run.Run{SecretRegistry: reg}
 	cmd := newCmdWithExpand(t, true)
-	cmd.SetContext(run.NewContext(context.Background(), ru))
+	cmd.SetContext(context.Background())
 
 	rec := &recordingPingWriter{}
-	ew := &expandPingWriter{w: rec, expander: expander{cmd: cmd}}
+	ew := &expandPingWriter{w: rec, expander: expander{cmd: cmd, ru: ru}}
 
 	src := &source.Source{
 		Handle:   "@a",
@@ -286,12 +285,12 @@ func TestExpandPingWriter_OpenCachesForResult(t *testing.T) {
 }
 
 func TestExpandMetadataWriter_SourceMetadata_Expands(t *testing.T) {
-	cmd := newExpanderCmd(t, true, map[string]string{
+	cmd, ru := newExpanderCmd(t, true, map[string]string{
 		"abc": "postgres://alice:hunter2@db/sakila",
 	})
 
 	rec := &recordingMetadataWriter{}
-	ew := &expandMetadataWriter{w: rec, expander: expander{cmd: cmd}}
+	ew := &expandMetadataWriter{w: rec, expander: expander{cmd: cmd, ru: ru}}
 
 	srcMeta := &metadata.Source{
 		Handle:   "@a",
@@ -309,10 +308,10 @@ func TestExpandMetadataWriter_SourceMetadata_Expands(t *testing.T) {
 // the source/group/collection paths, so a literal '$$' is not
 // double-unescaped.
 func TestExpandMetadataWriter_SecretsResolved_Skipped(t *testing.T) {
-	cmd := newExpanderCmd(t, true, nil)
+	cmd, ru := newExpanderCmd(t, true, nil)
 
 	rec := &recordingMetadataWriter{}
-	ew := &expandMetadataWriter{w: rec, expander: expander{cmd: cmd}}
+	ew := &expandMetadataWriter{w: rec, expander: expander{cmd: cmd, ru: ru}}
 
 	srcMeta := &metadata.Source{
 		Handle:          "@a",
@@ -323,26 +322,4 @@ func TestExpandMetadataWriter_SecretsResolved_Skipped(t *testing.T) {
 	require.NotNil(t, rec.gotSrcMeta)
 	require.Equal(t, "postgres://b:pa$$wd@h/db", rec.gotSrcMeta.Location,
 		"already-resolved location must not be re-unescaped")
-}
-
-// TestExpander_NoRunOnContext_NoPanic verifies that an expand decorator
-// over a command whose context carries no run does not panic when
-// --expand is set: active() returns false and the source passes through
-// unchanged. Guards the runCtx -> run.FromContextOrNil contract.
-func TestExpander_NoRunOnContext_NoPanic(t *testing.T) {
-	cmd := newCmdWithExpand(t, true)
-	cmd.SetContext(context.Background()) // no run installed
-
-	// Assert the flag is set, so active()==false below is necessarily due
-	// to the missing run (not an unset flag), making this a real test of
-	// the FromContextOrNil no-panic path.
-	require.True(t, cmdFlagIsSetTrue(cmd, flag.Expand))
-
-	e := expander{cmd: cmd}
-	require.False(t, e.active(), "active must be false when no run is on the context")
-
-	src := &source.Source{Handle: "@a", Location: "${keyring:abc}"}
-	got, err := e.src(src)
-	require.NoError(t, err)
-	require.Same(t, src, got, "no run -> pass through unchanged, no panic")
 }

--- a/cli/expand_writer_test.go
+++ b/cli/expand_writer_test.go
@@ -1,0 +1,304 @@
+package cli
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+
+	"github.com/neilotoole/sq/cli/output"
+	"github.com/neilotoole/sq/cli/run"
+	"github.com/neilotoole/sq/libsq/core/secret"
+	"github.com/neilotoole/sq/libsq/driver"
+	"github.com/neilotoole/sq/libsq/source"
+	"github.com/neilotoole/sq/libsq/source/drivertype"
+	"github.com/neilotoole/sq/libsq/source/metadata"
+)
+
+// countingResolver wraps stubResolver, counting Resolve invocations.
+type countingResolver struct {
+	stub  *stubResolver
+	count atomic.Int64
+}
+
+func (c *countingResolver) Resolve(ctx context.Context, path string) (string, error) {
+	c.count.Add(1)
+	return c.stub.Resolve(ctx, path)
+}
+
+// recordingSourceWriter is a fake output.SourceWriter that records the
+// values it receives.
+type recordingSourceWriter struct {
+	gotColl  *source.Collection
+	gotSrcs  []*source.Source
+	gotGroup *source.Group
+}
+
+var _ output.SourceWriter = (*recordingSourceWriter)(nil)
+
+func (w *recordingSourceWriter) Collection(coll *source.Collection) error {
+	w.gotColl = coll
+	return nil
+}
+
+func (w *recordingSourceWriter) Source(_ *source.Collection, src *source.Source) error {
+	w.gotSrcs = append(w.gotSrcs, src)
+	return nil
+}
+
+func (w *recordingSourceWriter) Added(_ *source.Collection, src *source.Source) error {
+	w.gotSrcs = append(w.gotSrcs, src)
+	return nil
+}
+
+func (w *recordingSourceWriter) Removed(srcs ...*source.Source) error {
+	w.gotSrcs = append(w.gotSrcs, srcs...)
+	return nil
+}
+
+func (w *recordingSourceWriter) Moved(_ *source.Collection, old, nu *source.Source) error {
+	w.gotSrcs = append(w.gotSrcs, old, nu)
+	return nil
+}
+
+func (w *recordingSourceWriter) Group(group *source.Group) error {
+	w.gotGroup = group
+	return nil
+}
+
+func (w *recordingSourceWriter) SetActiveGroup(group *source.Group) error {
+	w.gotGroup = group
+	return nil
+}
+
+func (w *recordingSourceWriter) Groups(tree *source.Group) error {
+	w.gotGroup = tree
+	return nil
+}
+
+// recordingPingWriter is a fake output.PingWriter that records the
+// sources it receives.
+type recordingPingWriter struct {
+	gotOpen   []*source.Source
+	gotResult []*source.Source
+}
+
+var _ output.PingWriter = (*recordingPingWriter)(nil)
+
+func (w *recordingPingWriter) Open(srcs []*source.Source) error {
+	w.gotOpen = srcs
+	return nil
+}
+
+func (w *recordingPingWriter) Result(src *source.Source, _ time.Duration, _ error) error {
+	w.gotResult = append(w.gotResult, src)
+	return nil
+}
+
+func (w *recordingPingWriter) Close() error { return nil }
+
+// recordingMetadataWriter is a fake output.MetadataWriter that records
+// the source metadata it receives.
+type recordingMetadataWriter struct {
+	gotSrcMeta *metadata.Source
+}
+
+var _ output.MetadataWriter = (*recordingMetadataWriter)(nil)
+
+func (w *recordingMetadataWriter) TableMetadata(*metadata.Table) error { return nil }
+
+func (w *recordingMetadataWriter) SourceMetadata(srcMeta *metadata.Source, _ bool) error {
+	w.gotSrcMeta = srcMeta
+	return nil
+}
+
+func (w *recordingMetadataWriter) DBProperties(map[string]any) error      { return nil }
+func (w *recordingMetadataWriter) DriverMetadata([]driver.Metadata) error { return nil }
+func (w *recordingMetadataWriter) Catalogs(string, []string) error        { return nil }
+func (w *recordingMetadataWriter) Schemata(string, []*metadata.Schema) error {
+	return nil
+}
+
+// newExpanderCmd returns a cmd suitable for the expand decorators: the
+// --expand flag is registered (and set per the set arg), and the cmd's
+// context carries a run.Run whose SecretRegistry "keyring" scheme is
+// backed by values.
+func newExpanderCmd(t *testing.T, set bool, values map[string]string) *cobra.Command {
+	t.Helper()
+	cmd := newCmdWithExpand(t, set)
+	ru := newTestRun(t, values)
+	cmd.SetContext(run.NewContext(context.Background(), ru))
+	return cmd
+}
+
+func TestExpandSourceWriter_Source_FlagSet_Expands(t *testing.T) {
+	cmd := newExpanderCmd(t, true, map[string]string{
+		"abc": "postgres://alice:hunter2@db/sakila",
+	})
+
+	rec := &recordingSourceWriter{}
+	ew := &expandSourceWriter{w: rec, expander: expander{cmd: cmd}}
+
+	src := &source.Source{
+		Handle:   "@a",
+		Type:     drivertype.Pg,
+		Location: "${keyring:abc}",
+	}
+	require.NoError(t, ew.Source(nil, src))
+	require.Len(t, rec.gotSrcs, 1)
+	require.Equal(t, "postgres://alice:hunter2@db/sakila", rec.gotSrcs[0].Location)
+	require.Equal(t, "${keyring:abc}", src.Location, "input must not be mutated")
+}
+
+func TestExpandSourceWriter_Source_FlagUnset_PassThrough(t *testing.T) {
+	cmd := newExpanderCmd(t, false, nil)
+
+	rec := &recordingSourceWriter{}
+	ew := &expandSourceWriter{w: rec, expander: expander{cmd: cmd}}
+
+	src := &source.Source{
+		Handle:   "@a",
+		Type:     drivertype.Pg,
+		Location: "${keyring:abc}",
+	}
+	require.NoError(t, ew.Source(nil, src))
+	require.Len(t, rec.gotSrcs, 1)
+	require.Same(t, src, rec.gotSrcs[0],
+		"flag unset must pass input through verbatim")
+}
+
+func TestExpandSourceWriter_ParseErrorPropagates(t *testing.T) {
+	cmd := newExpanderCmd(t, true, nil)
+
+	rec := &recordingSourceWriter{}
+	ew := &expandSourceWriter{w: rec, expander: expander{cmd: cmd}}
+
+	src := &source.Source{
+		Handle:   "@bad",
+		Type:     drivertype.Pg,
+		Location: "${malformed", // Unclosed brace: parse error.
+	}
+	err := ew.Source(nil, src)
+	require.Error(t, err, "malformed placeholder must surface as an error")
+	require.Contains(t, err.Error(), "@bad")
+	require.Empty(t, rec.gotSrcs, "delegate must not be invoked on error")
+}
+
+func TestExpandSourceWriter_Collection_Expands(t *testing.T) {
+	cmd := newExpanderCmd(t, true, map[string]string{
+		"abc": "postgres://alice:hunter2@db/sakila",
+	})
+
+	rec := &recordingSourceWriter{}
+	ew := &expandSourceWriter{w: rec, expander: expander{cmd: cmd}}
+
+	coll := &source.Collection{}
+	require.NoError(t, coll.Add(&source.Source{
+		Handle:   "@a",
+		Type:     drivertype.Pg,
+		Location: "${keyring:abc}",
+	}))
+
+	require.NoError(t, ew.Collection(coll))
+	require.NotNil(t, rec.gotColl)
+	require.NotSame(t, coll, rec.gotColl, "must clone when --expand is set")
+	require.Equal(t, "postgres://alice:hunter2@db/sakila",
+		rec.gotColl.Sources()[0].Location)
+	require.Equal(t, "${keyring:abc}", coll.Sources()[0].Location,
+		"input must not be mutated")
+}
+
+func TestExpandSourceWriter_Group_ExpandsNestedSources(t *testing.T) {
+	cmd := newExpanderCmd(t, true, map[string]string{
+		"abc": "postgres://alice:hunter2@db/sakila",
+		"def": "mysql://bob:opensesame@db/sakila",
+	})
+
+	rec := &recordingSourceWriter{}
+	ew := &expandSourceWriter{w: rec, expander: expander{cmd: cmd}}
+
+	group := &source.Group{
+		Name: "/",
+		Sources: []*source.Source{
+			{Handle: "@a", Type: drivertype.Pg, Location: "${keyring:abc}"},
+		},
+		Groups: []*source.Group{
+			{
+				Name: "prod",
+				Sources: []*source.Source{
+					{Handle: "@prod/b", Type: drivertype.MySQL, Location: "${keyring:def}"},
+				},
+			},
+		},
+	}
+
+	require.NoError(t, ew.Group(group))
+	require.NotNil(t, rec.gotGroup)
+	require.NotSame(t, group, rec.gotGroup)
+	require.Equal(t, "postgres://alice:hunter2@db/sakila",
+		rec.gotGroup.Sources[0].Location)
+	require.Equal(t, "mysql://bob:opensesame@db/sakila",
+		rec.gotGroup.Groups[0].Sources[0].Location,
+		"subgroup sources must expand too")
+	require.Equal(t, "${keyring:abc}", group.Sources[0].Location,
+		"input must not be mutated")
+	require.Equal(t, "${keyring:def}", group.Groups[0].Sources[0].Location,
+		"input subgroup must not be mutated")
+}
+
+// TestExpandPingWriter_OpenCachesForResult verifies that the ping
+// decorator resolves each source exactly once: Open expands and caches,
+// and Result reuses the cached expansion instead of repeating
+// resolver I/O.
+func TestExpandPingWriter_OpenCachesForResult(t *testing.T) {
+	counting := &countingResolver{stub: &stubResolver{values: map[string]string{
+		"abc": "postgres://alice:hunter2@db/sakila",
+	}}}
+	reg := secret.NewRegistry()
+	reg.Register("keyring", counting)
+	ru := &run.Run{SecretRegistry: reg}
+	cmd := newCmdWithExpand(t, true)
+	cmd.SetContext(run.NewContext(context.Background(), ru))
+
+	rec := &recordingPingWriter{}
+	ew := &expandPingWriter{w: rec, expander: expander{cmd: cmd}}
+
+	src := &source.Source{
+		Handle:   "@a",
+		Type:     drivertype.Pg,
+		Location: "${keyring:abc}",
+	}
+
+	require.NoError(t, ew.Open([]*source.Source{src}))
+	require.Len(t, rec.gotOpen, 1)
+	require.Equal(t, "postgres://alice:hunter2@db/sakila", rec.gotOpen[0].Location)
+
+	require.NoError(t, ew.Result(src, time.Millisecond, nil))
+	require.Len(t, rec.gotResult, 1)
+	require.Equal(t, "postgres://alice:hunter2@db/sakila", rec.gotResult[0].Location)
+
+	require.Equal(t, int64(1), counting.count.Load(),
+		"resolver must be invoked exactly once per source (Open caches for Result)")
+}
+
+func TestExpandMetadataWriter_SourceMetadata_Expands(t *testing.T) {
+	cmd := newExpanderCmd(t, true, map[string]string{
+		"abc": "postgres://alice:hunter2@db/sakila",
+	})
+
+	rec := &recordingMetadataWriter{}
+	ew := &expandMetadataWriter{w: rec, expander: expander{cmd: cmd}}
+
+	srcMeta := &metadata.Source{
+		Handle:   "@a",
+		Location: "${keyring:abc}",
+	}
+	require.NoError(t, ew.SourceMetadata(srcMeta, true))
+	require.NotNil(t, rec.gotSrcMeta)
+	require.Equal(t, "postgres://alice:hunter2@db/sakila", rec.gotSrcMeta.Location)
+	require.Equal(t, "${keyring:abc}", srcMeta.Location,
+		"input must not be mutated")
+}

--- a/cli/expand_writer_test.go
+++ b/cli/expand_writer_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/require"
 
+	"github.com/neilotoole/sq/cli/flag"
 	"github.com/neilotoole/sq/cli/output"
 	"github.com/neilotoole/sq/cli/run"
 	"github.com/neilotoole/sq/libsq/core/secret"
@@ -331,6 +332,11 @@ func TestExpandMetadataWriter_SecretsResolved_Skipped(t *testing.T) {
 func TestExpander_NoRunOnContext_NoPanic(t *testing.T) {
 	cmd := newCmdWithExpand(t, true)
 	cmd.SetContext(context.Background()) // no run installed
+
+	// Assert the flag is set, so active()==false below is necessarily due
+	// to the missing run (not an unset flag), making this a real test of
+	// the FromContextOrNil no-panic path.
+	require.True(t, cmdFlagIsSetTrue(cmd, flag.Expand))
 
 	e := expander{cmd: cmd}
 	require.False(t, e.active(), "active must be false when no run is on the context")

--- a/cli/flag/flag.go
+++ b/cli/flag/flag.go
@@ -129,7 +129,7 @@ const (
 	// asks the driver to open the source in read-only mode (currently
 	// honored by DuckDB; other drivers ignore it).
 	SQLReadOnly      = "readonly"
-	SQLReadOnlyUsage = "Open sources read-only (DuckDB only; other drivers ignore)"
+	SQLReadOnlyUsage = "Open sources read-only, if the driver supports it"
 
 	// SQLReadOnlyAlias is a convenience alias for SQLReadOnly. It is
 	// registered as a separate pflag on the sql subcommand (see

--- a/cli/output.go
+++ b/cli/output.go
@@ -397,6 +397,21 @@ func newWriters(cmd *cobra.Command, fs *files.Files, clnup *cleanup.Cleanup, o o
 		w.Record = recwFn(outCfg.out, outCfg.outPr)
 	}
 
+	if cmd != nil {
+		// Decorate the writers that print source locations so that the
+		// --expand flag is honored centrally, in the writer layer, much
+		// as Printing.Redact enforces redaction once for every writer.
+		// (Redaction is a Printing field the format writers consult;
+		// expansion is a cli-side decorator instead, because it performs
+		// fallible resolver I/O that shouldn't be duplicated into every
+		// writer impl. See expand_writer.go for that rationale.) Any
+		// command that prints a location gets --expand for free; the
+		// decorators no-op when the flag is unset.
+		w.Source = &expandSourceWriter{w: w.Source, expander: expander{cmd: cmd}}
+		w.Ping = &expandPingWriter{w: w.Ping, expander: expander{cmd: cmd}}
+		w.Metadata = &expandMetadataWriter{w: w.Metadata, expander: expander{cmd: cmd}}
+	}
+
 	return w, outCfg
 }
 

--- a/cli/output.go
+++ b/cli/output.go
@@ -303,8 +303,8 @@ If zero, no progress bar is rendered.`,
 )
 
 // newWriters returns an output.Writers instance configured per defaults and/or
-// flags from cmd. The returned writers in [outputConfig] may differ from
-// the stdout and stderr params (e.g. decorated to support colorization).
+// flags from ru.Cmd. The returned writers in [outputConfig] may differ from
+// ru.Stdout / ru.Stderr (e.g. decorated to support colorization).
 func newWriters(ru *run.Run, o options.Options) (w *output.Writers, outCfg *outputConfig) {
 	cmd, fs, clnup := ru.Cmd, ru.Files, ru.Cleanup
 	stdout, stderr := ru.Stdout, ru.Stderr

--- a/cli/output.go
+++ b/cli/output.go
@@ -28,6 +28,7 @@ import (
 	"github.com/neilotoole/sq/cli/output/xlsxw"
 	"github.com/neilotoole/sq/cli/output/xmlw"
 	"github.com/neilotoole/sq/cli/output/yamlw"
+	"github.com/neilotoole/sq/cli/run"
 	"github.com/neilotoole/sq/libsq/core/cleanup"
 	"github.com/neilotoole/sq/libsq/core/debugz"
 	"github.com/neilotoole/sq/libsq/core/errz"
@@ -305,7 +306,7 @@ If zero, no progress bar is rendered.`,
 // flags from cmd. The returned writers in [outputConfig] may differ from
 // the stdout and stderr params (e.g. decorated to support colorization).
 func newWriters(cmd *cobra.Command, fs *files.Files, clnup *cleanup.Cleanup, o options.Options,
-	stdout, stderr io.Writer,
+	stdout, stderr io.Writer, ru *run.Run,
 ) (w *output.Writers, outCfg *outputConfig) {
 	// Invoke getFormat to see if the format was specified
 	// via config or flag.
@@ -407,9 +408,9 @@ func newWriters(cmd *cobra.Command, fs *files.Files, clnup *cleanup.Cleanup, o o
 		// writer impl. See expand_writer.go for that rationale.) Any
 		// command that prints a location gets --expand for free; the
 		// decorators no-op when the flag is unset.
-		w.Source = &expandSourceWriter{w: w.Source, expander: expander{cmd: cmd}}
-		w.Ping = &expandPingWriter{w: w.Ping, expander: expander{cmd: cmd}}
-		w.Metadata = &expandMetadataWriter{w: w.Metadata, expander: expander{cmd: cmd}}
+		w.Source = &expandSourceWriter{w: w.Source, expander: expander{cmd: cmd, ru: ru}}
+		w.Ping = &expandPingWriter{w: w.Ping, expander: expander{cmd: cmd, ru: ru}}
+		w.Metadata = &expandMetadataWriter{w: w.Metadata, expander: expander{cmd: cmd, ru: ru}}
 	}
 
 	return w, outCfg

--- a/cli/output.go
+++ b/cli/output.go
@@ -305,9 +305,10 @@ If zero, no progress bar is rendered.`,
 // newWriters returns an output.Writers instance configured per defaults and/or
 // flags from cmd. The returned writers in [outputConfig] may differ from
 // the stdout and stderr params (e.g. decorated to support colorization).
-func newWriters(cmd *cobra.Command, fs *files.Files, clnup *cleanup.Cleanup, o options.Options,
-	stdout, stderr io.Writer, ru *run.Run,
-) (w *output.Writers, outCfg *outputConfig) {
+func newWriters(ru *run.Run, o options.Options) (w *output.Writers, outCfg *outputConfig) {
+	cmd, fs, clnup := ru.Cmd, ru.Files, ru.Cleanup
+	stdout, stderr := ru.Stdout, ru.Stderr
+
 	// Invoke getFormat to see if the format was specified
 	// via config or flag.
 	fm := getFormat(cmd, o)

--- a/cli/output/jsonw/metadatawriter.go
+++ b/cli/output/jsonw/metadatawriter.go
@@ -43,7 +43,7 @@ func (w *mdWriter) SourceMetadata(md *metadata.Source, showSchema bool) error {
 	}
 
 	// Don't render "tables", "table_count", and "view_count"
-	type mdNoSchema struct {
+	type mdNoSchema struct { //nolint:govet // field alignment
 		metadata.Source
 		Tables     *[]*metadata.Table `json:"tables,omitempty"`
 		TableCount *int64             `json:"table_count,omitempty"`

--- a/cli/output/yamlw/metadatawriter.go
+++ b/cli/output/yamlw/metadatawriter.go
@@ -48,7 +48,7 @@ func (w *mdWriter) SourceMetadata(md *metadata.Source, showSchema bool) error {
 	}
 
 	// Don't render "tables", "table_count", and "view_count"
-	type mdNoSchema struct {
+	type mdNoSchema struct { //nolint:govet // field alignment
 		metadata.Source `yaml:",omitempty,inline"`
 		Tables          *[]*metadata.Table `yaml:"tables,omitempty"`
 		TableCount      *int64             `yaml:"table_count,omitempty"`

--- a/cli/run.go
+++ b/cli/run.go
@@ -228,7 +228,7 @@ func preRun(cmd *cobra.Command, ru *run.Run) error {
 	cmd.SetContext(ctx)
 
 	var outCfg *outputConfig
-	ru.Writers, outCfg = newWriters(ru.Cmd, ru.Files, ru.Cleanup, cmdOpts, ru.Stdout, ru.Stderr)
+	ru.Writers, outCfg = newWriters(ru.Cmd, ru.Files, ru.Cleanup, cmdOpts, ru.Stdout, ru.Stderr, ru)
 	ru.Out = outCfg.out
 	ru.ErrOut = outCfg.errOut
 

--- a/cli/run.go
+++ b/cli/run.go
@@ -228,7 +228,7 @@ func preRun(cmd *cobra.Command, ru *run.Run) error {
 	cmd.SetContext(ctx)
 
 	var outCfg *outputConfig
-	ru.Writers, outCfg = newWriters(ru.Cmd, ru.Files, ru.Cleanup, cmdOpts, ru.Stdout, ru.Stderr, ru)
+	ru.Writers, outCfg = newWriters(ru, cmdOpts)
 	ru.Out = outCfg.out
 	ru.ErrOut = outCfg.errOut
 

--- a/cli/run/run.go
+++ b/cli/run/run.go
@@ -36,20 +36,10 @@ func NewContext(ctx context.Context, ru *Run) context.Context {
 }
 
 // FromContext extracts the Run added to ctx via NewContext. It panics
-// if no Run is present; callers that run after preRun (the vast
-// majority) rely on this fail-fast. Use FromContextOrNil from code that
-// may run before a Run is installed.
+// if no Run is present; this is a deliberate fail-fast, since every
+// command path installs a Run before any code that reads it runs.
 func FromContext(ctx context.Context) *Run {
 	return ctx.Value(runKey{}).(*Run)
-}
-
-// FromContextOrNil returns the Run added to ctx via NewContext, or nil
-// if none is present. Unlike FromContext it does not panic, for callers
-// that may run before a Run is installed (e.g. writer decorators built
-// over a bare context in tests).
-func FromContextOrNil(ctx context.Context) *Run {
-	ru, _ := ctx.Value(runKey{}).(*Run)
-	return ru
 }
 
 // Run is a container for injectable resources passed

--- a/cli/run/run.go
+++ b/cli/run/run.go
@@ -35,9 +35,21 @@ func NewContext(ctx context.Context, ru *Run) context.Context {
 	return context.WithValue(ctx, runKey{}, ru)
 }
 
-// FromContext extracts the Run added to ctx via NewContext.
+// FromContext extracts the Run added to ctx via NewContext. It panics
+// if no Run is present; callers that run after preRun (the vast
+// majority) rely on this fail-fast. Use FromContextOrNil from code that
+// may run before a Run is installed.
 func FromContext(ctx context.Context) *Run {
 	return ctx.Value(runKey{}).(*Run)
+}
+
+// FromContextOrNil returns the Run added to ctx via NewContext, or nil
+// if none is present. Unlike FromContext it does not panic, for callers
+// that may run before a Run is installed (e.g. writer decorators built
+// over a bare context in tests).
+func FromContextOrNil(ctx context.Context) *Run {
+	ru, _ := ctx.Value(runKey{}).(*Run)
+	return ru
 }
 
 // Run is a container for injectable resources passed

--- a/drivers/duckdb/access_mode.go
+++ b/drivers/duckdb/access_mode.go
@@ -3,6 +3,8 @@ package duckdb
 import (
 	"net/url"
 	"strings"
+
+	"github.com/neilotoole/sq/libsq/driver"
 )
 
 // accessModeKey is the DuckDB DSN query-string key controlling open mode.
@@ -67,10 +69,28 @@ func ApplyReadOnlyToLocation(loc string, explicit bool) (out string, changed boo
 	return loc + "?" + accessModeKey + "=READ_ONLY", true
 }
 
+// Compile-time check: driveri implements driver.ReadOnlyConflictDetector.
+var _ driver.ReadOnlyConflictDetector = (*driveri)(nil)
+
+// DetectReadOnlyConflict implements driver.ReadOnlyConflictDetector.
+// Only an explicit access_mode=READ_WRITE in loc is a hard conflict
+// with a read-only request: access_mode=AUTOMATIC is overridden to
+// READ_ONLY by the driver when the request is explicit (see
+// ApplyReadOnlyToLocation), and READ_ONLY already agrees. The returned
+// descriptor echoes the access_mode value as the user typed it.
+func (d *driveri) DetectReadOnlyConflict(loc string) (conflict string, ok bool) {
+	mode, has := ExplicitAccessMode(loc)
+	if !has || !strings.EqualFold(mode, "READ_WRITE") {
+		return "", false
+	}
+	return accessModeKey + "=" + mode, true
+}
+
 // ExplicitAccessMode returns the access_mode value the user set in loc's
-// query string, if any. Used by the CLI to detect --readonly vs URL
-// conflicts. Value is returned as-is (no case normalization) so callers
-// can echo what the user typed in error messages.
+// query string, if any. Used by DetectReadOnlyConflict to detect
+// --readonly vs URL conflicts. Value is returned as-is (no case
+// normalization) so callers can echo what the user typed in error
+// messages.
 func ExplicitAccessMode(loc string) (mode string, ok bool) {
 	if !strings.HasPrefix(loc, Prefix) {
 		return "", false

--- a/drivers/duckdb/access_mode_test.go
+++ b/drivers/duckdb/access_mode_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/neilotoole/sq/drivers/duckdb"
+	"github.com/neilotoole/sq/libsq/core/lg/lgt"
 	"github.com/neilotoole/sq/libsq/driver"
 	"github.com/neilotoole/sq/libsq/source"
 	"github.com/neilotoole/sq/libsq/source/drivertype"
@@ -230,4 +231,51 @@ func TestPing_ReadOnly_MissingFile(t *testing.T) {
 	require.Error(t, drvr.Ping(context.Background(), src, driver.ModeReadOnly),
 		"read-only ping of a missing file must fail")
 	require.NoFileExists(t, tmp, "ping must not create the file when read-only")
+}
+
+// TestDetectReadOnlyConflict verifies the driver.ReadOnlyConflictDetector
+// implementation: only an explicit access_mode=READ_WRITE in the location
+// is a conflict with a read-only request.
+func TestDetectReadOnlyConflict(t *testing.T) {
+	p := &duckdb.Provider{Log: lgt.New(t)}
+	drvr, err := p.DriverFor(drivertype.DuckDB)
+	require.NoError(t, err)
+
+	detector, ok := drvr.(driver.ReadOnlyConflictDetector)
+	require.True(t, ok,
+		"duckdb driver must implement driver.ReadOnlyConflictDetector")
+
+	testCases := []struct {
+		name         string
+		in           string
+		wantConflict string
+		wantOK       bool
+	}{
+		{name: "no_query", in: "duckdb:///f.duckdb", wantOK: false},
+		{name: "other_param", in: "duckdb:///f.duckdb?threads=4", wantOK: false},
+		{name: "read_only", in: "duckdb:///f.duckdb?access_mode=READ_ONLY", wantOK: false},
+		{name: "automatic", in: "duckdb:///f.duckdb?access_mode=AUTOMATIC", wantOK: false},
+		{
+			name:         "read_write",
+			in:           "duckdb:///f.duckdb?access_mode=READ_WRITE",
+			wantConflict: "access_mode=READ_WRITE",
+			wantOK:       true,
+		},
+		{
+			name:         "read_write_lowercase_echoes_user_input",
+			in:           "duckdb:///f.duckdb?access_mode=read_write",
+			wantConflict: "access_mode=read_write",
+			wantOK:       true,
+		},
+		{name: "empty", in: "", wantOK: false},
+		{name: "non_duckdb", in: "sqlite3:///f.db?access_mode=READ_WRITE", wantOK: false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotConflict, gotOK := detector.DetectReadOnlyConflict(tc.in)
+			require.Equal(t, tc.wantOK, gotOK)
+			require.Equal(t, tc.wantConflict, gotConflict)
+		})
+	}
 }

--- a/drivers/duckdb/duckdb.go
+++ b/drivers/duckdb/duckdb.go
@@ -127,7 +127,7 @@ func (d *driveri) doOpen(ctx context.Context, src *source.Source, mode driver.Ac
 		if mode == driver.ModeReadOnlyExplicit {
 			if conflict, ok := d.DetectReadOnlyConflict(loc); ok {
 				return nil, errz.Errorf(
-					"duckdb: read-only requested but %s conflicts with %s", src.Handle, conflict)
+					"duckdb: cannot open %s read-only: its location sets %s", src.Handle, conflict)
 			}
 		}
 		var changed bool

--- a/drivers/duckdb/duckdb.go
+++ b/drivers/duckdb/duckdb.go
@@ -115,6 +115,21 @@ func (d *driveri) Open(ctx context.Context, src *source.Source, mode driver.Acce
 func (d *driveri) doOpen(ctx context.Context, src *source.Source, mode driver.AccessMode) (*sql.DB, error) {
 	loc := src.Location
 	if mode.IsReadOnly() {
+		// Defense-in-depth: an explicit read-only request against a
+		// location that explicitly demands write access (access_mode=
+		// READ_WRITE) is a hard conflict. ApplyReadOnlyToLocation would
+		// silently let READ_WRITE win, so refuse here rather than open
+		// read-write under a read-only request. The CLI (cmd_sql) also
+		// surfaces this preemptively before any open; this guard covers
+		// every ModeReadOnlyExplicit caller (Open and Ping) regardless
+		// of entry point. Only explicit RO conflicts: implicit RO lets
+		// the location win (see ApplyReadOnlyToLocation).
+		if mode == driver.ModeReadOnlyExplicit {
+			if conflict, ok := d.DetectReadOnlyConflict(loc); ok {
+				return nil, errz.Errorf(
+					"duckdb: read-only requested but %s conflicts with %s", src.Handle, conflict)
+			}
+		}
 		var changed bool
 		loc, changed = ApplyReadOnlyToLocation(loc, mode == driver.ModeReadOnlyExplicit)
 		if changed {

--- a/drivers/duckdb/readonly_integration_test.go
+++ b/drivers/duckdb/readonly_integration_test.go
@@ -132,3 +132,27 @@ func TestReadOnly_URLAccessModeWins(t *testing.T) {
 	require.NoError(t, err,
 		"write must succeed when access_mode=READ_WRITE is explicit in URL")
 }
+
+// TestReadOnly_Explicit_ConflictWithURL verifies the driver-level
+// defense-in-depth guard: an explicit read-only open against a location
+// that explicitly demands write access (access_mode=READ_WRITE) is
+// refused, covering callers that bypass the CLI's preemptive conflict
+// check. Implicit ModeReadOnly, by contrast, lets the URL win (see
+// TestReadOnly_URLAccessModeWins).
+func TestReadOnly_Explicit_ConflictWithURL(t *testing.T) {
+	t.Parallel()
+	path := copyToTempDuckDB(t)
+
+	prov := &duckdb.Provider{Log: lgt.New(t)}
+	drvr, err := prov.DriverFor(testh.DuckDBType())
+	require.NoError(t, err)
+
+	src := testh.MakeDuckDBSource("@ro_explicit_conflict", path)
+	src.Location += "?access_mode=READ_WRITE"
+
+	ctx := context.Background()
+	_, err = drvr.Open(ctx, src, driver.ModeReadOnlyExplicit)
+	require.Error(t, err,
+		"explicit read-only must be refused when the location demands READ_WRITE")
+	require.Contains(t, err.Error(), "access_mode=READ_WRITE")
+}

--- a/libsq/driver/driver.go
+++ b/libsq/driver/driver.go
@@ -254,11 +254,12 @@ type SQLDriver interface {
 // ReadOnlyConflictDetector is an optional interface implemented by
 // drivers whose location syntax can explicitly demand write access,
 // contradicting a read-only request. The canonical example is DuckDB's
-// access_mode=READ_WRITE query parameter. The CLI consults this
-// interface when the user explicitly requests read-only access (sq sql
-// --readonly), so the contradiction surfaces as an error before any
-// connection is opened, instead of the location silently winning over
-// the flag.
+// access_mode=READ_WRITE query parameter. It is consulted in two places
+// when the user explicitly requests read-only access (sq sql --readonly):
+// the CLI surfaces the conflict preemptively, before any connection is
+// opened, and the driver itself rejects such an open as defense-in-depth
+// so the conflict can't slip through for a non-CLI caller. Either way the
+// location does not silently win over the read-only request.
 //
 // Drivers without a location-level access mode (most drivers) simply
 // don't implement the interface, and no conflict is possible. Mirrors

--- a/libsq/driver/driver.go
+++ b/libsq/driver/driver.go
@@ -251,6 +251,31 @@ type SQLDriver interface {
 	DBProperties(ctx context.Context, db sqlz.DB) (map[string]any, error)
 }
 
+// ReadOnlyConflictDetector is an optional interface implemented by
+// drivers whose location syntax can explicitly demand write access,
+// contradicting a read-only request. The canonical example is DuckDB's
+// access_mode=READ_WRITE query parameter. The CLI consults this
+// interface when the user explicitly requests read-only access (sq sql
+// --readonly), so the contradiction surfaces as an error before any
+// connection is opened, instead of the location silently winning over
+// the flag.
+//
+// Drivers without a location-level access mode (most drivers) simply
+// don't implement the interface, and no conflict is possible. Mirrors
+// the optional-capability pattern of [ConnParamDetector].
+type ReadOnlyConflictDetector interface {
+	// DetectReadOnlyConflict examines loc and reports whether it
+	// explicitly demands write access, conflicting with a read-only
+	// request. On conflict, the returned descriptor identifies the
+	// offending location component for use in the error message,
+	// echoing what the user typed (e.g. "access_mode=READ_WRITE"). A
+	// location that expresses no access preference, or one that is
+	// already compatible with read-only access, returns ok=false.
+	// Implementations must not perform I/O: this is a pure inspection
+	// of the location string.
+	DetectReadOnlyConflict(loc string) (conflict string, ok bool)
+}
+
 // Metadata holds driver metadata.
 //
 // TODO: Can driver.Metadata and dialect.Dialect be merged?

--- a/libsq/source/metadata/metadata.go
+++ b/libsq/source/metadata/metadata.go
@@ -111,20 +111,21 @@ func (s *Source) Clone() *Source {
 	}
 
 	s2 := &Source{
-		Handle:     s.Handle,
-		Location:   s.Location,
-		Name:       s.Name,
-		FQName:     s.FQName,
-		Schema:     s.Schema,
-		Catalog:    s.Catalog,
-		Driver:     s.Driver,
-		DBDriver:   s.DBDriver,
-		DBProduct:  s.DBProduct,
-		DBVersion:  s.DBVersion,
-		User:       s.User,
-		Size:       s.Size,
-		TableCount: s.TableCount,
-		ViewCount:  s.ViewCount,
+		Handle:          s.Handle,
+		Location:        s.Location,
+		Name:            s.Name,
+		FQName:          s.FQName,
+		Schema:          s.Schema,
+		Catalog:         s.Catalog,
+		Driver:          s.Driver,
+		DBDriver:        s.DBDriver,
+		DBProduct:       s.DBProduct,
+		DBVersion:       s.DBVersion,
+		User:            s.User,
+		Size:            s.Size,
+		TableCount:      s.TableCount,
+		ViewCount:       s.ViewCount,
+		SecretsResolved: s.SecretsResolved,
 	}
 
 	if s.DBProperties != nil {

--- a/libsq/source/metadata/metadata.go
+++ b/libsq/source/metadata/metadata.go
@@ -70,6 +70,14 @@ type Source struct { //nolint:govet // field alignment
 	// Typically the value is a scalar such as integer or string, but
 	// it can be a nested value such as map or array.
 	DBProperties map[string]any `json:"db_properties,omitempty" yaml:"db_properties,omitempty"`
+
+	// SecretsResolved indicates that Location holds resolved literal
+	// bytes rather than a placeholder template, mirroring
+	// [source.Source.SecretsResolved]. Drivers leave it false; the CLI
+	// inspect path sets it from the source so the --expand writer
+	// decorator can skip re-expanding an already-resolved location
+	// (which would double-unescape "$$"). Never persisted or serialized.
+	SecretsResolved bool `json:"-" yaml:"-"`
 }
 
 // Table returns the named table, or nil.

--- a/libsq/source/metadata/metadata_test.go
+++ b/libsq/source/metadata/metadata_test.go
@@ -105,20 +105,21 @@ func TestSource_Clone(t *testing.T) {
 	t.Run("full_source", func(t *testing.T) {
 		var size int64 = 1024
 		src := &metadata.Source{
-			Handle:     "@sakila",
-			Location:   "postgres://localhost/sakila",
-			Name:       "sakila",
-			FQName:     "sakila.public",
-			Schema:     "public",
-			Catalog:    "sakila",
-			Driver:     drivertype.Pg,
-			DBDriver:   drivertype.Pg,
-			DBProduct:  "PostgreSQL 14.0",
-			DBVersion:  "14.0",
-			User:       "postgres",
-			Size:       &size,
-			TableCount: 10,
-			ViewCount:  5,
+			Handle:          "@sakila",
+			Location:        "postgres://localhost/sakila",
+			Name:            "sakila",
+			FQName:          "sakila.public",
+			Schema:          "public",
+			Catalog:         "sakila",
+			Driver:          drivertype.Pg,
+			DBDriver:        drivertype.Pg,
+			DBProduct:       "PostgreSQL 14.0",
+			DBVersion:       "14.0",
+			User:            "postgres",
+			Size:            &size,
+			TableCount:      10,
+			ViewCount:       5,
+			SecretsResolved: true,
 			DBProperties: map[string]any{
 				"max_connections": 100,
 				"version":         "14.0",
@@ -149,6 +150,7 @@ func TestSource_Clone(t *testing.T) {
 		require.Equal(t, src.Size, got.Size)
 		require.Equal(t, src.TableCount, got.TableCount)
 		require.Equal(t, src.ViewCount, got.ViewCount)
+		require.Equal(t, src.SecretsResolved, got.SecretsResolved)
 
 		// Verify DBProperties is a deep copy
 		require.Equal(t, src.DBProperties, got.DBProperties)

--- a/site/content/en/docs/cmd/sql.help.txt
+++ b/site/content/en/docs/cmd/sql.help.txt
@@ -54,7 +54,7 @@ Flags:
       --no-cache                       Don't cache ingest data
       --driver.csv.delim string        Delimiter for ingest CSV data (default "comma")
       --driver.csv.empty-as-null       Treat ingest empty CSV fields as NULL (default true)
-      --readonly                       Open sources read-only (DuckDB only; other drivers ignore)
+      --readonly                       Open sources read-only, if the driver supports it
       --ro                             Alias for --readonly
       --help                           help for sql
 


### PR DESCRIPTION
Fixes #780 (items 1 and 3).

## Background

v0.54.0 enforces secret reveal once in the writer layer (`OptSecretsReveal` -> `pr.Redact`), so
every command and output format inherits `--reveal` automatically. Two other cross-cutting
behaviors from that release were left as per-command opt-ins, where the next command to touch the
path would silently do the wrong thing. This PR centralizes both at the same altitude as
`--reveal`, so new commands are correct by default.

(Issue #780 listed a third opt-in, scattered read-only ctx flips. That was resolved separately by
#815, which replaced the ctx-carried hint with an explicit, required `driver.AccessMode`
parameter. This PR is rebased onto #815; nothing read-only-marking-related remains here.)

## `--expand`

Expansion is now applied by decorators around the three writer interfaces that print source
locations (`SourceWriter`, `PingWriter`, `MetadataWriter`), wired once in `newWriters`
(`cli/output.go`); the decorators themselves live in `cli/expand_writer.go`. Lazy decoration is
used rather than eager preRun expansion because expansion does fallible resolver I/O (propagated
through the writers' existing error returns) and eager expansion of the config collection risks
persisting resolved secrets on commands that save config. Per-command expansion code is removed
from add/ls/mv/src/inspect/ping. User-visible widening: `sq group` and `sq rm --json` now honor
`--expand` (previously silently ignored).

Correctness properties of the centralized path:

- An already-resolved location is never re-expanded (re-resolving a literal would unescape `$$` a
  second time and corrupt it). The guard is uniform across all four paths: source, collection,
  group, and metadata. `metadata.Source` carries a `SecretsResolved` bit (set by `execInspect`)
  so `expandMetadataWriter` skips a resolved location (e.g. a stdin source) like the others.
- The decorators receive the run as an injected dependency at construction (`newWriters`), where
  it is always in hand; the context is read only for the live resolver ctx. No run-from-context
  lookup is needed, so there is no missing-run case to handle.
- Because expansion is lazy, a malformed `${...}` placeholder under `--expand` surfaces at write
  time (after the source opens) rather than fail-fast; the parse error still surfaces. This is
  the accepted cost of writer-layer expansion and is documented at the call site.
- The ping writer expands each source once at `Open` (cached so the per-source `Result` calls
  don't repeat resolver I/O) and drops the cache at `Close`, so resolved (possibly plaintext)
  locations aren't retained past the run.
- `expandSourceLocation` is the single skip+expand site shared by the source and collection
  helpers. `sq config export` keeps its own `--expand` implementation (it re-escapes for a
  byte-identical config round-trip and is strict on resolver error); the two sites are
  cross-referenced in comments.

## `--readonly` conflict check

The check no longer hardcodes DuckDB. A new optional `driver.ReadOnlyConflictDetector` capability
(following the `ConnParamDetector` precedent) is implemented by duckdb (delegating to
`ExplicitAccessMode`) and consulted generically by `cmd_sql` via type assertion. Flag usage text
and site help no longer say "DuckDB only".

As defense-in-depth, DuckDB's `doOpen` also refuses an explicit read-only open against a location
that demands `access_mode=READ_WRITE`, so the conflict is caught for any caller (covering both
`Open` and `Ping`), not only the `cmd_sql` preflight. Both sites share the same
`DetectReadOnlyConflict` predicate. Implicit read-only still lets the location win (the documented
escape hatch).

## Incidental fix

While reworking `cli/cmd_ping.go` for the `--expand` removal, review surfaced a pre-existing
goroutine leak in `pingSource`: `doneCh` was unbuffered, so when the `select` returned on
`ctx.Done()` (the timeout/cancel path `ping` relies on) the ping goroutine blocked forever on its
send, holding the resolved source. `doneCh` is now buffered (size 1) so the send always completes.

## Testing

Central-path `--expand` exercised end-to-end via `sq group`, `sq mv`, and `sq rm`; the `--readonly`
conflict caught through both the `ReadOnlyConflictDetector` interface and a real DuckDB
explicit-RO-vs-`READ_WRITE` open; plus unit coverage for the `SecretsResolved` skip
(source/collection/metadata); and a goroutine-leak guard for the pingSource timeout path. CI green: build,
`test-nix` (macOS + Ubuntu), `test-windows-smoke`, and `lint` all pass.



