### PR TITLE
oracle: type ambiguous computed NUMBER as decimal (#844)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,16 @@ Breaking changes are annotated with ☢️, and alpha/beta features with 🐥.
 
 ### Fixed
 
+- [#844]: On [Oracle](https://sq.io/docs/drivers/oracle), a query whose result is a
+  computed `NUMBER` with a fractional value (e.g. a division like `.actor_id / 8`, or a
+  native `AVG`) no longer fails with a scan error. Oracle reports no usable precision or
+  scale for such computed numbers, so `sq` now types them as `decimal` (which is exact and
+  can hold a fractional value) rather than assuming an integer. This applies to both
+  [SLQ](https://sq.io/docs/query) queries and native [`sq sql`](https://sq.io/docs/cmd/sql).
+  - ☢️ A consequence is that an integer-valued computed result on Oracle (`max()`, `min()`,
+    an integer literal, integer arithmetic, or a `COUNT(*)` issued via `sq sql`) is now also
+    a `decimal`, so in JSON output it renders as a quoted string (e.g. `"200"`) rather than a
+    bare number. The `count()` and `rownum()` functions in SLQ remain integers.
 - [#594]: On [SQL Server](https://sq.io/docs/drivers/sqlserver), `avg()` over an
   integer column no longer performs integer division and truncates the result.
   For example, the average of `1..200` now returns `100.5`, not `100`.
@@ -1753,6 +1763,7 @@ make working with lots of sources much easier.
 [#821]: https://github.com/neilotoole/sq/issues/821
 [#834]: https://github.com/neilotoole/sq/issues/834
 [#839]: https://github.com/neilotoole/sq/issues/839
+[#844]: https://github.com/neilotoole/sq/issues/844
 
 [v0.15.2]: https://github.com/neilotoole/sq/releases/tag/v0.15.2
 [v0.15.3]: https://github.com/neilotoole/sq/compare/v0.15.2...v0.15.3

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,6 +117,20 @@ sq-side caller, not deep inside the external code.
 Avoid `fmt.Errorf` and `errors.New` outside sentinel declarations — they
 produce stackless errors that surface upstream with no useful trace.
 
+### Passing data: prefer explicit signatures over `context.Value`
+
+Don't smuggle values through `context.Context` to avoid a signature or
+interface change. `context.Value` is for request-scoped metadata
+(cancellation, deadlines, trace/logging IDs), not for data a function needs
+to compute its result. If a value materially affects what a function returns
+or does, thread it as an explicit parameter (or field), even when that means
+changing an exported signature or a driver-interface method. sq is pre-v1.0.0,
+so such changes are acceptable and expected; reach for the cleaner API rather
+than working around the old one.
+
+If a `context.Value`-based approach genuinely seems warranted (it rarely is),
+stop and ask before taking that path.
+
 ### English spelling
 
 Use US English in all prose: code comments, godoc, user-facing strings,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,6 +131,12 @@ than working around the old one.
 If a `context.Value`-based approach genuinely seems warranted (it rarely is),
 stop and ask before taking that path.
 
+One legacy exception predates this rule: render-time result-column kind hints
+are passed to a driver's `RecordMeta` via `context.Value`
+(`render.NewContextWithResultColumnKinds`). It's tracked for removal in
+[#848](https://github.com/neilotoole/sq/issues/848); don't extend it or model
+new code on it.
+
 ### English spelling
 
 Use US English in all prose: code comments, godoc, user-facing strings,

--- a/drivers/oracle/internal_test.go
+++ b/drivers/oracle/internal_test.go
@@ -156,10 +156,12 @@ func TestRefineBareNumberKind(t *testing.T) {
 		ok               bool
 		want             kind.Kind
 	}{
-		// COUNT(*), SUM, integer literals — Oracle reports (38, 255).
-		{"floating_38_255", 38, oracleScaleFloating, true, kind.Int},
-		// Same shape, different precision — still floating.
-		{"floating_0_255", 0, oracleScaleFloating, true, kind.Int},
+		// The floating-scale form (scale 255) is ambiguous: COUNT(*), SUM, AVG,
+		// integer literals, and division all report it. It maps to kind.Decimal
+		// so fractional values (e.g. division) don't crash an int64 scan (#844).
+		{"floating_38_255", 38, oracleScaleFloating, true, kind.Decimal},
+		// Same shape, different precision — still floating, still decimal.
+		{"floating_0_255", 0, oracleScaleFloating, true, kind.Decimal},
 		// NUMBER(p,0) with p in [1..19] is int range.
 		{"int_5_0", 5, 0, true, kind.Int},
 		{"int_19_0", 19, 0, true, kind.Int},

--- a/drivers/oracle/oracle.go
+++ b/drivers/oracle/oracle.go
@@ -189,6 +189,16 @@ func (d *driveri) Renderer() *render.Renderer {
 	// digits; a sum of values with more decimal places is rounded to that scale.
 	r.FunctionOverrides[ast.FuncNameSum] = render.FuncOverrideCastResult(
 		fmt.Sprintf("NUMBER(%d, %d)", render.AggDecimalPrecision, render.AggDecimalScale))
+	// count(), count_unique(), and rownum() are integer-valued, but Oracle reports
+	// their result column as the same floating-scale NUMBER as division and other
+	// arithmetic, which refineBareNumberKind now classifies as kind.Decimal to
+	// avoid the fractional-value scan crash (issue #844). Without intervention
+	// these would surface as a decimal string ("200") instead of an integer. Pin
+	// them to kind.Int so they scan as int64 and stay numbers, matching every
+	// other driver. RecordMeta applies these hints via ResultColumnKindsFromContext.
+	r.FunctionResultKinds[ast.FuncNameCount] = kind.Int
+	r.FunctionResultKinds[ast.FuncNameCountUnique] = kind.Int
+	r.FunctionResultKinds[ast.FuncNameRowNum] = kind.Int
 	return r
 }
 
@@ -598,6 +608,13 @@ func (d *driveri) RecordMeta(
 	sColTypeData := make([]*record.ColumnTypeData, len(colTypes))
 	ogColNames := make([]string, len(colTypes))
 
+	// kindHints carries forced result-column kinds recorded during rendering,
+	// e.g. count() and rownum() pinned to kind.Int. Oracle reports their result
+	// column as a floating-scale NUMBER that refineBareNumberKind classifies as
+	// kind.Decimal (to avoid the fractional-value scan crash, issue #844), so
+	// without a hint these integer-valued functions would surface as decimal.
+	kindHints := render.ResultColumnKindsFromContext(ctx)
+
 	for i, colType := range colTypes {
 		knd := kindFromDBTypeName(d.log, colType.Name(), colType.DatabaseTypeName())
 		// Refine bare NUMBER using precision/scale from the column type metadata.
@@ -605,6 +622,11 @@ func (d *driveri) RecordMeta(
 		// DatabaseTypeName(), so DecimalSize() distinguishes integer-range columns.
 		if colType.DatabaseTypeName() == "NUMBER" && knd == kind.Decimal {
 			knd = refineBareNumberKind(colType.DecimalSize())
+		}
+		if hint, ok := kindHints[i]; ok {
+			// Force the renderer-pinned kind; setScanType derives the scan
+			// target from it, so kind.Int yields an int64 scan.
+			knd = hint
 		}
 		colTypeData := record.NewColumnTypeData(colType, knd)
 		d.setScanType(colTypeData, knd)

--- a/drivers/oracle/render.go
+++ b/drivers/oracle/render.go
@@ -136,21 +136,26 @@ const oracleScaleFloating = 255
 
 // refineBareNumberKind refines a kind.Decimal classification for a bare-NUMBER
 // column using the precision/scale info from sql.ColumnType.DecimalSize(). It
-// returns kind.Int when the column's precision/scale indicate integer-range
-// values, and kind.Decimal otherwise (the safe default).
+// returns kind.Int only when the precision/scale pin the column to the integer
+// range, and kind.Decimal otherwise (the safe default).
 //
-// COUNT(*), SUM, and integer literals come back as NUMBER(38, oracleScaleFloating);
-// other SQL drivers (Postgres, MySQL, …) return such aggregates as int64, so
-// we map the floating-scale form to kind.Int to match cross-driver convention.
-// NUMBER(p, 0) with p in [1..19] is also int-range.
+// The floating-scale form NUMBER(38, oracleScaleFloating) is ambiguous: COUNT(*),
+// SUM, AVG, integer literals, division, and other arithmetic all report it, and
+// Oracle won't say whether the value is integral. Classifying it as kind.Int
+// crashes the scan when the value is fractional (e.g. a division like
+// actor_id/8 yields "7.25", which won't parse into int64). So the floating-scale
+// form maps to kind.Decimal, which is exact and scans any value without error,
+// for both SLQ and native sq sql. See issue #844.
+//
+// count(), count_unique(), and rownum() are integer-valued but share this
+// ambiguous form; they are pinned back to kind.Int via Renderer.FunctionResultKinds
+// (see Renderer), which RecordMeta applies. A bare NUMBER(p, 0) with p in [1..19]
+// is unambiguously int-range and stays kind.Int.
 func refineBareNumberKind(precision, scale int64, ok bool) kind.Kind {
 	if !ok {
 		return kind.Decimal
 	}
-	switch {
-	case scale == oracleScaleFloating:
-		return kind.Int
-	case scale == 0 && precision > 0 && precision <= 19:
+	if scale == 0 && precision > 0 && precision <= 19 {
 		return kind.Int
 	}
 	return kind.Decimal

--- a/libsq/libsq_test.go
+++ b/libsq/libsq_test.go
@@ -153,7 +153,9 @@ func TestQuerySQL_Count(t *testing.T) { //nolint:tparallel
 				require.Equal(t, int64(sakila.TblActorCount), v)
 			case decimal.Decimal:
 				require.Equal(t, drivertype.Oracle, src.Type)
-				require.Equal(t, int64(sakila.TblActorCount), v.IntPart())
+				// Exact equality (not v.IntPart(), which would truncate and hide a
+				// stray fractional count).
+				require.Equal(t, decimal.NewFromInt(int64(sakila.TblActorCount)), v)
 			default:
 				require.Failf(t, "unexpected count type", "got %T", v)
 			}

--- a/libsq/libsq_test.go
+++ b/libsq/libsq_test.go
@@ -163,6 +163,31 @@ func TestQuerySQL_Count(t *testing.T) { //nolint:tparallel
 	}
 }
 
+// TestQuerySQL_OracleFractionalNumber guards #844 for native sq sql: on Oracle a
+// computed NUMBER with a fractional value (division, AVG) reports a bare NUMBER with
+// no integer scale, so it must surface as decimal and not crash an int64 scan. This
+// is the native counterpart to the SLQ coverage in TestQuery_oracle_fractionalNumber.
+func TestQuerySQL_OracleFractionalNumber(t *testing.T) {
+	th := testh.New(t)
+	src := th.Source(sakila.Ora23) // skips the test if Oracle is not configured.
+
+	requireDecimal := func(sink *testh.RecordSink, want string) {
+		t.Helper()
+		require.Equal(t, 1, len(sink.Recs))
+		v, ok := sink.Recs[0][0].(decimal.Decimal)
+		require.Truef(t, ok, "want decimal.Decimal, got %T", sink.Recs[0][0])
+		require.Equal(t, want, stringz.FormatDecimal(v))
+	}
+
+	sink, err := th.QuerySQL(src, nil, "SELECT actor_id/8 AS q FROM actor WHERE actor_id = 58")
+	require.NoError(t, err)
+	requireDecimal(sink, "7.25")
+
+	sink, err = th.QuerySQL(src, nil, "SELECT AVG(actor_id) AS q FROM actor")
+	require.NoError(t, err)
+	requireDecimal(sink, "100.5")
+}
+
 // TestJoinDuplicateColNamesAreRenamed verifies that sq correctly handles JOIN
 // queries that produce duplicate column names in the result set.
 //

--- a/libsq/libsq_test.go
+++ b/libsq/libsq_test.go
@@ -6,12 +6,14 @@ import (
 	"testing"
 
 	"github.com/samber/lo"
+	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/neilotoole/sq/libsq/core/sqlz"
 	"github.com/neilotoole/sq/libsq/core/stringz"
 	"github.com/neilotoole/sq/libsq/source"
+	"github.com/neilotoole/sq/libsq/source/drivertype"
 	"github.com/neilotoole/sq/testh"
 	"github.com/neilotoole/sq/testh/sakila"
 	"github.com/neilotoole/sq/testh/tu"
@@ -143,9 +145,18 @@ func TestQuerySQL_Count(t *testing.T) { //nolint:tparallel
 
 			sink, err = th.QuerySQL(src, nil, "SELECT COUNT(*) FROM "+sakila.TblActor)
 			require.NoError(t, err)
-			count, ok := sink.Recs[0][0].(int64)
-			require.True(t, ok)
-			require.Equal(t, int64(sakila.TblActorCount), count)
+			// Oracle reports COUNT(*) in native SQL as a bare NUMBER with no integer
+			// scale, surfaced as decimal. SLQ count() is pinned back to int via a
+			// renderer hint, but native sq sql has no such hook; see #844.
+			switch v := sink.Recs[0][0].(type) {
+			case int64:
+				require.Equal(t, int64(sakila.TblActorCount), v)
+			case decimal.Decimal:
+				require.Equal(t, drivertype.Oracle, src.Type)
+				require.Equal(t, int64(sakila.TblActorCount), v.IntPart())
+			default:
+				require.Failf(t, "unexpected count type", "got %T", v)
+			}
 		})
 	}
 }

--- a/libsq/query_count_test.go
+++ b/libsq/query_count_test.go
@@ -6,6 +6,7 @@ import (
 	_ "github.com/mattn/go-sqlite3"
 
 	"github.com/neilotoole/sq/libsq/source/drivertype"
+	"github.com/neilotoole/sq/testh/sakila"
 )
 
 //nolint:exhaustive
@@ -20,6 +21,10 @@ func TestQuery_count(t *testing.T) {
 				drivertype.ClickHouse: "SELECT count(*) AS `quantity` FROM `actor`",
 			},
 			wantRecCount: 1,
+			// count() must surface as int64 on every driver, including Oracle,
+			// where the result is pinned to kind.Int (Renderer.FunctionResultKinds)
+			// so it does not regress to a decimal string. See #844.
+			sinkFns: []SinkTestFunc{assertSinkCellValue(0, 0, int64(sakila.TblActorCount))},
 		},
 		{
 			name:    "count-same-alias",

--- a/libsq/query_expr_test.go
+++ b/libsq/query_expr_test.go
@@ -224,6 +224,28 @@ func TestQuery_expr_literal(t *testing.T) {
 	}
 }
 
+// TestQuery_oracle_fractionalNumber guards #844 end-to-end: on Oracle a computed
+// NUMBER with a fractional value (here, division) must surface as a decimal rather
+// than crash an int64 scan. Oracle-only because division semantics and the result
+// type differ across drivers (#838), so a cross-driver value assertion is not
+// meaningful; the integer-division drivers would truncate to 7, not 7.25.
+func TestQuery_oracle_fractionalNumber(t *testing.T) {
+	testCases := []queryTestCase{
+		{
+			name:         "division",
+			in:           `@sakila | .actor | where(.actor_id == 58) | (.actor_id / 8)`,
+			onlyFor:      []drivertype.Type{drivertype.Oracle},
+			wantRecCount: 1,
+			sinkFns:      []SinkTestFunc{assertSinkColDecimal(0, "7.25", nil)},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			execQueryTestCase(t, tc)
+		})
+	}
+}
+
 //nolint:exhaustive
 func TestQuery_expr_where_bool(t *testing.T) {
 	// Note that there's no actual field .actor.is_alive, thus we're only testing

--- a/libsq/query_expr_test.go
+++ b/libsq/query_expr_test.go
@@ -90,7 +90,7 @@ func TestQuery_expr_literal(t *testing.T) {
 				drivertype.ClickHouse: "SELECT `first_name`, 1 AS `1` FROM `actor`",
 			},
 			wantRecCount: sakila.TblActorCount,
-			sinkFns:      []SinkTestFunc{assertSinkColValue(1, int64(1))},
+			sinkFns:      []SinkTestFunc{assertSinkColInt(1, 1)},
 		},
 		{
 			name:    "table/literal",
@@ -101,7 +101,7 @@ func TestQuery_expr_literal(t *testing.T) {
 				drivertype.ClickHouse: "SELECT 1 AS `1` FROM `actor`",
 			},
 			wantRecCount: sakila.TblActorCount,
-			sinkFns:      []SinkTestFunc{assertSinkColValue(0, int64(1))},
+			sinkFns:      []SinkTestFunc{assertSinkColInt(0, 1)},
 		},
 		{
 			name:    "no-table/literal",
@@ -113,7 +113,7 @@ func TestQuery_expr_literal(t *testing.T) {
 				drivertype.Oracle:     `SELECT 1 AS "1" FROM DUAL`,
 			},
 			wantRecCount: 1,
-			sinkFns:      []SinkTestFunc{assertSinkColValue(0, int64(1))},
+			sinkFns:      []SinkTestFunc{assertSinkColInt(0, 1)},
 		},
 		{
 			name:    "no-table/literal_addition",
@@ -125,7 +125,7 @@ func TestQuery_expr_literal(t *testing.T) {
 				drivertype.Oracle:     `SELECT 1+1 AS "1+1" FROM DUAL`,
 			},
 			wantRecCount: 1,
-			sinkFns:      []SinkTestFunc{assertSinkColValue(0, int64(2))},
+			sinkFns:      []SinkTestFunc{assertSinkColInt(0, 2)},
 		},
 		{
 			name:    "table/literal_parens",
@@ -136,7 +136,7 @@ func TestQuery_expr_literal(t *testing.T) {
 				drivertype.ClickHouse: "SELECT (1) AS `(1)` FROM `actor`",
 			},
 			wantRecCount: sakila.TblActorCount,
-			sinkFns:      []SinkTestFunc{assertSinkColValue(0, int64(1))},
+			sinkFns:      []SinkTestFunc{assertSinkColInt(0, 1)},
 		},
 		{
 			name:    "table/addition",
@@ -147,7 +147,7 @@ func TestQuery_expr_literal(t *testing.T) {
 				drivertype.ClickHouse: "SELECT 1+2 AS `1+2` FROM `actor`",
 			},
 			wantRecCount: sakila.TblActorCount,
-			sinkFns:      []SinkTestFunc{assertSinkColValue(0, int64(3))},
+			sinkFns:      []SinkTestFunc{assertSinkColInt(0, 3)},
 		},
 		{
 			name:    "table/addition_whitespace",
@@ -158,7 +158,7 @@ func TestQuery_expr_literal(t *testing.T) {
 				drivertype.ClickHouse: "SELECT 1+2+3 AS `1+2+3` FROM `actor`",
 			},
 			wantRecCount: sakila.TblActorCount,
-			sinkFns:      []SinkTestFunc{assertSinkColValue(0, int64(6))},
+			sinkFns:      []SinkTestFunc{assertSinkColInt(0, 6)},
 		},
 		{
 			name:    "table/math_parens",
@@ -169,7 +169,7 @@ func TestQuery_expr_literal(t *testing.T) {
 				drivertype.ClickHouse: "SELECT ((2+2)*3) AS `((2+2)*3)` FROM `actor`",
 			},
 			wantRecCount: sakila.TblActorCount,
-			sinkFns:      []SinkTestFunc{assertSinkColValue(0, int64(12))},
+			sinkFns:      []SinkTestFunc{assertSinkColInt(0, 12)},
 		},
 		{
 			name:    "table/literal_alias",
@@ -182,7 +182,7 @@ func TestQuery_expr_literal(t *testing.T) {
 			wantRecCount: sakila.TblActorCount,
 			sinkFns: []SinkTestFunc{
 				assertSinkColName(0, "total"),
-				assertSinkColValue(0, int64(1)),
+				assertSinkColInt(0, 1),
 			},
 		},
 		{
@@ -194,7 +194,7 @@ func TestQuery_expr_literal(t *testing.T) {
 				drivertype.ClickHouse: "SELECT (1+2) AS `total` FROM `actor`",
 			},
 			sinkFns: []SinkTestFunc{
-				assertSinkColValue(0, int64(3)),
+				assertSinkColInt(0, 3),
 				assertSinkColName(0, "total"),
 			},
 			wantRecCount: sakila.TblActorCount,
@@ -210,7 +210,7 @@ func TestQuery_expr_literal(t *testing.T) {
 				drivertype.ClickHouse: "SELECT (1+2) AS `count` FROM `actor`",
 			},
 			sinkFns: []SinkTestFunc{
-				assertSinkColValue(0, int64(3)),
+				assertSinkColInt(0, 3),
 				assertSinkColName(0, "count"),
 			},
 			wantRecCount: sakila.TblActorCount,

--- a/libsq/query_func_test.go
+++ b/libsq/query_func_test.go
@@ -30,7 +30,7 @@ func TestQuery_func(t *testing.T) {
 			wantRecCount: 1,
 			sinkFns: []SinkTestFunc{
 				assertSinkColName(0, "max(.actor_id)"),
-				assertSinkColValue(0, int64(200)),
+				assertSinkColInt(0, 200),
 			},
 		},
 		{
@@ -44,7 +44,7 @@ func TestQuery_func(t *testing.T) {
 			wantRecCount: 1,
 			sinkFns: []SinkTestFunc{
 				assertSinkColName(0, "min(.actor_id)"),
-				assertSinkColValue(0, int64(1)),
+				assertSinkColInt(0, 1),
 			},
 		},
 		{
@@ -61,7 +61,7 @@ func TestQuery_func(t *testing.T) {
 			wantRecCount: 1,
 			sinkFns: []SinkTestFunc{
 				assertSinkColName(0, "avg(.actor_id)"),
-				assertSinkColValue(0, float64(100.5)),
+				assertSinkColValue(float64(100.5)),
 			},
 		},
 		{
@@ -145,7 +145,7 @@ func TestQuery_func_schema(t *testing.T) {
 			wantRecCount: 1,
 			sinkFns: []SinkTestFunc{
 				assertSinkColName(0, "schema()"),
-				assertSinkColValue(0, "dbo"),
+				assertSinkColValue("dbo"),
 			},
 		},
 		{
@@ -161,7 +161,7 @@ func TestQuery_func_schema(t *testing.T) {
 			wantRecCount: 1,
 			sinkFns: []SinkTestFunc{
 				assertSinkColName(0, "schema()"),
-				assertSinkColValue(0, "dbo"),
+				assertSinkColValue("dbo"),
 			},
 		},
 		{
@@ -172,7 +172,7 @@ func TestQuery_func_schema(t *testing.T) {
 			wantRecCount: 1,
 			sinkFns: []SinkTestFunc{
 				assertSinkColName(0, "schema()"),
-				assertSinkColValue(0, "public"),
+				assertSinkColValue("public"),
 			},
 		},
 		{
@@ -186,7 +186,7 @@ func TestQuery_func_schema(t *testing.T) {
 			wantRecCount: 1,
 			sinkFns: []SinkTestFunc{
 				assertSinkColName(0, "schema()"),
-				assertSinkColValue(0, infoSchema),
+				assertSinkColValue(infoSchema),
 			},
 		},
 		{
@@ -197,7 +197,7 @@ func TestQuery_func_schema(t *testing.T) {
 			wantRecCount: 1,
 			sinkFns: []SinkTestFunc{
 				assertSinkColName(0, "schema()"),
-				assertSinkColValue(0, "sakila"),
+				assertSinkColValue("sakila"),
 			},
 		},
 		{
@@ -211,7 +211,7 @@ func TestQuery_func_schema(t *testing.T) {
 			wantRecCount: 1,
 			sinkFns: []SinkTestFunc{
 				assertSinkColName(0, "schema()"),
-				assertSinkColValue(0, infoSchema),
+				assertSinkColValue(infoSchema),
 			},
 		},
 		{
@@ -222,7 +222,7 @@ func TestQuery_func_schema(t *testing.T) {
 			wantRecCount: 1,
 			sinkFns: []SinkTestFunc{
 				assertSinkColName(0, "schema()"),
-				assertSinkColValue(0, "main"),
+				assertSinkColValue("main"),
 			},
 		},
 		{
@@ -233,7 +233,7 @@ func TestQuery_func_schema(t *testing.T) {
 			wantRecCount: 1,
 			sinkFns: []SinkTestFunc{
 				assertSinkColName(0, "schema()"),
-				assertSinkColValue(0, "sakila"),
+				assertSinkColValue("sakila"),
 			},
 		},
 		{
@@ -265,7 +265,7 @@ func TestQuery_func_catalog(t *testing.T) {
 			wantRecCount: 1,
 			sinkFns: []SinkTestFunc{
 				assertSinkColName(0, "catalog()"),
-				assertSinkColValue(0, "sakila"),
+				assertSinkColValue("sakila"),
 			},
 		},
 		{
@@ -279,7 +279,7 @@ func TestQuery_func_catalog(t *testing.T) {
 			wantRecCount: 1,
 			sinkFns: []SinkTestFunc{
 				assertSinkColName(0, "catalog()"),
-				assertSinkColValue(0, "model"),
+				assertSinkColValue("model"),
 			},
 		},
 		{
@@ -290,7 +290,7 @@ func TestQuery_func_catalog(t *testing.T) {
 			wantRecCount: 1,
 			sinkFns: []SinkTestFunc{
 				assertSinkColName(0, "catalog()"),
-				assertSinkColValue(0, "sakila"),
+				assertSinkColValue("sakila"),
 			},
 		},
 		{
@@ -304,7 +304,7 @@ func TestQuery_func_catalog(t *testing.T) {
 			wantRecCount: 1,
 			sinkFns: []SinkTestFunc{
 				assertSinkColName(0, "catalog()"),
-				assertSinkColValue(0, "postgres"),
+				assertSinkColValue("postgres"),
 			},
 		},
 		{
@@ -315,7 +315,7 @@ func TestQuery_func_catalog(t *testing.T) {
 			wantRecCount: 1,
 			sinkFns: []SinkTestFunc{
 				assertSinkColName(0, "catalog()"),
-				assertSinkColValue(0, "def"),
+				assertSinkColValue("def"),
 			},
 		},
 		{
@@ -329,7 +329,7 @@ func TestQuery_func_catalog(t *testing.T) {
 			wantRecCount: 1,
 			sinkFns: []SinkTestFunc{
 				assertSinkColName(0, "catalog()"),
-				assertSinkColValue(0, "default"),
+				assertSinkColValue("default"),
 			},
 		},
 		{
@@ -340,7 +340,7 @@ func TestQuery_func_catalog(t *testing.T) {
 			wantRecCount: 1,
 			sinkFns: []SinkTestFunc{
 				assertSinkColName(0, "catalog()"),
-				assertSinkColValue(0, "sakila"),
+				assertSinkColValue("sakila"),
 			},
 		},
 		{
@@ -351,7 +351,7 @@ func TestQuery_func_catalog(t *testing.T) {
 			wantRecCount: 1,
 			sinkFns: []SinkTestFunc{
 				assertSinkColName(0, "catalog()"),
-				assertSinkColValue(0, "SAKILA"),
+				assertSinkColValue("SAKILA"),
 			},
 		},
 	}
@@ -396,8 +396,8 @@ func TestQuery_func_rownum(t *testing.T) {
 			wantRecCount: 200,
 			sinkFns: []SinkTestFunc{
 				assertSinkColName(0, "rownum()+1"),
-				assertSinkCellValue(0, 0, int64(2)),
-				assertSinkCellValue(199, 0, int64(201)),
+				assertSinkCellInt(0, 2),
+				assertSinkCellInt(199, 201),
 			},
 		},
 		{
@@ -412,8 +412,8 @@ func TestQuery_func_rownum(t *testing.T) {
 			wantRecCount: 200,
 			sinkFns: []SinkTestFunc{
 				assertSinkColName(0, "zero_index"),
-				assertSinkCellValue(0, 0, int64(0)),
-				assertSinkCellValue(199, 0, int64(199)),
+				assertSinkCellInt(0, 0),
+				assertSinkCellInt(199, 199),
 			},
 		},
 		{

--- a/libsq/query_func_test.go
+++ b/libsq/query_func_test.go
@@ -61,7 +61,7 @@ func TestQuery_func(t *testing.T) {
 			wantRecCount: 1,
 			sinkFns: []SinkTestFunc{
 				assertSinkColName(0, "avg(.actor_id)"),
-				assertSinkColValue(float64(100.5)),
+				assertSinkColValue(0, float64(100.5)),
 			},
 		},
 		{
@@ -145,7 +145,7 @@ func TestQuery_func_schema(t *testing.T) {
 			wantRecCount: 1,
 			sinkFns: []SinkTestFunc{
 				assertSinkColName(0, "schema()"),
-				assertSinkColValue("dbo"),
+				assertSinkColValue(0, "dbo"),
 			},
 		},
 		{
@@ -161,7 +161,7 @@ func TestQuery_func_schema(t *testing.T) {
 			wantRecCount: 1,
 			sinkFns: []SinkTestFunc{
 				assertSinkColName(0, "schema()"),
-				assertSinkColValue("dbo"),
+				assertSinkColValue(0, "dbo"),
 			},
 		},
 		{
@@ -172,7 +172,7 @@ func TestQuery_func_schema(t *testing.T) {
 			wantRecCount: 1,
 			sinkFns: []SinkTestFunc{
 				assertSinkColName(0, "schema()"),
-				assertSinkColValue("public"),
+				assertSinkColValue(0, "public"),
 			},
 		},
 		{
@@ -186,7 +186,7 @@ func TestQuery_func_schema(t *testing.T) {
 			wantRecCount: 1,
 			sinkFns: []SinkTestFunc{
 				assertSinkColName(0, "schema()"),
-				assertSinkColValue(infoSchema),
+				assertSinkColValue(0, infoSchema),
 			},
 		},
 		{
@@ -197,7 +197,7 @@ func TestQuery_func_schema(t *testing.T) {
 			wantRecCount: 1,
 			sinkFns: []SinkTestFunc{
 				assertSinkColName(0, "schema()"),
-				assertSinkColValue("sakila"),
+				assertSinkColValue(0, "sakila"),
 			},
 		},
 		{
@@ -211,7 +211,7 @@ func TestQuery_func_schema(t *testing.T) {
 			wantRecCount: 1,
 			sinkFns: []SinkTestFunc{
 				assertSinkColName(0, "schema()"),
-				assertSinkColValue(infoSchema),
+				assertSinkColValue(0, infoSchema),
 			},
 		},
 		{
@@ -222,7 +222,7 @@ func TestQuery_func_schema(t *testing.T) {
 			wantRecCount: 1,
 			sinkFns: []SinkTestFunc{
 				assertSinkColName(0, "schema()"),
-				assertSinkColValue("main"),
+				assertSinkColValue(0, "main"),
 			},
 		},
 		{
@@ -233,7 +233,7 @@ func TestQuery_func_schema(t *testing.T) {
 			wantRecCount: 1,
 			sinkFns: []SinkTestFunc{
 				assertSinkColName(0, "schema()"),
-				assertSinkColValue("sakila"),
+				assertSinkColValue(0, "sakila"),
 			},
 		},
 		{
@@ -265,7 +265,7 @@ func TestQuery_func_catalog(t *testing.T) {
 			wantRecCount: 1,
 			sinkFns: []SinkTestFunc{
 				assertSinkColName(0, "catalog()"),
-				assertSinkColValue("sakila"),
+				assertSinkColValue(0, "sakila"),
 			},
 		},
 		{
@@ -279,7 +279,7 @@ func TestQuery_func_catalog(t *testing.T) {
 			wantRecCount: 1,
 			sinkFns: []SinkTestFunc{
 				assertSinkColName(0, "catalog()"),
-				assertSinkColValue("model"),
+				assertSinkColValue(0, "model"),
 			},
 		},
 		{
@@ -290,7 +290,7 @@ func TestQuery_func_catalog(t *testing.T) {
 			wantRecCount: 1,
 			sinkFns: []SinkTestFunc{
 				assertSinkColName(0, "catalog()"),
-				assertSinkColValue("sakila"),
+				assertSinkColValue(0, "sakila"),
 			},
 		},
 		{
@@ -304,7 +304,7 @@ func TestQuery_func_catalog(t *testing.T) {
 			wantRecCount: 1,
 			sinkFns: []SinkTestFunc{
 				assertSinkColName(0, "catalog()"),
-				assertSinkColValue("postgres"),
+				assertSinkColValue(0, "postgres"),
 			},
 		},
 		{
@@ -315,7 +315,7 @@ func TestQuery_func_catalog(t *testing.T) {
 			wantRecCount: 1,
 			sinkFns: []SinkTestFunc{
 				assertSinkColName(0, "catalog()"),
-				assertSinkColValue("def"),
+				assertSinkColValue(0, "def"),
 			},
 		},
 		{
@@ -329,7 +329,7 @@ func TestQuery_func_catalog(t *testing.T) {
 			wantRecCount: 1,
 			sinkFns: []SinkTestFunc{
 				assertSinkColName(0, "catalog()"),
-				assertSinkColValue("default"),
+				assertSinkColValue(0, "default"),
 			},
 		},
 		{
@@ -340,7 +340,7 @@ func TestQuery_func_catalog(t *testing.T) {
 			wantRecCount: 1,
 			sinkFns: []SinkTestFunc{
 				assertSinkColName(0, "catalog()"),
-				assertSinkColValue("sakila"),
+				assertSinkColValue(0, "sakila"),
 			},
 		},
 		{
@@ -351,7 +351,7 @@ func TestQuery_func_catalog(t *testing.T) {
 			wantRecCount: 1,
 			sinkFns: []SinkTestFunc{
 				assertSinkColName(0, "catalog()"),
-				assertSinkColValue("SAKILA"),
+				assertSinkColValue(0, "SAKILA"),
 			},
 		},
 	}
@@ -396,8 +396,8 @@ func TestQuery_func_rownum(t *testing.T) {
 			wantRecCount: 200,
 			sinkFns: []SinkTestFunc{
 				assertSinkColName(0, "rownum()+1"),
-				assertSinkCellInt(0, 2),
-				assertSinkCellInt(199, 201),
+				assertSinkCellInt(0, 0, 2),
+				assertSinkCellInt(199, 0, 201),
 			},
 		},
 		{
@@ -412,8 +412,8 @@ func TestQuery_func_rownum(t *testing.T) {
 			wantRecCount: 200,
 			sinkFns: []SinkTestFunc{
 				assertSinkColName(0, "zero_index"),
-				assertSinkCellInt(0, 0),
-				assertSinkCellInt(199, 199),
+				assertSinkCellInt(0, 0, 0),
+				assertSinkCellInt(199, 0, 199),
 			},
 		},
 		{

--- a/libsq/query_func_test.go
+++ b/libsq/query_func_test.go
@@ -396,6 +396,10 @@ func TestQuery_func_rownum(t *testing.T) {
 			wantRecCount: 200,
 			sinkFns: []SinkTestFunc{
 				assertSinkColName(0, "rownum()+1"),
+				// rownum() as a direct result column is pinned to int (see the
+				// "plain" case, which asserts int64). Here rownum() is inside an
+				// arithmetic expression, which the pin does not reach, so on Oracle
+				// the result surfaces as decimal; assertSinkCellInt accounts for that.
 				assertSinkCellInt(0, 0, 2),
 				assertSinkCellInt(199, 0, 201),
 			},

--- a/libsq/query_test.go
+++ b/libsq/query_test.go
@@ -276,13 +276,50 @@ func assertSinkCellValue(rowi, coli int, val any) SinkTestFunc {
 	}
 }
 
+// oracleInt returns the value an integer-valued result carries for src type:
+// int64(n) for every driver except Oracle, where computed integer expressions
+// (literals, arithmetic, max/min, native count) surface as decimal.Decimal.
+// Oracle reports such results as a bare NUMBER with no integer scale, which sq
+// classifies as kind.Decimal to avoid a fractional-value scan crash (issue
+// #844); SLQ count()/rownum() are pinned back to int, but other computed
+// integers are not. Operand-aware typing that would keep them integer is tracked
+// in #838.
+func oracleInt(srcType drivertype.Type, n int64) any {
+	if srcType == drivertype.Oracle {
+		return decimal.NewFromInt(n)
+	}
+	return n
+}
+
+// assertSinkColInt asserts that column coli of every record is the integer n,
+// accounting for Oracle surfacing computed integers as decimal (see oracleInt).
+func assertSinkColInt(coli int, n int64) SinkTestFunc {
+	return func(tb testing.TB, sink *testh.RecordSink) {
+		tb.Helper()
+		want := oracleInt(sink.SrcType, n)
+		for rowi, rec := range sink.Recs {
+			assert.Equal(tb, want, rec[coli], "record[%d:%d] (%s)", rowi, coli, sink.RecMeta[coli].Name())
+		}
+	}
+}
+
+// assertSinkCellInt asserts that the first column of record rowi is the integer
+// n, accounting for Oracle surfacing computed integers as decimal (see oracleInt).
+func assertSinkCellInt(rowi int, n int64) SinkTestFunc {
+	return func(tb testing.TB, sink *testh.RecordSink) {
+		tb.Helper()
+		want := oracleInt(sink.SrcType, n)
+		assert.Equal(tb, want, sink.Recs[rowi][0], "record[%d:0] (%s)", rowi, sink.RecMeta[0].Name())
+	}
+}
+
 // assertSinkColValue returns a SinkTestFunc that asserts that
-// the column with index coli of each record matches val.
-func assertSinkColValue(coli int, val any) SinkTestFunc {
+// the first column of each record matches val.
+func assertSinkColValue(val any) SinkTestFunc {
 	return func(tb testing.TB, sink *testh.RecordSink) {
 		tb.Helper()
 		for rowi, rec := range sink.Recs {
-			assert.Equal(tb, val, rec[coli], "record[%d:%d] (%s)", rowi, coli, sink.RecMeta[coli].Name())
+			assert.Equal(tb, val, rec[0], "record[%d:0] (%s)", rowi, sink.RecMeta[0].Name())
 		}
 	}
 }

--- a/libsq/query_test.go
+++ b/libsq/query_test.go
@@ -303,23 +303,27 @@ func assertSinkColInt(coli int, n int64) SinkTestFunc {
 	}
 }
 
-// assertSinkCellInt asserts that the first column of record rowi is the integer
-// n, accounting for Oracle surfacing computed integers as decimal (see oracleInt).
-func assertSinkCellInt(rowi int, n int64) SinkTestFunc {
+// assertSinkCellInt asserts that cell (rowi, coli) is the integer n, accounting
+// for Oracle surfacing computed integers as decimal (see oracleInt).
+//
+//nolint:unparam // coli is kept for parity with the assertSinkCell/Col family.
+func assertSinkCellInt(rowi, coli int, n int64) SinkTestFunc {
 	return func(tb testing.TB, sink *testh.RecordSink) {
 		tb.Helper()
 		want := oracleInt(sink.SrcType, n)
-		assert.Equal(tb, want, sink.Recs[rowi][0], "record[%d:0] (%s)", rowi, sink.RecMeta[0].Name())
+		assert.Equal(tb, want, sink.Recs[rowi][coli], "record[%d:%d] (%s)", rowi, coli, sink.RecMeta[coli].Name())
 	}
 }
 
 // assertSinkColValue returns a SinkTestFunc that asserts that
-// the first column of each record matches val.
-func assertSinkColValue(val any) SinkTestFunc {
+// the column with index coli of each record matches val.
+//
+//nolint:unparam // coli is kept for parity with the assertSinkCol family.
+func assertSinkColValue(coli int, val any) SinkTestFunc {
 	return func(tb testing.TB, sink *testh.RecordSink) {
 		tb.Helper()
 		for rowi, rec := range sink.Recs {
-			assert.Equal(tb, val, rec[0], "record[%d:0] (%s)", rowi, sink.RecMeta[0].Name())
+			assert.Equal(tb, val, rec[coli], "record[%d:%d] (%s)", rowi, coli, sink.RecMeta[coli].Name())
 		}
 	}
 }

--- a/libsq/query_test.go
+++ b/libsq/query_test.go
@@ -336,6 +336,8 @@ func assertSinkColValue(coli int, val any) SinkTestFunc {
 // defensively. A driver listed in perDriver uses its override value instead of
 // want, covering backends like SQLite/rqlite that compute decimal sums in
 // floating point and so surface a drifted value. See issue #839.
+//
+//nolint:unparam // coli is kept for parity with the assertSinkCol family.
 func assertSinkColDecimal(coli int, want string, perDriver driverMap) SinkTestFunc {
 	return func(tb testing.TB, sink *testh.RecordSink) {
 		tb.Helper()


### PR DESCRIPTION
Fixes #844.

## Summary

On Oracle, a query whose result is a computed `NUMBER` with a fractional value
(e.g. a division like `.actor_id / 8`, or a native `AVG`) failed at scan time:

```
$ sq '@sakila_or | .actor | (.actor_id / 8)' -j
sq: query against @sakila_or: sql: Scan error on column index 1,
  name "(.ACTOR_ID/8)": converting driver.Value type string ("7.25")
  to a int64: invalid syntax
```

sq typed the bare `NUMBER` result column as `int64`, but go-ora hands the
fractional value back as a string, and `"7.25"` will not parse into an `int64`.
This reproduced via native `sq sql` too (so it was not SLQ-specific), and the
same class of crash hit a native `SELECT AVG(actor_id)`.

The fix types ambiguous computed `NUMBER` as `decimal` (exact, scans any value),
and pins the integer-valued functions `count()` / `count_unique()` / `rownum()`
back to integer.

## Root cause investigation

Oracle reports **no usable precision or scale** for a computed `NUMBER`. The
question driving the fix was whether COUNT (always integer) could be told apart
from division (often fractional) at the type layer. The answer is no, and I
verified it from the wire up.

### 1. The data dictionary

Creating views over the expressions and reading `USER_TAB_COLUMNS` shows Oracle's
own resolved types: `COUNT`, `MAX`, `MIN`, literal, `SUM`, `AVG`, division,
multiplication, addition all resolve to unconstrained `NUMBER` (precision NULL,
scale NULL). Only a real stored column (`actor_id`) carries `(5, 0)`.

### 2. The go-ora wire describe

I patched go-ora's TTC describe parser (`parameter.go`) to log the raw
precision/scale bytes the server sends, before any normalization:

| Expression | raw precision | raw scale |
|---|---|---|
| `COUNT(*)` | 0 | **0** |
| `MAX(actor_id)` | 0 | **0** |
| `actor_id/8` (division) | 0 | **0** |
| `actor_id+1` | 0 | **0** |
| `AVG(actor_id)` | 0 | **0** |
| `SUM(actor_id)` | 0 | **0** |
| `42` (int literal) | 0 | **-127** |
| `actor_id` (real `NUMBER(5,0)`) | 5 | 0 |

`COUNT` and division arrive **byte-identical** (`prec=0, scale=0`). The integer
literal `42` is the lone oddball at `scale=-127` (Oracle's "floating" sentinel),
which cuts against intuition: the scale byte varies, but not in any way that
correlates with integer-vs-fractional. go-ora collapses both `(0,0)` and the
`-127` form to its internal `NUMBER(38, 255)` sentinel, but there was nothing
meaningful to preserve, because the inputs were already indistinguishable.

### 3. The Oracle JDBC driver (the reference)

To rule out a go-ora-specific limitation, I cross-checked against Oracle's own
pure-Java `ojdbc11` (23.6) driver, dumping `ResultSetMetaData` plus the returned
Java object type for the identical queries:

| Expression | JDBC typeName | prec | scale | colClassName | returned object |
|---|---|---|---|---|---|
| `COUNT(*)` | NUMBER | 0 | 0 | **BigDecimal** | `200` |
| `MAX(actor_id)` | NUMBER | 0 | 0 | **BigDecimal** | `200` |
| `actor_id/8` | NUMBER | 0 | 0 | **BigDecimal** | `0.125` |
| `actor_id+1` | NUMBER | 0 | 0 | **BigDecimal** | `2` |
| `42` literal | NUMBER | 0 | **-127** | **BigDecimal** | `42` |
| `AVG(actor_id)` | NUMBER | 0 | 0 | **BigDecimal** | `100.5` |
| `SUM(actor_id)` | NUMBER | 0 | 0 | **BigDecimal** | `20100` |
| `actor_id` `NUMBER(5,0)` | NUMBER | 5 | 0 | **BigDecimal** | `1` |

Two takeaways:

- **JDBC receives the exact same metadata as go-ora** (prec=0/scale=0 for COUNT
  and division; scale=-127 for the literal). The ambiguity is the Oracle
  server's, not the driver's. A reference client cannot manufacture a
  distinction the server never sent; OCI/JDBC speak the same TTC describe.
- **Oracle's mature JDBC driver's strategy is "decimal, always."** It maps every
  `NUMBER`, integer-valued or not, to `java.math.BigDecimal` (the Java analog of
  `kind.Decimal`). It uses no float anywhere and makes no attempt to auto-narrow
  COUNT to an integer; it leaves narrowing to the caller, who has context (a Java
  consumer who knows a column is a count calls `rs.getInt()`).

This directly informed the design: default the ambiguous bucket to the exact
type (decimal), and let the layer with context narrow it. sq's equivalent of
"the caller who knows" is its own AST, which is exactly what the per-function
pins do here and what operand-aware typing (#838) would generalize.

### Float was considered and rejected

Float would render integers cleanly as JSON numbers, but: it loses precision on
fractional results; it diverges from the `sum()`/exactness direction (#839); and
it makes Oracle internally inconsistent (`sum()` keeps its decimal cast and stays
a string, while `max`/`count` would become float numbers). Decimal matches both
JDBC's strategy and sq's existing direction, and fails visibly (a string) rather
than silently (a rounded number).

## The change

- `refineBareNumberKind` (`drivers/oracle/render.go`): the floating-scale bare
  `NUMBER` form now maps to `kind.Decimal` instead of `kind.Int`. This is the
  whole crash fix, and it reaches native `sq sql` too (which a renderer-level
  cast never could, since sq injects no SQL there).
- `count()`, `count_unique()`, `rownum()` are pinned to `kind.Int` via
  `Renderer.FunctionResultKinds`, applied in oracle `RecordMeta` from
  `ResultColumnKindsFromContext` (the mechanism SQLite/rqlite already use to pin
  `sum()` to decimal).

## Behavior

| Case | Before | After |
|---|---|---|
| native `actor_id/8` | scan crash | `"0.125"`, `"7.25"` |
| native `AVG(actor_id)` | scan crash | `"100.5"` |
| SLQ `count()` | `200` | `200` (unchanged) |
| SLQ `rownum()` | `1..200` | `1..200` (unchanged) |
| SLQ `sum()` / `avg()` | `"20100"` / `100.5` | unchanged |
| SLQ `max()` / `min()`, integer arithmetic, native `COUNT(*)` | number | decimal string (`"200"`) |

The last row is a deliberate, deferred consequence: integer-valued *computed*
results on Oracle (not stored columns) now surface as decimal, so in JSON they
render as quoted strings. Operand-aware integer narrowing for SLQ is tracked in
**#838**; the decimal string-vs-number rendering knob is **#846**
(`format.decimal`). The CHANGELOG entry marks this with the breaking-change flag.

## Testing

- New/updated `refineBareNumberKind` unit test for the floating-scale -> decimal
  classification.
- Updated cross-driver tests that asserted `int64` for now-decimal Oracle results:
  `TestQuery_func` (max/min), `TestQuery_func_rownum` (the `rownum()+1` /
  `rownum()-1` arithmetic cases), `TestQuery_expr_literal` (all 11 cases), and
  `TestQuerySQL_Count` (native count). Done via small focused helpers
  (`oracleInt` / `assertSinkColInt` / `assertSinkCellInt`).
- `make lint`, `make lint-markdown`, and `make fmt` clean.
- Green across all five live SQL drivers: `libsq`, `drivers/oracle`,
  `libsq/driver`, and the oracle-touching `cli` tests.


## Follow-ups

- #848: the `count()`/`count_unique()`/`rownum()` pins here reach the driver via
  the `context.Value`-based result-column kind hint mechanism (from #839). That
  side-channel should be threaded explicitly through `RecordMeta` instead;
  tracked separately and best folded into #838's render-path threading work.
