### PR TITLE
gh594: harmonize avg() to float64 across SQL drivers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,7 +52,9 @@ Breaking changes are annotated with ☢️, and alpha/beta features with 🐥.
 - ☢️ [#594]: [`avg()`](https://sq.io/docs/query#avg) now returns a consistent `float`
   on every SQL driver. Previously the result type varied by backend (a float on
   some, an integer or a decimal string on others), so an `avg()` value could not
-  be consumed portably across sources. This is a breaking change for
+  be consumed portably across sources. `float` was chosen to match `jq`'s numeric
+  model, which represents all numbers as IEEE 754 floating point. This is a
+  breaking change for
   [Postgres](https://sq.io/docs/drivers/postgres) and
   [MySQL](https://sq.io/docs/drivers/mysql), which previously returned a lossless
   decimal (rendered as a quoted string in JSON output): an `avg()` value is now a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,10 @@ Breaking changes are annotated with ☢️, and alpha/beta features with 🐥.
 
 ### Changed
 
+- [#594]: [`avg()`](https://sq.io/docs/query#avg) now returns a consistent `float`
+  on every SQL driver. Previously the result type varied by backend (a float on
+  some, an integer or a decimal string on others), so an `avg()` value could not
+  be consumed portably across sources.
 - [#610]: The DuckDB driver now
   [opens sources read-only](https://sq.io/docs/drivers/duckdb#read-only-access-by-default)
   for commands that don't write (`sq`, `inspect`, `diff`, `ping`), and the new
@@ -77,6 +81,9 @@ Breaking changes are annotated with ☢️, and alpha/beta features with 🐥.
 
 ### Fixed
 
+- [#594]: On [SQL Server](https://sq.io/docs/drivers/sqlserver), `avg()` over an
+  integer column no longer performs integer division and truncates the result.
+  For example, the average of `1..200` now returns `100.5`, not `100`.
 - [#741], [#743]: [`sq add`](https://sq.io/docs/cmd/add) shell completion now supports
   [ClickHouse](https://sq.io/docs/drivers/clickhouse) and
   [Oracle](https://sq.io/docs/drivers/oracle).
@@ -1661,6 +1668,7 @@ make working with lots of sources much easier.
 [#570]: https://github.com/neilotoole/sq/pull/570
 [#571]: https://github.com/neilotoole/sq/pull/571
 [#572]: https://github.com/neilotoole/sq/pull/572
+[#594]: https://github.com/neilotoole/sq/issues/594
 [#601]: https://github.com/neilotoole/sq/issues/601
 [#602]: https://github.com/neilotoole/sq/pull/602
 [#610]: https://github.com/neilotoole/sq/issues/610

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,10 +49,16 @@ Breaking changes are annotated with ☢️, and alpha/beta features with 🐥.
 
 ### Changed
 
-- [#594]: [`avg()`](https://sq.io/docs/query#avg) now returns a consistent `float`
+- ☢️ [#594]: [`avg()`](https://sq.io/docs/query#avg) now returns a consistent `float`
   on every SQL driver. Previously the result type varied by backend (a float on
   some, an integer or a decimal string on others), so an `avg()` value could not
-  be consumed portably across sources.
+  be consumed portably across sources. This is a breaking change for
+  [Postgres](https://sq.io/docs/drivers/postgres) and
+  [MySQL](https://sq.io/docs/drivers/mysql), which previously returned a lossless
+  decimal (rendered as a quoted string in JSON output): an `avg()` value is now a
+  JSON number, and may lose precision for averages beyond float64's range
+  (~15-17 significant digits). Callers needing lossless decimal can fall back to
+  native SQL via [`sq sql`](https://sq.io/docs/cmd/sql).
 - [#610]: The DuckDB driver now
   [opens sources read-only](https://sq.io/docs/drivers/duckdb#read-only-access-by-default)
   for commands that don't write (`sq`, `inspect`, `diff`, `ping`), and the new

--- a/drivers/mysql/mysql.go
+++ b/drivers/mysql/mysql.go
@@ -149,7 +149,9 @@ func placeholders(numCols, numRows int) string {
 func (d *driveri) Renderer() *render.Renderer {
 	r := render.NewDefaultRenderer()
 	r.FunctionNames[ast.FuncNameSchema] = "DATABASE"
-	r.FunctionOverrides[ast.FuncNameAvg] = doRenderFuncAvg
+	// avg() returns a portable float64 instead of MySQL's native DECIMAL
+	// (which sq surfaces as a decimal.Decimal). See issue #594.
+	r.FunctionOverrides[ast.FuncNameAvg] = render.FuncOverrideCastResult("DOUBLE")
 	r.FunctionOverrides[ast.FuncNameCatalog] = doRenderFuncCatalog
 	r.FunctionOverrides[ast.FuncNameRowNum] = renderFuncRowNum
 	r.FunctionOverrides[ast.FuncNameContains] = renderFuncContainsBinary
@@ -706,17 +708,6 @@ func doRetry(ctx context.Context, fn func() error) error {
 func tblfmt[T string | tablefq.T](tbl T) string {
 	tfq := tablefq.From(tbl)
 	return tfq.Render(stringz.BacktickQuote)
-}
-
-// doRenderFuncAvg renders avg() wrapped in a cast to a floating type, so that
-// avg() returns a portable float64 instead of MySQL's native DECIMAL (which sq
-// surfaces as a decimal.Decimal). See issue #594.
-func doRenderFuncAvg(rc *render.Context, fn *ast.FuncNode) (string, error) {
-	inner, err := render.RenderFuncDefault(rc, fn)
-	if err != nil {
-		return "", err
-	}
-	return "CAST(" + inner + " AS DOUBLE)", nil
 }
 
 const selectCatalog = `SELECT CATALOG_NAME FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = DATABASE() LIMIT 1`

--- a/drivers/mysql/mysql.go
+++ b/drivers/mysql/mysql.go
@@ -149,6 +149,7 @@ func placeholders(numCols, numRows int) string {
 func (d *driveri) Renderer() *render.Renderer {
 	r := render.NewDefaultRenderer()
 	r.FunctionNames[ast.FuncNameSchema] = "DATABASE"
+	r.FunctionOverrides[ast.FuncNameAvg] = doRenderFuncAvg
 	r.FunctionOverrides[ast.FuncNameCatalog] = doRenderFuncCatalog
 	r.FunctionOverrides[ast.FuncNameRowNum] = renderFuncRowNum
 	r.FunctionOverrides[ast.FuncNameContains] = renderFuncContainsBinary
@@ -705,6 +706,17 @@ func doRetry(ctx context.Context, fn func() error) error {
 func tblfmt[T string | tablefq.T](tbl T) string {
 	tfq := tablefq.From(tbl)
 	return tfq.Render(stringz.BacktickQuote)
+}
+
+// doRenderFuncAvg renders avg() wrapped in a cast to a floating type, so that
+// avg() returns a portable float64 instead of MySQL's native DECIMAL (which sq
+// surfaces as a decimal.Decimal). See issue #594.
+func doRenderFuncAvg(rc *render.Context, fn *ast.FuncNode) (string, error) {
+	inner, err := render.RenderFuncDefault(rc, fn)
+	if err != nil {
+		return "", err
+	}
+	return "CAST(" + inner + " AS DOUBLE)", nil
 }
 
 const selectCatalog = `SELECT CATALOG_NAME FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = DATABASE() LIMIT 1`

--- a/drivers/oracle/oracle.go
+++ b/drivers/oracle/oracle.go
@@ -173,39 +173,16 @@ func (d *driveri) Renderer() *render.Renderer {
 	const oracleCatalogFrag = `SYS_CONTEXT('USERENV', 'DB_NAME')`
 	r.FunctionOverrides[ast.FuncNameSchema] = render.FuncOverrideString(oracleSchemaFrag)
 	r.FunctionOverrides[ast.FuncNameCatalog] = render.FuncOverrideString(oracleCatalogFrag)
-	r.FunctionOverrides[ast.FuncNameAvg] = doRenderFuncAvg
-	r.FunctionOverrides[ast.FuncNameSum] = doRenderFuncSum
+	// Oracle returns AVG/SUM as NUMBER(38, 255) (floating-scale,
+	// indistinguishable from COUNT at the metadata layer), which classifies as
+	// kind.Int. Both can yield fractional values (AVG always, SUM over a
+	// decimal column), so scanning into int64 fails. Casting to BINARY_DOUBLE
+	// pins the result to a float so it scans cleanly. Tradeoff: integer-valued
+	// sums lose precision beyond ~15-17 significant digits; users needing
+	// lossless big-integer sums should use raw SQL. See issue #594.
+	r.FunctionOverrides[ast.FuncNameAvg] = render.FuncOverrideCastResult("BINARY_DOUBLE")
+	r.FunctionOverrides[ast.FuncNameSum] = render.FuncOverrideCastResult("BINARY_DOUBLE")
 	return r
-}
-
-// doRenderFuncAvg wraps avg() in CAST(... AS BINARY_DOUBLE). Oracle returns
-// AVG over an integer column as NUMBER(38, 255) (floating-scale, indistinguishable
-// from COUNT/SUM at the metadata layer), which classifies as kind.Int. AVG
-// can yield fractional values, so scanning into int64 fails. The cast pins
-// the result type to a float so it scans cleanly.
-func doRenderFuncAvg(rc *render.Context, fn *ast.FuncNode) (string, error) {
-	inner, err := render.RenderFuncDefault(rc, fn)
-	if err != nil {
-		return "", err
-	}
-	return "CAST(" + inner + " AS BINARY_DOUBLE)", nil
-}
-
-// doRenderFuncSum wraps sum() in CAST(... AS BINARY_DOUBLE). Same shape as
-// doRenderFuncAvg: Oracle returns SUM as NUMBER(38, 255) regardless of operand
-// type, which the metadata layer classifies as kind.Int. SUM over a decimal
-// column (e.g. payment.amount) yields fractional values, so scanning into
-// int64 fails. Casting to BINARY_DOUBLE pins the result to a float.
-//
-// Tradeoff: integer-valued sums lose precision beyond ~15-17 significant
-// digits. Acceptable for sq's ad-hoc use; users needing lossless big-integer
-// sums should use raw SQL. See #594 for cross-driver type harmonization.
-func doRenderFuncSum(rc *render.Context, fn *ast.FuncNode) (string, error) {
-	inner, err := render.RenderFuncDefault(rc, fn)
-	if err != nil {
-		return "", err
-	}
-	return "CAST(" + inner + " AS BINARY_DOUBLE)", nil
 }
 
 // Open implements driver.Driver.

--- a/drivers/postgres/postgres.go
+++ b/drivers/postgres/postgres.go
@@ -144,20 +144,11 @@ func (d *driveri) Renderer() *render.Renderer {
 	r := render.NewDefaultRenderer()
 	r.FunctionNames[ast.FuncNameSchema] = "current_schema"
 	r.FunctionNames[ast.FuncNameCatalog] = "current_database"
-	r.FunctionOverrides[ast.FuncNameAvg] = doRenderFuncAvg
+	// avg() returns a portable float64 instead of Postgres's native numeric
+	// (which sq surfaces as a decimal.Decimal). See issue #594.
+	r.FunctionOverrides[ast.FuncNameAvg] = render.FuncOverrideCastResult("DOUBLE PRECISION")
 	render.RegisterILikeFamily(r)
 	return r
-}
-
-// doRenderFuncAvg renders avg() wrapped in a cast to a floating type, so that
-// avg() returns a portable float64 instead of Postgres's native numeric
-// (which sq surfaces as a decimal.Decimal). See issue #594.
-func doRenderFuncAvg(rc *render.Context, fn *ast.FuncNode) (string, error) {
-	inner, err := render.RenderFuncDefault(rc, fn)
-	if err != nil {
-		return "", err
-	}
-	return "CAST(" + inner + " AS DOUBLE PRECISION)", nil
 }
 
 // Open implements driver.Driver.

--- a/drivers/postgres/postgres.go
+++ b/drivers/postgres/postgres.go
@@ -144,8 +144,20 @@ func (d *driveri) Renderer() *render.Renderer {
 	r := render.NewDefaultRenderer()
 	r.FunctionNames[ast.FuncNameSchema] = "current_schema"
 	r.FunctionNames[ast.FuncNameCatalog] = "current_database"
+	r.FunctionOverrides[ast.FuncNameAvg] = doRenderFuncAvg
 	render.RegisterILikeFamily(r)
 	return r
+}
+
+// doRenderFuncAvg renders avg() wrapped in a cast to a floating type, so that
+// avg() returns a portable float64 instead of Postgres's native numeric
+// (which sq surfaces as a decimal.Decimal). See issue #594.
+func doRenderFuncAvg(rc *render.Context, fn *ast.FuncNode) (string, error) {
+	inner, err := render.RenderFuncDefault(rc, fn)
+	if err != nil {
+		return "", err
+	}
+	return "CAST(" + inner + " AS DOUBLE PRECISION)", nil
 }
 
 // Open implements driver.Driver.

--- a/drivers/sqlserver/sqlserver.go
+++ b/drivers/sqlserver/sqlserver.go
@@ -164,6 +164,7 @@ func (d *driveri) Renderer() *render.Renderer {
 
 	r.FunctionNames[ast.FuncNameSchema] = "SCHEMA_NAME"
 	r.FunctionNames[ast.FuncNameCatalog] = "DB_NAME"
+	r.FunctionOverrides[ast.FuncNameAvg] = doRenderFuncAvg
 	r.FunctionOverrides[ast.FuncNameRowNum] = renderFuncRowNum
 	r.FunctionOverrides[ast.FuncNameContains] = renderFuncContainsCollate
 	r.FunctionOverrides[ast.FuncNameStartsWith] = renderFuncStartsWithCollate
@@ -188,6 +189,27 @@ func (d *driveri) Renderer() *render.Renderer {
 	}
 
 	return r
+}
+
+// doRenderFuncAvg renders avg() for SQL Server. SQL Server computes AVG over an
+// integer column using integer division, truncating the fractional part (e.g.
+// the average of 1..200 returns 100, not 100.5). The fix must cast the operand,
+// not the result: CAST(AVG(col) AS FLOAT) still truncates, because AVG has
+// already returned an int. Casting the operand makes AVG compute in floating
+// point. See issue #594.
+func doRenderFuncAvg(rc *render.Context, fn *ast.FuncNode) (string, error) {
+	args := fn.Children()
+	if len(args) != 1 {
+		// avg() always takes exactly one operand. Fall back to the default
+		// rendering for any unexpected shape rather than emit broken SQL.
+		return render.RenderFuncDefault(rc, fn)
+	}
+
+	operand, err := render.RenderFuncArg(rc, args[0])
+	if err != nil {
+		return "", err
+	}
+	return "avg(CAST(" + operand + " AS FLOAT))", nil
 }
 
 // Open implements driver.Driver.

--- a/drivers/sqlserver/sqlserver.go
+++ b/drivers/sqlserver/sqlserver.go
@@ -164,7 +164,11 @@ func (d *driveri) Renderer() *render.Renderer {
 
 	r.FunctionNames[ast.FuncNameSchema] = "SCHEMA_NAME"
 	r.FunctionNames[ast.FuncNameCatalog] = "DB_NAME"
-	r.FunctionOverrides[ast.FuncNameAvg] = doRenderFuncAvg
+	// SQL Server computes AVG over an integer column using integer division,
+	// truncating the fractional part (e.g. the average of 1..200 returns 100,
+	// not 100.5). Cast the operand, not the result: CAST(AVG(col) AS FLOAT)
+	// still truncates because AVG has already returned an int. See issue #594.
+	r.FunctionOverrides[ast.FuncNameAvg] = render.FuncOverrideCastOperand("FLOAT")
 	r.FunctionOverrides[ast.FuncNameRowNum] = renderFuncRowNum
 	r.FunctionOverrides[ast.FuncNameContains] = renderFuncContainsCollate
 	r.FunctionOverrides[ast.FuncNameStartsWith] = renderFuncStartsWithCollate
@@ -189,27 +193,6 @@ func (d *driveri) Renderer() *render.Renderer {
 	}
 
 	return r
-}
-
-// doRenderFuncAvg renders avg() for SQL Server. SQL Server computes AVG over an
-// integer column using integer division, truncating the fractional part (e.g.
-// the average of 1..200 returns 100, not 100.5). The fix must cast the operand,
-// not the result: CAST(AVG(col) AS FLOAT) still truncates, because AVG has
-// already returned an int. Casting the operand makes AVG compute in floating
-// point. See issue #594.
-func doRenderFuncAvg(rc *render.Context, fn *ast.FuncNode) (string, error) {
-	args := fn.Children()
-	if len(args) != 1 {
-		// avg() always takes exactly one operand. Fall back to the default
-		// rendering for any unexpected shape rather than emit broken SQL.
-		return render.RenderFuncDefault(rc, fn)
-	}
-
-	operand, err := render.RenderFuncArg(rc, args[0])
-	if err != nil {
-		return "", err
-	}
-	return "avg(CAST(" + operand + " AS FLOAT))", nil
 }
 
 // Open implements driver.Driver.

--- a/libsq/ast/render/function.go
+++ b/libsq/ast/render/function.go
@@ -59,44 +59,47 @@ func RenderFuncDefault(rc *Context, fn *ast.FuncNode) (string, error) {
 			sb.WriteString(", ")
 		}
 
-		switch node := child.(type) {
-		case *ast.ColSelectorNode, *ast.TblColSelectorNode, *ast.TblSelectorNode:
-			s, err := renderSelectorNode(rc.Dialect, node)
-			if err != nil {
-				return "", err
-			}
-			sb.WriteString(s)
-		case *ast.OperatorNode:
-			sb.WriteString(node.Text())
-		case *ast.LiteralNode:
-			// TODO: This is all a bit of a mess. We probably need to
-			// move to using bound parameters instead of inlining
-			// literal values.
-			val, wasQuoted, err := unquoteLiteral(node.Text())
-			if err != nil {
-				return "", err
-			}
-
-			if wasQuoted {
-				// The literal had quotes, so it's a regular string.
-				sb.WriteString(stringz.SingleQuote(val))
-			} else {
-				sb.WriteString(val)
-			}
-		case *ast.ExprNode:
-			s, err := rc.Renderer.Expr(rc, node)
-			if err != nil {
-				return "", err
-			}
-			sb.WriteString(s)
-		default:
-			return "", errz.Errorf("unknown AST child node %T: %s", node, node)
+		s, err := RenderFuncArg(rc, child)
+		if err != nil {
+			return "", err
 		}
+		sb.WriteString(s)
 	}
 
 	sb.WriteRune(')')
 	sql := sb.String()
 	return sql, nil
+}
+
+// RenderFuncArg renders a single function-argument node to SQL. It's exported
+// so that a driver's FunctionOverrides impl can render an operand in isolation,
+// for example to wrap it in a CAST. See the SQL Server avg() override, which
+// emits avg(CAST(col AS FLOAT)) to defeat integer-AVG truncation.
+func RenderFuncArg(rc *Context, node ast.Node) (string, error) {
+	switch node := node.(type) {
+	case *ast.ColSelectorNode, *ast.TblColSelectorNode, *ast.TblSelectorNode:
+		return renderSelectorNode(rc.Dialect, node)
+	case *ast.OperatorNode:
+		return node.Text(), nil
+	case *ast.LiteralNode:
+		// TODO: This is all a bit of a mess. We probably need to
+		// move to using bound parameters instead of inlining
+		// literal values.
+		val, wasQuoted, err := unquoteLiteral(node.Text())
+		if err != nil {
+			return "", err
+		}
+
+		if wasQuoted {
+			// The literal had quotes, so it's a regular string.
+			return stringz.SingleQuote(val), nil
+		}
+		return val, nil
+	case *ast.ExprNode:
+		return rc.Renderer.Expr(rc, node)
+	default:
+		return "", errz.Errorf("unknown AST child node %T: %s", node, node)
+	}
 }
 
 // doFuncRowNum renders the rownum() function.

--- a/libsq/ast/render/render.go
+++ b/libsq/ast/render/render.go
@@ -380,6 +380,11 @@ func FuncOverrideCastResult(castType string) func(*Context, *ast.FuncNode) (stri
 // SQL Server's AVG over an integer column performs integer division and
 // truncates, so a result cast comes too late. The function name is resolved
 // through Renderer.FunctionNames, matching RenderFuncDefault. See issue #594.
+//
+// It is intended for single-operand aggregates such as avg() and sum(). It does
+// not reproduce RenderFuncDefault's count/count_unique special-casing (the
+// no-arg count(*) form, or count_unique becoming count(DISTINCT ...)), so it
+// must not be registered for count or count_unique.
 func FuncOverrideCastOperand(castType string) func(*Context, *ast.FuncNode) (string, error) {
 	return func(rc *Context, fn *ast.FuncNode) (string, error) {
 		fnName := strings.ToLower(fn.FuncName())

--- a/libsq/ast/render/render.go
+++ b/libsq/ast/render/render.go
@@ -357,3 +357,46 @@ func FuncOverrideString(s string) func(*Context, *ast.FuncNode) (string, error) 
 		return s, nil
 	}
 }
+
+// FuncOverrideCastResult returns a FunctionOverrides impl that renders fn with
+// the default function renderer and wraps the whole result in
+// CAST(... AS castType). Use it to coerce an aggregate's result to a portable
+// type where the engine's aggregate is already non-truncating, e.g.
+// CAST(avg(col) AS DOUBLE PRECISION) on Postgres. See issue #594.
+func FuncOverrideCastResult(castType string) func(*Context, *ast.FuncNode) (string, error) {
+	return func(rc *Context, fn *ast.FuncNode) (string, error) {
+		inner, err := RenderFuncDefault(rc, fn)
+		if err != nil {
+			return "", err
+		}
+		return "CAST(" + inner + " AS " + castType + ")", nil
+	}
+}
+
+// FuncOverrideCastOperand returns a FunctionOverrides impl that renders fn but
+// wraps each operand in CAST(... AS castType), e.g. avg(CAST(col AS FLOAT)).
+// Unlike FuncOverrideCastResult, this casts the operands, which is required
+// where the engine would otherwise compute the aggregate in the operand's type:
+// SQL Server's AVG over an integer column performs integer division and
+// truncates, so a result cast comes too late. The function name is resolved
+// through Renderer.FunctionNames, matching RenderFuncDefault. See issue #594.
+func FuncOverrideCastOperand(castType string) func(*Context, *ast.FuncNode) (string, error) {
+	return func(rc *Context, fn *ast.FuncNode) (string, error) {
+		fnName := strings.ToLower(fn.FuncName())
+		if mapped, ok := rc.Renderer.FunctionNames[fnName]; ok {
+			fnName = mapped
+		}
+
+		children := fn.Children()
+		args := make([]string, len(children))
+		for i, child := range children {
+			s, err := RenderFuncArg(rc, child)
+			if err != nil {
+				return "", err
+			}
+			args[i] = "CAST(" + s + " AS " + castType + ")"
+		}
+
+		return fnName + "(" + strings.Join(args, ", ") + ")", nil
+	}
+}

--- a/libsq/query_func_test.go
+++ b/libsq/query_func_test.go
@@ -51,23 +51,16 @@ func TestQuery_func(t *testing.T) {
 			in:      `@sakila | .actor | avg(.actor_id)`,
 			wantSQL: `SELECT avg("actor_id") AS "avg(.actor_id)" FROM "actor"`,
 			override: driverMap{
-				drivertype.MySQL:      "SELECT avg(`actor_id`) AS `avg(.actor_id)` FROM `actor`",
+				drivertype.Pg:         `SELECT CAST(avg("actor_id") AS DOUBLE PRECISION) AS "avg(.actor_id)" FROM "actor"`,
+				drivertype.MySQL:      "SELECT CAST(avg(`actor_id`) AS DOUBLE) AS `avg(.actor_id)` FROM `actor`",
+				drivertype.MSSQL:      `SELECT avg(CAST("actor_id" AS FLOAT)) AS "avg(.actor_id)" FROM "actor"`,
 				drivertype.ClickHouse: "SELECT avg(`actor_id`) AS `avg(.actor_id)` FROM `actor`",
 				drivertype.Oracle:     `SELECT CAST(avg("ACTOR_ID") AS BINARY_DOUBLE) AS "AVG(.ACTOR_ID)" FROM "ACTOR"`,
 			},
 			wantRecCount: 1,
 			sinkFns: []SinkTestFunc{
 				assertSinkColName(0, "avg(.actor_id)"),
-
-				// FIXME: The driver impls handle avg() differently. Some return
-				// float64, some int, some decimal (string). The SLQ impl of avg()
-				// needs to be modified to returned a consistent type.
-				// assertSinkColValue(0, float64(100.5)),
-				//
-				// See also:
-				// - https://github.com/golang/go/issues/30870
-				// - https://github.com/golang-sql/decomposer
-
+				assertSinkColValue(0, float64(100.5)),
 			},
 		},
 	}

--- a/site/content/en/docs/query/index.md
+++ b/site/content/en/docs/query/index.md
@@ -896,6 +896,19 @@ avg(.amount)
 4.2006673312974065
 ```
 
+`avg` returns a floating-point value on every SQL driver, so its type is
+consistent regardless of source. On Postgres and MySQL, whose native `AVG`
+returns an exact decimal, `sq` casts the result to a float for portability,
+which can lose precision for averages beyond roughly 15 to 17 significant
+digits. If you need the exact decimal, query with native SQL via the
+[`sq sql`](/docs/cmd/sql) command.
+
+{{< alert icon="👉" >}}
+On SQL Server, `AVG` over an integer column natively performs integer division
+and truncates (the average of `1` to `200` would be `100`, not `100.5`). `sq`
+casts the operand to a float so `avg` returns the true fractional value.
+{{< /alert >}}
+
 ### `count`
 
 The no-arg `count` function returns the total number of rows.


### PR DESCRIPTION
Closes #594.

## Problem

`avg()` rendered to each backend's native `AVG()` and surfaced whatever Go type
the driver returned, so the same query produced three categorically different
results depending on the source:

- `float64` on SQLite, rqlite, DuckDB, ClickHouse, Oracle
- `decimal.Decimal` on Postgres and MySQL
- a truncated `int64` on SQL Server

The SQL Server case was an actual correctness bug: `AVG` over an integer column
performs integer division and truncates, so `avg` of `1..200` returned `100`,
not `100.5`. There was also no portable type for callers to consume `avg()`
output across sources.

Per the discussion in #594, the fix follows sq's jq-style ergonomics: `avg()`
returns a uniform `float64` everywhere (Option A). A lossless-decimal path is
tracked separately as follow-ups (#836 explicit SLQ cast, #837 aggregate
result-type config option).

## Changes

Register a per-driver `avg()` override that pins the result to a float:

| Driver | Rendered SQL |
| --- | --- |
| Postgres | `CAST(avg(col) AS DOUBLE PRECISION)` |
| MySQL | `CAST(avg(col) AS DOUBLE)` |
| SQL Server | `avg(CAST(col AS FLOAT))` |
| SQLite / rqlite / DuckDB / ClickHouse | unchanged (already float) |
| Oracle | unchanged (`CAST(... AS BINARY_DOUBLE)`, done previously) |

SQL Server casts the **operand**, not the result: `CAST(AVG(col) AS FLOAT)`
would still truncate because `AVG` has already done integer division. To render
the operand in isolation, `render.RenderFuncArg` is extracted from
`RenderFuncDefault` (a behavior-preserving refactor).

## Testing

Re-enabled the previously-commented value assertion in `query_func_test.go`
(`assertSinkColValue(0, float64(100.5))`) for every driver and removed the
FIXME. Verified live against the sakila Docker sources:

- `TestQuery_func/avg` passes on all six configured SQL drivers (SQLite,
  Postgres, MySQL, SQL Server, ClickHouse, Oracle). Before this change,
  Postgres/MySQL (decimal) and SQL Server (`int64(100)`) failed the assertion.
- Full `TestQuery` suite and the touched driver packages pass.
- End-to-end CLI check across all eight SQL drivers (including DuckDB and
  rqlite) returns a clean `100.5` float; the SQL Server truncation is fixed.

## Scope

`avg()` only. `sum()` has related but distinct type variance (the sum of
integers is exact, so `float` would regress precision) and is tracked
separately in #839; it is intentionally not changed here.

## Related

- Discussion #845 : numeric type and decimal handling (design and feedback).
