### PR TITLE
docs: add Cursor Cloud setup notes to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -221,3 +221,48 @@ is present.
 
 Optional: set `DISABLE_TELEMETRY=1` to opt out of anonymous Skills CLI
 telemetry ([docs](https://skills.sh/docs/cli)).
+
+## Cursor Cloud specific instructions
+
+The Cursor Cloud VM ships with Go (per `go.mod`), `gcc`, and `make`. The update
+script installs `libicu-dev` (see below) and runs `go mod download`. Standard
+commands live in the `Makefile` (`make build`, `make test-short`, `make lint`);
+don't duplicate them, just use them. Notes below are the non-obvious gotchas.
+
+### Always unset `NO_COLOR` and `FORCE_COLOR` when running tests
+
+The VM environment exports `NO_COLOR=1` and `FORCE_COLOR=0`. Both break the Go
+test suite, in opposite directions, so the raw `make test` / `go test` commands
+fail in this environment unless you unset them:
+
+- `NO_COLOR=1` makes `fatih/color` a hard "no color" override that
+  `libsq/core/colorz` tests can't toggle back on, so `colorz` tests fail.
+- `FORCE_COLOR=0` is treated as "force color on" by
+  `libsq/core/termz.IsColorTerminal` (it only checks for a non-empty value), so
+  CLI output tests that write to a `*bytes.Buffer` hit an `*os.File` type
+  assertion and panic.
+
+Run the suite (or any `go test`) with both unset, e.g.:
+
+```bash
+env -u NO_COLOR -u FORCE_COLOR make test-short
+env -u NO_COLOR -u FORCE_COLOR go test -short -tags "sqlite_vtable sqlite_stat4 sqlite_fts5 sqlite_icu sqlite_introspect sqlite_json sqlite_math_functions" ./...
+```
+
+CI doesn't set either variable (and runs tests without a TTY), which is why CI
+is green. Building and running the `sq` binary itself is unaffected; this only
+bites the test suite.
+
+### `libicu-dev` is required for the Makefile build
+
+The `Makefile` `BUILD_TAGS` include `sqlite_icu`, so `mattn/go-sqlite3` needs
+ICU headers (`unicode/utypes.h`). The update script installs `libicu-dev`. The
+GitHub CI `BUILD_TAGS` omit `sqlite_icu`, so CI does not need it; if you build
+with CI's tag set you can skip ICU. `make lint` also shells out to
+`shellcheck` (for `install.sh`), which the update script installs.
+
+### Docker-backed driver tests are skipped
+
+Integration tests for Postgres, MySQL, SQL Server, and ClickHouse need the
+`sakiladb/*` Docker images; Docker is not installed by default. Use
+`make test-short` (or `go test -short`) to skip them, as above.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Set up the Cursor Cloud dev environment for the `sq` CLI and captured the
non-obvious gotchas in `AGENTS.md` under a new `## Cursor Cloud specific
instructions` section. The only code/docs change is the `AGENTS.md` addition;
no source was modified.

## Environment setup

- Toolchain present on the VM: Go 1.26.3 (auto-fetched per `go.mod`), `gcc`, `make`.
- Installed `libicu-dev` (required because the `Makefile` `BUILD_TAGS` include
  `sqlite_icu`, which needs `unicode/utypes.h`) and `shellcheck` (used by `make lint`).
- Update script (runs on VM startup): `sudo apt-get update` / `sudo apt-get install -y libicu-dev shellcheck` / `go mod download`.

## Key finding documented in AGENTS.md

The VM exports `NO_COLOR=1` and `FORCE_COLOR=0`, which break the Go test suite
in opposite ways:

- `NO_COLOR=1` makes `fatih/color` a hard override, so `libsq/core/colorz` tests fail.
- `FORCE_COLOR=0` is treated as "force color on" by `termz.IsColorTerminal`
  (non-empty check), so CLI output tests panic on an `*os.File` assertion against a `*bytes.Buffer`.

Run the suite with both unset: `env -u NO_COLOR -u FORCE_COLOR make test-short`.
CI is green because it sets neither and runs without a TTY.

## Verification

- `make build` → `dist/sq` builds, `sq version` runs.
- `env -u NO_COLOR -u FORCE_COLOR make test-short` → all packages pass.
- `make lint` → 0 issues; `make lint-markdown` → 0 errors.
- Hello-world: ingested a CSV, listed sources, ran an SLQ filter to JSON, and a raw SQL aggregation to CSV via the embedded SQLite engine.

[sq_hello_world_demo.log](https://cursor.com/agents/bc-bd62966c-3f3d-4174-a460-b0df96976246/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsq_hello_world_demo.log)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bd62966c-3f3d-4174-a460-b0df96976246"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bd62966c-3f3d-4174-a460-b0df96976246"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

