### PR TITLE
sqlite3/rqlite: SQL double-quote identifiers in alter and truncate paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,10 @@ Breaking changes are annotated with ☢️, and alpha/beta features with 🐥.
 - [#783]: [`sq add`](https://sq.io/docs/cmd/add) and [`sq mv`](https://sq.io/docs/cmd/mv)
   no longer permit a source handle nested below an existing source's handle (e.g. adding
   `@prod/db/x` when `@prod` exists).
+- [#821]: Renaming, adding a column to, or truncating a table on the
+  [SQLite](https://sq.io/docs/drivers/sqlite) and [rqlite](https://sq.io/docs/drivers/rqlite)
+  drivers no longer fails for tables or columns whose name contains a double quote (e.g. a
+  `we"ird` table created from a CSV header).
 
 ## [v0.53.0] - 2026-05-25
 
@@ -1691,6 +1695,7 @@ make working with lots of sources much easier.
 [#759]: https://github.com/neilotoole/sq/issues/759
 [#782]: https://github.com/neilotoole/sq/issues/782
 [#783]: https://github.com/neilotoole/sq/issues/783
+[#821]: https://github.com/neilotoole/sq/issues/821
 
 [v0.15.2]: https://github.com/neilotoole/sq/releases/tag/v0.15.2
 [v0.15.3]: https://github.com/neilotoole/sq/compare/v0.15.2...v0.15.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,9 +102,9 @@ Breaking changes are annotated with ☢️, and alpha/beta features with 🐥.
 - [#783]: [`sq add`](https://sq.io/docs/cmd/add) and [`sq mv`](https://sq.io/docs/cmd/mv)
   no longer permit a source handle nested below an existing source's handle (e.g. adding
   `@prod/db/x` when `@prod` exists).
-- [#821]: Renaming, adding a column to, or truncating a table on the
-  [SQLite](https://sq.io/docs/drivers/sqlite) and [rqlite](https://sq.io/docs/drivers/rqlite)
-  drivers no longer fails for tables or columns whose name contains a double quote (e.g. a
+- [#821]: On the [SQLite](https://sq.io/docs/drivers/sqlite) and
+  [rqlite](https://sq.io/docs/drivers/rqlite) drivers, renaming a table, adding a column, or
+  truncating it no longer fails when a table or column name contains a double quote (e.g. a
   `we"ird` table created from a CSV header).
 
 ## [v0.53.0] - 2026-05-25

--- a/drivers/rqlite/rqlite.go
+++ b/drivers/rqlite/rqlite.go
@@ -259,7 +259,7 @@ func (d *driveri) Truncate(ctx context.Context, src *source.Source, tbl string, 
 	// Truncate has src in hand (unlike most SQLDriver methods, which
 	// take a bare db), so its errors get the connection-error
 	// enrichments too, consistent with the query and metadata paths.
-	affected, err := sqlz.ExecAffected(ctx, db, fmt.Sprintf("DELETE FROM %q", tbl))
+	affected, err := sqlz.ExecAffected(ctx, db, "DELETE FROM "+stringz.DoubleQuote(tbl))
 	if err != nil {
 		return affected, enrichConnError(errw(err), src)
 	}
@@ -1003,14 +1003,15 @@ func (d *driveri) getTableRecordMeta(ctx context.Context, db sqlz.DB, tblName st
 
 // AlterTableRename implements driver.SQLDriver.
 func (d *driveri) AlterTableRename(ctx context.Context, db sqlz.DB, tbl, newName string) error {
-	q := fmt.Sprintf(`ALTER TABLE %q RENAME TO %q`, tbl, newName)
+	q := fmt.Sprintf(`ALTER TABLE %s RENAME TO %s`, stringz.DoubleQuote(tbl), stringz.DoubleQuote(newName))
 	_, err := db.ExecContext(ctx, q)
 	return errz.Wrapf(errw(err), "rqlite: alter table: failed to rename table {%s} to {%s}", tbl, newName)
 }
 
 // AlterTableAddColumn implements driver.SQLDriver.
 func (d *driveri) AlterTableAddColumn(ctx context.Context, db sqlz.DB, tbl, col string, knd kind.Kind) error {
-	q := fmt.Sprintf("ALTER TABLE %q ADD COLUMN %q %s", tbl, col, DBTypeForKind(knd))
+	q := fmt.Sprintf("ALTER TABLE %s ADD COLUMN %s %s",
+		stringz.DoubleQuote(tbl), stringz.DoubleQuote(col), DBTypeForKind(knd))
 	_, err := db.ExecContext(ctx, q)
 	if err != nil {
 		return errz.Wrapf(errw(err), "rqlite: alter table: failed to add column {%s} to table {%s}", col, tbl)
@@ -1020,7 +1021,8 @@ func (d *driveri) AlterTableAddColumn(ctx context.Context, db sqlz.DB, tbl, col 
 
 // AlterTableRenameColumn implements driver.SQLDriver.
 func (d *driveri) AlterTableRenameColumn(ctx context.Context, db sqlz.DB, tbl, col, newName string) error {
-	q := fmt.Sprintf("ALTER TABLE %q RENAME COLUMN %q TO %q", tbl, col, newName)
+	q := fmt.Sprintf("ALTER TABLE %s RENAME COLUMN %s TO %s",
+		stringz.DoubleQuote(tbl), stringz.DoubleQuote(col), stringz.DoubleQuote(newName))
 	_, err := db.ExecContext(ctx, q)
 	return errz.Wrapf(errw(err), "rqlite: alter table: failed to rename column {%s.%s} to {%s}", tbl, col, newName)
 }

--- a/drivers/rqlite/rqlite_test.go
+++ b/drivers/rqlite/rqlite_test.go
@@ -299,6 +299,65 @@ func TestTruncate_Reset(t *testing.T) {
 	require.Equal(t, int64(1), id, "AUTOINCREMENT counter should have been reset")
 }
 
+// TestAlterTruncate_EmbeddedQuoteIdentifier reproduces gh821: the
+// AlterTableRename, AlterTableRenameColumn, AlterTableAddColumn, and Truncate
+// paths used %q for SQL identifier quoting, which emits Go backslash escaping
+// that SQLite rejects for names containing a double quote (e.g. a we"ird table,
+// creatable from a CSV header). Each path must use SQL double-quote escaping.
+func TestAlterTruncate_EmbeddedQuoteIdentifier(t *testing.T) {
+	tu.SkipShort(t, true)
+	t.Parallel()
+
+	th := testh.New(t)
+	src := th.Source(sakila.Rq)
+	grip := th.Open(src)
+	drvr := grip.SQLDriver()
+	db, err := grip.DB(th.Context)
+	require.NoError(t, err)
+
+	uniq := stringz.Uniq8()
+	tblName := `we"ird_` + uniq
+	newName := `we"ird2_` + uniq
+	t.Cleanup(func() {
+		_ = drvr.DropTable(th.Context, db, tablefq.T{Table: tblName}, true)
+		_ = drvr.DropTable(th.Context, db, tablefq.T{Table: newName}, true)
+	})
+
+	_, err = db.ExecContext(th.Context,
+		fmt.Sprintf("CREATE TABLE %s (id INTEGER)", stringz.DoubleQuote(tblName)))
+	require.NoError(t, err)
+
+	// AlterTableAddColumn: add a column whose name also contains a quote.
+	const colName = `na"me`
+	require.NoError(t, drvr.AlterTableAddColumn(th.Context, db, tblName, colName, kind.Text))
+
+	// AlterTableRenameColumn: rename the quoted column to another quoted name.
+	const renamedCol = `re"named`
+	require.NoError(t, drvr.AlterTableRenameColumn(th.Context, db, tblName, colName, renamedCol))
+
+	md, err := grip.TableMetadata(th.Context, tblName)
+	require.NoError(t, err)
+	require.Len(t, md.Columns, 2)
+	require.Equal(t, renamedCol, md.Columns[1].Name)
+
+	// Truncate: insert a row, then delete all rows via the truncate path.
+	_, err = db.ExecContext(th.Context,
+		fmt.Sprintf("INSERT INTO %s (id) VALUES (1)", stringz.DoubleQuote(tblName)))
+	require.NoError(t, err)
+	affected, err := drvr.Truncate(th.Context, src, tblName, false)
+	require.NoError(t, err)
+	require.Equal(t, int64(1), affected)
+
+	// AlterTableRename: rename the quoted table to another quoted name.
+	require.NoError(t, drvr.AlterTableRename(th.Context, db, tblName, newName))
+	exists, err := drvr.TableExists(th.Context, db, newName)
+	require.NoError(t, err)
+	require.True(t, exists)
+	exists, err = drvr.TableExists(th.Context, db, tblName)
+	require.NoError(t, err)
+	require.False(t, exists)
+}
+
 func TestCopyTable_StructureOnly(t *testing.T) {
 	tu.SkipShort(t, true)
 	t.Parallel()

--- a/drivers/sqlite3/alter.go
+++ b/drivers/sqlite3/alter.go
@@ -17,21 +17,23 @@ import (
 
 // AlterTableRename implements driver.SQLDriver.
 func (d *driveri) AlterTableRename(ctx context.Context, db sqlz.DB, tbl, newName string) error {
-	q := fmt.Sprintf(`ALTER TABLE %q RENAME TO %q`, tbl, newName)
+	q := fmt.Sprintf(`ALTER TABLE %s RENAME TO %s`, stringz.DoubleQuote(tbl), stringz.DoubleQuote(newName))
 	_, err := db.ExecContext(ctx, q)
 	return errz.Wrapf(errw(err), "alter table: failed to rename table {%s} to {%s}", tbl, newName)
 }
 
 // AlterTableRenameColumn implements driver.SQLDriver.
 func (d *driveri) AlterTableRenameColumn(ctx context.Context, db sqlz.DB, tbl, col, newName string) error {
-	q := fmt.Sprintf("ALTER TABLE %q RENAME COLUMN %q TO %q", tbl, col, newName)
+	q := fmt.Sprintf("ALTER TABLE %s RENAME COLUMN %s TO %s",
+		stringz.DoubleQuote(tbl), stringz.DoubleQuote(col), stringz.DoubleQuote(newName))
 	_, err := db.ExecContext(ctx, q)
 	return errz.Wrapf(errw(err), "alter table: failed to rename column {%s.%s} to {%s}", tbl, col, newName)
 }
 
 // AlterTableAddColumn implements driver.SQLDriver.
 func (d *driveri) AlterTableAddColumn(ctx context.Context, db sqlz.DB, tbl, col string, knd kind.Kind) error {
-	q := fmt.Sprintf("ALTER TABLE %q ADD COLUMN %q ", tbl, col) + DBTypeForKind(knd)
+	q := fmt.Sprintf("ALTER TABLE %s ADD COLUMN %s ",
+		stringz.DoubleQuote(tbl), stringz.DoubleQuote(col)) + DBTypeForKind(knd)
 
 	_, err := db.ExecContext(ctx, q)
 	if err != nil {

--- a/drivers/sqlite3/sqlite3.go
+++ b/drivers/sqlite3/sqlite3.go
@@ -183,7 +183,7 @@ func (d *driveri) Truncate(ctx context.Context, src *source.Source, tbl string, 
 		return 0, errw(err)
 	}
 
-	affected, err = sqlz.ExecAffected(ctx, tx, fmt.Sprintf("DELETE FROM %q", tbl))
+	affected, err = sqlz.ExecAffected(ctx, tx, "DELETE FROM "+stringz.DoubleQuote(tbl))
 	if err != nil {
 		return affected, errz.Append(err, errw(tx.Rollback()))
 	}

--- a/drivers/sqlite3/sqlite3_test.go
+++ b/drivers/sqlite3/sqlite3_test.go
@@ -499,6 +499,64 @@ func TestDriveri_AlterTableColumnKinds_QuotedIdentifier(t *testing.T) {
 	}
 }
 
+// TestDriveri_AlterTruncate_EmbeddedQuoteIdentifier reproduces gh821: the
+// AlterTableRename, AlterTableRenameColumn, AlterTableAddColumn, and Truncate
+// paths used %q for SQL identifier quoting, which emits Go backslash escaping
+// that SQLite rejects for names containing a double quote (e.g. a we"ird table,
+// creatable from a CSV header). Each path must use SQL double-quote escaping.
+func TestDriveri_AlterTruncate_EmbeddedQuoteIdentifier(t *testing.T) {
+	const (
+		tblName = `we"ird`
+		colName = `na"me`
+	)
+
+	th := testh.New(t)
+	src := &source.Source{
+		Handle:   "@test",
+		Type:     drivertype.SQLite,
+		Location: "sqlite3://" + tu.TempFile(t, "test.db"),
+	}
+
+	grip := th.Open(src)
+	db, err := grip.DB(th.Context)
+	require.NoError(t, err)
+	drvr := grip.SQLDriver()
+
+	_, err = db.ExecContext(th.Context,
+		fmt.Sprintf("CREATE TABLE %s (id INTEGER)", stringz.DoubleQuote(tblName)))
+	require.NoError(t, err)
+
+	// AlterTableAddColumn: add a column whose name also contains a quote.
+	require.NoError(t, drvr.AlterTableAddColumn(th.Context, db, tblName, colName, kind.Text))
+
+	// AlterTableRenameColumn: rename the quoted column to another quoted name.
+	const renamedCol = `re"named`
+	require.NoError(t, drvr.AlterTableRenameColumn(th.Context, db, tblName, colName, renamedCol))
+
+	md, err := grip.TableMetadata(th.Context, tblName)
+	require.NoError(t, err)
+	require.Len(t, md.Columns, 2)
+	require.Equal(t, renamedCol, md.Columns[1].Name)
+
+	// Truncate: insert a row, then delete all rows via the truncate path.
+	_, err = db.ExecContext(th.Context,
+		fmt.Sprintf("INSERT INTO %s (id) VALUES (1)", stringz.DoubleQuote(tblName)))
+	require.NoError(t, err)
+	affected, err := drvr.Truncate(th.Context, src, tblName, false)
+	require.NoError(t, err)
+	require.Equal(t, int64(1), affected)
+
+	// AlterTableRename: rename the quoted table to another quoted name.
+	const newName = `we"ird2`
+	require.NoError(t, drvr.AlterTableRename(th.Context, db, tblName, newName))
+	exists, err := drvr.TableExists(th.Context, db, newName)
+	require.NoError(t, err)
+	require.True(t, exists)
+	exists, err = drvr.TableExists(th.Context, db, tblName)
+	require.NoError(t, err)
+	require.False(t, exists)
+}
+
 // TestDriveri_AlterTableColumnKinds_EscapedQuoteColumnName reproduces gh789
 // case 1: a column literally named my"col (declared in DDL as "my""col")
 // failed the column lookup in AlterTableColumnKinds because trimIdentQuotes


### PR DESCRIPTION
## Summary

Follow-up sweep from the #813 deep review. The `sqlite3` and `rqlite` drivers
still used Go's `%q` verb to quote SQL identifiers in their alter and truncate
paths. `%q` emits Go-style backslash escaping (e.g. `"we\"ird"`), which SQLite
rejects. A table or column whose name contains a double quote therefore broke
with malformed-SQL errors on rename, add-column, and truncate.

This is the same class of flaw that #777 fixed in `getTableMetadata` and #813
fixed in the metadata queries. The fix is identical: use `stringz.DoubleQuote`
(the drivers' dialect `Enquote`), which emits the SQL-standard doubled-quote
escaping (`"we""ird"`). Identifier positions cannot be parameterized, so
quoting is the correct mechanism.

Fixes #821.

## Why it matters

Names with embedded double quotes are reachable today, not just theoretical:

- The already-fixed table-creation paths accept them.
- CSV headers can introduce embedded quotes, which flow through to column and
  table names.

A name that merely collides with a SQL keyword already worked (because `%q`
does add quotes); exposure was limited to names containing an embedded quote,
where `%q`'s backslash escaping diverges from SQLite's doubled-quote rule.

Worth landing before #778 dedupes the two drivers, so the unified code doesn't
inherit the flaw.

## Sites fixed

| File | Function |
| ---- | -------- |
| `drivers/sqlite3/alter.go` | `AlterTableRename`, `AlterTableRenameColumn`, `AlterTableAddColumn` |
| `drivers/sqlite3/sqlite3.go` | `Truncate` (`DELETE FROM`) |
| `drivers/rqlite/rqlite.go` | `AlterTableRename`, `AlterTableRenameColumn`, `AlterTableAddColumn`, `Truncate` |

Each `%q` identifier placeholder became `%s` fed through `stringz.DoubleQuote`.
The two `DELETE FROM` statements became string concatenation rather than
`fmt.Sprintf`, per the `perfsprint` linter.

`AlterTableColumnKinds` in both drivers was already correct (it uses
`stringz.DoubleQuote` via the DDL-rewrite path) and is untouched.

## Tests

Added one focused test per driver exercising all four fixed paths against
identifiers containing an embedded double quote (`we"ird` table, `na"me`
column), covering create, add-column, rename-column, truncate, and
rename-table:

- `TestDriveri_AlterTruncate_EmbeddedQuoteIdentifier` (sqlite3, local temp DB,
  runs under `-short`).
- `TestAlterTruncate_EmbeddedQuoteIdentifier` (rqlite, container-backed, gated
  by `tu.SkipShort`).

I confirmed the tests genuinely catch the regression: with the source
temporarily reverted to `%q`, the sqlite3 test fails; with the fix it passes.

## Verification

- `make lint` - 0 issues.
- `make lint-markdown` - 0 errors.
- `go test ./drivers/sqlite3/ ./drivers/rqlite/` - both suites pass, with the
  rqlite suite run live against a local `sakiladb/rqlite:10` container
  (`SQ_TEST_SRC__SAKILA_RQ=localhost:4001`).
- `CHANGELOG.md` updated under `Unreleased` -> `Fixed`.