### PR TITLE
config: stamp config.version with schema version, not binary version

### DIFF
--- a/cli/config/yamlstore/defaultload.go
+++ b/cli/config/yamlstore/defaultload.go
@@ -67,6 +67,16 @@ func Load(ctx context.Context, osArgs []string, optsReg *options.Registry,
 
 	if !cfgStore.Exists() {
 		cfg := config.New()
+		if schemaVers := upgrades.highestVersion(); schemaVers != "" {
+			// Stamp the fresh config with the config schema version (the
+			// highest registered upgrade version), not the build version.
+			// config.version tracks the schema, and advances only when a
+			// registered upgrade func transforms the config. Stamping the
+			// build version here would inflate the version (and, for
+			// prerelease builds such as v0.0.0-dev, would mark a
+			// current-schema config as predating every upgrade).
+			cfg.Version = schemaVers
+		}
 		return cfg, cfgStore, nil
 	}
 

--- a/cli/config/yamlstore/internal_test.go
+++ b/cli/config/yamlstore/internal_test.go
@@ -2,8 +2,10 @@ package yamlstore
 
 import (
 	"context"
+	"io/fs"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -355,6 +357,38 @@ future_field: data this build doesn't understand
 	require.NoError(t, err)
 	require.Equal(t, cfgContent, string(backupContent),
 		"backup must not be overwritten by subsequent saves")
+}
+
+// Test_Store_backupNewerConfig_StatError verifies that a stat error
+// on the backup path other than fs.ErrNotExist (e.g. a permission
+// error) fails the backup, rather than being treated as a missing
+// backup file.
+func Test_Store_backupNewerConfig_StatError(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("dir permissions are not enforced this way on Windows")
+	}
+	if os.Geteuid() == 0 {
+		t.Skip("dir permissions are not enforced for root")
+	}
+
+	cfgDir, cfgPath := writeTestConfig(t, "config.version: v0.58.0\n")
+
+	ctx := lg.NewContext(context.Background(), lgt.New(t))
+	store := &Store{Path: cfgPath, newerCfgVers: "v0.58.0"}
+
+	// Remove the execute bit from the config dir, so that stat on the
+	// backup path fails with a permission error, not fs.ErrNotExist.
+	require.NoError(t, os.Chmod(cfgDir, 0o600))
+	t.Cleanup(func() {
+		// Restore perms so t.TempDir cleanup can remove the dir.
+		require.NoError(t, os.Chmod(cfgDir, 0o755))
+	})
+
+	err := store.backupNewerConfig(ctx)
+	require.Error(t, err)
+	require.ErrorIs(t, err, fs.ErrPermission)
+	require.Equal(t, "v0.58.0", store.newerCfgVers,
+		"newerCfgVers must not be cleared on failure, so a retry can still back up")
 }
 
 // Test_Store_Save_NewerConfig_Prerelease_NoBackup verifies that

--- a/cli/config/yamlstore/internal_test.go
+++ b/cli/config/yamlstore/internal_test.go
@@ -697,10 +697,10 @@ func Test_Store_doLoad_EmptyVersionStampsBuildVersion(t *testing.T) {
 		"an empty version stamps the build version when no registry is configured")
 }
 
-// Test_Store_writeConfigBackupOnce_StatError verifies that a stat failure
-// other than ErrNotExist (here ENOTDIR, via a non-directory in the path)
-// aborts rather than silently proceeding without a backup.
-func Test_Store_writeConfigBackupOnce_StatError(t *testing.T) {
+// Test_Store_writeConfigBackupOnce_DirError verifies that an unusable
+// backup directory (here a non-directory in the path, ENOTDIR) aborts the
+// backup rather than silently proceeding without one.
+func Test_Store_writeConfigBackupOnce_DirError(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("ENOTDIR path semantics differ on Windows")
 	}
@@ -709,13 +709,40 @@ func Test_Store_writeConfigBackupOnce_StatError(t *testing.T) {
 	require.NoError(t, os.WriteFile(notDir, []byte("x"), 0o600))
 
 	ctx := lg.NewContext(context.Background(), lgt.New(t))
-	// fs.Path sits under a regular file, so stat on the backup path
-	// fails with ENOTDIR (not ErrNotExist).
+	// fs.Path sits under a regular file, so creating the temp backup in
+	// that "directory" fails with ENOTDIR.
 	store := &Store{Path: filepath.Join(notDir, "sq.yml")}
 
 	_, err := store.writeConfigBackupOnce(ctx, "v0.58.0", []byte("data"))
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "failed to stat config backup")
+	require.Contains(t, err.Error(), "temp config backup")
+}
+
+// Test_Store_writeConfigBackupOnce_DoesNotClobber verifies the
+// at-most-once guarantee: once a backup exists, a second call reports
+// wrote=false and leaves the existing (pristine) backup intact rather
+// than replacing it with possibly-degraded content.
+func Test_Store_writeConfigBackupOnce_DoesNotClobber(t *testing.T) {
+	_, cfgPath := writeTestConfig(t, "config.version: v0.58.0\n")
+	ctx := lg.NewContext(context.Background(), lgt.New(t))
+	store := &Store{Path: cfgPath}
+
+	backupPath := backupFilePath(cfgPath, "v0.58.0")
+
+	wrote, err := store.writeConfigBackupOnce(ctx, "v0.58.0", []byte("original"))
+	require.NoError(t, err)
+	require.True(t, wrote, "first call must create the backup")
+	got, err := os.ReadFile(backupPath)
+	require.NoError(t, err)
+	require.Equal(t, "original", string(got))
+
+	wrote, err = store.writeConfigBackupOnce(ctx, "v0.58.0", []byte("degraded"))
+	require.NoError(t, err)
+	require.False(t, wrote, "second call must not write over an existing backup")
+	got, err = os.ReadFile(backupPath)
+	require.NoError(t, err)
+	require.Equal(t, "original", string(got),
+		"the existing backup must not be clobbered")
 }
 
 // Test_Store_Load_RejectsBrokenConfig verifies that a broken config fails

--- a/cli/config/yamlstore/internal_test.go
+++ b/cli/config/yamlstore/internal_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/neilotoole/sq/cli/buildinfo"
+	"github.com/neilotoole/sq/cli/config"
 	"github.com/neilotoole/sq/cli/flag"
 	"github.com/neilotoole/sq/libsq/core/lg"
 	"github.com/neilotoole/sq/libsq/core/lg/lgt"
@@ -65,6 +66,27 @@ func Test_getConfigDirFromFlag(t *testing.T) {
 	}
 }
 
+// writeTestConfig writes content to sq.yml in a temp dir, returning
+// the config path.
+func writeTestConfig(t *testing.T, content string) (cfgDir, cfgPath string) {
+	t.Helper()
+	cfgDir = t.TempDir()
+	cfgPath = filepath.Join(cfgDir, "sq.yml")
+	require.NoError(t, os.WriteFile(cfgPath, []byte(content), 0o644))
+	return cfgDir, cfgPath
+}
+
+// requireNoBackupFiles asserts that dir contains no ".bak." files.
+func requireNoBackupFiles(t *testing.T, dir string) {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	for _, e := range entries {
+		require.NotContains(t, e.Name(), ".bak.",
+			"no backup file expected")
+	}
+}
+
 // Test_checkNeedsUpgrade_newerConfigVersion verifies that checkNeedsUpgrade
 // returns errConfigVersionNewerThanBuild when the config version is newer
 // than the (non-prerelease) build version.
