### PR TITLE
location: escape cwd-derived bytes when absolutizing into a template

### DIFF
--- a/cli/cmd_add.go
+++ b/cli/cmd_add.go
@@ -484,10 +484,14 @@ func applyPassword(ctx context.Context, cmd *cobra.Command, ru *run.Run, loc str
 // mungeLocationForType applies driver-specific location munging for
 // the file-based DB types (SQLite, DuckDB); other types pass through
 // unchanged. Only meaningful for non-placeholder locations: a
-// placeholder location is opaque at add time, and gets the same
-// munging at connect time via driver.ResolveSourceSecrets.
+// placeholder location is opaque at add time, and gets the
+// literal-mode munging at connect time via
+// driver.ResolveSourceSecrets. The template variant is used here
+// because loc is the typed location, a placeholder template: any cwd
+// bytes spliced in by path absolutization are escaped, so a cwd
+// containing '$' cannot corrupt the stored template (gh #797).
 func mungeLocationForType(ctx context.Context, typ drivertype.Type, loc string) (string, error) {
-	munged, err := location.MungeForDriver(typ, loc)
+	munged, err := location.MungeTemplateForDriver(typ, loc)
 	if err != nil {
 		return "", err
 	}

--- a/cli/cmd_add_test.go
+++ b/cli/cmd_add_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/neilotoole/sq/cli"
 	"github.com/neilotoole/sq/cli/testrun"
 	"github.com/neilotoole/sq/libsq/core/options"
+	"github.com/neilotoole/sq/libsq/core/secret"
 	"github.com/neilotoole/sq/libsq/driver"
 	"github.com/neilotoole/sq/libsq/source"
 	"github.com/neilotoole/sq/libsq/source/drivertype"
@@ -1217,4 +1218,130 @@ func (nonSQLDriverStub) DriverMetadata() driver.Metadata {
 
 func (nonSQLDriverStub) ValidateSource(*source.Source) (*source.Source, error) {
 	panic("not implemented")
+}
+
+// dollarDirNames are directory names containing bytes significant in
+// the placeholder-template grammar. Adding a source via a relative
+// path from inside such a directory splices these filesystem bytes
+// into the stored location template, which must escape them (gh #797).
+var dollarDirNames = []string{
+	"q$exports",
+	"q$$exports",
+	"${env:X}",
+}
+
+// chdirDollarDir creates dirName under a fresh temp dir, chdirs into
+// it, and returns the resolved cwd (os.Getwd after chdir, so macOS
+// /tmp symlinks don't skew expectations).
+func chdirDollarDir(t *testing.T, dirName string) string {
+	t.Helper()
+	dir := filepath.Join(t.TempDir(), dirName)
+	require.NoError(t, os.Mkdir(dir, 0o750))
+	t.Chdir(dir)
+	cwd, err := os.Getwd()
+	require.NoError(t, err)
+	return cwd
+}
+
+// TestCmdAdd_CwdDollarDir_CSV is the gh #797 round trip for the
+// generic document-file path (location.Abs): sq add of a relative CSV
+// path from inside a directory whose name contains '$' bytes must (a)
+// succeed, (b) store a template that resolves back to the true
+// filesystem path, (c) form no accidental ${scheme:path} ref, and (d)
+// remain queryable end to end.
+func TestCmdAdd_CwdDollarDir_CSV(t *testing.T) {
+	for _, dirName := range dollarDirNames {
+		t.Run(tu.Name(dirName), func(t *testing.T) {
+			cwd := chdirDollarDir(t, dirName)
+			require.NoError(t, os.WriteFile("actor.csv", []byte("a,b\n1,2\n3,4\n"), 0o600))
+
+			th := testh.New(t)
+			tr := testrun.New(th.Context, t, nil)
+			const handle = "@actor797"
+			// No --skip-verify: the post-add ping exercises the
+			// connect-time resolution of the stored template.
+			require.NoError(t, tr.Exec("add", "actor.csv", "--handle", handle),
+				"sq add of a relative path must succeed when the cwd contains '$' bytes")
+
+			src, err := tr.Run.Config.Collection.Get(handle)
+			require.NoError(t, err)
+
+			refs, err := secret.ExtractRefs(src.Location)
+			require.NoError(t, err, "stored template must parse cleanly")
+			require.Empty(t, refs, "filesystem-derived bytes must not form placeholder refs")
+
+			resolvedSrc, err := driver.ResolveSourceSecrets(th.Context, src)
+			require.NoError(t, err)
+			require.Equal(t, filepath.Join(cwd, "actor.csv"), resolvedSrc.Location,
+				"resolved location must be the true filesystem path")
+
+			// And the source is actually queryable.
+			tr = testrun.New(th.Context, t, tr)
+			require.NoError(t, tr.Exec(".data", "--json"))
+			var results []map[string]any
+			tr.Bind(&results)
+			require.Len(t, results, 2)
+		})
+	}
+}
+
+// TestCmdAdd_CwdDollarDir_FileDB is the gh #797 round trip for the
+// file-DB munge path (sqlite3, duckdb). The sqlite3 case pings (which
+// would create a stray DB file at a misinterpreted path if the cwd
+// bytes weren't escaped); duckdb skips verification since no real
+// duckdb database file is available here.
+func TestCmdAdd_CwdDollarDir_FileDB(t *testing.T) {
+	drvrs := []struct {
+		typ        drivertype.Type
+		prefix     string
+		fname      string
+		skipVerify bool
+	}{
+		{typ: drivertype.SQLite, prefix: "sqlite3://", fname: "sakila.db"},
+		{typ: drivertype.DuckDB, prefix: "duckdb://", fname: "sakila.duckdb", skipVerify: true},
+	}
+
+	for _, drvr := range drvrs {
+		for _, dirName := range dollarDirNames {
+			t.Run(tu.Name(drvr.typ.String(), dirName), func(t *testing.T) {
+				cwd := chdirDollarDir(t, dirName)
+				require.NoError(t, os.WriteFile(drvr.fname, nil, 0o600))
+
+				th := testh.New(t)
+				tr := testrun.New(th.Context, t, nil)
+				const handle = "@filedb797"
+				args := []string{"add", drvr.fname, "--driver", drvr.typ.String(), "--handle", handle}
+				if drvr.skipVerify {
+					args = append(args, "--skip-verify")
+				}
+				require.NoError(t, tr.Exec(args...),
+					"sq add of a relative path must succeed when the cwd contains '$' bytes")
+
+				src, err := tr.Run.Config.Collection.Get(handle)
+				require.NoError(t, err)
+
+				wantTmpl := drvr.prefix + filepath.ToSlash(filepath.Join(secret.Escape(cwd), drvr.fname))
+				require.Equal(t, wantTmpl, src.Location,
+					"stored template must escape the cwd-derived bytes")
+
+				refs, err := secret.ExtractRefs(src.Location)
+				require.NoError(t, err, "stored template must parse cleanly")
+				require.Empty(t, refs, "filesystem-derived bytes must not form placeholder refs")
+
+				resolvedSrc, err := driver.ResolveSourceSecrets(th.Context, src)
+				require.NoError(t, err)
+				wantLit := drvr.prefix + filepath.ToSlash(filepath.Join(cwd, drvr.fname))
+				require.Equal(t, wantLit, resolvedSrc.Location,
+					"resolved location must be the true filesystem path")
+
+				// The DB file the user pointed at must be the only file in
+				// the dir: a misinterpreted path would have caused sqlite3
+				// to create a stray DB elsewhere (or fail the ping).
+				entries, err := os.ReadDir(cwd)
+				require.NoError(t, err)
+				require.Len(t, entries, 1)
+				require.Equal(t, drvr.fname, entries[0].Name())
+			})
+		}
+	}
 }

--- a/cli/cmd_add_test.go
+++ b/cli/cmd_add_test.go
@@ -1232,9 +1232,13 @@ var dollarDirNames = []string{
 
 // chdirDollarDir creates dirName under a fresh temp dir, chdirs into
 // it, and returns the resolved cwd (os.Getwd after chdir, so macOS
-// /tmp symlinks don't skew expectations).
+// /tmp symlinks don't skew expectations). Subtests using a dirName
+// that can't exist on Windows (':' is invalid in a path component)
+// are skipped there; the plain '$' dir names still run.
 func chdirDollarDir(t *testing.T, dirName string) string {
 	t.Helper()
+	tu.SkipWindowsIf(t, strings.Contains(dirName, ":"),
+		"dir name %q contains ':', which is invalid in a Windows path component", dirName)
 	dir := filepath.Join(t.TempDir(), dirName)
 	require.NoError(t, os.Mkdir(dir, 0o750))
 	t.Chdir(dir)

--- a/drivers/duckdb/duckdb.go
+++ b/drivers/duckdb/duckdb.go
@@ -210,10 +210,13 @@ func PathFromLocation(src *source.Source) (string, error) {
 // MungeLocation to be OS-independent.
 //
 // MungeLocation is idempotent, and is a thin wrapper around
-// location.MungeForDriver, which also munges locations resolved from
-// secret placeholders at connect time (driver.ResolveSourceSecrets).
+// location.MungeTemplateForDriver: the user-typed location is a
+// placeholder template, so cwd bytes spliced in by absolutization are
+// escaped (gh #797). Locations resolved from secret placeholders at
+// connect time are literal bytes and take the no-escape path via
+// location.MungeForDriver (driver.ResolveSourceSecrets).
 func MungeLocation(loc string) (string, error) {
-	return location.MungeForDriver(drivertype.DuckDB, loc)
+	return location.MungeTemplateForDriver(drivertype.DuckDB, loc)
 }
 
 // Ping implements driver.Driver.

--- a/drivers/sqlite3/sqlite3.go
+++ b/drivers/sqlite3/sqlite3.go
@@ -1137,8 +1137,11 @@ func filePathFromLocation(loc string) string {
 // MungeLocation to be OS-independent.
 //
 // MungeLocation is idempotent, and is a thin wrapper around
-// location.MungeForDriver, which also munges locations resolved from
-// secret placeholders at connect time (driver.ResolveSourceSecrets).
+// location.MungeTemplateForDriver: the user-typed location is a
+// placeholder template, so cwd bytes spliced in by absolutization are
+// escaped (gh #797). Locations resolved from secret placeholders at
+// connect time are literal bytes and take the no-escape path via
+// location.MungeForDriver (driver.ResolveSourceSecrets).
 func MungeLocation(loc string) (string, error) {
-	return location.MungeForDriver(drivertype.SQLite, loc)
+	return location.MungeTemplateForDriver(drivertype.SQLite, loc)
 }

--- a/libsq/source/location/internal_test.go
+++ b/libsq/source/location/internal_test.go
@@ -1,11 +1,14 @@
 package location
 
 import (
+	"os"
+	"path/filepath"
 	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/neilotoole/sq/libsq/core/secret"
 	"github.com/neilotoole/sq/libsq/source/drivertype"
 	"github.com/neilotoole/sq/testh/tu"
 )
@@ -204,6 +207,97 @@ func TestParse(t *testing.T) {
 			require.Equal(t, tc.want, *got)
 		})
 	}
+}
+
+// TestIsRootedNoVolume exercises the predicate behind the Windows
+// rooted-no-volume branch of absTemplatePath. The branch itself is
+// reachable only on Windows (on Unix a rooted path is absolute, and
+// '\' is not a separator), so the backslash and volume-bearing cases
+// are GOOS-gated; the separator-free cases hold everywhere.
+func TestIsRootedNoVolume(t *testing.T) {
+	require.False(t, isRootedNoVolume(""))
+	require.False(t, isRootedNoVolume("foo"))
+	require.False(t, isRootedNoVolume("./foo"))
+	require.True(t, isRootedNoVolume("/foo"),
+		"'/' is a separator on every GOOS, and VolumeName('/foo') is empty")
+
+	if runtime.GOOS == "windows" {
+		require.True(t, isRootedNoVolume(`\foo`))
+		require.False(t, isRootedNoVolume(`C:\foo`), "volume present: absolute, not this case")
+		require.False(t, isRootedNoVolume(`C:foo`), "drive-relative: not rooted")
+		require.False(t, isRootedNoVolume(`\\server\c$\foo`), "UNC: volume present")
+	} else {
+		require.False(t, isRootedNoVolume(`\foo`), "'\\' is not a separator on Unix")
+	}
+}
+
+// TestJoinVolumeTemplatePath verifies the attribution rule of the
+// rooted-no-volume join: the volume (filesystem-derived bytes) is
+// escaped, while the typed path bytes pass through exactly as typed.
+// The table inputs are already-clean backslash-style strings, on which
+// filepath.Clean is the identity on every GOOS, so these assertions
+// are effective cross-platform even though absTemplatePath reaches
+// the join only on Windows. The trailing ".."-cleaning case depends
+// on Windows separator semantics and is GOOS-gated.
+func TestJoinVolumeTemplatePath(t *testing.T) {
+	testCases := []struct {
+		volume string
+		p      string
+		want   string
+	}{
+		{volume: "", p: `\foo`, want: `\foo`},
+		{volume: "C:", p: `\foo\sakila.db`, want: `C:\foo\sakila.db`},
+		// UNC administrative share: the volume's '$' is escaped.
+		{volume: `\\server\c$`, p: `\data\sakila.db`, want: `\\server\c$$\data\sakila.db`},
+		// Typed '$$' in p is preserved as typed, not re-escaped.
+		{volume: `\\server\c$`, p: `\q$$x\sakila.db`, want: `\\server\c$$\q$$x\sakila.db`},
+	}
+	for _, tc := range testCases {
+		t.Run(tu.Name(tc.volume, tc.p), func(t *testing.T) {
+			require.Equal(t, tc.want, joinVolumeTemplatePath(tc.volume, tc.p))
+		})
+	}
+
+	// Unescaping the joined template recovers the true filesystem path.
+	got := joinVolumeTemplatePath(`\\server\c$`, `\q$$x\sakila.db`)
+	require.Equal(t, `\\server\c$\q$x\sakila.db`, secret.Unescape(got))
+
+	if runtime.GOOS == "windows" {
+		// Clean resolves ".." segments, matching filepath.Abs semantics.
+		require.Equal(t, `C:\bar.db`, joinVolumeTemplatePath("C:", `\foo\..\bar.db`))
+	}
+}
+
+// TestAbsTemplatePath_RootedNoVolume_Windows exercises the
+// rooted-no-volume branch of absTemplatePath end to end: from inside
+// a '$'-bearing cwd, a rooted but volume-less path must resolve
+// against the cwd's volume root (matching filepath.Abs), not be
+// joined under the escaped cwd. Rooted-no-volume paths exist only on
+// Windows (on Unix a rooted path is absolute and takes the IsAbs fast
+// path), so this test is Windows-only; the helpers it composes are
+// covered cross-platform by TestIsRootedNoVolume and
+// TestJoinVolumeTemplatePath.
+func TestAbsTemplatePath_RootedNoVolume_Windows(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("rooted-no-volume paths exist only on Windows")
+	}
+
+	dir := filepath.Join(t.TempDir(), "q$exports")
+	require.NoError(t, os.Mkdir(dir, 0o750))
+	t.Chdir(dir)
+	cwd, err := os.Getwd()
+	require.NoError(t, err)
+
+	const rooted = `\foo\sakila.db`
+	got, err := absTemplatePath(rooted)
+	require.NoError(t, err)
+	require.Equal(t, secret.Escape(filepath.VolumeName(cwd))+rooted, got)
+
+	// Parity with filepath.Abs: unescaping the template yields exactly
+	// what Abs produces for the same input.
+	wantAbs, err := filepath.Abs(rooted)
+	require.NoError(t, err)
+	require.Equal(t, wantAbs, secret.Unescape(got))
 }
 
 // TestPickSentinels verifies that the placeholder-substitution sentinel

--- a/libsq/source/location/location.go
+++ b/libsq/source/location/location.go
@@ -447,6 +447,12 @@ func parseRqlite(loc string, fields *Fields) (*Fields, error) {
 // Abs returns the absolute path of loc. That is, relative
 // paths etc. are resolved. If loc is not a file path or
 // it cannot be processed, loc is returned unmodified.
+//
+// Abs treats loc as placeholder-template bytes (the form in which
+// source locations are stored): the cwd bytes joined in when
+// absolutizing a relative path are literal filesystem bytes, so any
+// '$' they contain is escaped via secret.Escape, while loc's typed
+// bytes pass through exactly as typed. See absTemplatePath.
 func Abs(loc string) string {
 	if fpath, ok := isFpath(loc); ok {
 		return fpath
@@ -455,7 +461,9 @@ func Abs(loc string) string {
 	return loc
 }
 
-// isFpath returns the absolute filepath and true if loc is a file path.
+// isFpath returns the absolute filepath and true if loc is a file
+// path. The returned fpath is template bytes: cwd-derived bytes are
+// escaped per absTemplatePath.
 func isFpath(loc string) (fpath string, ok bool) {
 	// This is not exactly an industrial-strength algorithm...
 
@@ -488,7 +496,7 @@ func isFpath(loc string) (fpath string, ok bool) {
 		return "", false
 	}
 
-	fpath, err := filepath.Abs(loc)
+	fpath, err := absTemplatePath(loc)
 	if err != nil {
 		return "", false
 	}

--- a/libsq/source/location/munge.go
+++ b/libsq/source/location/munge.go
@@ -178,7 +178,19 @@ func mungeFileDBLocation(prefix, loc string, allowMemory, template bool) (string
 //     template bytes: its decisions depend only on separators and
 //     "." / ".." segments, and no segment containing '$' can be "."
 //     or "..".
-//   - A relative tmplPath becomes filepath.Join(Escape(cwd),
+//   - A Windows rooted-no-volume tmplPath (e.g. `\foo`) is not
+//     absolute (filepath.IsAbs is false because the volume is
+//     missing), but filepath.Abs does not join it under the cwd
+//     either: it resolves the path against the cwd's volume root, so
+//     cwd `D:\work` yields `D:\foo`. That resolution is replicated
+//     here as Clean(Escape(VolumeName(cwd)) + tmplPath). Only the
+//     volume name is cwd-derived, so only it is escaped: a UNC volume
+//     can itself contain '$' (administrative shares, e.g.
+//     `\\server\c$`), while a drive volume like "C:" cannot, making
+//     Escape a no-op there. See joinVolumeTemplatePath for why Clean
+//     is exact on the escaped form. On Unix a rooted path is always
+//     absolute, so this case is unreachable there.
+//   - Any other relative tmplPath becomes filepath.Join(Escape(cwd),
 //     tmplPath). Escape never adds or removes separators or changes
 //     whether a segment equals "." or "..", so the Clean inside Join
 //     makes identical structural decisions on the escaped and
@@ -209,15 +221,48 @@ func absTemplatePath(tmplPath string) (string, error) {
 		return "", errz.Err(err)
 	}
 	if !strings.Contains(cwd, "$") {
-		// Escape(cwd) == cwd, so the escape-aware join below reduces
+		// Escape(cwd) == cwd, so the escape-aware logic below reduces
 		// to filepath.Abs. Call it directly so behavior on '$'-free
 		// cwds (the overwhelmingly common case) is bit-for-bit
-		// unchanged, including Windows drive-relative handling.
+		// unchanged, including Windows drive-relative and
+		// rooted-no-volume handling.
 		fp, err := filepath.Abs(tmplPath)
 		if err != nil {
 			return "", errz.Err(err)
 		}
 		return fp, nil
 	}
+	if isRootedNoVolume(tmplPath) {
+		// Windows-only: filepath.Abs resolves a rooted-no-volume path
+		// against the cwd's volume root, not under the cwd.
+		return joinVolumeTemplatePath(filepath.VolumeName(cwd), tmplPath), nil
+	}
 	return filepath.Join(secret.Escape(cwd), tmplPath), nil
+}
+
+// isRootedNoVolume reports whether p is rooted (begins with a path
+// separator) but carries no volume name. On Windows such a path (e.g.
+// `\foo` or `/foo`) is not absolute, because filepath.IsAbs requires
+// a volume; filepath.Abs resolves it against the current volume's
+// root rather than joining it under the cwd. On Unix, VolumeName is
+// always empty and a rooted path satisfies filepath.IsAbs, so
+// absTemplatePath never reaches this check there.
+func isRootedNoVolume(p string) bool {
+	return p != "" && os.IsPathSeparator(p[0]) && filepath.VolumeName(p) == ""
+}
+
+// joinVolumeTemplatePath resolves a rooted-no-volume template path p
+// against volume (the cwd's volume name) the way filepath.Abs would:
+// the volume is prepended and the result cleaned. Attribution per
+// absTemplatePath: p is the user's typed bytes, preserved as typed;
+// volume is filesystem-derived and is escaped, because a UNC volume
+// can itself contain '$' (administrative shares, e.g. `\\server\c$`).
+// Escaping does not perturb Clean's volume parsing: Escape only
+// doubles '$' runs, never adding or removing separators, so the
+// escaped share name remains a single path segment and Clean makes
+// the same structural decisions as on the unescaped form. And p
+// begins with a separator, so '$' runs cannot span the volume/path
+// boundary and the round trip is exact.
+func joinVolumeTemplatePath(volume, p string) string {
+	return filepath.Clean(secret.Escape(volume) + p)
 }

--- a/libsq/source/location/munge.go
+++ b/libsq/source/location/munge.go
@@ -1,10 +1,12 @@
 package location
 
 import (
+	"os"
 	"path/filepath"
 	"strings"
 
 	"github.com/neilotoole/sq/libsq/core/errz"
+	"github.com/neilotoole/sq/libsq/core/secret"
 	"github.com/neilotoole/sq/libsq/source/drivertype"
 )
 
@@ -28,11 +30,16 @@ import (
 // separator, so paths whose POSIX filename legally contains '?' are
 // not supported.
 //
+// MungeForDriver operates on literal location bytes: loc is used
+// verbatim, with no placeholder-template interpretation. It is the
+// connect-time munge, applied to a location whose secret placeholders
+// and '$$' escapes have already been resolved to literal form (see
+// driver.ResolveSourceSecrets). For the add-time munge of a typed
+// location, which is a placeholder template, use
+// MungeTemplateForDriver.
+//
 // MungeForDriver is idempotent: an already-canonical location is
-// returned unchanged. This matters because it runs both at add time
-// (on the literal location the user typed) and at connect time (on a
-// location resolved from secret placeholders, which may already be in
-// canonical form); see driver.ResolveSourceSecrets.
+// returned unchanged.
 //
 // Errors returned by MungeForDriver do not echo the location: at
 // connect time the location bytes are resolved secret material.
@@ -46,11 +53,34 @@ import (
 // probably isn't a problem in practice, but longer-term it may make
 // sense to rewrite the munging to be OS-independent.
 func MungeForDriver(typ drivertype.Type, loc string) (string, error) {
+	return mungeForDriver(typ, loc, false)
+}
+
+// MungeTemplateForDriver is the placeholder-template counterpart of
+// MungeForDriver, for use at add time on the location the user typed.
+// The typed location is a placeholder template ('$$' escapes a
+// literal '$'), and absolutizing a relative path splices in literal
+// filesystem bytes from the current working directory; those
+// cwd-derived bytes are escaped (secret.Escape) before joining, while
+// the user's typed bytes are preserved exactly as typed. See
+// absTemplatePath for the attribution rule. Otherwise the
+// canonicalization is identical to MungeForDriver, including
+// idempotence: re-munging a stored template does not re-escape it,
+// because an already-absolute path acquires no cwd bytes.
+//
+// loc must be a ref-free template (no well-formed ${scheme:path}
+// placeholders): placeholder-bearing locations are opaque at add time
+// and must not be munged at all.
+func MungeTemplateForDriver(typ drivertype.Type, loc string) (string, error) {
+	return mungeForDriver(typ, loc, true)
+}
+
+func mungeForDriver(typ drivertype.Type, loc string, template bool) (string, error) {
 	switch typ { //nolint:exhaustive // all other driver types pass through via default
 	case drivertype.SQLite:
-		return mungeFileDBLocation("sqlite3://", loc, false)
+		return mungeFileDBLocation("sqlite3://", loc, false, template)
 	case drivertype.DuckDB:
-		return mungeFileDBLocation("duckdb://", loc, true)
+		return mungeFileDBLocation("duckdb://", loc, true, template)
 	default:
 		return loc, nil
 	}
@@ -59,8 +89,11 @@ func MungeForDriver(typ drivertype.Type, loc string) (string, error) {
 // mungeFileDBLocation canonicalizes a file-based DB location per
 // MungeForDriver. Arg prefix is the canonical location prefix, e.g.
 // "sqlite3://". If allowMemory is true, the ":memory:" path sentinel
-// is preserved instead of being treated as a file path.
-func mungeFileDBLocation(prefix, loc string, allowMemory bool) (string, error) {
+// is preserved instead of being treated as a file path. If template
+// is true, loc is placeholder-template bytes and absolutization is
+// escape-aware (see MungeTemplateForDriver); otherwise loc is literal
+// bytes.
+func mungeFileDBLocation(prefix, loc string, allowMemory, template bool) (string, error) {
 	loc2 := strings.TrimSpace(loc)
 	if loc2 == "" {
 		return "", errz.New("location must not be empty")
@@ -85,7 +118,13 @@ func mungeFileDBLocation(prefix, loc string, allowMemory bool) (string, error) {
 		return prefix + ":memory:", nil
 	}
 
-	fp, err := filepath.Abs(pathPart)
+	var fp string
+	var err error
+	if template {
+		fp, err = absTemplatePath(pathPart)
+	} else {
+		fp, err = filepath.Abs(pathPart)
+	}
 	if err != nil {
 		// Don't echo the path: it may be resolved secret material, or
 		// carry secret connection params in a "?key=val" suffix.
@@ -97,4 +136,68 @@ func mungeFileDBLocation(prefix, loc string, allowMemory bool) (string, error) {
 		return prefix + fp + "?" + queryPart, nil
 	}
 	return prefix + fp, nil
+}
+
+// absTemplatePath absolutizes a path that is placeholder-template
+// bytes ('$$' escapes a literal '$'), preserving the template
+// semantics of the result (gh #797). Stored source locations are
+// templates, but the cwd that absolutization joins in is literal
+// filesystem bytes: a directory literally named "q$$exports" or
+// "${env:X}" must land in the template escaped, or the stored
+// location acquires escapes (or worse, well-formed refs) the user
+// never typed.
+//
+// The attribution rule: tmplPath is the user's typed bytes and is
+// preserved exactly as typed; the cwd is filesystem-derived and gets
+// secret.Escape before joining. Attribution is exact (not
+// heuristic) because the join is computed here rather than recovered
+// from filepath.Abs output:
+//
+//   - An absolute tmplPath acquires no cwd bytes; it is only
+//     filepath.Clean-ed, matching filepath.Abs. Clean is safe on
+//     template bytes: its decisions depend only on separators and
+//     "." / ".." segments, and no segment containing '$' can be "."
+//     or "..".
+//   - A relative tmplPath becomes filepath.Join(Escape(cwd),
+//     tmplPath). Escape never adds or removes separators or changes
+//     whether a segment equals "." or "..", so the Clean inside Join
+//     makes identical structural decisions on the escaped and
+//     unescaped forms ("../" segments in tmplPath consume whole
+//     escaped cwd segments). And '$' runs cannot span the '/'
+//     boundary between the two parts, so unescaping the joined
+//     result unescapes each part independently. Hence the round
+//     trip is exact: Unescape(Join(Escape(cwd), t)) ==
+//     Join(cwd, Unescape(t)) for any ref-free template t.
+//
+// Known limitation: on Windows, a drive-relative tmplPath (e.g.
+// "C:foo") is resolved against the per-drive working directory by
+// filepath.Abs, which this join does not replicate. When the cwd
+// contains no '$' (always, in practice), the function defers to
+// filepath.Abs and behavior is unchanged; a '$'-bearing cwd plus a
+// drive-relative path gets plain Join(cwd, path) semantics. The munge
+// code is already documented as OS-dependent.
+//
+// tmplPath must be ref-free: callers (isFpath, MungeTemplateForDriver)
+// exclude locations bearing well-formed ${scheme:path} placeholders
+// before absolutizing.
+func absTemplatePath(tmplPath string) (string, error) {
+	if filepath.IsAbs(tmplPath) {
+		return filepath.Clean(tmplPath), nil
+	}
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "", errz.Err(err)
+	}
+	if !strings.Contains(cwd, "$") {
+		// Escape(cwd) == cwd, so the escape-aware join below reduces
+		// to filepath.Abs. Call it directly so behavior on '$'-free
+		// cwds (the overwhelmingly common case) is bit-for-bit
+		// unchanged, including Windows drive-relative handling.
+		fp, err := filepath.Abs(tmplPath)
+		if err != nil {
+			return "", errz.Err(err)
+		}
+		return fp, nil
+	}
+	return filepath.Join(secret.Escape(cwd), tmplPath), nil
 }

--- a/libsq/source/location/munge.go
+++ b/libsq/source/location/munge.go
@@ -70,8 +70,28 @@ func MungeForDriver(typ drivertype.Type, loc string) (string, error) {
 //
 // loc must be a ref-free template (no well-formed ${scheme:path}
 // placeholders): placeholder-bearing locations are opaque at add time
-// and must not be munged at all.
+// and must not be munged at all. For the file-DB types, this contract
+// is enforced: a loc bearing a placeholder, or with malformed
+// placeholder syntax, returns an error rather than being munged.
+// Pass-through driver types stay pass-through and are not inspected.
+// As elsewhere in this file, the error does not echo the location.
 func MungeTemplateForDriver(typ drivertype.Type, loc string) (string, error) {
+	switch typ { //nolint:exhaustive // only the file-DB types munge; others pass through
+	case drivertype.SQLite, drivertype.DuckDB:
+		// Enforce the ref-free contract before any path bytes are
+		// touched: munging a placeholder-bearing template would
+		// absolutize text the user meant as a placeholder, silently
+		// changing the template's semantics. The errors don't echo the
+		// location or the parse detail: templates can carry
+		// sensitive-adjacent text.
+		refs, err := secret.ExtractRefs(loc)
+		if err != nil {
+			return "", errz.New("cannot munge location: invalid placeholder syntax")
+		}
+		if len(refs) > 0 {
+			return "", errz.New("cannot munge location: template contains ${scheme:path} placeholders")
+		}
+	}
 	return mungeForDriver(typ, loc, true)
 }
 
@@ -177,9 +197,9 @@ func mungeFileDBLocation(prefix, loc string, allowMemory, template bool) (string
 // drive-relative path gets plain Join(cwd, path) semantics. The munge
 // code is already documented as OS-dependent.
 //
-// tmplPath must be ref-free: callers (isFpath, MungeTemplateForDriver)
-// exclude locations bearing well-formed ${scheme:path} placeholders
-// before absolutizing.
+// tmplPath must be ref-free: MungeTemplateForDriver rejects locations
+// bearing well-formed ${scheme:path} placeholders before absolutizing,
+// and isFpath excludes them.
 func absTemplatePath(tmplPath string) (string, error) {
 	if filepath.IsAbs(tmplPath) {
 		return filepath.Clean(tmplPath), nil

--- a/libsq/source/location/munge_test.go
+++ b/libsq/source/location/munge_test.go
@@ -156,6 +156,54 @@ func TestMungeTemplateForDriver_EscapesCwdDollarBytes(t *testing.T) {
 	}
 }
 
+// TestMungeTemplateForDriver_RejectsPlaceholders verifies that the
+// file-DB template munge enforces its ref-free contract: a location
+// bearing a well-formed ${scheme:path} placeholder (or with malformed
+// placeholder syntax) errors instead of being munged, and the error
+// does not echo the location. Pass-through driver types stay
+// pass-through, placeholders and all.
+func TestMungeTemplateForDriver_RejectsPlaceholders(t *testing.T) {
+	placeholderLocs := []string{
+		"${env:SQ_DB_PATH}",
+		"sqlite3://${env:SQ_DB_PATH}",
+		"/var/db/${env:DB_NAME}.db",
+		"sakila.db?key=${keyring:sakila/key}",
+	}
+
+	for _, typ := range []drivertype.Type{drivertype.SQLite, drivertype.DuckDB} {
+		for _, loc := range placeholderLocs {
+			t.Run(tu.Name(typ.String(), loc), func(t *testing.T) {
+				_, err := location.MungeTemplateForDriver(typ, loc)
+				require.Error(t, err)
+				require.NotContains(t, err.Error(), loc,
+					"error must not echo the location")
+			})
+		}
+
+		t.Run(tu.Name(typ.String(), "malformed"), func(t *testing.T) {
+			_, err := location.MungeTemplateForDriver(typ, "sakila${env:.db")
+			require.Error(t, err)
+			require.NotContains(t, err.Error(), "sakila",
+				"error must not echo the location")
+		})
+
+		t.Run(tu.Name(typ.String(), "escaped dollar is ref-free"), func(t *testing.T) {
+			// '$$' is the escape for a literal '$': no ref is formed, so
+			// the template munges normally.
+			got, err := location.MungeTemplateForDriver(typ, "/var/db/q$${env:X}.db")
+			require.NoError(t, err)
+			require.Equal(t, string(typ)+":///var/db/q$${env:X}.db", got)
+		})
+	}
+
+	// A pass-through driver type is not inspected: the location returns
+	// verbatim, placeholder or not.
+	const pgLoc = "postgres://alice:${keyring:sakila/pw}@db/sakila"
+	got, err := location.MungeTemplateForDriver(drivertype.Pg, pgLoc)
+	require.NoError(t, err)
+	require.Equal(t, pgLoc, got)
+}
+
 // TestMungeTemplateForDriver_QuerySuffixPreserved verifies that the
 // "?key=val" connection-string suffix passes through template-mode
 // munging verbatim, with only the cwd-derived path bytes escaped.

--- a/libsq/source/location/munge_test.go
+++ b/libsq/source/location/munge_test.go
@@ -3,6 +3,7 @@ package location_test
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -53,9 +54,13 @@ var dollarDirNames = []string{
 
 // chdirNew creates dirName under a fresh temp dir, chdirs into it, and
 // returns the resolved cwd (os.Getwd after chdir, so macOS /tmp
-// symlinks don't skew expectations).
+// symlinks don't skew expectations). Subtests using a dirName that
+// can't exist on Windows (':' is invalid in a path component) are
+// skipped there; the plain '$' dir names still run.
 func chdirNew(t *testing.T, dirName string) string {
 	t.Helper()
+	tu.SkipWindowsIf(t, strings.Contains(dirName, ":"),
+		"dir name %q contains ':', which is invalid in a Windows path component", dirName)
 	dir := filepath.Join(t.TempDir(), dirName)
 	require.NoError(t, os.Mkdir(dir, 0o750))
 	t.Chdir(dir)

--- a/libsq/source/location/munge_test.go
+++ b/libsq/source/location/munge_test.go
@@ -1,12 +1,16 @@
 package location_test
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/neilotoole/sq/libsq/core/secret"
 	"github.com/neilotoole/sq/libsq/source/drivertype"
 	"github.com/neilotoole/sq/libsq/source/location"
+	"github.com/neilotoole/sq/testh/tu"
 )
 
 func TestMungeForDriver_EmptyPath(t *testing.T) {
@@ -35,4 +39,131 @@ func TestMungeForDriver_EmptyPath(t *testing.T) {
 	got, err := location.MungeForDriver(drivertype.DuckDB, "duckdb://:memory:")
 	require.NoError(t, err)
 	require.Equal(t, "duckdb://:memory:", got)
+}
+
+// dollarDirNames are directory names containing bytes that are
+// significant in the placeholder-template grammar. A cwd ending in one
+// of these must be escaped when spliced into a stored location
+// template (gh #797).
+var dollarDirNames = []string{
+	"q$exports",
+	"q$$exports",
+	"${env:X}",
+}
+
+// chdirNew creates dirName under a fresh temp dir, chdirs into it, and
+// returns the resolved cwd (os.Getwd after chdir, so macOS /tmp
+// symlinks don't skew expectations).
+func chdirNew(t *testing.T, dirName string) string {
+	t.Helper()
+	dir := filepath.Join(t.TempDir(), dirName)
+	require.NoError(t, os.Mkdir(dir, 0o750))
+	t.Chdir(dir)
+	cwd, err := os.Getwd()
+	require.NoError(t, err)
+	return cwd
+}
+
+// TestAbs_EscapesCwdDollarBytes verifies that location.Abs treats its
+// result as a placeholder template: the cwd bytes it splices in are
+// escaped (every filesystem '$' doubled), so unescaping the stored
+// template yields the true filesystem path and no accidental
+// ${scheme:path} ref is formed (gh #797).
+func TestAbs_EscapesCwdDollarBytes(t *testing.T) {
+	for _, dirName := range dollarDirNames {
+		t.Run(tu.Name(dirName), func(t *testing.T) {
+			cwd := chdirNew(t, dirName)
+
+			got := location.Abs("report.csv")
+
+			refs, err := secret.ExtractRefs(got)
+			require.NoError(t, err, "stored template must parse cleanly")
+			require.Empty(t, refs, "cwd bytes must not form placeholder refs")
+			require.Equal(t, secret.Escape(cwd)+string(filepath.Separator)+"report.csv", got)
+			require.Equal(t, filepath.Join(cwd, "report.csv"), secret.Unescape(got),
+				"unescaped template must be the true filesystem path")
+		})
+	}
+}
+
+// TestAbs_PreservesUserTypedBytes verifies that only the cwd-derived
+// bytes are escaped: the user's typed bytes (which are already
+// template bytes, where '$$' means a literal '$') pass through
+// exactly as typed.
+func TestAbs_PreservesUserTypedBytes(t *testing.T) {
+	t.Run("relative with typed escape", func(t *testing.T) {
+		cwd := chdirNew(t, "q$$exports")
+		got := location.Abs("data$$file.csv")
+		require.Equal(t, secret.Escape(cwd)+string(filepath.Separator)+"data$$file.csv", got,
+			"typed '$$' must not be re-escaped")
+		require.Equal(t, filepath.Join(cwd, "data$file.csv"), secret.Unescape(got))
+	})
+
+	t.Run("absolute path untouched", func(t *testing.T) {
+		// An absolute typed path contains no cwd-derived bytes: every
+		// byte is the user's, so nothing is escaped.
+		loc := filepath.Join(t.TempDir(), "q$$exports", "file.csv")
+		require.Equal(t, loc, location.Abs(loc))
+	})
+}
+
+// TestMungeTemplateForDriver_EscapesCwdDollarBytes verifies the same
+// cwd-escape contract for the file-DB munge path (sqlite3, duckdb),
+// and that the stored template round-trips at connect time: unescape
+// plus literal-mode MungeForDriver yields the true filesystem path
+// with no double-escape (gh #797).
+func TestMungeTemplateForDriver_EscapesCwdDollarBytes(t *testing.T) {
+	drvrs := []struct {
+		typ    drivertype.Type
+		prefix string
+		fname  string
+	}{
+		{typ: drivertype.SQLite, prefix: "sqlite3://", fname: "sakila.db"},
+		{typ: drivertype.DuckDB, prefix: "duckdb://", fname: "sakila.duckdb"},
+	}
+
+	for _, drvr := range drvrs {
+		for _, dirName := range dollarDirNames {
+			t.Run(tu.Name(drvr.typ.String(), dirName), func(t *testing.T) {
+				cwd := chdirNew(t, dirName)
+
+				got, err := location.MungeTemplateForDriver(drvr.typ, drvr.fname)
+				require.NoError(t, err)
+
+				wantTmpl := drvr.prefix + filepath.ToSlash(filepath.Join(secret.Escape(cwd), drvr.fname))
+				require.Equal(t, wantTmpl, got)
+
+				refs, err := secret.ExtractRefs(got)
+				require.NoError(t, err, "stored template must parse cleanly")
+				require.Empty(t, refs, "cwd bytes must not form placeholder refs")
+
+				// Idempotent: re-munging the stored template must not
+				// double-escape the already-escaped cwd bytes.
+				again, err := location.MungeTemplateForDriver(drvr.typ, got)
+				require.NoError(t, err)
+				require.Equal(t, got, again)
+
+				// Connect-time round trip (driver.ResolveSourceSecrets):
+				// unescape the template, then literal-mode munge. The result
+				// must be the true filesystem path, unescaped exactly once.
+				resolved := secret.Unescape(got)
+				litMunged, err := location.MungeForDriver(drvr.typ, resolved)
+				require.NoError(t, err)
+				wantLit := drvr.prefix + filepath.ToSlash(filepath.Join(cwd, drvr.fname))
+				require.Equal(t, wantLit, litMunged)
+			})
+		}
+	}
+}
+
+// TestMungeTemplateForDriver_QuerySuffixPreserved verifies that the
+// "?key=val" connection-string suffix passes through template-mode
+// munging verbatim, with only the cwd-derived path bytes escaped.
+func TestMungeTemplateForDriver_QuerySuffixPreserved(t *testing.T) {
+	cwd := chdirNew(t, "q$$exports")
+
+	got, err := location.MungeTemplateForDriver(drivertype.SQLite, "sakila.db?mode=ro")
+	require.NoError(t, err)
+	want := "sqlite3://" + filepath.ToSlash(filepath.Join(secret.Escape(cwd), "sakila.db")) + "?mode=ro"
+	require.Equal(t, want, got)
 }


### PR DESCRIPTION
Fixes #797.

Stored locations are placeholder templates, but add-time path absolutization joined raw
filesystem bytes into the template: a cwd containing `$$` produced a stored template
rejected for an escape the user never typed, and a cwd segment shaped like `${env:X}` was
stored as an accidental well-formed ref (the TDD repro showed it even hijacked the
placeholder branch at add time).

The attribution of cwd-derived vs user-typed bytes is exact, not heuristic: instead of
recovering it from filepath.Abs output, the new absTemplatePath computes the join directly
as Join(Escape(cwd), typedPath), preserving the user's bytes verbatim and escaping only
the os.Getwd bytes. The godoc carries the correctness argument: Escape never changes path
separators or whether a segment is "." or "..", so Clean makes identical structural
decisions on escaped and unescaped forms, and Unescape(Join(Escape(cwd), t)) ==
Join(cwd, Unescape(t)) for any ref-free template. A $-free cwd (the universal case)
defers to plain filepath.Abs, bit-for-bit unchanged.

Munging is split along the secret package's templates-vs-literals boundary:
MungeTemplateForDriver (add time, escape-aware) vs the existing MungeForDriver (connect
time, literal resolved bytes, untouched), so resolved secret values are never re-escaped
and the "convert exactly once" rule holds.

Testing: round-trip CLI tests with real directories named q$exports, q$$exports, and
${env:X} under t.TempDir (add succeeds, stored template resolves to the true path, source
is queryable, no stray DB file at a misinterpreted path), plus unit tests for both munge
variants including idempotence. All failed pre-fix. make lint clean; -short suites green.