### PR TITLE
location: Redact masks secret query params

### DIFF
--- a/cli/complete_location_suggestions.go
+++ b/cli/complete_location_suggestions.go
@@ -169,9 +169,11 @@ func (s *locSuggestions) Locations() []string {
 		}
 		loc := location.StripSecrets(src.Location)
 		if _, err := parseSourceLoc(loc, s.typ); err != nil {
-			// Log the stripped value, not Redact(src.Location): Redact
-			// passes sqlite3/duckdb locations through unchanged, so a
-			// malformed location could leak secret query params here.
+			// Log the stripped value, not Redact(src.Location): the
+			// stripped value is the actual completion candidate that
+			// failed to parse, so it's what the warning should show.
+			// (Redact now masks secret query params too, so this is a
+			// relevance choice, not a leak-avoidance one.)
 			s.log.Warn("Parse source location",
 				lga.Loc, loc, lga.Err, err)
 			return nil

--- a/libsq/source/location/location.go
+++ b/libsq/source/location/location.go
@@ -638,12 +638,15 @@ func pickSentinels(loc string, n int) ([]string, bool) {
 	return nil, false
 }
 
-// redactRaw is the underlying URL/DSN redactor, operating on a location
-// whose ${scheme:path} placeholders (if any) have been replaced with the
-// given sentinels (see Redact). It masks the userinfo password and then
-// the values of secret-bearing query parameters; a query value composed
-// entirely of sentinels is a placeholder template, not a literal secret,
-// and is left intact.
+// redactRaw is the underlying URL/DSN redactor. It masks the userinfo
+// password and then the values of secret-bearing query parameters.
+// When Redact has swapped the location's ${scheme:path} placeholders for
+// sentinels, it passes them here so that a query value composed entirely
+// of sentinels is recognized as a placeholder template, not a literal
+// secret, and left intact. sentinels is nil when loc has no placeholders
+// to preserve, and on Redact's astronomically-unlikely fallback path
+// where placeholders remain in loc and are masked like any literal
+// secret.
 func redactRaw(loc string, sentinels []string) string {
 	if loc == "" {
 		return loc

--- a/libsq/source/location/location.go
+++ b/libsq/source/location/location.go
@@ -546,7 +546,15 @@ func isHTTP(s string) (u *url.URL, ok bool) {
 }
 
 // Redact returns a redacted version of the source location loc, with
-// the password component (if any) masked.
+// the password component (if any) masked, and the values of
+// secret-bearing query parameters (see IsSecretQueryParam) masked with
+// the same "xxxxx" convention, e.g.
+// "sqlite3:///data/app.db?_auth_pass=xxxxx". Non-secret bytes,
+// including query parameter order and escaping, are preserved.
+//
+// Redact differs from StripSecrets, which removes secrets entirely so
+// the location remains valid for reuse (e.g. as a shell-completion
+// candidate); Redact output is for display and logging only.
 //
 // If loc contains one or more ${scheme:path} secret-resolver placeholders,
 // each placeholder is temporarily replaced with a digit-only sentinel
@@ -555,14 +563,17 @@ func isHTTP(s string) (u *url.URL, ok bool) {
 // path, query) because the digit sentinel is valid in each. A
 // placeholder in the password position is masked along with the
 // password; the placeholder text is lost in the redacted form (use
-// 'sq config keyring ls' to enumerate references).
+// 'sq config keyring ls' to enumerate references). A secret query
+// value composed entirely of placeholders likewise passes through
+// verbatim; a mixed literal/placeholder value is masked like any
+// literal secret.
 func Redact(loc string) string {
 	if !strings.Contains(loc, "${") {
-		return redactRaw(loc)
+		return redactRaw(loc, nil)
 	}
 	refs, err := secret.ExtractRefs(loc)
 	if err != nil || len(refs) == 0 {
-		return redactRaw(loc)
+		return redactRaw(loc, nil)
 	}
 
 	sentinels, ok := pickSentinels(loc, len(refs))
@@ -572,7 +583,7 @@ func Redact(loc string) string {
 		// preservation: placeholders get masked along with the
 		// password, which is correct (no credentials leak) but loses
 		// the placeholder text. Astronomically unlikely path.
-		return redactRaw(loc)
+		return redactRaw(loc, nil)
 	}
 	placeholders := make([]string, len(refs))
 	sentinelled := loc
@@ -580,7 +591,7 @@ func Redact(loc string) string {
 		placeholders[i] = "${" + ref.Scheme + ":" + ref.Path + "}"
 		sentinelled = strings.Replace(sentinelled, placeholders[i], sentinels[i], 1)
 	}
-	redacted := redactRaw(sentinelled)
+	redacted := redactRaw(sentinelled, sentinels)
 	// Restore surviving sentinels. Sentinels that got eaten by redaction
 	// (because they were in the password position) are not restored —
 	// the placeholder text is consumed by the password mask.
@@ -619,47 +630,75 @@ func pickSentinels(loc string, n int) ([]string, bool) {
 	return nil, false
 }
 
-// redactRaw is the underlying URL/DSN redactor with no placeholder
-// awareness. Redact wraps this with sentinel substitution when the input
-// contains ${scheme:path} placeholders.
-func redactRaw(loc string) string {
+// redactRaw is the underlying URL/DSN redactor, operating on a location
+// whose ${scheme:path} placeholders (if any) have been replaced with the
+// given sentinels (see Redact). It masks the userinfo password and then
+// the values of secret-bearing query parameters; a query value composed
+// entirely of sentinels is a placeholder template, not a literal secret,
+// and is left intact.
+func redactRaw(loc string, sentinels []string) string {
+	if loc == "" {
+		return loc
+	}
+
+	var redacted string
 	switch {
-	case loc == "",
-		strings.HasPrefix(loc, "/"),
+	case strings.HasPrefix(loc, "/"),
 		strings.HasPrefix(loc, "sqlite3://"),
 		strings.HasPrefix(loc, "duckdb://"):
-
-		// REVISIT: If it's a sqlite/duckdb URI, could it have auth details in there?
-		// e.g. "?_auth_pass=foo"
-		return loc
+		// File-style locations have no userinfo password to mask, but
+		// may carry secret-bearing query params (e.g. sqlite3's
+		// "?_auth_pass=..."), masked below.
+		redacted = loc
 	case strings.HasPrefix(loc, "http://"), strings.HasPrefix(loc, "https://"):
 		u, err := url.ParseRequestURI(loc)
 		if err != nil {
-			return redactBestEffort(loc)
+			redacted = redactBestEffort(loc)
+			break
 		}
-
-		return u.Redacted()
+		redacted = u.Redacted()
 	case strings.HasPrefix(loc, "rqlite://"):
 		// rqlite is a network SQL driver unknown to dburl; redact its
 		// userinfo explicitly rather than relying on the best-effort
 		// regex fallback below.
 		u, err := url.ParseRequestURI(loc)
 		if err != nil {
-			return redactBestEffort(loc)
+			redacted = redactBestEffort(loc)
+			break
 		}
 		if _, ok := u.User.Password(); ok {
 			u.User = url.UserPassword(u.User.Username(), "xxxxx")
 		}
-		return u.String()
+		redacted = u.String()
+	default:
+		// At this point, we expect it's a DSN.
+		dbu, err := dburl.Parse(loc)
+		if err != nil {
+			redacted = redactBestEffort(loc)
+			break
+		}
+		redacted = dbu.Redacted()
 	}
 
-	// At this point, we expect it's a DSN
-	dbu, err := dburl.Parse(loc)
-	if err != nil {
-		return redactBestEffort(loc)
-	}
+	return maskSecretQueryParams(redacted, sentinels)
+}
 
-	return dbu.Redacted()
+// maskSecretQueryParams masks the value of each secret-bearing query
+// parameter in loc (per IsSecretQueryParam) with "xxxxx", preserving
+// non-secret bytes verbatim. A URL fragment is preserved: per URL
+// syntax an unencoded '#' always starts the fragment, so it is carved
+// off before query processing lest it be swallowed by a masked value.
+func maskSecretQueryParams(loc string, sentinels []string) string {
+	head, frag, hasFrag := strings.Cut(loc, "#")
+	base, query, hasQuery := strings.Cut(head, "?")
+	masked := base
+	if hasQuery {
+		masked += "?" + replaceSecretQueryValues(query, "xxxxx", sentinels)
+	}
+	if hasFrag {
+		masked += "#" + frag
+	}
+	return masked
 }
 
 // redactRawUserinfo masks the password portion of any "user:pw@host"
@@ -771,7 +810,7 @@ func stripSecretsRaw(loc string, sentinels []string) string {
 	base = stripUserinfoPassword(base, sentinels)
 	stripped := base
 	if hasQuery {
-		stripped += "?" + stripSecretQueryValues(query, sentinels)
+		stripped += "?" + replaceSecretQueryValues(query, "", sentinels)
 	}
 	if hasFrag {
 		stripped += "#" + frag
@@ -807,11 +846,13 @@ func stripUserinfoPassword(base string, sentinels []string) string {
 	return base[:i+colon] + base[i+at:]
 }
 
-// stripSecretQueryValues empties the value of each secret-bearing
-// key=value pair (per IsSecretQueryParam) in the raw query string,
-// preserving pair order and the escaping of untouched pairs. Values
-// composed entirely of sentinels are kept.
-func stripSecretQueryValues(query string, sentinels []string) string {
+// replaceSecretQueryValues sets the value of each secret-bearing
+// key=value pair (per IsSecretQueryParam) in the raw query string to
+// newValue, preserving pair order and the escaping of untouched pairs.
+// Values composed entirely of sentinels are kept, as are empty values.
+// StripSecrets passes newValue="" (the location stays reusable);
+// Redact passes the "xxxxx" display mask.
+func replaceSecretQueryValues(query, newValue string, sentinels []string) string {
 	pairs := strings.Split(query, "&")
 	for i, pair := range pairs {
 		k, v, ok := strings.Cut(pair, "=")
@@ -828,7 +869,7 @@ func stripSecretQueryValues(query string, sentinels []string) string {
 		if isOnlySentinels(v, sentinels) {
 			continue
 		}
-		pairs[i] = k + "="
+		pairs[i] = k + "=" + newValue
 	}
 	return strings.Join(pairs, "&")
 }

--- a/libsq/source/location/location_test.go
+++ b/libsq/source/location/location_test.go
@@ -403,3 +403,110 @@ func TestStripSecrets(t *testing.T) {
 		})
 	}
 }
+
+// TestRedact_SecretQueryParams verifies that Redact masks the values of
+// secret-bearing query parameters (per location.IsSecretQueryParam) with
+// the "xxxxx" display mask, across both file-style (sqlite3/duckdb) and
+// DSN-style locations, while leaving userinfo masking and non-secret
+// bytes unchanged. Values consisting entirely of ${scheme:path}
+// placeholders are config-visible text, not secrets, and pass through
+// verbatim.
+func TestRedact_SecretQueryParams(t *testing.T) {
+	testCases := []struct {
+		name string
+		loc  string
+		want string
+	}{
+		{
+			name: "sqlite3 auth query params",
+			loc:  "sqlite3:///data/app.db?_auth_user=admin&_auth_pass=hunter2",
+			want: "sqlite3:///data/app.db?_auth_user=admin&_auth_pass=xxxxx",
+		},
+		{
+			name: "sqlite3 no query unchanged",
+			loc:  "sqlite3:///path/to/sqlite.db",
+			want: "sqlite3:///path/to/sqlite.db",
+		},
+		{
+			name: "sqlite3 non-secret params unchanged",
+			loc:  "sqlite3:///data/app.db?cache=shared&mode=ro",
+			want: "sqlite3:///data/app.db?cache=shared&mode=ro",
+		},
+		{
+			name: "sqlite3 empty secret value unchanged",
+			loc:  "sqlite3:///data/app.db?_auth_pass=",
+			want: "sqlite3:///data/app.db?_auth_pass=",
+		},
+		{
+			name: "sqlite3 fragment after secret query param",
+			loc:  "sqlite3:///data/app.db?_auth_pass=hunter2#frag",
+			want: "sqlite3:///data/app.db?_auth_pass=xxxxx#frag",
+		},
+		{
+			name: "duckdb token query param",
+			loc:  "duckdb:///data/sakila.duckdb?motherduck_token=tok123",
+			want: "duckdb:///data/sakila.duckdb?motherduck_token=xxxxx",
+		},
+		{
+			name: "postgres sslpassword",
+			loc:  "postgres://alice@localhost/sakila?sslpassword=hunter2",
+			want: "postgres://alice@localhost/sakila?sslpassword=xxxxx",
+		},
+		{
+			name: "postgres userinfo and secret query value both masked",
+			loc:  "postgres://alice:hunter2@localhost/sakila?sslpassword=abc&sslmode=require",
+			want: "postgres://alice:xxxxx@localhost/sakila?sslpassword=xxxxx&sslmode=require",
+		},
+		{
+			name: "sqlserver password query param",
+			loc:  "sqlserver://alice:hunter2@server:1433?database=sakila&password=abc",
+			want: "sqlserver://alice:xxxxx@server:1433?database=sakila&password=xxxxx",
+		},
+		{
+			name: "rqlite userinfo and token query param",
+			loc:  "rqlite://alice:hunter2@localhost:4001/mydb?auth_token=abc",
+			want: "rqlite://alice:xxxxx@localhost:4001/mydb?auth_token=xxxxx",
+		},
+		{
+			name: "http url with token query param",
+			loc:  "https://acme.com/data.csv?token=abc&format=csv",
+			want: "https://acme.com/data.csv?token=xxxxx&format=csv",
+		},
+		{
+			name: "bare path with secret query param",
+			loc:  "/data/app.db?_auth_pass=hunter2",
+			want: "/data/app.db?_auth_pass=xxxxx",
+		},
+		{
+			name: "placeholder secret query value kept verbatim",
+			loc:  "sqlite3:///data/app.db?_auth_user=admin&_auth_pass=${keyring:app-db}",
+			want: "sqlite3:///data/app.db?_auth_user=admin&_auth_pass=${keyring:app-db}",
+		},
+		{
+			name: "placeholder secret query value in DSN kept verbatim",
+			loc:  "postgres://alice@localhost/sakila?sslpassword=${env:PGPASS}",
+			want: "postgres://alice@localhost/sakila?sslpassword=${env:PGPASS}",
+		},
+		{
+			name: "mixed literal and placeholder query value masked",
+			loc:  "sqlite3:///data/app.db?_auth_pass=abc${env:DBPASS}",
+			want: "sqlite3:///data/app.db?_auth_pass=xxxxx",
+		},
+		{
+			name: "placeholder userinfo password still masked",
+			loc:  "postgres://alice:${keyring:pg-prod}@localhost/sakila?sslmode=require",
+			want: "postgres://alice:xxxxx@localhost/sakila?sslmode=require",
+		},
+		{
+			name: "placeholder in non-secret position untouched",
+			loc:  "postgres://alice@localhost/sakila?application_name=${env:APP}",
+			want: "postgres://alice@localhost/sakila?application_name=${env:APP}",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, location.Redact(tc.loc))
+		})
+	}
+}

--- a/site/content/en/docs/secrets/index.md
+++ b/site/content/en/docs/secrets/index.md
@@ -52,7 +52,9 @@ and inline plaintext is dumped as-is. Treat the exported file the same as
 ## Redaction
 
 `sq` redacts URL-style passwords in the location of a source when that
-location is printed. For a source
+location is printed. Secret-bearing query parameters, such as Postgres's
+`?sslpassword=` or SQLite's `?_auth_pass=`, are masked the same way.
+For a source
 
 ```yaml
 - handle: '@sakila/pg'


### PR DESCRIPTION
Fixes #811.

## Problem

`location.Redact` is the display/log redactor (used by `sq ls -v`, warnings, and
debug output). It masked only the userinfo password, so secret-bearing query
parameters printed verbatim:

- File-style locations (`sqlite3://`, `duckdb://`, bare paths) were returned
  unchanged. A standing `REVISIT` comment acknowledged the `?_auth_pass=` gap.
- Server DSNs were passed through `dburl.Redacted()`, which masks userinfo but
  not query values like Postgres `?sslpassword=` or SQLServer `?password=`.

So a SQLite auth password, a MotherDuck token, or a Postgres `sslpassword` would
appear in plaintext anywhere a location was printed.

## Change

`redactRaw` now routes every branch (file-style, http(s), rqlite, generic DSN,
and the best-effort fallbacks) through a final `maskSecretQueryParams` pass. The
userinfo masking on each branch is byte-for-byte unchanged; the query masking is
layered on top.

The query-masking core is shared with `StripSecrets` (added in #800). That PR's
`stripSecretQueryValues(query, sentinels)` is generalized to
`replaceSecretQueryValues(query, newValue, sentinels)`:

- `StripSecrets` passes `newValue=""` so completion candidates stay reusable.
- `Redact` passes `newValue="xxxxx"`, the existing display mask.

Both surfaces now share one implementation of secret-param detection, pair
ordering, and escaping, so the strip and redact paths cannot drift on which
params count as secret or how non-secret bytes are preserved.

Placeholder handling matches the rest of `Redact`: a secret query value composed
entirely of `${scheme:path}` resolver placeholders passes through verbatim (it is
config-visible text, not a literal secret), while a mixed literal/placeholder
value is masked like any literal.

`maskSecretQueryParams` carves the URL fragment off before splitting on `?`. Per
URL syntax an unencoded `#` always begins the fragment, so a `#frag` trailing a
masked query value must be preserved rather than swallowed into the masked value.

## Scope note

http(s) query params matching `IsSecretQueryParam` (e.g. `?token=`) are now
masked on display too. This is a deliberate widening beyond the DSN cases named
in the issue: the same predicate already governs stripping, and there is no
reason a secret token should redact differently by scheme.

The `complete_location_suggestions.go` comment that previously justified logging
the stripped value as leak-avoidance ("Redact passes sqlite3/duckdb through
unchanged") is updated: with Redact now masking query params, logging the
stripped value is a relevance choice (it is the actual completion candidate that
failed to parse), not a safety workaround.

## Docs

The site Redaction section gains one sentence noting that secret-bearing query
parameters (e.g. Postgres `?sslpassword=`, SQLite `?_auth_pass=`) are masked the
same way as URL passwords. The `Redact` godoc now states its contract explicitly
and contrasts it with `StripSecrets` (Redact is for display/logging and masks in
place; StripSecrets removes secrets so the location stays valid for reuse).

## Testing

17-case table test, written failing-first, covering: file-style `_auth_pass`,
duckdb `motherduck_token`, postgres `sslpassword` (with and without userinfo),
sqlserver `password`, rqlite `auth_token`, http `token`, bare-path query params,
non-secret params left intact, empty secret values, a fragment trailing a masked
value, full-placeholder pass-through (both file-style and DSN), mixed
literal/placeholder masking, and placeholder userinfo/non-secret positions. No
existing test asserted leaking output, so there is no assertion churn.

`make lint` clean on the changed packages; `-short` suites green. Branch is even
with `master`.