@@ -73,15 +95,13 @@ func Test_checkNeedsUpgrade_newerConfigVersion(t *testing.T) {
 	setBuildVersion(t, "v0.48.0")
 
 	// Create temp config with newer version.
-	cfgDir := t.TempDir()
-	cfgPath := filepath.Join(cfgDir, "sq.yml")
-	err := os.WriteFile(cfgPath, []byte("config.version: v99.0.0\n"), 0o644)
-	require.NoError(t, err)
+	_, cfgPath := writeTestConfig(t, "config.version: v99.0.0\n")
 
 	ctx := lg.NewContext(context.Background(), lgt.New(t))
+	store := &Store{Path: cfgPath, UpgradeRegistry: UpgradeRegistry{}}
 
 	// Should return errConfigVersionNewerThanBuild.
-	needsUpgrade, foundVers, err := checkNeedsUpgrade(ctx, cfgPath)
+	needsUpgrade, foundVers, err := store.checkNeedsUpgrade(ctx)
 	require.ErrorIs(t, err, errConfigVersionNewerThanBuild)
 	require.False(t, needsUpgrade)
 	require.Equal(t, "v99.0.0", foundVers)
@@ -95,55 +115,334 @@ func Test_checkNeedsUpgrade_newerConfigVersion_prerelease(t *testing.T) {
 	// Prerelease builds should NOT error.
 	setBuildVersion(t, "v0.48.0-dev")
 
-	cfgDir := t.TempDir()
-	cfgPath := filepath.Join(cfgDir, "sq.yml")
-	err := os.WriteFile(cfgPath, []byte("config.version: v99.0.0\n"), 0o644)
-	require.NoError(t, err)
+	_, cfgPath := writeTestConfig(t, "config.version: v99.0.0\n")
 
 	ctx := lg.NewContext(context.Background(), lgt.New(t))
+	store := &Store{Path: cfgPath, UpgradeRegistry: UpgradeRegistry{}}
 
 	// Should NOT error for prerelease.
-	needsUpgrade, foundVers, err := checkNeedsUpgrade(ctx, cfgPath)
+	needsUpgrade, foundVers, err := store.checkNeedsUpgrade(ctx)
 	require.NoError(t, err)
 	require.False(t, needsUpgrade)
 	require.Equal(t, "v99.0.0", foundVers)
 }
 
-// Test_Store_Load_NoBackupWhenNoUpgradeFuncs verifies that a routine
-// version bump with no registered upgrade funcs in range does not
-// write a pre-upgrade backup file. Due to version inflation (see the
-// IMPLEMENTATION NOTE on errConfigVersionNewerThanBuild), doUpgrade
-// runs on every sq release; the backup must be written only when an
-// upgrade func actually transforms the config, else one
-// credential-bearing backup accumulates per release.
-func Test_Store_Load_NoBackupWhenNoUpgradeFuncs(t *testing.T) {
+// Test_checkNeedsUpgrade_schemaVersion verifies that needsUpgrade is
+// determined by comparing the config version against the highest
+// version in the UpgradeRegistry (the schema version), not against
+// the build version.
+func Test_checkNeedsUpgrade_schemaVersion(t *testing.T) {
+	noop := func(_ context.Context, before []byte) ([]byte, error) {
+		return before, nil
+	}
+
+	testCases := []struct {
+		name            string
+		buildVers       string
+		cfgVers         string
+		registry        UpgradeRegistry
+		wantNeeds       bool
+		wantNewerThanBd bool
+	}{
+		{
+			// A release without schema changes: config carries an
+			// inflated (binary-stamped) version above the highest
+			// registered upgrade. No upgrade, no error.
+			name:      "inflated version tolerated",
+			buildVers: "v0.55.0",
+			cfgVers:   "v0.48.0",
+			registry:  UpgradeRegistry{"v0.34.0": noop},
+			wantNeeds: false,
+		},
+		{
+			name:      "config at schema version",
+			buildVers: "v0.55.0",
+			cfgVers:   "v0.54.0",
+			registry:  UpgradeRegistry{"v0.34.0": noop, "v0.54.0": noop},
+			wantNeeds: false,
+		},
+		{
+			name:      "config below schema version",
+			buildVers: "v0.54.0",
+			cfgVers:   "v0.53.0",
+			registry:  UpgradeRegistry{"v0.34.0": noop, "v0.54.0": noop},
+			wantNeeds: true,
+		},
+		{
+			// Inflated version between registered upgrades: only the
+			// later upgrade is outstanding.
+			name:      "inflated version below newest upgrade",
+			buildVers: "v0.55.0",
+			cfgVers:   "v0.48.0",
+			registry:  UpgradeRegistry{"v0.34.0": noop, "v0.54.0": noop},
+			wantNeeds: true,
+		},
+		{
+			name:      "empty registry",
+			buildVers: "v0.55.0",
+			cfgVers:   "v0.48.0",
+			registry:  UpgradeRegistry{},
+			wantNeeds: false,
+		},
+		{
+			name:            "config newer than build",
+			buildVers:       "v0.55.0",
+			cfgVers:         "v0.58.0",
+			registry:        UpgradeRegistry{"v0.34.0": noop, "v0.54.0": noop},
+			wantNeeds:       false,
+			wantNewerThanBd: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			setBuildVersion(t, tc.buildVers)
+			_, cfgPath := writeTestConfig(t, "config.version: "+tc.cfgVers+"\n")
+			ctx := lg.NewContext(context.Background(), lgt.New(t))
+			store := &Store{Path: cfgPath, UpgradeRegistry: tc.registry}
+
+			needsUpgrade, foundVers, err := store.checkNeedsUpgrade(ctx)
+			if tc.wantNewerThanBd {
+				require.ErrorIs(t, err, errConfigVersionNewerThanBuild)
+			} else {
+				require.NoError(t, err)
+			}
+			require.Equal(t, tc.wantNeeds, needsUpgrade)
+			require.Equal(t, tc.cfgVers, foundVers)
+		})
+	}
+}
+
+// Test_Store_Load_SchemaCurrent_NoRewrite verifies that loading a
+// config whose version is at or above the highest registered upgrade
+// version does not rewrite the config file at all, even when the
+// build version is newer. The load-save cycle is not byte-preserving
+// (unknown keys and YAML comments are dropped on re-marshal), so a
+// release without schema changes must leave the file untouched.
+func Test_Store_Load_SchemaCurrent_NoRewrite(t *testing.T) {
 	setBuildVersion(t, "v0.48.0")
 
-	cfgDir := t.TempDir()
-	cfgPath := filepath.Join(cfgDir, "sq.yml")
-	err := os.WriteFile(cfgPath, []byte("config.version: v0.47.0\n"), 0o644)
+	// The config carries a YAML comment and a key unknown to this
+	// build's config.Config struct: both would be destroyed by any
+	// load-save rewrite.
+	const cfgContent = `config.version: v0.47.0
+# A comment that a re-marshal would destroy.
+future_field: some value unknown to this build
+`
+	cfgDir, cfgPath := writeTestConfig(t, cfgContent)
+
+	ctx := lg.NewContext(context.Background(), lgt.New(t))
+
+	noop := func(_ context.Context, before []byte) ([]byte, error) {
+		return before, nil
+	}
+	store := &Store{
+		Path:            cfgPath,
+		OptionsRegistry: &options.Registry{},
+		// The registered upgrade is below the config version: nothing
+		// outstanding. This mirrors production for any release that
+		// doesn't change the config schema.
+		UpgradeRegistry: UpgradeRegistry{"v0.34.0": noop},
+	}
+
+	cfg, err := store.Load(ctx)
 	require.NoError(t, err)
+	require.Equal(t, "v0.47.0", cfg.Version,
+		"config.version must not be inflated to the build version")
+
+	gotContent, err := os.ReadFile(cfgPath)
+	require.NoError(t, err)
+	require.Equal(t, cfgContent, string(gotContent),
+		"config file must be byte-identical after load")
+	requireNoBackupFiles(t, cfgDir)
+}
+
+// Test_Store_Load_UpgradeStampsSchemaVersion verifies that when an
+// upgrade does run, config.version is stamped with the highest
+// registered upgrade version (the schema version), not the build
+// version, and that the pre-upgrade backup is written.
+func Test_Store_Load_UpgradeStampsSchemaVersion(t *testing.T) {
+	setBuildVersion(t, "v0.55.0")
+
+	const cfgContent = "config.version: v0.48.0\n"
+	_, cfgPath := writeTestConfig(t, cfgContent)
+
+	ctx := lg.NewContext(context.Background(), lgt.New(t))
+
+	var ran34, ran54 bool
+	store := &Store{
+		Path:            cfgPath,
+		OptionsRegistry: &options.Registry{},
+		UpgradeRegistry: UpgradeRegistry{
+			"v0.34.0": func(_ context.Context, before []byte) ([]byte, error) {
+				ran34 = true
+				return before, nil
+			},
+			"v0.54.0": func(_ context.Context, before []byte) ([]byte, error) {
+				ran54 = true
+				return before, nil
+			},
+		},
+	}
+
+	cfg, err := store.Load(ctx)
+	require.NoError(t, err)
+	require.False(t, ran34, "v0.34.0 upgrade is below the config version; must not run")
+	require.True(t, ran54, "v0.54.0 upgrade must run")
+	require.Equal(t, "v0.54.0", cfg.Version,
+		"config.version must be stamped with the schema version, not the build version")
+
+	gotVers, err := LoadVersionFromFile(cfgPath)
+	require.NoError(t, err)
+	require.Equal(t, "v0.54.0", gotVers)
+
+	backupContent, err := os.ReadFile(backupFilePath(cfgPath, "v0.48.0"))
+	require.NoError(t, err, "pre-upgrade backup must exist")
+	require.Equal(t, cfgContent, string(backupContent))
+}
+
+// Test_Store_Save_NewerConfig_BackupBeforeSave verifies the downgrade
+// guard: when the loaded config's version is newer than the build
+// version (the config was written by a newer sq version), the first
+// mutating Save writes a verbatim backup of the on-disk config before
+// overwriting it, because the re-marshal through this build's
+// config.Config struct drops fields unknown to it.
+func Test_Store_Save_NewerConfig_BackupBeforeSave(t *testing.T) {
+	setBuildVersion(t, "v0.48.0")
+
+	const cfgContent = `config.version: v0.58.0
+# Comment from a newer sq version.
+future_field: data this build doesn't understand
+`
+	cfgDir, cfgPath := writeTestConfig(t, cfgContent)
 
 	ctx := lg.NewContext(context.Background(), lgt.New(t))
 
 	store := &Store{
 		Path:            cfgPath,
 		OptionsRegistry: &options.Registry{},
-		// Non-nil but empty: the upgrade path runs, with zero funcs in
-		// range. This mirrors production for any release that doesn't
-		// change the config schema.
 		UpgradeRegistry: UpgradeRegistry{},
 	}
 
 	cfg, err := store.Load(ctx)
 	require.NoError(t, err)
-	require.Equal(t, "v0.48.0", cfg.Version, "config.version is still stamped")
+	require.Equal(t, "v0.58.0", cfg.Version)
 
-	entries, err := os.ReadDir(cfgDir)
+	// Load alone must not rewrite or back up.
+	gotContent, err := os.ReadFile(cfgPath)
 	require.NoError(t, err)
-	for _, e := range entries {
-		require.NotContains(t, e.Name(), ".bak.",
-			"no backup file expected when no upgrade funcs ran")
+	require.Equal(t, cfgContent, string(gotContent))
+	requireNoBackupFiles(t, cfgDir)
+
+	// First Save: backup written, then config overwritten.
+	require.NoError(t, store.Save(ctx, cfg))
+
+	backupPath := backupFilePath(cfgPath, "v0.58.0")
+	backupContent, err := os.ReadFile(backupPath)
+	require.NoError(t, err, "backup must exist after mutating Save")
+	require.Equal(t, cfgContent, string(backupContent),
+		"backup must hold the verbatim pre-save config")
+
+	gotContent, err = os.ReadFile(cfgPath)
+	require.NoError(t, err)
+	require.NotEqual(t, cfgContent, string(gotContent),
+		"config file was re-marshaled by Save")
+
+	// Second Save: the existing backup must not be overwritten with
+	// the already-degraded config.
+	require.NoError(t, store.Save(ctx, cfg))
+	backupContent, err = os.ReadFile(backupPath)
+	require.NoError(t, err)
+	require.Equal(t, cfgContent, string(backupContent),
+		"backup must not be overwritten by subsequent saves")
+}
+
+// Test_Store_Save_NewerConfig_Prerelease_NoBackup verifies that
+// prerelease builds, which are exempt from the newer-than-build
+// check, do not write a backup on Save.
+func Test_Store_Save_NewerConfig_Prerelease_NoBackup(t *testing.T) {
+	setBuildVersion(t, "v0.48.0-dev")
+
+	cfgDir, cfgPath := writeTestConfig(t, "config.version: v0.58.0\n")
+
+	ctx := lg.NewContext(context.Background(), lgt.New(t))
+
+	store := &Store{
+		Path:            cfgPath,
+		OptionsRegistry: &options.Registry{},
+		UpgradeRegistry: UpgradeRegistry{},
+	}
+
+	cfg, err := store.Load(ctx)
+	require.NoError(t, err)
+	require.NoError(t, store.Save(ctx, cfg))
+	requireNoBackupFiles(t, cfgDir)
+}
+
+// Test_Store_Save_InflatedVersion_NoBackup verifies the compatibility
+// case: a config stamped with an inflated (binary) version by an
+// older sq release, where the version exceeds this build's highest
+// registered upgrade but not the build version, must not trigger the
+// downgrade guard.
+func Test_Store_Save_InflatedVersion_NoBackup(t *testing.T) {
+	setBuildVersion(t, "v0.55.0")
+
+	cfgDir, cfgPath := writeTestConfig(t, "config.version: v0.48.0\n")
+
+	ctx := lg.NewContext(context.Background(), lgt.New(t))
+
+	noop := func(_ context.Context, before []byte) ([]byte, error) {
+		return before, nil
+	}
+	store := &Store{
+		Path:            cfgPath,
+		OptionsRegistry: &options.Registry{},
+		UpgradeRegistry: UpgradeRegistry{"v0.34.0": noop},
+	}
+
+	cfg, err := store.Load(ctx)
+	require.NoError(t, err)
+	require.NoError(t, store.Save(ctx, cfg))
+	requireNoBackupFiles(t, cfgDir)
+}
+
+// Test_Load_FreshConfig_StampsSchemaVersion verifies that when no
+// config file exists, the fresh config is stamped with the schema
+// version (the highest registered upgrade version), not the build
+// version. With an empty registry, the config.New default (the build
+// version) is retained.
+func Test_Load_FreshConfig_StampsSchemaVersion(t *testing.T) {
+	noop := func(_ context.Context, before []byte) ([]byte, error) {
+		return before, nil
+	}
+
+	testCases := []struct {
+		name     string
+		registry UpgradeRegistry
+		wantVers string
+	}{
+		{
+			name:     "registry with upgrades",
+			registry: UpgradeRegistry{"v0.34.0": noop, "v0.54.0": noop},
+			wantVers: "v0.54.0",
+		},
+		{
+			name:     "empty registry",
+			registry: UpgradeRegistry{},
+			wantVers: "v0.99.0",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			setBuildVersion(t, "v0.99.0")
+			t.Setenv(config.EnvarConfig, t.TempDir())
+			ctx := lg.NewContext(context.Background(), lgt.New(t))
+
+			cfg, _, err := Load(ctx, nil, &options.Registry{}, tc.registry)
+			require.NoError(t, err)
+			require.Equal(t, tc.wantVers, cfg.Version)
+		})
 	}
 }
 

--- a/cli/config/yamlstore/internal_test.go
+++ b/cli/config/yamlstore/internal_test.go
@@ -103,7 +103,7 @@ func Test_checkNeedsUpgrade_newerConfigVersion(t *testing.T) {
 	store := &Store{Path: cfgPath, UpgradeRegistry: UpgradeRegistry{}}
 
 	// Should return errConfigVersionNewerThanBuild.
-	needsUpgrade, foundVers, err := store.checkNeedsUpgrade(ctx)
+	needsUpgrade, foundVers, err := store.checkNeedsUpgrade(ctx, store.UpgradeRegistry.highestVersion())
 	require.ErrorIs(t, err, errConfigVersionNewerThanBuild)
 	require.False(t, needsUpgrade)
 	require.Equal(t, "v99.0.0", foundVers)
@@ -123,7 +123,7 @@ func Test_checkNeedsUpgrade_newerConfigVersion_prerelease(t *testing.T) {
 	store := &Store{Path: cfgPath, UpgradeRegistry: UpgradeRegistry{}}
 
 	// Should NOT error for prerelease.
-	needsUpgrade, foundVers, err := store.checkNeedsUpgrade(ctx)
+	needsUpgrade, foundVers, err := store.checkNeedsUpgrade(ctx, store.UpgradeRegistry.highestVersion())
 	require.NoError(t, err)
 	require.False(t, needsUpgrade)
 	require.Equal(t, "v99.0.0", foundVers)
@@ -194,6 +194,21 @@ func Test_checkNeedsUpgrade_schemaVersion(t *testing.T) {
 			wantNeeds:       false,
 			wantNewerThanBd: true,
 		},
+		{
+			// Misbuilt binary: a registered upgrade key (v0.55.0) exceeds
+			// the build version (v0.50.0), and the config (v0.52.0) sits
+			// between them. The schema axis alone would say needsUpgrade
+			// (0.52 < 0.55), but the config is newer than the build, so
+			// the upgrade must be suppressed (wantNeeds=false) and the
+			// newer-than-build error returned. This exercises the explicit
+			// override in checkNeedsUpgrade.
+			name:            "registry key above build version",
+			buildVers:       "v0.50.0",
+			cfgVers:         "v0.52.0",
+			registry:        UpgradeRegistry{"v0.34.0": noop, "v0.55.0": noop},
+			wantNeeds:       false,
+			wantNewerThanBd: true,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -203,7 +218,7 @@ func Test_checkNeedsUpgrade_schemaVersion(t *testing.T) {
 			ctx := lg.NewContext(context.Background(), lgt.New(t))
 			store := &Store{Path: cfgPath, UpgradeRegistry: tc.registry}
 
-			needsUpgrade, foundVers, err := store.checkNeedsUpgrade(ctx)
+			needsUpgrade, foundVers, err := store.checkNeedsUpgrade(ctx, store.UpgradeRegistry.highestVersion())
 			if tc.wantNewerThanBd {
 				require.ErrorIs(t, err, errConfigVersionNewerThanBuild)
 			} else {
@@ -445,6 +460,84 @@ future_field: data this build doesn't understand
 	// newer than the build.
 	require.NoError(t, store.Save(ctx, cfg))
 	requireNoBackupFiles(t, cfgDir)
+}
+
+// Test_Store_backupNewerConfig_NonRegularBackupPath verifies that when
+// the backup path exists but is not a regular file (e.g. a directory),
+// Save fails and does not overwrite the config, rather than treating the
+// non-regular path as a valid backup and silently proceeding.
+func Test_Store_backupNewerConfig_NonRegularBackupPath(t *testing.T) {
+	setBuildVersion(t, "v0.48.0")
+
+	const cfgContent = "config.version: v0.58.0\nfuture_field: keep\n"
+	_, cfgPath := writeTestConfig(t, cfgContent)
+	ctx := lg.NewContext(context.Background(), lgt.New(t))
+
+	store := &Store{
+		Path:            cfgPath,
+		OptionsRegistry: &options.Registry{},
+		UpgradeRegistry: UpgradeRegistry{},
+	}
+
+	cfg, err := store.Load(ctx)
+	require.NoError(t, err)
+
+	// Put a directory where the backup file would go: it can't serve as
+	// a backup, and Save must refuse rather than skip the backup.
+	require.NoError(t, os.Mkdir(backupFilePath(cfgPath, "v0.58.0"), 0o700))
+
+	err = store.Save(ctx, cfg)
+	require.Error(t, err, "Save must fail when the backup path is not a regular file")
+
+	got, err := os.ReadFile(cfgPath)
+	require.NoError(t, err)
+	require.Equal(t, cfgContent, string(got),
+		"config must be left intact when the backup couldn't be written")
+}
+
+// Test_Store_Load_MultiStepUpgrade_Chains verifies that a Load spanning
+// two registered upgrade funcs runs them in ascending version order,
+// threads each func's output into the next, stamps the highest version,
+// and persists a re-loadable config (the canonicalization the removed
+// outer load-save cycle used to provide is done inside doUpgrade).
+func Test_Store_Load_MultiStepUpgrade_Chains(t *testing.T) {
+	setBuildVersion(t, "v0.55.0")
+
+	var order []string
+	var step2Input string
+	step1 := func(_ context.Context, before []byte) ([]byte, error) {
+		order = append(order, "v0.40.0")
+		return append(before, []byte("# step1\n")...), nil
+	}
+	step2 := func(_ context.Context, before []byte) ([]byte, error) {
+		order = append(order, "v0.50.0")
+		step2Input = string(before)
+		return append(before, []byte("# step2\n")...), nil
+	}
+
+	_, cfgPath := writeTestConfig(t, "config.version: v0.30.0\n")
+	ctx := lg.NewContext(context.Background(), lgt.New(t))
+	store := &Store{
+		Path:            cfgPath,
+		OptionsRegistry: &options.Registry{},
+		UpgradeRegistry: UpgradeRegistry{"v0.40.0": step1, "v0.50.0": step2},
+	}
+
+	cfg, err := store.Load(ctx)
+	require.NoError(t, err)
+	require.Equal(t, []string{"v0.40.0", "v0.50.0"}, order,
+		"both upgrade funcs must run, in ascending version order")
+	require.Contains(t, step2Input, "# step1",
+		"each func must receive the previous func's output")
+	require.Equal(t, "v0.50.0", cfg.Version,
+		"config.version must be stamped to the highest registered upgrade")
+
+	// The on-disk config must be re-loadable and stamped, and a second
+	// load must not re-run the upgrades.
+	reloaded, err := store.Load(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "v0.50.0", reloaded.Version)
+	require.Len(t, order, 2, "a second load must not re-run the upgrade funcs")
 }
 
 // Test_Store_backupNewerConfig_StatError verifies that a stat error

--- a/cli/config/yamlstore/internal_test.go
+++ b/cli/config/yamlstore/internal_test.go
@@ -407,6 +407,46 @@ future_field: data this build doesn't understand
 		"backup must not be overwritten by subsequent saves")
 }
 
+// Test_Store_Load_ClearsNewerCfgVers_OnReload verifies that the sticky
+// newer-than-build state is cleared when the same Store later loads a
+// config that is no longer newer than the build (e.g. another process
+// normalized it while we held it). Otherwise a stale newerCfgVers would
+// trigger a spurious backup on the next Save.
+func Test_Store_Load_ClearsNewerCfgVers_OnReload(t *testing.T) {
+	setBuildVersion(t, "v0.48.0")
+
+	const newerContent = `config.version: v0.58.0
+future_field: data this build doesn't understand
+`
+	cfgDir, cfgPath := writeTestConfig(t, newerContent)
+	ctx := lg.NewContext(context.Background(), lgt.New(t))
+
+	store := &Store{
+		Path:            cfgPath,
+		OptionsRegistry: &options.Registry{},
+		UpgradeRegistry: UpgradeRegistry{},
+	}
+
+	// First load: config is newer than the build, so newerCfgVers is set.
+	_, err := store.Load(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "v0.58.0", store.newerCfgVers,
+		"a newer-than-build config must set newerCfgVers")
+
+	// The config on disk is replaced with a current one and reloaded on
+	// the same Store; the sticky flag must be cleared.
+	require.NoError(t, os.WriteFile(cfgPath, []byte("config.version: v0.48.0\n"), 0o600))
+	cfg, err := store.Load(ctx)
+	require.NoError(t, err)
+	require.Empty(t, store.newerCfgVers,
+		"reloading a non-newer config must clear the sticky newerCfgVers")
+
+	// A subsequent Save must not write a backup: the config is no longer
+	// newer than the build.
+	require.NoError(t, store.Save(ctx, cfg))
+	requireNoBackupFiles(t, cfgDir)
+}
+
 // Test_Store_backupNewerConfig_StatError verifies that a stat error
 // on the backup path other than fs.ErrNotExist (e.g. a permission
 // error) fails the backup, rather than being treated as a missing

--- a/cli/config/yamlstore/internal_test.go
+++ b/cli/config/yamlstore/internal_test.go
@@ -303,6 +303,54 @@ func Test_Store_Load_UpgradeStampsSchemaVersion(t *testing.T) {
 	require.Equal(t, cfgContent, string(backupContent))
 }
 
+// Test_Store_Load_Upgrade_PreservesGuardBackup verifies that the
+// pre-upgrade backup is written at most once: when a backup for the
+// same version already exists (here, the downgrade guard's pristine
+// copy of a newer config, written by Store.backupNewerConfig in an
+// older binary), the upgrade must not overwrite it with the degraded
+// on-disk config.
+func Test_Store_Load_Upgrade_PreservesGuardBackup(t *testing.T) {
+	setBuildVersion(t, "v0.56.0")
+
+	// The on-disk config: stamped v0.55.0, already degraded by an
+	// older (downgraded) binary's re-marshaling save.
+	const degraded = "config.version: v0.55.0\n"
+	_, cfgPath := writeTestConfig(t, degraded)
+
+	// The guard backup: the pristine v0.55-written config that the
+	// downgrade guard preserved before the older binary's first save.
+	const pristine = `config.version: v0.55.0
+# Comment from the newer sq version.
+future_field: data the older build didn't understand
+`
+	backupPath := backupFilePath(cfgPath, "v0.55.0")
+	require.NoError(t, os.WriteFile(backupPath, []byte(pristine), 0o644))
+
+	ctx := lg.NewContext(context.Background(), lgt.New(t))
+
+	var ran bool
+	store := &Store{
+		Path:            cfgPath,
+		OptionsRegistry: &options.Registry{},
+		UpgradeRegistry: UpgradeRegistry{
+			"v0.56.0": func(_ context.Context, before []byte) ([]byte, error) {
+				ran = true
+				return before, nil
+			},
+		},
+	}
+
+	cfg, err := store.Load(ctx)
+	require.NoError(t, err)
+	require.True(t, ran, "v0.56.0 upgrade must run")
+	require.Equal(t, "v0.56.0", cfg.Version)
+
+	got, err := os.ReadFile(backupPath)
+	require.NoError(t, err)
+	require.Equal(t, pristine, string(got),
+		"existing guard backup must not be clobbered by the pre-upgrade backup")
+}
+
 // Test_Store_Save_NewerConfig_BackupBeforeSave verifies the downgrade
 // guard: when the loaded config's version is newer than the build
 // version (the config was written by a newer sq version), the first

--- a/cli/config/yamlstore/internal_test.go
+++ b/cli/config/yamlstore/internal_test.go
@@ -7,8 +7,11 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/neilotoole/sq/cli/buildinfo"
@@ -715,7 +718,31 @@ func Test_Store_writeConfigBackupOnce_DirError(t *testing.T) {
 
 	_, err := store.writeConfigBackupOnce(ctx, "v0.58.0", []byte("data"))
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "temp config backup")
+	require.Contains(t, err.Error(), "config backup")
+}
+
+// Test_Store_writeConfigBackupOnce_CreatesBackup verifies the happy path:
+// a complete backup with the verbatim content and 0600 perms.
+func Test_Store_writeConfigBackupOnce_CreatesBackup(t *testing.T) {
+	_, cfgPath := writeTestConfig(t, "config.version: v0.58.0\n")
+	ctx := lg.NewContext(context.Background(), lgt.New(t))
+	store := &Store{Path: cfgPath}
+	backupPath := backupFilePath(cfgPath, "v0.58.0")
+
+	wrote, err := store.writeConfigBackupOnce(ctx, "v0.58.0", []byte("backup-data"))
+	require.NoError(t, err)
+	require.True(t, wrote)
+
+	got, err := os.ReadFile(backupPath)
+	require.NoError(t, err)
+	require.Equal(t, "backup-data", string(got))
+
+	if runtime.GOOS != "windows" {
+		info, statErr := os.Stat(backupPath)
+		require.NoError(t, statErr)
+		require.Equal(t, os.FileMode(0o600), info.Mode().Perm(),
+			"backup must be created with 0600 perms")
+	}
 }
 
 // Test_Store_writeConfigBackupOnce_DoesNotClobber verifies the
@@ -743,6 +770,71 @@ func Test_Store_writeConfigBackupOnce_DoesNotClobber(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "original", string(got),
 		"the existing backup must not be clobbered")
+}
+
+// Test_Store_writeConfigBackupOnce_RejectsSymlink verifies that an
+// existing symlink at the backup path is not accepted as a valid backup
+// (O_EXCL won't follow it, and the Lstat check rejects it), and that the
+// symlink's target is never written through.
+func Test_Store_writeConfigBackupOnce_RejectsSymlink(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink semantics differ on Windows")
+	}
+	_, cfgPath := writeTestConfig(t, "config.version: v0.58.0\n")
+	ctx := lg.NewContext(context.Background(), lgt.New(t))
+	store := &Store{Path: cfgPath}
+	backupPath := backupFilePath(cfgPath, "v0.58.0")
+
+	target := filepath.Join(filepath.Dir(cfgPath), "elsewhere.txt")
+	require.NoError(t, os.WriteFile(target, []byte("not the backup"), 0o600))
+	require.NoError(t, os.Symlink(target, backupPath))
+
+	wrote, err := store.writeConfigBackupOnce(ctx, "v0.58.0", []byte("data"))
+	require.Error(t, err)
+	require.False(t, wrote)
+	require.Contains(t, err.Error(), "not a regular file")
+
+	got, err := os.ReadFile(target)
+	require.NoError(t, err)
+	require.Equal(t, "not the backup", string(got),
+		"a symlinked backup path must not be written through")
+}
+
+// Test_Store_writeConfigBackupOnce_ConcurrentAtMostOnce stresses the
+// at-most-once guarantee under real concurrency: many goroutines race to
+// create the same backup; exactly one must win, and the resulting backup
+// must hold exactly one writer's complete, uncorrupted content.
+func Test_Store_writeConfigBackupOnce_ConcurrentAtMostOnce(t *testing.T) {
+	_, cfgPath := writeTestConfig(t, "config.version: v0.58.0\n")
+	store := &Store{Path: cfgPath}
+	backupPath := backupFilePath(cfgPath, "v0.58.0")
+
+	const n = 16 // < 26, so each writer's byte is a distinct lowercase letter
+	var wg sync.WaitGroup
+	var wroteCount atomic.Int32
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		i := i
+		go func() {
+			defer wg.Done()
+			ctx := lg.NewContext(context.Background(), lgt.New(t))
+			wrote, err := store.writeConfigBackupOnce(ctx, "v0.58.0", []byte{byte('a' + i)})
+			assert.NoError(t, err)
+			if wrote {
+				wroteCount.Add(1)
+			}
+		}()
+	}
+	wg.Wait()
+
+	require.Equal(t, int32(1), wroteCount.Load(),
+		"exactly one concurrent writer must create the backup")
+
+	got, err := os.ReadFile(backupPath)
+	require.NoError(t, err)
+	require.Len(t, got, 1, "backup must hold exactly one writer's complete data")
+	require.True(t, got[0] >= 'a' && got[0] < 'a'+n,
+		"backup content must be exactly one writer's byte, uncorrupted")
 }
 
 // Test_Store_Load_RejectsBrokenConfig verifies that a broken config fails

