### PR TITLE
clickhouse: stop truncating dotted result-column names (#834)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,11 @@ Breaking changes are annotated with ☢️, and alpha/beta features with 🐥.
   [rqlite](https://sq.io/docs/drivers/rqlite) drivers, renaming a table, adding a column, or
   truncating it no longer fails when a table or column name contains a double quote (e.g. a
   `we"ird` table created from a CSV header).
+- [#834]: On the [ClickHouse](https://sq.io/docs/drivers/clickhouse) driver, a result-column
+  name containing a dot (e.g. the default alias `avg(.actor_id)`, or an explicit alias like
+  `"a.b"`) is no longer truncated to the segment after the last dot. The table qualifier that
+  ClickHouse adds to disambiguate duplicate join columns is still stripped so duplicates are
+  renamed consistently (e.g. `actor_id_1`).
 
 ## [v0.53.0] - 2026-05-25
 
@@ -1696,6 +1701,7 @@ make working with lots of sources much easier.
 [#782]: https://github.com/neilotoole/sq/issues/782
 [#783]: https://github.com/neilotoole/sq/issues/783
 [#821]: https://github.com/neilotoole/sq/issues/821
+[#834]: https://github.com/neilotoole/sq/issues/834
 
 [v0.15.2]: https://github.com/neilotoole/sq/releases/tag/v0.15.2
 [v0.15.3]: https://github.com/neilotoole/sq/compare/v0.15.2...v0.15.3

--- a/drivers/clickhouse/internal_test.go
+++ b/drivers/clickhouse/internal_test.go
@@ -48,6 +48,7 @@ var (
 	IsNullableTypeUnwrapped    = isNullableTypeUnwrapped
 	TableTypeFromEngine        = tableTypeFromEngine
 	ConvertArrayToString       = convertArrayToString
+	ResolveQualifiedColNames   = resolveQualifiedColNames
 )
 
 // clickhouse.go exports.

--- a/drivers/clickhouse/metadata.go
+++ b/drivers/clickhouse/metadata.go
@@ -557,16 +557,10 @@ func recordMetaFromColumnTypes(ctx context.Context, colTypes []*sql.ColumnType) 
 
 		sColTypeData[i] = colTypeData
 
-		// ClickHouse returns qualified column names (e.g., "actor.actor_id") for
-		// JOIN queries, unlike other databases that return just "actor_id". Strip
-		// the table prefix so the column munging mechanism can detect duplicates
-		// and rename them consistently (e.g., "actor_id_1").
-		colName := colTypeData.Name
-		if idx := strings.LastIndex(colName, "."); idx != -1 {
-			colName = colName[idx+1:]
-		}
-		ogColNames[i] = colName
+		ogColNames[i] = colTypeData.Name
 	}
+
+	ogColNames = resolveQualifiedColNames(ogColNames)
 
 	mungedColNames, err := driver.MungeResultColNames(ctx, ogColNames)
 	if err != nil {
@@ -579,6 +573,61 @@ func recordMetaFromColumnTypes(ctx context.Context, colTypes []*sql.ColumnType) 
 	}
 
 	return recMeta, nil
+}
+
+// resolveQualifiedColNames strips a leading table qualifier from a result-column
+// name, but only when doing so resolves a collision with another column. For a
+// duplicate-column JOIN, ClickHouse disambiguates the colliding columns by
+// keeping their table qualifier (e.g. "film_actor.actor_id"), unlike most
+// databases which return the bare name. Stripping the qualifier lets the
+// downstream dedup mechanism (driver.MungeResultColNames) rename the duplicate
+// consistently (e.g. "actor_id_1"), matching the other drivers.
+//
+// ClickHouse only ever qualifies a name to disambiguate a duplicate, so this
+// mirrors that: a dotted name is collapsed to its trailing segment only when
+// that segment also occurs as another column's name. Names whose dot is part of
+// an alias or expression (e.g. "avg(.actor_id)", "a.b", ".lead") collide with
+// nothing and are preserved verbatim. See https://github.com/neilotoole/sq/issues/834.
+//
+// Comparison is case-insensitive to match MungeResultColNames, which detects
+// duplicates with strings.EqualFold.
+func resolveQualifiedColNames(names []string) []string {
+	// trailing returns the segment after the final dot, or the whole name when
+	// there's no dot. This is the bare column name a qualifier would reduce to.
+	trailing := func(name string) string {
+		if idx := strings.LastIndex(name, "."); idx != -1 {
+			return name[idx+1:]
+		}
+		return name
+	}
+
+	out := make([]string, len(names))
+	for i, name := range names {
+		if !strings.Contains(name, ".") {
+			out[i] = name
+			continue
+		}
+
+		bare := trailing(name)
+		var collides bool
+		for j, other := range names {
+			if j == i {
+				continue
+			}
+			if strings.EqualFold(trailing(other), bare) {
+				collides = true
+				break
+			}
+		}
+
+		if collides {
+			out[i] = bare
+		} else {
+			out[i] = name
+		}
+	}
+
+	return out
 }
 
 // getNewRecordFunc returns a NewRecordFunc that transforms scanned row data

--- a/drivers/clickhouse/metadata.go
+++ b/drivers/clickhouse/metadata.go
@@ -575,19 +575,24 @@ func recordMetaFromColumnTypes(ctx context.Context, colTypes []*sql.ColumnType) 
 	return recMeta, nil
 }
 
-// resolveQualifiedColNames strips a leading table qualifier from a result-column
-// name, but only when doing so resolves a collision with another column. For a
-// duplicate-column JOIN, ClickHouse disambiguates the colliding columns by
-// keeping their table qualifier (e.g. "film_actor.actor_id"), unlike most
-// databases which return the bare name. Stripping the qualifier lets the
-// downstream dedup mechanism (driver.MungeResultColNames) rename the duplicate
-// consistently (e.g. "actor_id_1"), matching the other drivers.
+// resolveQualifiedColNames strips the table qualifier (everything up to the
+// final dot) from a result-column name, but only when doing so resolves a
+// collision with another column. For a duplicate-column JOIN, ClickHouse
+// disambiguates the colliding columns by keeping their table qualifier (e.g.
+// "film_actor.actor_id"), unlike most databases which return the bare name.
+// Stripping the qualifier lets the downstream dedup mechanism
+// (driver.MungeResultColNames) rename the duplicate consistently (e.g.
+// "actor_id_1"), matching the other drivers.
 //
 // ClickHouse only ever qualifies a name to disambiguate a duplicate, so this
 // mirrors that: a dotted name is collapsed to its trailing segment only when
 // that segment also occurs as another column's name. Names whose dot is part of
 // an alias or expression (e.g. "avg(.actor_id)", "a.b", ".lead") collide with
-// nothing and are preserved verbatim. See https://github.com/neilotoole/sq/issues/834.
+// nothing and are preserved verbatim. When two qualified columns collide on
+// their trailing segment (e.g. "sales.amount" and "returns.amount"), both are
+// reduced to the bare name and then deduped ("amount", "amount_1"); the
+// distinguishing qualifiers are intentionally dropped to match the other
+// drivers. See https://github.com/neilotoole/sq/issues/834.
 //
 // Comparison is case-insensitive to match MungeResultColNames, which detects
 // duplicates with strings.EqualFold.
@@ -601,26 +606,19 @@ func resolveQualifiedColNames(names []string) []string {
 		return name
 	}
 
+	// Count how many columns share each trailing segment, case-insensitively
+	// (matching MungeResultColNames). A segment that occurs more than once marks
+	// a collision that a qualifier would disambiguate.
+	freq := make(map[string]int, len(names))
+	for _, name := range names {
+		freq[strings.ToLower(trailing(name))]++
+	}
+
 	out := make([]string, len(names))
 	for i, name := range names {
-		if !strings.Contains(name, ".") {
-			out[i] = name
-			continue
-		}
-
-		bare := trailing(name)
-		var collides bool
-		for j, other := range names {
-			if j == i {
-				continue
-			}
-			if strings.EqualFold(trailing(other), bare) {
-				collides = true
-				break
-			}
-		}
-
-		if collides {
+		// bare != name iff name is qualified (contains a dot). Strip the
+		// qualifier only when the bare name collides with another column.
+		if bare := trailing(name); bare != name && freq[strings.ToLower(bare)] > 1 {
 			out[i] = bare
 		} else {
 			out[i] = name

--- a/drivers/clickhouse/metadata_test.go
+++ b/drivers/clickhouse/metadata_test.go
@@ -530,3 +530,71 @@ func TestMetadata_UnusualColumnTypes(t *testing.T) {
 			col.Name, col.Kind, col.BaseType, col.ColumnType)
 	}
 }
+
+// TestResolveQualifiedColNames verifies that the ClickHouse driver strips a
+// table qualifier from a result-column name only when doing so resolves a
+// collision with another column, mirroring ClickHouse's own behavior of
+// qualifying a name only to disambiguate duplicates. Aliases and expressions
+// that merely happen to contain a dot are preserved verbatim. See #834.
+func TestResolveQualifiedColNames(t *testing.T) {
+	testCases := []struct {
+		name string
+		in   []string
+		want []string
+	}{
+		{
+			// Default function alias (SLQ source text) contains a dot; it
+			// collides with nothing, so it must be preserved verbatim.
+			name: "default_func_alias_preserved",
+			in:   []string{"avg(.actor_id)"},
+			want: []string{"avg(.actor_id)"},
+		},
+		{
+			// Leading-dot alias collides with nothing; preserved verbatim.
+			name: "leading_dot_alias_preserved",
+			in:   []string{".lead"},
+			want: []string{".lead"},
+		},
+		{
+			// User-supplied dotted alias collides with nothing; preserved.
+			name: "user_dotted_alias_preserved",
+			in:   []string{"a.b"},
+			want: []string{"a.b"},
+		},
+		{
+			// Duplicate-column join: ClickHouse qualifies the colliding
+			// columns (film_actor.actor_id, film_actor.last_update). The
+			// qualifier must be stripped so downstream dedup can rename them
+			// to actor_id_1 / last_update_1.
+			name: "duplicate_join_qualifier_stripped",
+			in: []string{
+				"actor_id", "first_name", "last_name", "last_update",
+				"film_actor.actor_id", "film_id", "film_actor.last_update",
+			},
+			want: []string{
+				"actor_id", "first_name", "last_name", "last_update",
+				"actor_id", "film_id", "last_update",
+			},
+		},
+		{
+			// Parenthesized alias without a dot is untouched.
+			name: "parens_no_dot_preserved",
+			in:   []string{"x(y)"},
+			want: []string{"x(y)"},
+		},
+		{
+			// Collision detection is case-insensitive, matching the
+			// downstream dedup mechanism (MungeResultColNames uses EqualFold).
+			name: "collision_case_insensitive",
+			in:   []string{"Actor_ID", "film_actor.actor_id"},
+			want: []string{"Actor_ID", "actor_id"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := clickhouse.ResolveQualifiedColNames(tc.in)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/drivers/clickhouse/metadata_test.go
+++ b/drivers/clickhouse/metadata_test.go
@@ -589,6 +589,32 @@ func TestResolveQualifiedColNames(t *testing.T) {
 			in:   []string{"Actor_ID", "film_actor.actor_id"},
 			want: []string{"Actor_ID", "actor_id"},
 		},
+		{
+			// When two qualified columns collide on their trailing segment,
+			// both are reduced to the bare name; the distinguishing qualifiers
+			// are intentionally dropped to match the other drivers (the bare
+			// duplicates are then deduped downstream to "amount", "amount_1").
+			name: "both_qualified_collide",
+			in:   []string{"sales.amount", "returns.amount"},
+			want: []string{"amount", "amount"},
+		},
+		{
+			// A user alias whose trailing segment collides with a real column
+			// is treated as a qualifier and stripped. This degrades the alias,
+			// but the case is pathological (deliberately aliasing "x.actor_id"
+			// alongside a real "actor_id") and acceptable.
+			name: "alias_collides_with_bare",
+			in:   []string{"x.actor_id", "actor_id"},
+			want: []string{"actor_id", "actor_id"},
+		},
+		{
+			// Degenerate trailing-dot names (which ClickHouse never emits)
+			// reduce to an empty trailing segment that collides; current
+			// behavior strips both to "". Documents the edge, not a guarantee.
+			name: "trailing_dot_degenerate",
+			in:   []string{"actor.", "film."},
+			want: []string{"", ""},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/libsq/query_join_test.go
+++ b/libsq/query_join_test.go
@@ -362,6 +362,25 @@ func TestQuery_join_others(t *testing.T) {
 				assertSinkColMungedNames(colsJoinActorFilmActor...),
 			},
 		},
+		{
+			// A dotted column alias must survive a join. Selecting actor_id
+			// from both tables produces a duplicate that ClickHouse
+			// disambiguates with a table qualifier (film_actor.actor_id); the
+			// driver strips that qualifier so dedup yields actor_id_1. The
+			// explicitly dotted alias "a.b" collides with nothing, so it must
+			// be preserved verbatim rather than truncated to "b". See #834.
+			name:    "gh834/dotted-alias-with-dup-cols",
+			in:      `@sakila | .actor:a | join(.film_actor:fa, .a.actor_id == .fa.actor_id) | .a.actor_id, .fa.actor_id, .a.first_name:"a.b"`,
+			wantSQL: `SELECT "a"."actor_id", "fa"."actor_id", "a"."first_name" AS "a.b" FROM "actor" AS "a" INNER JOIN "film_actor" AS "fa" ON "a"."actor_id" = "fa"."actor_id"`,
+			override: driverMap{
+				drivertype.MySQL:      "SELECT `a`.`actor_id`, `fa`.`actor_id`, `a`.`first_name` AS `a.b` FROM `actor` AS `a` INNER JOIN `film_actor` AS `fa` ON `a`.`actor_id` = `fa`.`actor_id`",
+				drivertype.ClickHouse: "SELECT `a`.`actor_id`, `fa`.`actor_id`, `a`.`first_name` AS `a.b` FROM `actor` AS `a` INNER JOIN `film_actor` AS `fa` ON `a`.`actor_id` = `fa`.`actor_id`",
+			},
+			wantRecCount: sakila.TblFilmActorCount,
+			sinkFns: []SinkTestFunc{
+				assertSinkColMungedNames("actor_id", "actor_id_1", "a.b"),
+			},
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
Fixes #834.

## Problem

The ClickHouse driver unconditionally stripped everything before the last dot in every result-column name (`drivers/clickhouse/metadata.go`). The intent was to remove the table qualifier ClickHouse adds to disambiguate duplicate join columns (e.g. `film_actor.actor_id`), but it over-applied and corrupted any name containing a dot:

- the default function alias `avg(.actor_id)` came back as `actor_id)`;
- an explicit alias like `"a.b"` came back as `b`.

The value was always correct; only the column name was wrong, which broke JSON keys, CSV/table headers, and anything consuming result columns by name. This was sq's own munging, not ClickHouse server behavior and not `clickhouse-go` (both preserve the name verbatim).

## Fix

Replace the unconditional strip with `resolveQualifiedColNames`, which mirrors ClickHouse's own behavior. ClickHouse only ever qualifies a name to disambiguate a duplicate, so a dotted name is collapsed to its trailing segment only when that segment also occurs as another column's name. Aliases and expressions whose dot collides with nothing are preserved verbatim. Duplicate-join columns are still stripped so the downstream dedup (`driver.MungeResultColNames`) renames them consistently (e.g. `actor_id_1`).

Collision detection is O(n) via a case-insensitive frequency map over trailing segments, matching the `EqualFold` dedup downstream. When two *qualified* columns collide on their trailing segment (e.g. `sales.amount` and `returns.amount`), both are reduced to the bare name and deduped (`amount`, `amount_1`); the distinguishing qualifiers are intentionally dropped to match the other drivers.

## Verification

Run against a live ClickHouse (`sakiladb/clickhouse:25`, `clickhouse-go` v2.46.0):

- `avg(.actor_id)` -> JSON key `avg(.actor_id)` (was `actor_id)`).
- explicit alias `"a.b"` -> `a.b` (was `b`).
- `TestQuery_func*` (avg/sum, includes ClickHouse) green.
- Unit test `TestResolveQualifiedColNames` covers: default function alias, leading-dot alias, user dotted alias, duplicate-join qualifier, parens-without-dot, case-insensitive collision, both-qualified collision, a user alias colliding with a bare column, and degenerate trailing-dot input.
- Integration test `TestQuery_join_others/gh834/dotted-alias-with-dup-cols` joins `actor` and `film_actor`, selecting `actor_id` from both plus a dotted alias `"a.b"`, and asserts result columns `["actor_id", "actor_id_1", "a.b"]`. It passes across sqlite3, postgres, mysql, sqlserver, clickhouse, and oracle: the duplicate `actor_id` still dedups to `actor_id_1` while the dotted alias is preserved.