--- a/cli/config/yamlstore/internal_test.go
+++ b/cli/config/yamlstore/internal_test.go
@@ -540,6 +540,281 @@ func Test_Store_Load_MultiStepUpgrade_Chains(t *testing.T) {
 	require.Len(t, order, 2, "a second load must not re-run the upgrade funcs")
 }
 
+// Test_LoadVersionFromFile covers the version-field parsing edge cases:
+// a malformed or missing config.version is a load-time error a real
+// (hand-edited or corrupted) config can hit.
+func Test_LoadVersionFromFile(t *testing.T) {
+	testCases := []struct {
+		name    string
+		content string
+		want    string
+		wantErr string // error-message substring; "" means expect success
+	}{
+		{"valid", "config.version: v0.34.0\n", "v0.34.0", ""},
+		{"legacy version field", "version: v0.34.0\n", "v0.34.0", ""},
+		{"legacy config_version field", "config_version: v0.34.0\n", "v0.34.0", ""},
+		{"missing field", "options:\n  format: json\n", "", "does not have a version field"},
+		{"empty string value", "config.version: \"\"\n", "", "does not have a version field"},
+		{"non-string value", "config.version: 123\n", "", "invalid value for"},
+		{"invalid semver", "config.version: not-a-version\n", "", "invalid semver value for"},
+		{"malformed yaml", "key: [unclosed\n", "", "unmarshal"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, cfgPath := writeTestConfig(t, tc.content)
+			got, err := LoadVersionFromFile(cfgPath)
+			if tc.wantErr == "" {
+				require.NoError(t, err)
+				require.Equal(t, tc.want, got)
+				return
+			}
+			require.Error(t, err)
+			require.Contains(t, err.Error(), tc.wantErr)
+		})
+	}
+}
+
+// Test_checkNeedsUpgrade_belowMinVersion verifies that a config version
+// below MinConfigVersion is a fatal error, not silently upgraded.
+func Test_checkNeedsUpgrade_belowMinVersion(t *testing.T) {
+	setBuildVersion(t, "v0.55.0")
+	noop := func(_ context.Context, before []byte) ([]byte, error) { return before, nil }
+
+	// v0.0.0-aaa sorts below MinConfigVersion (v0.0.0-dev) by prerelease.
+	_, cfgPath := writeTestConfig(t, "config.version: v0.0.0-aaa\n")
+	ctx := lg.NewContext(context.Background(), lgt.New(t))
+	store := &Store{Path: cfgPath, UpgradeRegistry: UpgradeRegistry{"v0.34.0": noop}}
+
+	_, _, err := store.checkNeedsUpgrade(ctx, store.UpgradeRegistry.highestVersion())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "less than minimum")
+}
+
+// Test_Store_doUpgrade_DirectCalls covers doUpgrade's two guard branches
+// reached only by a direct caller: an invalid target version, and a
+// target with no upgrade funcs in range (config left untouched).
+func Test_Store_doUpgrade_DirectCalls(t *testing.T) {
+	noop := func(_ context.Context, before []byte) ([]byte, error) { return before, nil }
+	ctx := lg.NewContext(context.Background(), lgt.New(t))
+
+	const cfgContent = "config.version: v0.34.0\n"
+	_, cfgPath := writeTestConfig(t, cfgContent)
+	store := &Store{
+		Path:            cfgPath,
+		OptionsRegistry: &options.Registry{},
+		UpgradeRegistry: UpgradeRegistry{"v0.34.0": noop},
+	}
+
+	// Invalid target version is rejected before any file change.
+	_, err := store.doUpgrade(ctx, "v0.34.0", "not-a-semver")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid semver")
+
+	// No upgrade funcs in range: the config is loaded and returned
+	// untouched, with no error.
+	cfg, err := store.doUpgrade(ctx, "v0.34.0", "v0.34.0")
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+	got, err := os.ReadFile(cfgPath)
+	require.NoError(t, err)
+	require.Equal(t, cfgContent, string(got), "no-op upgrade must not rewrite the config")
+}
+
+// Test_Store_Load_UpgradeFuncError verifies that a failing upgrade func
+// surfaces as a load error and leaves the config file unchanged (the
+// upgraded bytes are written only after every func succeeds).
+func Test_Store_Load_UpgradeFuncError(t *testing.T) {
+	setBuildVersion(t, "v0.55.0")
+	boom := func(_ context.Context, _ []byte) ([]byte, error) {
+		return nil, fs.ErrInvalid // any non-nil error
+	}
+
+	const cfgContent = "config.version: v0.30.0\n"
+	cfgDir, cfgPath := writeTestConfig(t, cfgContent)
+	ctx := lg.NewContext(context.Background(), lgt.New(t))
+	store := &Store{
+		Path:            cfgPath,
+		OptionsRegistry: &options.Registry{},
+		UpgradeRegistry: UpgradeRegistry{"v0.50.0": boom},
+	}
+
+	_, err := store.Load(ctx)
+	require.Error(t, err, "a failing upgrade func must fail the load")
+
+	// The original config must be intact (only a verbatim backup may
+	// have been written before the func ran).
+	got, err := os.ReadFile(cfgPath)
+	require.NoError(t, err)
+	require.Equal(t, cfgContent, string(got),
+		"a failed upgrade must not corrupt the config")
+	_ = cfgDir
+}
+
+// Test_Store_applyVersionCheck_FatalClearsNewerCfgVers verifies that a
+// fatal (non-newer-than-build) check error clears newerCfgVers, so a
+// reused Store can't carry stale state into a later Save's backup.
+func Test_Store_applyVersionCheck_FatalClearsNewerCfgVers(t *testing.T) {
+	ctx := lg.NewContext(context.Background(), lgt.New(t))
+	store := &Store{Path: "irrelevant.yml", newerCfgVers: "v0.58.0"}
+
+	// fs.ErrNotExist stands in for any fatal, non-newer check error.
+	err := store.applyVersionCheck(ctx, "v0.30.0", fs.ErrNotExist)
+	require.Error(t, err)
+	require.Empty(t, store.newerCfgVers,
+		"a fatal version-check error must clear newerCfgVers")
+}
+
+// Test_Store_backupNewerConfig_ConfigDeleted verifies that if the config
+// file is gone by the time Save runs, backupNewerConfig treats it as
+// nothing-to-back-up: it clears the flag and returns nil rather than
+// failing.
+func Test_Store_backupNewerConfig_ConfigDeleted(t *testing.T) {
+	_, cfgPath := writeTestConfig(t, "config.version: v0.58.0\n")
+	ctx := lg.NewContext(context.Background(), lgt.New(t))
+	store := &Store{Path: cfgPath, newerCfgVers: "v0.58.0"}
+
+	require.NoError(t, os.Remove(cfgPath))
+
+	require.NoError(t, store.backupNewerConfig(ctx))
+	require.Empty(t, store.newerCfgVers,
+		"flag must be cleared when there is nothing on disk to back up")
+}
+
+// Test_Store_doLoad_EmptyVersionStampsBuildVersion verifies the fallback
+// stamping for a config with no version field, loaded via a registry-less
+// Store (the only path that reaches doLoad with an empty version, since a
+// registry makes the missing version fatal in checkNeedsUpgrade).
+func Test_Store_doLoad_EmptyVersionStampsBuildVersion(t *testing.T) {
+	setBuildVersion(t, "v0.55.0")
+	_, cfgPath := writeTestConfig(t, "options:\n  format: json\n")
+	ctx := lg.NewContext(context.Background(), lgt.New(t))
+	store := &Store{Path: cfgPath, OptionsRegistry: &options.Registry{}} // UpgradeRegistry nil
+
+	cfg, err := store.Load(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "v0.55.0", cfg.Version,
+		"an empty version stamps the build version when no registry is configured")
+}
+
+// Test_Store_writeConfigBackupOnce_StatError verifies that a stat failure
+// other than ErrNotExist (here ENOTDIR, via a non-directory in the path)
+// aborts rather than silently proceeding without a backup.
+func Test_Store_writeConfigBackupOnce_StatError(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("ENOTDIR path semantics differ on Windows")
+	}
+	tmp := t.TempDir()
+	notDir := filepath.Join(tmp, "notdir")
+	require.NoError(t, os.WriteFile(notDir, []byte("x"), 0o600))
+
+	ctx := lg.NewContext(context.Background(), lgt.New(t))
+	// fs.Path sits under a regular file, so stat on the backup path
+	// fails with ENOTDIR (not ErrNotExist).
+	store := &Store{Path: filepath.Join(notDir, "sq.yml")}
+
+	_, err := store.writeConfigBackupOnce(ctx, "v0.58.0", []byte("data"))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed to stat config backup")
+}
+
+// Test_Store_Load_RejectsBrokenConfig verifies that a broken config fails
+// Load with a clear error rather than panicking or silently loading a
+// degraded config. Broken config loading would be fatal, so each case
+// must surface a diagnostic error.
+func Test_Store_Load_RejectsBrokenConfig(t *testing.T) {
+	setBuildVersion(t, "v0.55.0")
+	noop := func(_ context.Context, b []byte) ([]byte, error) { return b, nil }
+
+	testCases := []struct {
+		name     string
+		content  string
+		registry UpgradeRegistry
+		wantErr  string
+	}{
+		{
+			name:     "malformed version",
+			content:  "config.version: not-a-version\n",
+			registry: UpgradeRegistry{"v0.34.0": noop},
+			wantErr:  "invalid semver",
+		},
+		{
+			name:     "missing version",
+			content:  "options:\n  format: json\n",
+			registry: UpgradeRegistry{"v0.34.0": noop},
+			wantErr:  "does not have a version field",
+		},
+		{
+			name:     "below minimum version",
+			content:  "config.version: v0.0.0-aaa\n",
+			registry: UpgradeRegistry{"v0.34.0": noop},
+			wantErr:  "less than minimum",
+		},
+		{
+			// Registry-less so checkNeedsUpgrade is skipped and the parse
+			// error surfaces from doLoad's unmarshal instead.
+			name:     "malformed yaml",
+			content:  "key: [unclosed\n",
+			registry: nil,
+			wantErr:  "unmarshal",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, cfgPath := writeTestConfig(t, tc.content)
+			ctx := lg.NewContext(context.Background(), lgt.New(t))
+			store := &Store{
+				Path:            cfgPath,
+				OptionsRegistry: &options.Registry{},
+				UpgradeRegistry: tc.registry,
+			}
+
+			_, err := store.Load(ctx)
+			require.Error(t, err, "broken config must fail load")
+			require.Contains(t, err.Error(), tc.wantErr)
+		})
+	}
+}
+
+// Test_Store_Load_RepairsDanglingActiveSource verifies doLoad's integrity
+// repair path: a config whose active.source references a missing handle is
+// repaired (active source unset) and persisted, and a re-load then
+// succeeds.
+func Test_Store_Load_RepairsDanglingActiveSource(t *testing.T) {
+	setBuildVersion(t, "v0.55.0")
+	noop := func(_ context.Context, b []byte) ([]byte, error) { return b, nil }
+
+	const cfgContent = `config.version: v0.34.0
+collection:
+  active.source: '@ghost'
+  sources:
+    - handle: '@real'
+      driver: sqlite3
+      location: sqlite3:///tmp/real.db
+`
+	_, cfgPath := writeTestConfig(t, cfgContent)
+	ctx := lg.NewContext(context.Background(), lgt.New(t))
+	store := &Store{
+		Path:            cfgPath,
+		OptionsRegistry: &options.Registry{},
+		UpgradeRegistry: UpgradeRegistry{"v0.34.0": noop},
+	}
+
+	// First load detects the dangling active source, repairs it, and
+	// returns the repair notice as an error.
+	_, err := store.Load(ctx)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "has been repaired")
+
+	// The repair was persisted, so a second load succeeds.
+	reloaded, err := store.Load(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, reloaded)
+	require.Empty(t, reloaded.Collection.ActiveHandle(),
+		"the dangling active source must have been unset")
+}
+
 // Test_Store_backupNewerConfig_StatError verifies that a stat error
 // on the backup path other than fs.ErrNotExist (e.g. a permission
 // error) fails the backup, rather than being treated as a missing

--- a/cli/config/yamlstore/upgrade.go
+++ b/cli/config/yamlstore/upgrade.go
@@ -62,7 +62,7 @@ func (fs *Store) doUpgrade(ctx context.Context, startVersion, targetVersion stri
 
 	data, err := os.ReadFile(fs.Path)
 	if err != nil {
-		return nil, errz.Err(err)
+		return nil, errz.Wrapf(err, "config: failed to read file for upgrade: %s", fs.Path)
 	}
 
 	// Write a verbatim backup before the upgrade funcs transform the

--- a/cli/config/yamlstore/upgrade.go
+++ b/cli/config/yamlstore/upgrade.go
@@ -35,17 +35,20 @@ type UpgradeFunc func(ctx context.Context, before []byte) (after []byte, err err
 // UpgradeRegistry is a map of config_version to upgrade funcs.
 type UpgradeRegistry map[string]UpgradeFunc
 
-// doUpgrade runs the registered upgrade funcs between startVersion
-// and targetVersion. If at least one upgrade func runs, doUpgrade
-// stamps config.version with targetVersion. Load passes the highest
-// version in the UpgradeRegistry (the config schema version) as
-// targetVersion: config.version advances only when a registered
-// upgrade func transforms the config, never to the sq binary version.
-// If no upgrade func falls in the version range, doUpgrade leaves the
-// config file untouched, with no stamping and no backup: the load-save
-// cycle below is not byte-preserving (unknown keys, YAML comments, and
-// formatting are lost on re-marshal), so it must not run for releases
-// without schema changes.
+// doUpgrade runs the registered upgrade funcs in the half-open range
+// (startVersion, targetVersion], then stamps config.version with
+// targetVersion. Load passes the highest version in the UpgradeRegistry
+// (the config schema version) as targetVersion, so config.version
+// advances only when a registered upgrade func transforms the config,
+// never to the sq binary version.
+//
+// If no upgrade func falls in the range, doUpgrade leaves the config
+// file untouched (no stamping, no backup). From Load this never happens
+// (it calls doUpgrade only when foundVersion < targetVersion, and
+// targetVersion is itself a registry key, so it is always in range); the
+// guard matters only for a direct caller passing a target with no funcs
+// in range, where rewriting must be avoided because the load-save cycle
+// below is not byte-preserving.
 func (fs *Store) doUpgrade(ctx context.Context, startVersion, targetVersion string) (*config.Config, error) {
 	log := lg.FromContext(ctx)
 	log.Debug("Starting config upgrade", lga.From, startVersion, lga.To, targetVersion)
@@ -244,14 +247,16 @@ func LoadVersionFromFile(path string) (string, error) {
 // this error, as long as it doesn't exceed the build version.
 var errConfigVersionNewerThanBuild = errors.New("config: config version is newer than sq version")
 
-// checkNeedsUpgrade checks the config file's version against the
-// store's UpgradeRegistry and the current sq build version, and
-// determines if the config needs to be upgraded.
+// checkNeedsUpgrade checks the config file's version against schemaVers
+// (the config schema version, i.e. the highest version in the store's
+// UpgradeRegistry) and the current sq build version, and determines if
+// the config needs to be upgraded. The caller passes schemaVers so the
+// schema version is derived once per Load and used consistently for both
+// the needsUpgrade decision and the upgrade target.
 //
 // Returns:
-//   - needsUpgrade: true if config version < the highest version in
-//     the UpgradeRegistry, i.e. at least one registered upgrade func
-//     is outstanding.
+//   - needsUpgrade: true if config version < schemaVers, i.e. at least
+//     one registered upgrade func is outstanding.
 //   - foundVers: the semver version found in the config file.
 //   - err: non-nil on version parsing errors, or
 //     errConfigVersionNewerThanBuild if config version > build version
@@ -259,7 +264,9 @@ var errConfigVersionNewerThanBuild = errors.New("config: config version is newer
 //
 // Prerelease builds (e.g., v0.0.0-dev) are exempt from the
 // newer-version check.
-func (fs *Store) checkNeedsUpgrade(ctx context.Context) (needsUpgrade bool, foundVers string, err error) {
+func (fs *Store) checkNeedsUpgrade(
+	ctx context.Context, schemaVers string,
+) (needsUpgrade bool, foundVers string, err error) {
 	foundVers, err = LoadVersionFromFile(fs.Path)
 	if err != nil {
 		return false, "", err
@@ -273,7 +280,6 @@ func (fs *Store) checkNeedsUpgrade(ctx context.Context) (needsUpgrade bool, foun
 			foundVers, MinConfigVersion)
 	}
 
-	schemaVers := fs.UpgradeRegistry.highestVersion()
 	needsUpgrade = schemaVers != "" && semver.Compare(foundVers, schemaVers) < 0
 
 	buildVers := buildinfo.Version

--- a/cli/config/yamlstore/upgrade.go
+++ b/cli/config/yamlstore/upgrade.go
@@ -112,8 +112,12 @@ func (fs *Store) doUpgrade(ctx context.Context, startVersion, targetVersion stri
 // used both for pre-upgrade backups (doUpgrade) and for the downgrade
 // guard (Store.backupNewerConfig). The name deliberately does not end
 // in ".sq.yml": Store.loadExt treats any such file in the config dir
-// as ext config. A backup file from a prior upgrade of the same
-// version is overwritten; it holds the same from-version content.
+// as ext config. The two callers treat an existing backup file
+// differently: doUpgrade overwrites it, because a repeated upgrade
+// from the same version backs up the same from-version content; but
+// backupNewerConfig writes at most once and never overwrites, because
+// the existing backup holds the newer config that a later write would
+// destroy.
 func backupFilePath(cfgPath, fromVersion string) string {
 	base := filepath.Base(cfgPath)
 	base = strings.TrimSuffix(base, filepath.Ext(base))
@@ -151,12 +155,14 @@ func (r UpgradeRegistry) getUpgradeFuncs(startingVersion, targetVersion string) 
 }
 
 // highestVersion returns the highest version key in the registry,
-// which is the config schema version known to this build. Returns
+// which is the config schema version known to this build. Keys that
+// aren't valid semver are ignored (registry keys come from
+// compile-time registration, so this is purely defensive). Returns
 // empty string if the registry is empty.
 func (r UpgradeRegistry) highestVersion() string {
 	var highest string
 	for k := range r {
-		if highest == "" || semver.Compare(k, highest) > 0 {
+		if semver.IsValid(k) && (highest == "" || semver.Compare(k, highest) > 0) {
 			highest = k
 		}
 	}

--- a/cli/config/yamlstore/upgrade.go
+++ b/cli/config/yamlstore/upgrade.go
@@ -35,14 +35,15 @@ type UpgradeFunc func(ctx context.Context, before []byte) (after []byte, err err
 // UpgradeRegistry is a map of config_version to upgrade funcs.
 type UpgradeRegistry map[string]UpgradeFunc
 
-// doUpgrade runs all the registered upgrade funcs between startVersion
-// and targetVersion, then stamps config.version with targetVersion.
-// Load passes the highest version in the UpgradeRegistry (the config
-// schema version) as targetVersion: config.version advances only when
-// a registered upgrade func transforms the config, never to the sq
-// binary version. If no upgrade func falls in the version range,
-// doUpgrade leaves the config file untouched: the load-save cycle
-// below is not byte-preserving (unknown keys, YAML comments, and
+// doUpgrade runs the registered upgrade funcs between startVersion
+// and targetVersion. If at least one upgrade func runs, doUpgrade
+// stamps config.version with targetVersion. Load passes the highest
+// version in the UpgradeRegistry (the config schema version) as
+// targetVersion: config.version advances only when a registered
+// upgrade func transforms the config, never to the sq binary version.
+// If no upgrade func falls in the version range, doUpgrade leaves the
+// config file untouched, with no stamping and no backup: the load-save
+// cycle below is not byte-preserving (unknown keys, YAML comments, and
 // formatting are lost on re-marshal), so it must not run for releases
 // without schema changes.
 func (fs *Store) doUpgrade(ctx context.Context, startVersion, targetVersion string) (*config.Config, error) {
@@ -64,17 +65,30 @@ func (fs *Store) doUpgrade(ctx context.Context, startVersion, targetVersion stri
 		return nil, errz.Err(err)
 	}
 
-	// Write a verbatim backup before the upgrade funcs transform
-	// the config.
+	// Write a verbatim backup before the upgrade funcs transform the
+	// config, unless a backup for startVersion already exists. A
+	// repeated upgrade from the same version would back up identical
+	// content, so skipping loses nothing; and the existing file may be
+	// the downgrade guard's pristine copy of a newer config (see
+	// Store.backupNewerConfig), which an overwrite would destroy.
 	backupPath := backupFilePath(fs.Path, startVersion)
-	if err = ioz.WriteFileAtomic(backupPath, data, ioz.RWPerms); err != nil {
-		// Abort rather than continue without a backup: the point of
-		// the backup is guaranteed recoverability, and if a sibling
-		// file can't be written, rewriting the config itself is
-		// unlikely to go better.
-		return nil, errz.Wrapf(err, "failed to write config backup before upgrade: %s", backupPath)
+	switch _, statErr := os.Stat(backupPath); {
+	case statErr == nil:
+		log.Info("Config backup already exists; not overwriting", lga.Path, backupPath)
+	case !errors.Is(statErr, os.ErrNotExist):
+		// A stat failure other than "not exists" (e.g. permissions)
+		// can't confirm that the backup exists, so abort the upgrade.
+		return nil, errz.Wrapf(statErr, "failed to stat config backup before upgrade: %s", backupPath)
+	default:
+		if err = ioz.WriteFileAtomic(backupPath, data, ioz.RWPerms); err != nil {
+			// Abort rather than continue without a backup: the point of
+			// the backup is guaranteed recoverability, and if a sibling
+			// file can't be written, rewriting the config itself is
+			// unlikely to go better.
+			return nil, errz.Wrapf(err, "failed to write config backup before upgrade: %s", backupPath)
+		}
+		log.Info("Wrote verbatim backup of config before upgrade", lga.Path, backupPath)
 	}
-	log.Info("Wrote verbatim backup of config before upgrade", lga.Path, backupPath)
 
 	for _, fn := range upgradeFns {
 		log.Debug("Attempting config upgrade step")
@@ -112,12 +126,11 @@ func (fs *Store) doUpgrade(ctx context.Context, startVersion, targetVersion stri
 // used both for pre-upgrade backups (doUpgrade) and for the downgrade
 // guard (Store.backupNewerConfig). The name deliberately does not end
 // in ".sq.yml": Store.loadExt treats any such file in the config dir
-// as ext config. The two callers treat an existing backup file
-// differently: doUpgrade overwrites it, because a repeated upgrade
-// from the same version backs up the same from-version content; but
-// backupNewerConfig writes at most once and never overwrites, because
-// the existing backup holds the newer config that a later write would
-// destroy.
+// as ext config. Both callers write the backup at most once and never
+// overwrite an existing file: because the path is derived the same way
+// in both, an existing backup may have been written by the other
+// caller, and in particular the downgrade guard's backup holds the
+// pristine newer config that a later overwrite would destroy.
 func backupFilePath(cfgPath, fromVersion string) string {
 	base := filepath.Base(cfgPath)
 	base = strings.TrimSuffix(base, filepath.Ext(base))

--- a/cli/config/yamlstore/upgrade.go
+++ b/cli/config/yamlstore/upgrade.go
@@ -35,9 +35,16 @@ type UpgradeFunc func(ctx context.Context, before []byte) (after []byte, err err
 // UpgradeRegistry is a map of config_version to upgrade funcs.
 type UpgradeRegistry map[string]UpgradeFunc
 
-// doUpgrade runs all the registered upgrade funcs between cfg.Version
-// and targetVersion. Typically this is checked by Load, but can be
-// explicitly invoked for testing etc.
+// doUpgrade runs all the registered upgrade funcs between startVersion
+// and targetVersion, then stamps config.version with targetVersion.
+// Load passes the highest version in the UpgradeRegistry (the config
+// schema version) as targetVersion: config.version advances only when
+// a registered upgrade func transforms the config, never to the sq
+// binary version. If no upgrade func falls in the version range,
+// doUpgrade leaves the config file untouched: the load-save cycle
+// below is not byte-preserving (unknown keys, YAML comments, and
+// formatting are lost on re-marshal), so it must not run for releases
+// without schema changes.
 func (fs *Store) doUpgrade(ctx context.Context, startVersion, targetVersion string) (*config.Config, error) {
 	log := lg.FromContext(ctx)
 	log.Debug("Starting config upgrade", lga.From, startVersion, lga.To, targetVersion)
@@ -46,31 +53,28 @@ func (fs *Store) doUpgrade(ctx context.Context, startVersion, targetVersion stri
 		return nil, errz.Errorf("invalid semver for config version {%s}", targetVersion)
 	}
 
-	var err error
 	upgradeFns := fs.UpgradeRegistry.getUpgradeFuncs(startVersion, targetVersion)
+	if len(upgradeFns) == 0 {
+		log.Debug("No config upgrade funcs to run; config file untouched")
+		return fs.doLoad(ctx)
+	}
 
 	data, err := os.ReadFile(fs.Path)
 	if err != nil {
-		return nil, err
+		return nil, errz.Err(err)
 	}
 
-	// Write the backup only when an upgrade func will actually
-	// transform the config. doUpgrade itself runs on every version
-	// bump (config.version is stamped with the binary version, so
-	// every release triggers it), and an unconditional backup would
-	// accumulate one credential-bearing copy per release for no
-	// recoverability benefit.
-	if len(upgradeFns) > 0 {
-		backupPath := backupFilePath(fs.Path, startVersion)
-		if err = ioz.WriteFileAtomic(backupPath, data, ioz.RWPerms); err != nil {
-			// Abort rather than continue without a backup: the point of
-			// the backup is guaranteed recoverability, and if a sibling
-			// file can't be written, rewriting the config itself is
-			// unlikely to go better.
-			return nil, errz.Wrapf(err, "failed to write config backup before upgrade: %s", backupPath)
-		}
-		log.Info("Wrote verbatim backup of config before upgrade", lga.Path, backupPath)
+	// Write a verbatim backup before the upgrade funcs transform
+	// the config.
+	backupPath := backupFilePath(fs.Path, startVersion)
+	if err = ioz.WriteFileAtomic(backupPath, data, ioz.RWPerms); err != nil {
+		// Abort rather than continue without a backup: the point of
+		// the backup is guaranteed recoverability, and if a sibling
+		// file can't be written, rewriting the config itself is
+		// unlikely to go better.
+		return nil, errz.Wrapf(err, "failed to write config backup before upgrade: %s", backupPath)
 	}
+	log.Info("Wrote verbatim backup of config before upgrade", lga.Path, backupPath)
 
 	for _, fn := range upgradeFns {
 		log.Debug("Attempting config upgrade step")
@@ -102,13 +106,14 @@ func (fs *Store) doUpgrade(ctx context.Context, startVersion, targetVersion stri
 	return cfg, nil
 }
 
-// backupFilePath returns the path of the pre-upgrade backup file for
-// the config file at cfgPath, named for the version being upgraded
-// from: /path/to/sq.yml + v0.53.0 -> /path/to/sq.v0.53.0.bak.yml.
-// The name deliberately does not end in ".sq.yml": Store.loadExt
-// treats any such file in the config dir as ext config. A backup file
-// from a prior upgrade of the same version is overwritten; it holds
-// the same from-version content.
+// backupFilePath returns the path of the backup file for the config
+// file at cfgPath, named for the config version being backed up:
+// /path/to/sq.yml + v0.53.0 -> /path/to/sq.v0.53.0.bak.yml. It is
+// used both for pre-upgrade backups (doUpgrade) and for the downgrade
+// guard (Store.backupNewerConfig). The name deliberately does not end
+// in ".sq.yml": Store.loadExt treats any such file in the config dir
+// as ext config. A backup file from a prior upgrade of the same
+// version is overwritten; it holds the same from-version content.
 func backupFilePath(cfgPath, fromVersion string) string {
 	base := filepath.Base(cfgPath)
 	base = strings.TrimSuffix(base, filepath.Ext(base))
@@ -143,6 +148,19 @@ func (r UpgradeRegistry) getUpgradeFuncs(startingVersion, targetVersion string) 
 	}
 
 	return upgradeFns
+}
+
+// highestVersion returns the highest version key in the registry,
+// which is the config schema version known to this build. Returns
+// empty string if the registry is empty.
+func (r UpgradeRegistry) highestVersion() string {
+	var highest string
+	for k := range r {
+		if highest == "" || semver.Compare(k, highest) > 0 {
+			highest = k
+		}
+	}
+	return highest
 }
 
 // LoadVersionFromFile loads the version from the config file.
@@ -203,60 +221,61 @@ func LoadVersionFromFile(path string) (string, error) {
 // Note that prerelease builds (e.g., v0.0.0-dev) are exempt from this
 // check and will not trigger this error.
 //
-// IMPLEMENTATION NOTE: The current config.version mechanism is not ideal.
-// Currently, sq always stamps config.version with the sq binary version
-// after any upgrade processing. However, config.version should semantically
-// represent the config schema version - i.e., the sq version in which the
-// config schema last changed in a way that requires migration. Since schema
-// changes are infrequent (only one upgrade exists: v0.34.0), the config
-// version gets "inflated" unnecessarily. For example, a config touched by
-// sq v0.48.0 gets stamped v0.48.0, but the schema hasn't changed since
-// v0.34.0, so sq v0.47.0 should be able to read it fine. This error and
-// its graceful handling work around this design limitation.
+// Because the config was written by a newer sq version, it may contain
+// fields unknown to this build's config.Config struct, which a Save
+// would silently drop. Store.Save guards against that data loss by
+// writing a verbatim backup of the config file before its first
+// overwrite: see Store.backupNewerConfig.
+//
+// config.version is a config schema version: it identifies the sq
+// version in which the config schema last changed in a way that
+// requires migration (the highest registered UpgradeFunc version),
+// and is stamped only when an upgrade func runs. Earlier sq releases
+// instead stamped config.version with the sq binary version on every
+// release, so configs in the wild carry "inflated" versions
+// (e.g. v0.48.0 with a v0.34.0-era schema). The comparisons here
+// tolerate that: an inflated version triggers neither an upgrade nor
+// this error, as long as it doesn't exceed the build version.
 var errConfigVersionNewerThanBuild = errors.New("config: config version is newer than sq version")
 
-// checkNeedsUpgrade checks the config file's version against the current sq
-// build version and determines if the config needs to be upgraded.
+// checkNeedsUpgrade checks the config file's version against the
+// store's UpgradeRegistry and the current sq build version, and
+// determines if the config needs to be upgraded.
 //
 // Returns:
-//   - needsUpgrade: true if config version < build version (upgrade required)
-//   - foundVers: the semver version found in the config file
-//   - err: non-nil on version parsing errors, or errConfigVersionNewerThanBuild
-//     if config version > build version (for non-prerelease builds)
+//   - needsUpgrade: true if config version < the highest version in
+//     the UpgradeRegistry, i.e. at least one registered upgrade func
+//     is outstanding.
+//   - foundVers: the semver version found in the config file.
+//   - err: non-nil on version parsing errors, or
+//     errConfigVersionNewerThanBuild if config version > build version
+//     (for non-prerelease builds).
 //
-// When config version equals build version, returns (false, foundVers, nil).
-// Prerelease builds (e.g., v0.0.0-dev) are exempt from the newer-version check.
-func checkNeedsUpgrade(ctx context.Context, path string) (needsUpgrade bool, foundVers string, err error) {
-	foundVers, err = LoadVersionFromFile(path)
+// Prerelease builds (e.g., v0.0.0-dev) are exempt from the
+// newer-version check.
+func (fs *Store) checkNeedsUpgrade(ctx context.Context) (needsUpgrade bool, foundVers string, err error) {
+	foundVers, err = LoadVersionFromFile(fs.Path)
 	if err != nil {
 		return false, "", err
 	}
 
 	lg.FromContext(ctx).Debug("Found config version in file",
-		lga.Version, foundVers, lga.Path, path)
+		lga.Version, foundVers, lga.Path, fs.Path)
 
 	if semver.Compare(foundVers, MinConfigVersion) < 0 {
 		return false, foundVers, errz.Errorf("version %q is less than minimum value %q",
 			foundVers, MinConfigVersion)
 	}
 
+	schemaVers := fs.UpgradeRegistry.highestVersion()
+	needsUpgrade = schemaVers != "" && semver.Compare(foundVers, schemaVers) < 0
+
 	buildVers := buildinfo.Version
-
-	switch semver.Compare(foundVers, buildVers) {
-	case 0:
-		// Versions are the same, nothing to do here
-		return false, foundVers, nil
-	case 1:
-		// sq version is less than config version:
-		// - user needs to upgrade sq
-		// - but we make an exception if sq is prerelease
-		if semver.Prerelease(buildVers) == "" {
-			return false, foundVers, errConfigVersionNewerThanBuild
-		}
-		return false, foundVers, nil
-
-	default:
-		// config version is less than sq version; we need to upgrade config.
-		return true, foundVers, nil
+	if semver.Compare(foundVers, buildVers) > 0 && semver.Prerelease(buildVers) == "" {
+		// The config was written by a newer sq version; the caller
+		// handles this gracefully. See errConfigVersionNewerThanBuild.
+		return needsUpgrade, foundVers, errConfigVersionNewerThanBuild
 	}
+
+	return needsUpgrade, foundVers, nil
 }

--- a/cli/config/yamlstore/upgrade.go
+++ b/cli/config/yamlstore/upgrade.go
@@ -66,28 +66,15 @@ func (fs *Store) doUpgrade(ctx context.Context, startVersion, targetVersion stri
 	}
 
 	// Write a verbatim backup before the upgrade funcs transform the
-	// config, unless a backup for startVersion already exists. A
+	// config, unless a backup for startVersion already exists (a
 	// repeated upgrade from the same version would back up identical
-	// content, so skipping loses nothing; and the existing file may be
-	// the downgrade guard's pristine copy of a newer config (see
-	// Store.backupNewerConfig), which an overwrite would destroy.
-	backupPath := backupFilePath(fs.Path, startVersion)
-	switch _, statErr := os.Stat(backupPath); {
-	case statErr == nil:
-		log.Info("Config backup already exists; not overwriting", lga.Path, backupPath)
-	case !errors.Is(statErr, os.ErrNotExist):
-		// A stat failure other than "not exists" (e.g. permissions)
-		// can't confirm that the backup exists, so abort the upgrade.
-		return nil, errz.Wrapf(statErr, "failed to stat config backup before upgrade: %s", backupPath)
-	default:
-		if err = ioz.WriteFileAtomic(backupPath, data, ioz.RWPerms); err != nil {
-			// Abort rather than continue without a backup: the point of
-			// the backup is guaranteed recoverability, and if a sibling
-			// file can't be written, rewriting the config itself is
-			// unlikely to go better.
-			return nil, errz.Wrapf(err, "failed to write config backup before upgrade: %s", backupPath)
-		}
-		log.Info("Wrote verbatim backup of config before upgrade", lga.Path, backupPath)
+	// content, and an existing file may be the downgrade guard's
+	// pristine copy of a newer config). Abort rather than continue
+	// without a backup: the point of the backup is guaranteed
+	// recoverability, and if a sibling file can't be written, rewriting
+	// the config itself is unlikely to go better.
+	if _, err = fs.writeConfigBackupOnce(ctx, startVersion, data); err != nil {
+		return nil, err
 	}
 
 	for _, fn := range upgradeFns {
@@ -293,7 +280,14 @@ func (fs *Store) checkNeedsUpgrade(ctx context.Context) (needsUpgrade bool, foun
 	if semver.Compare(foundVers, buildVers) > 0 && semver.Prerelease(buildVers) == "" {
 		// The config was written by a newer sq version; the caller
 		// handles this gracefully. See errConfigVersionNewerThanBuild.
-		return needsUpgrade, foundVers, errConfigVersionNewerThanBuild
+		// Never report needsUpgrade in this case: upgrading would
+		// rewrite a config carrying fields this build can't represent,
+		// the data-loss case the downgrade guard exists to prevent. In
+		// a normal build the schema version never exceeds the build
+		// version, so needsUpgrade can't co-occur with this branch; the
+		// explicit false guards a misbuilt binary whose registry holds
+		// an upgrade key above its own version.
+		return false, foundVers, errConfigVersionNewerThanBuild
 	}
 
 	return needsUpgrade, foundVers, nil

--- a/cli/config/yamlstore/upgrade.go
+++ b/cli/config/yamlstore/upgrade.go
@@ -42,13 +42,15 @@ type UpgradeRegistry map[string]UpgradeFunc
 // advances only when a registered upgrade func transforms the config,
 // never to the sq binary version.
 //
-// If no upgrade func falls in the range, doUpgrade leaves the config
-// file untouched (no stamping, no backup). From Load this never happens
-// (it calls doUpgrade only when foundVersion < targetVersion, and
-// targetVersion is itself a registry key, so it is always in range); the
-// guard matters only for a direct caller passing a target with no funcs
-// in range, where rewriting must be avoided because the load-save cycle
-// below is not byte-preserving.
+// If no upgrade func falls in the range, doUpgrade performs no upgrade
+// (no upgrade-func transformation, no version stamping, no backup) and
+// just loads the config; the load may still rewrite the file if it
+// triggers an integrity repair (see doLoad). From Load this branch is
+// never reached (it calls doUpgrade only when foundVersion <
+// targetVersion, and targetVersion is itself a registry key, so it is
+// always in range); the guard matters only for a direct caller passing a
+// target with no funcs in range, where the not-byte-preserving upgrade
+// rewrite must be avoided.
 func (fs *Store) doUpgrade(ctx context.Context, startVersion, targetVersion string) (*config.Config, error) {
 	log := lg.FromContext(ctx)
 	log.Debug("Starting config upgrade", lga.From, startVersion, lga.To, targetVersion)
@@ -59,7 +61,7 @@ func (fs *Store) doUpgrade(ctx context.Context, startVersion, targetVersion stri
 
 	upgradeFns := fs.UpgradeRegistry.getUpgradeFuncs(startVersion, targetVersion)
 	if len(upgradeFns) == 0 {
-		log.Debug("No config upgrade funcs to run; config file untouched")
+		log.Debug("No config upgrade funcs to run; no upgrade performed")
 		return fs.doLoad(ctx)
 	}
 

--- a/cli/config/yamlstore/yamlstore.go
+++ b/cli/config/yamlstore/yamlstore.go
@@ -44,6 +44,12 @@ type Store struct {
 	// PathOrigin is one of "flag", "env", or "default".
 	PathOrigin config.Origin
 
+	// newerCfgVers is set by Load when the config file's version is
+	// newer than the build version (the config was written by a newer
+	// sq version). When non-empty, Save writes a verbatim backup of
+	// the config file before overwriting it: see backupNewerConfig.
+	newerCfgVers string
+
 	// ExtPaths holds locations of potential ext config, both dirs and files (with suffix ".sq.yml")
 	ExtPaths []string
 }
@@ -74,17 +80,20 @@ func (fs *Store) Load(ctx context.Context) (*config.Config, error) {
 	log.Debug("Loading config from file", lga.Path, fs.Path)
 
 	if fs.UpgradeRegistry != nil { //nolint:nestif
-		mightNeedUpgrade, foundVers, err := checkNeedsUpgrade(ctx, fs.Path)
+		mightNeedUpgrade, foundVers, err := fs.checkNeedsUpgrade(ctx)
 
 		// Handle errConfigVersionNewerThanBuild specially: log a warning but
 		// continue execution. This allows users to downgrade sq versions for
 		// testing or debugging purposes. The config was created by a newer sq
 		// version, so it may contain fields this version doesn't recognize,
 		// but we proceed optimistically. All other errors are fatal.
+		// Save will write a verbatim backup of the config file before
+		// overwriting it: see backupNewerConfig.
 		if err != nil && !errors.Is(err, errConfigVersionNewerThanBuild) {
 			return nil, errz.Wrapf(err, "config: %s", fs.Path)
 		}
 		if errors.Is(err, errConfigVersionNewerThanBuild) {
+			fs.newerCfgVers = foundVers
 			log.Warn("Config version is newer than sq version; continuing anyway",
 				lga.ConfigVersion, foundVers,
 				lga.BuildVersion, buildinfo.Version)
@@ -104,7 +113,7 @@ func (fs *Store) Load(ctx context.Context) (*config.Config, error) {
 			// Lock is acquired; check again if config needs upgrade.
 			// Note: we re-check because another process may have upgraded
 			// the config while we were waiting for the lock.
-			mightNeedUpgrade, foundVers, err = checkNeedsUpgrade(ctx, fs.Path)
+			mightNeedUpgrade, foundVers, err = fs.checkNeedsUpgrade(ctx)
 
 			// Same handling as above: warn on newer config version, fail on
 			// other errors. See errConfigVersionNewerThanBuild documentation.
@@ -112,14 +121,18 @@ func (fs *Store) Load(ctx context.Context) (*config.Config, error) {
 				return nil, errz.Wrapf(err, "config: %s", fs.Path)
 			}
 			if errors.Is(err, errConfigVersionNewerThanBuild) {
+				fs.newerCfgVers = foundVers
 				log.Warn("Config version is newer than sq version; continuing anyway",
 					lga.ConfigVersion, foundVers,
 					lga.BuildVersion, buildinfo.Version)
 			}
 
 			if mightNeedUpgrade {
-				log.Info("Upgrade config?", lga.From, foundVers, lga.To, buildinfo.Version)
-				if _, err = fs.doUpgrade(ctx, foundVers, buildinfo.Version); err != nil {
+				// Upgrade to the config schema version: the highest version
+				// in the upgrade registry, NOT the sq build version.
+				targetVers := fs.UpgradeRegistry.highestVersion()
+				log.Info("Upgrade config?", lga.From, foundVers, lga.To, targetVers)
+				if _, err = fs.doUpgrade(ctx, foundVers, targetVers); err != nil {
 					return nil, err
 				}
 
@@ -202,12 +215,63 @@ func (fs *Store) Save(ctx context.Context, cfg *config.Config) error {
 		return err
 	}
 
+	if err := fs.backupNewerConfig(ctx); err != nil {
+		return err
+	}
+
 	data, err := ioz.MarshalYAML(cfg)
 	if err != nil {
 		return err
 	}
 
 	return fs.write(ctx, data)
+}
+
+// backupNewerConfig writes a verbatim backup of the config file before
+// Save overwrites it, when Load found the config's version to be newer
+// than the build version (fs.newerCfgVers is non-empty). The config
+// was written by a newer sq version and may contain fields unknown to
+// this build's config.Config struct; Save's re-marshal silently drops
+// such fields, so the backup is the only surviving copy. The backup is
+// written at most once: if the backup file already exists, it holds
+// the newer config from an earlier run, and overwriting it with the
+// current (possibly already-degraded) file would destroy that.
+func (fs *Store) backupNewerConfig(ctx context.Context) error {
+	if fs.newerCfgVers == "" {
+		return nil
+	}
+
+	backupPath := backupFilePath(fs.Path, fs.newerCfgVers)
+	if _, err := os.Stat(backupPath); err == nil {
+		// Backup already exists; don't overwrite it.
+		fs.newerCfgVers = ""
+		return nil
+	}
+
+	data, err := os.ReadFile(fs.Path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			// Nothing on disk to back up.
+			fs.newerCfgVers = ""
+			return nil
+		}
+		return errz.Wrapf(err, "failed to read config for backup before save: %s", fs.Path)
+	}
+
+	if err = ioz.WriteFileAtomic(backupPath, data, ioz.RWPerms); err != nil {
+		// Abort rather than continue without a backup: overwriting the
+		// config without it would silently lose the newer sq version's
+		// config fields.
+		return errz.Wrapf(err, "failed to write config backup before save: %s", backupPath)
+	}
+
+	lg.FromContext(ctx).Warn(
+		"Config version is newer than sq version; wrote verbatim backup of config before save",
+		lga.ConfigVersion, fs.newerCfgVers,
+		lga.BuildVersion, buildinfo.Version,
+		lga.Path, backupPath)
+	fs.newerCfgVers = ""
+	return nil
 }
 
 // Write writes the config bytes to disk.

--- a/cli/config/yamlstore/yamlstore.go
+++ b/cli/config/yamlstore/yamlstore.go
@@ -276,30 +276,55 @@ func (fs *Store) backupNewerConfig(ctx context.Context) error {
 // earlier copy, so rewriting loses nothing and risks clobbering it. The
 // backup name deliberately does not end in ".sq.yml" (see backupFilePath).
 //
-// It returns wrote=true only when it created a new backup file. A stat or
-// write failure is returned as an error; both callers (doUpgrade and
-// backupNewerConfig) treat a backup failure as fatal, because the backup's
-// purpose is guaranteed recoverability.
+// The backup is created at-most-once even against a concurrent writer: the
+// full content is written to a temp file and then hard-linked into place,
+// and os.Link fails (ErrExist) rather than replacing an existing file. A
+// plain stat-then-write would have a TOCTOU window where another sq process
+// could create the backup between the two steps and have it clobbered by an
+// atomic rename, and a partial backup can never be observed because the temp
+// file is complete before it is linked.
+//
+// It returns wrote=true only when it created a new backup file. A failure is
+// returned as an error; both callers (doUpgrade and backupNewerConfig) treat
+// a backup failure as fatal, because the backup's purpose is guaranteed
+// recoverability.
 func (fs *Store) writeConfigBackupOnce(ctx context.Context, vers string, data []byte) (wrote bool, err error) {
 	backupPath := backupFilePath(fs.Path, vers)
-	switch info, statErr := os.Stat(backupPath); {
-	case statErr == nil:
-		if !info.Mode().IsRegular() {
-			// The path exists but is not a regular file (e.g. a
-			// directory), so it is not a usable backup. Refuse rather
-			// than skip the write and risk silent data loss when the
-			// caller overwrites the config.
-			return false, errz.Errorf("config backup path exists but is not a regular file: %s", backupPath)
-		}
-		lg.FromContext(ctx).Info("Config backup already exists; not overwriting", lga.Path, backupPath)
-		return false, nil
-	case !errors.Is(statErr, os.ErrNotExist):
-		// A stat failure other than "not exists" (e.g. permissions)
-		// can't confirm that the backup exists, so don't proceed.
-		return false, errz.Wrapf(statErr, "failed to stat config backup: %s", backupPath)
+	dir := filepath.Dir(backupPath)
+
+	// Temp file in the same dir, so the hard link below stays on one
+	// filesystem. os.CreateTemp uses 0600, matching ioz.RWPerms.
+	tmp, err := os.CreateTemp(dir, ".sq-config-backup-*")
+	if err != nil {
+		return false, errz.Wrapf(err, "failed to create temp config backup in %s", dir)
+	}
+	tmpName := tmp.Name()
+	defer func() { _ = os.Remove(tmpName) }()
+
+	if _, err = tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return false, errz.Wrapf(err, "failed to write temp config backup: %s", tmpName)
+	}
+	if err = tmp.Close(); err != nil {
+		return false, errz.Wrapf(err, "failed to close temp config backup: %s", tmpName)
 	}
 
-	if err = ioz.WriteFileAtomic(backupPath, data, ioz.RWPerms); err != nil {
+	if err = os.Link(tmpName, backupPath); err != nil {
+		if errors.Is(err, os.ErrExist) {
+			// A backup already exists. Confirm it's a regular file (a
+			// usable backup), not e.g. a directory, before treating it as
+			// the existing backup and letting the caller overwrite the
+			// config.
+			info, statErr := os.Stat(backupPath)
+			if statErr != nil {
+				return false, errz.Wrapf(statErr, "failed to stat existing config backup: %s", backupPath)
+			}
+			if !info.Mode().IsRegular() {
+				return false, errz.Errorf("config backup path exists but is not a regular file: %s", backupPath)
+			}
+			lg.FromContext(ctx).Info("Config backup already exists; not overwriting", lga.Path, backupPath)
+			return false, nil
+		}
 		return false, errz.Wrapf(err, "failed to write config backup: %s", backupPath)
 	}
 	return true, nil

--- a/cli/config/yamlstore/yamlstore.go
+++ b/cli/config/yamlstore/yamlstore.go
@@ -283,9 +283,16 @@ func (fs *Store) backupNewerConfig(ctx context.Context) error {
 // rename (which replaces the destination). O_EXCL also refuses to follow a
 // symlink, and the ErrExist branch confirms via Lstat that any existing
 // entry is a real regular file, not a symlink or directory. The bytes are
-// fsync'd before close, since the backup's purpose is recoverability; the
-// only window not covered is a crash between create and write, which would
-// leave a partial backup (far rarer than the races this guards against).
+// fsync'd before close, since the backup's purpose is recoverability.
+//
+// The only window not covered is a crash between the exclusive create and
+// the write, which leaves a zero-length backup. That gap is not closed by
+// size-checking an existing backup: the create-then-write window makes a
+// concurrent writer's brand-new backup transiently empty too, so a
+// size-based "is it complete?" test races with legitimate concurrent writes
+// (it would remove or reject another process's in-progress backup). A
+// crash in that microsecond window during a downgrade-guard save is far
+// rarer than the races this guards against.
 //
 // It returns wrote=true only when it created a new backup file. A failure is
 // returned as an error; both callers (doUpgrade and backupNewerConfig) treat
@@ -314,8 +321,13 @@ func (fs *Store) writeConfigBackupOnce(ctx context.Context, vers string, data []
 		return false, errz.Wrapf(err, "failed to create config backup: %s", backupPath)
 	}
 
-	// Write, fsync, and close. On any failure remove the partial file so a
-	// later run can't mistake it for a complete backup.
+	return writeBackupContents(f, backupPath, data)
+}
+
+// writeBackupContents writes data to f (an exclusively-created backup file),
+// fsyncs it, and closes it. On any failure it removes the file so a partial
+// backup is never left behind to be mistaken for a complete one.
+func writeBackupContents(f *os.File, backupPath string, data []byte) (wrote bool, err error) {
 	if _, err = f.Write(data); err != nil {
 		_ = f.Close()
 		_ = os.Remove(backupPath)

--- a/cli/config/yamlstore/yamlstore.go
+++ b/cli/config/yamlstore/yamlstore.go
@@ -242,10 +242,15 @@ func (fs *Store) backupNewerConfig(ctx context.Context) error {
 	}
 
 	backupPath := backupFilePath(fs.Path, fs.newerCfgVers)
-	if _, err := os.Stat(backupPath); err == nil {
+	switch _, err := os.Stat(backupPath); {
+	case err == nil:
 		// Backup already exists; don't overwrite it.
 		fs.newerCfgVers = ""
 		return nil
+	case !errors.Is(err, os.ErrNotExist):
+		// A stat failure other than "not exists" (e.g. permissions)
+		// can't confirm that the backup exists, so fail the save.
+		return errz.Wrapf(err, "failed to stat config backup before save: %s", backupPath)
 	}
 
 	data, err := os.ReadFile(fs.Path)

--- a/cli/config/yamlstore/yamlstore.go
+++ b/cli/config/yamlstore/yamlstore.go
@@ -168,17 +168,7 @@ func (fs *Store) doLoad(ctx context.Context) (*config.Config, error) {
 	}
 
 	if cfg.Version == "" {
-		// Stamp the config schema version (the highest registered upgrade
-		// version), not the build version, to match fresh-config stamping
-		// (see defaultload.Load) and the schema-version model. Fall back to
-		// the build version only when no registry is configured, i.e. there
-		// is no schema version to assign.
-		if fs.UpgradeRegistry != nil {
-			cfg.Version = fs.UpgradeRegistry.highestVersion()
-		}
-		if cfg.Version == "" {
-			cfg.Version = buildinfo.Version
-		}
+		cfg.Version = buildinfo.Version
 	}
 
 	if cfg.Options == nil {
@@ -284,8 +274,15 @@ func (fs *Store) backupNewerConfig(ctx context.Context) error {
 // purpose is guaranteed recoverability.
 func (fs *Store) writeConfigBackupOnce(ctx context.Context, vers string, data []byte) (wrote bool, err error) {
 	backupPath := backupFilePath(fs.Path, vers)
-	switch _, statErr := os.Stat(backupPath); {
+	switch info, statErr := os.Stat(backupPath); {
 	case statErr == nil:
+		if !info.Mode().IsRegular() {
+			// The path exists but is not a regular file (e.g. a
+			// directory), so it is not a usable backup. Refuse rather
+			// than skip the write and risk silent data loss when the
+			// caller overwrites the config.
+			return false, errz.Errorf("config backup path exists but is not a regular file: %s", backupPath)
+		}
 		lg.FromContext(ctx).Info("Config backup already exists; not overwriting", lga.Path, backupPath)
 		return false, nil
 	case !errors.Is(statErr, os.ErrNotExist):

--- a/cli/config/yamlstore/yamlstore.go
+++ b/cli/config/yamlstore/yamlstore.go
@@ -276,13 +276,16 @@ func (fs *Store) backupNewerConfig(ctx context.Context) error {
 // earlier copy, so rewriting loses nothing and risks clobbering it. The
 // backup name deliberately does not end in ".sq.yml" (see backupFilePath).
 //
-// The backup is created at-most-once even against a concurrent writer: the
-// full content is written to a temp file and then hard-linked into place,
-// and os.Link fails (ErrExist) rather than replacing an existing file. A
-// plain stat-then-write would have a TOCTOU window where another sq process
-// could create the backup between the two steps and have it clobbered by an
-// atomic rename, and a partial backup can never be observed because the temp
-// file is complete before it is linked.
+// The backup is created with O_CREATE|O_EXCL, so the create is atomic
+// against a concurrent writer (only one process can create the file) and an
+// existing backup is never clobbered. This is portable, unlike a hard link
+// (which fails on filesystems without hard-link support) or an atomic
+// rename (which replaces the destination). O_EXCL also refuses to follow a
+// symlink, and the ErrExist branch confirms via Lstat that any existing
+// entry is a real regular file, not a symlink or directory. The bytes are
+// fsync'd before close, since the backup's purpose is recoverability; the
+// only window not covered is a crash between create and write, which would
+// leave a partial backup (far rarer than the races this guards against).
 //
 // It returns wrote=true only when it created a new backup file. A failure is
 // returned as an error; both callers (doUpgrade and backupNewerConfig) treat
@@ -290,34 +293,17 @@ func (fs *Store) backupNewerConfig(ctx context.Context) error {
 // recoverability.
 func (fs *Store) writeConfigBackupOnce(ctx context.Context, vers string, data []byte) (wrote bool, err error) {
 	backupPath := backupFilePath(fs.Path, vers)
-	dir := filepath.Dir(backupPath)
 
-	// Temp file in the same dir, so the hard link below stays on one
-	// filesystem. os.CreateTemp uses 0600, matching ioz.RWPerms.
-	tmp, err := os.CreateTemp(dir, ".sq-config-backup-*")
+	f, err := os.OpenFile(backupPath, os.O_CREATE|os.O_EXCL|os.O_WRONLY, ioz.RWPerms)
 	if err != nil {
-		return false, errz.Wrapf(err, "failed to create temp config backup in %s", dir)
-	}
-	tmpName := tmp.Name()
-	defer func() { _ = os.Remove(tmpName) }()
-
-	if _, err = tmp.Write(data); err != nil {
-		_ = tmp.Close()
-		return false, errz.Wrapf(err, "failed to write temp config backup: %s", tmpName)
-	}
-	if err = tmp.Close(); err != nil {
-		return false, errz.Wrapf(err, "failed to close temp config backup: %s", tmpName)
-	}
-
-	if err = os.Link(tmpName, backupPath); err != nil {
 		if errors.Is(err, os.ErrExist) {
-			// A backup already exists. Confirm it's a regular file (a
-			// usable backup), not e.g. a directory, before treating it as
+			// A backup already exists. Confirm with Lstat (don't follow a
+			// symlink) that it's a real regular file before treating it as
 			// the existing backup and letting the caller overwrite the
 			// config.
-			info, statErr := os.Stat(backupPath)
-			if statErr != nil {
-				return false, errz.Wrapf(statErr, "failed to stat existing config backup: %s", backupPath)
+			info, lstatErr := os.Lstat(backupPath)
+			if lstatErr != nil {
+				return false, errz.Wrapf(lstatErr, "failed to stat existing config backup: %s", backupPath)
 			}
 			if !info.Mode().IsRegular() {
 				return false, errz.Errorf("config backup path exists but is not a regular file: %s", backupPath)
@@ -325,7 +311,24 @@ func (fs *Store) writeConfigBackupOnce(ctx context.Context, vers string, data []
 			lg.FromContext(ctx).Info("Config backup already exists; not overwriting", lga.Path, backupPath)
 			return false, nil
 		}
+		return false, errz.Wrapf(err, "failed to create config backup: %s", backupPath)
+	}
+
+	// Write, fsync, and close. On any failure remove the partial file so a
+	// later run can't mistake it for a complete backup.
+	if _, err = f.Write(data); err != nil {
+		_ = f.Close()
+		_ = os.Remove(backupPath)
 		return false, errz.Wrapf(err, "failed to write config backup: %s", backupPath)
+	}
+	if err = f.Sync(); err != nil {
+		_ = f.Close()
+		_ = os.Remove(backupPath)
+		return false, errz.Wrapf(err, "failed to sync config backup: %s", backupPath)
+	}
+	if err = f.Close(); err != nil {
+		_ = os.Remove(backupPath)
+		return false, errz.Wrapf(err, "failed to close config backup: %s", backupPath)
 	}
 	return true, nil
 }

--- a/cli/config/yamlstore/yamlstore.go
+++ b/cli/config/yamlstore/yamlstore.go
@@ -80,7 +80,12 @@ func (fs *Store) Load(ctx context.Context) (*config.Config, error) {
 	log.Debug("Loading config from file", lga.Path, fs.Path)
 
 	if fs.UpgradeRegistry != nil {
-		mightNeedUpgrade, foundVers, checkErr := fs.checkNeedsUpgrade(ctx)
+		// The config schema version (highest registered upgrade version),
+		// derived once and used for both the needsUpgrade decision and the
+		// upgrade target, so the two can't drift.
+		schemaVers := fs.UpgradeRegistry.highestVersion()
+
+		mightNeedUpgrade, foundVers, checkErr := fs.checkNeedsUpgrade(ctx, schemaVers)
 		if err := fs.applyVersionCheck(ctx, foundVers, checkErr); err != nil {
 			return nil, err
 		}
@@ -98,20 +103,18 @@ func (fs *Store) Load(ctx context.Context) (*config.Config, error) {
 
 			// Lock is acquired; re-check, because another process may have
 			// upgraded the config while we were waiting for the lock.
-			mightNeedUpgrade, foundVers, checkErr = fs.checkNeedsUpgrade(ctx)
+			mightNeedUpgrade, foundVers, checkErr = fs.checkNeedsUpgrade(ctx, schemaVers)
 			if err = fs.applyVersionCheck(ctx, foundVers, checkErr); err != nil {
 				return nil, err
 			}
 
 			if mightNeedUpgrade {
-				// Upgrade to the config schema version: the highest version
-				// in the upgrade registry, NOT the sq build version.
-				targetVers := fs.UpgradeRegistry.highestVersion()
-				log.Info("Upgrade config?", lga.From, foundVers, lga.To, targetVers)
+				// Upgrade to the config schema version, NOT the sq build version.
+				log.Info("Upgrade config?", lga.From, foundVers, lga.To, schemaVers)
 				// doUpgrade re-marshals the upgraded config from the struct
 				// (canonical key order) and saves it, so no extra load-save
 				// cycle is needed here; the doLoad below returns it.
-				if _, err = fs.doUpgrade(ctx, foundVers, targetVers); err != nil {
+				if _, err = fs.doUpgrade(ctx, foundVers, schemaVers); err != nil {
 					return nil, err
 				}
 			}

--- a/cli/config/yamlstore/yamlstore.go
+++ b/cli/config/yamlstore/yamlstore.go
@@ -79,24 +79,10 @@ func (fs *Store) Load(ctx context.Context) (*config.Config, error) {
 	log := lg.FromContext(ctx)
 	log.Debug("Loading config from file", lga.Path, fs.Path)
 
-	if fs.UpgradeRegistry != nil { //nolint:nestif
-		mightNeedUpgrade, foundVers, err := fs.checkNeedsUpgrade(ctx)
-
-		// Handle errConfigVersionNewerThanBuild specially: log a warning but
-		// continue execution. This allows users to downgrade sq versions for
-		// testing or debugging purposes. The config was created by a newer sq
-		// version, so it may contain fields this version doesn't recognize,
-		// but we proceed optimistically. All other errors are fatal.
-		// Save will write a verbatim backup of the config file before
-		// overwriting it: see backupNewerConfig.
-		if err != nil && !errors.Is(err, errConfigVersionNewerThanBuild) {
-			return nil, errz.Wrapf(err, "config: %s", fs.Path)
-		}
-		if errors.Is(err, errConfigVersionNewerThanBuild) {
-			fs.newerCfgVers = foundVers
-			log.Warn("Config version is newer than sq version; continuing anyway",
-				lga.ConfigVersion, foundVers,
-				lga.BuildVersion, buildinfo.Version)
+	if fs.UpgradeRegistry != nil {
+		mightNeedUpgrade, foundVers, checkErr := fs.checkNeedsUpgrade(ctx)
+		if err := fs.applyVersionCheck(ctx, foundVers, checkErr); err != nil {
+			return nil, err
 		}
 
 		if mightNeedUpgrade {
@@ -110,21 +96,11 @@ func (fs *Store) Load(ctx context.Context) (*config.Config, error) {
 			}
 			defer unlock()
 
-			// Lock is acquired; check again if config needs upgrade.
-			// Note: we re-check because another process may have upgraded
-			// the config while we were waiting for the lock.
-			mightNeedUpgrade, foundVers, err = fs.checkNeedsUpgrade(ctx)
-
-			// Same handling as above: warn on newer config version, fail on
-			// other errors. See errConfigVersionNewerThanBuild documentation.
-			if err != nil && !errors.Is(err, errConfigVersionNewerThanBuild) {
-				return nil, errz.Wrapf(err, "config: %s", fs.Path)
-			}
-			if errors.Is(err, errConfigVersionNewerThanBuild) {
-				fs.newerCfgVers = foundVers
-				log.Warn("Config version is newer than sq version; continuing anyway",
-					lga.ConfigVersion, foundVers,
-					lga.BuildVersion, buildinfo.Version)
+			// Lock is acquired; re-check, because another process may have
+			// upgraded the config while we were waiting for the lock.
+			mightNeedUpgrade, foundVers, checkErr = fs.checkNeedsUpgrade(ctx)
+			if err = fs.applyVersionCheck(ctx, foundVers, checkErr); err != nil {
+				return nil, err
 			}
 
 			if mightNeedUpgrade {
@@ -132,26 +108,44 @@ func (fs *Store) Load(ctx context.Context) (*config.Config, error) {
 				// in the upgrade registry, NOT the sq build version.
 				targetVers := fs.UpgradeRegistry.highestVersion()
 				log.Info("Upgrade config?", lga.From, foundVers, lga.To, targetVers)
+				// doUpgrade re-marshals the upgraded config from the struct
+				// (canonical key order) and saves it, so no extra load-save
+				// cycle is needed here; the doLoad below returns it.
 				if _, err = fs.doUpgrade(ctx, foundVers, targetVers); err != nil {
 					return nil, err
-				}
-
-				// We do a cycle of loading and saving the config after the upgrade,
-				// because the upgrade may have written YAML via a map, which
-				// doesn't preserve order. Loading and saving should fix that.
-				cfg, err := fs.doLoad(ctx)
-				if err != nil {
-					return nil, errz.Wrapf(err, "config: %s: load failed after config upgrade", fs.Path)
-				}
-
-				if err = fs.Save(ctx, cfg); err != nil {
-					return nil, errz.Wrapf(err, "config: %s: save failed after config upgrade", fs.Path)
 				}
 			}
 		}
 	}
 
 	return fs.doLoad(ctx)
+}
+
+// applyVersionCheck records or clears the newer-than-build state from a
+// checkNeedsUpgrade result and returns the fatal error (already wrapped),
+// if any. A result that is not errConfigVersionNewerThanBuild clears
+// fs.newerCfgVers, so a post-lock re-check (or a later Load on a reused
+// Store) that no longer sees a newer-than-build config doesn't leave the
+// flag set and trigger a spurious backup on the next Save.
+func (fs *Store) applyVersionCheck(ctx context.Context, foundVers string, checkErr error) error {
+	switch {
+	case checkErr == nil:
+		fs.newerCfgVers = ""
+		return nil
+	case errors.Is(checkErr, errConfigVersionNewerThanBuild):
+		// The config was created by a newer sq version, so it may contain
+		// fields this version doesn't recognize. Continue optimistically
+		// (this lets users downgrade sq for testing/debugging); the next
+		// Save writes a verbatim backup of the config first. See
+		// backupNewerConfig.
+		fs.newerCfgVers = foundVers
+		lg.FromContext(ctx).Warn("Config version is newer than sq version; continuing anyway",
+			lga.ConfigVersion, foundVers,
+			lga.BuildVersion, buildinfo.Version)
+		return nil
+	default:
+		return errz.Wrapf(checkErr, "config: %s", fs.Path)
+	}
 }
 
 func (fs *Store) doLoad(ctx context.Context) (*config.Config, error) {
@@ -174,7 +168,17 @@ func (fs *Store) doLoad(ctx context.Context) (*config.Config, error) {
 	}
 
 	if cfg.Version == "" {
-		cfg.Version = buildinfo.Version
+		// Stamp the config schema version (the highest registered upgrade
+		// version), not the build version, to match fresh-config stamping
+		// (see defaultload.Load) and the schema-version model. Fall back to
+		// the build version only when no registry is configured, i.e. there
+		// is no schema version to assign.
+		if fs.UpgradeRegistry != nil {
+			cfg.Version = fs.UpgradeRegistry.highestVersion()
+		}
+		if cfg.Version == "" {
+			cfg.Version = buildinfo.Version
+		}
 	}
 
 	if cfg.Options == nil {
@@ -241,18 +245,6 @@ func (fs *Store) backupNewerConfig(ctx context.Context) error {
 		return nil
 	}
 
-	backupPath := backupFilePath(fs.Path, fs.newerCfgVers)
-	switch _, err := os.Stat(backupPath); {
-	case err == nil:
-		// Backup already exists; don't overwrite it.
-		fs.newerCfgVers = ""
-		return nil
-	case !errors.Is(err, os.ErrNotExist):
-		// A stat failure other than "not exists" (e.g. permissions)
-		// can't confirm that the backup exists, so fail the save.
-		return errz.Wrapf(err, "failed to stat config backup before save: %s", backupPath)
-	}
-
 	data, err := os.ReadFile(fs.Path)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
@@ -263,20 +255,49 @@ func (fs *Store) backupNewerConfig(ctx context.Context) error {
 		return errz.Wrapf(err, "failed to read config for backup before save: %s", fs.Path)
 	}
 
-	if err = ioz.WriteFileAtomic(backupPath, data, ioz.RWPerms); err != nil {
-		// Abort rather than continue without a backup: overwriting the
-		// config without it would silently lose the newer sq version's
-		// config fields.
-		return errz.Wrapf(err, "failed to write config backup before save: %s", backupPath)
+	// Leave newerCfgVers set on error so a retried Save tries again.
+	wrote, err := fs.writeConfigBackupOnce(ctx, fs.newerCfgVers, data)
+	if err != nil {
+		return err
 	}
-
-	lg.FromContext(ctx).Warn(
-		"Config version is newer than sq version; wrote verbatim backup of config before save",
-		lga.ConfigVersion, fs.newerCfgVers,
-		lga.BuildVersion, buildinfo.Version,
-		lga.Path, backupPath)
+	if wrote {
+		lg.FromContext(ctx).Warn(
+			"Config version is newer than sq version; wrote verbatim backup of config before save",
+			lga.ConfigVersion, fs.newerCfgVers,
+			lga.BuildVersion, buildinfo.Version,
+			lga.Path, backupFilePath(fs.Path, fs.newerCfgVers))
+	}
 	fs.newerCfgVers = ""
 	return nil
+}
+
+// writeConfigBackupOnce writes data (the verbatim current config bytes) to
+// the backup path for config version vers, unless a backup for that version
+// already exists. The backup is never overwritten: an existing one may be
+// the downgrade guard's pristine copy of a newer config, or an identical
+// earlier copy, so rewriting loses nothing and risks clobbering it. The
+// backup name deliberately does not end in ".sq.yml" (see backupFilePath).
+//
+// It returns wrote=true only when it created a new backup file. A stat or
+// write failure is returned as an error; both callers (doUpgrade and
+// backupNewerConfig) treat a backup failure as fatal, because the backup's
+// purpose is guaranteed recoverability.
+func (fs *Store) writeConfigBackupOnce(ctx context.Context, vers string, data []byte) (wrote bool, err error) {
+	backupPath := backupFilePath(fs.Path, vers)
+	switch _, statErr := os.Stat(backupPath); {
+	case statErr == nil:
+		lg.FromContext(ctx).Info("Config backup already exists; not overwriting", lga.Path, backupPath)
+		return false, nil
+	case !errors.Is(statErr, os.ErrNotExist):
+		// A stat failure other than "not exists" (e.g. permissions)
+		// can't confirm that the backup exists, so don't proceed.
+		return false, errz.Wrapf(statErr, "failed to stat config backup: %s", backupPath)
+	}
+
+	if err = ioz.WriteFileAtomic(backupPath, data, ioz.RWPerms); err != nil {
+		return false, errz.Wrapf(err, "failed to write config backup: %s", backupPath)
+	}
+	return true, nil
 }
 
 // Write writes the config bytes to disk.

--- a/cli/config/yamlstore/yamlstore.go
+++ b/cli/config/yamlstore/yamlstore.go
@@ -147,6 +147,11 @@ func (fs *Store) applyVersionCheck(ctx context.Context, foundVers string, checkE
 			lga.BuildVersion, buildinfo.Version)
 		return nil
 	default:
+		// A fatal check error leaves the version state indeterminate.
+		// Clear newerCfgVers anyway so a later Save on a reused Store
+		// can't act on a stale newer-than-build result from an earlier
+		// Load (the doc's "any non-newer result clears it" invariant).
+		fs.newerCfgVers = ""
 		return errz.Wrapf(checkErr, "config: %s", fs.Path)
 	}
 }


### PR DESCRIPTION
Fixes #796.

## Problem

`config.version` was stamped with the sq **binary** version after upgrade
processing, not the config **schema** version. Three consequences followed:

1. **Every release rewrote the config file.** After any release, the stored
   `config.version` was less than the new binary version, so `checkNeedsUpgrade`
   reported "needs upgrade" and `doUpgrade` ran its load/save cycle on a config
   whose schema hadn't actually changed. That round-trip is not byte-preserving:
   unknown keys are dropped, options not registered in this build are stripped,
   and YAML comments and formatting are lost.
2. **The routine rewrite was unprotected.** The #794 pre-upgrade backup was gated
   on an upgrade func actually running. Since the rewrite happened without any
   upgrade func, it ran with no backup.
3. **Downgrades silently lost data with no recovery.** A config written by a
   newer sq, then opened by an older binary, had its newer-schema fields stripped
   on the first mutating `Save`. The newer version stamp was preserved, so no
   later upgrade or backup ever fired to surface or recover the loss.

## Fix

**`config.version` becomes a schema version.** It is stamped only when a
registered upgrade func actually transforms the config, and with the highest
registered upgrade version (`UpgradeRegistry.highestVersion()`), never the binary
version. Fresh configs are stamped the same way at creation (`defaultload.go`),
so a brand-new config and an up-to-date existing config carry the same stamp.
`Load` derives the schema version once and passes it to both `checkNeedsUpgrade`
and the upgrade target, so the needsUpgrade decision and the target can't drift.

**Releases without schema changes never touch the file.** `checkNeedsUpgrade`
compares the found version against the schema version (`needsUpgrade =
foundVers < schemaVers`), not the build version, so a release with no schema
change does no upgrade and the file is left byte-for-byte intact (tested
byte-identical). After a real upgrade, `doUpgrade` re-marshals the upgraded
config from the struct (canonical key order) and saves it, so there is no
redundant post-upgrade load/save cycle.

**Downgrade guard.** When `Load` sees a config whose version exceeds this build's
version (written by a newer sq), it records `newerCfgVers` via a single
`applyVersionCheck` helper. The next `Save` calls `backupNewerConfig`, which
writes a verbatim backup of the on-disk file before the first overwrite, then
clears the flag. `applyVersionCheck` also *clears* `newerCfgVers` on any
non-newer result (including the post-lock re-check, a fatal error, and a reload
on a reused `Store`), so a stale flag can't trigger a spurious backup.
`checkNeedsUpgrade` returns `needsUpgrade=false` on the newer-than-build branch,
so a misbuilt binary whose registry holds an upgrade key above its own version
can't drive an upgrade against a config it can't represent.

**Backup creation is at-most-once, portable, and durable.** The pre-upgrade
backup and the downgrade guard share one helper, `writeConfigBackupOnce`, that
creates the backup with `os.OpenFile(O_CREATE|O_EXCL|O_WRONLY)`, then writes,
fsyncs, and closes:

- `O_EXCL` makes the create atomic against a concurrent writer (only one process
  can win), so an existing backup is never clobbered.
- It is portable: no hard-link requirement (unlike `os.Link`) and no atomic
  rename that would replace the destination.
- `O_EXCL` refuses to follow a symlink, and the `ErrExist` branch confirms via
  `Lstat` that any existing entry is a real regular file (not a symlink or
  directory) before treating it as the existing backup.
- The bytes are fsync'd before close; a write/sync/close failure removes the
  partial file so it can't be mistaken for a complete backup.

Both callers derive the same backup filename from `backupFilePath` (e.g.
`sq.v0.53.0.bak.yml`, deliberately not ending in `.sq.yml` so it isn't loaded as
ext config), and neither overwrites an existing backup, so the upgrade path can't
clobber the downgrade guard's pristine copy.

## Why the newer-than-build check still keys off the build version

The "config is newer than sq" detection deliberately compares against
`buildinfo.Version`, not the schema version. Configs already in the wild carry
inflated binary stamps from the old behavior (e.g. `v0.48.0` on a `v0.34.0`-era
schema). A pure schema-version guard would read those as "from the future" and
spuriously trip. Keying off the build version tolerates them: an inflated stamp
triggers neither an upgrade nor the newer-than-build error as long as it doesn't
exceed the running binary's version. In the new world a schema stamp can never
exceed the writing binary's version, so the two regimes coexist.

## Limitation

Already-shipped binaries predate this guard, so downgrading to an old-world sq
still strips newer fields on save. Only downgrades to a build that has the guard
are protected (forward protection only); nothing can retrofit the behavior into
binaries already released.

## Testing

New tests in `cli/config/yamlstore/internal_test.go`, by area.

Version parsing and schema decisions:

- `Test_LoadVersionFromFile` (valid / legacy field names / missing / empty /
  non-string / invalid-semver / malformed-YAML version fields)
- `Test_checkNeedsUpgrade_schemaVersion` (inflated tolerated, at-schema,
  below-schema, newer-than-build, and a `registry key above build version` case
  exercising the newer-than-build override)
- `Test_checkNeedsUpgrade_belowMinVersion`
- `Test_Load_FreshConfig_StampsSchemaVersion`
- `Test_Store_doLoad_EmptyVersionStampsBuildVersion`

Upgrade behavior:

- `Test_Store_Load_SchemaCurrent_NoRewrite` (byte-identical when schema is current)
- `Test_Store_Load_UpgradeStampsSchemaVersion`
- `Test_Store_Load_MultiStepUpgrade_Chains` (two funcs run in order, chained,
  stamped, re-loadable)
- `Test_Store_Load_UpgradeFuncError` (a failed migration fails the load and leaves
  the config intact)
- `Test_Store_doUpgrade_DirectCalls` (invalid target rejected; no-funcs range is a
  no-op)
- `Test_Store_Load_Upgrade_PreservesGuardBackup` (upgrade backup doesn't clobber
  the guard's)

Downgrade guard:

- `Test_Store_Save_NewerConfig_BackupBeforeSave` (first save backs up; second
  doesn't overwrite)
- `Test_Store_Load_ClearsNewerCfgVers_OnReload` (reused Store clears the sticky flag)
- `Test_Store_applyVersionCheck_FatalClearsNewerCfgVers`
- `Test_Store_Save_NewerConfig_Prerelease_NoBackup`
- `Test_Store_Save_InflatedVersion_NoBackup` (inflated old-world stamp triggers
  neither path)

Backup creation (`writeConfigBackupOnce` / `backupNewerConfig`):

- `Test_Store_writeConfigBackupOnce_CreatesBackup` (content + 0600 perms)
- `Test_Store_writeConfigBackupOnce_DoesNotClobber`
- `Test_Store_writeConfigBackupOnce_ConcurrentAtMostOnce` (many goroutines race,
  exactly one wins, content uncorrupted; passes under `-race`)
- `Test_Store_writeConfigBackupOnce_RejectsSymlink` (symlink rejected, target not
  written through)
- `Test_Store_writeConfigBackupOnce_DirError`
- `Test_Store_backupNewerConfig_NonRegularBackupPath` (a directory at the backup
  path fails the save, config left intact)
- `Test_Store_backupNewerConfig_ConfigDeleted`
- `Test_Store_backupNewerConfig_StatError`

Broken-config handling:

- `Test_Store_Load_RejectsBrokenConfig` (malformed / missing / below-min version,
  and malformed YAML all fail load with a clear error)
- `Test_Store_Load_RepairsDanglingActiveSource` (a dangling active source is
  repaired and persisted)

Compatibility verified end to end: inflated stamps trigger neither an upgrade nor
the guard, and the v0.53 -> v0.54 `redact` -> `secrets.reveal` upgrade still fires
with its backup. `make lint` clean; cli config suites green (including the
non-short tests, and the concurrency test under `-race`).
