### PR TITLE
driver: thread RecordMeta kind hints explicitly, not via context (#848)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,11 +131,10 @@ than working around the old one.
 If a `context.Value`-based approach genuinely seems warranted (it rarely is),
 stop and ask before taking that path.
 
-One legacy exception predates this rule: render-time result-column kind hints
-are passed to a driver's `RecordMeta` via `context.Value`
-(`render.NewContextWithResultColumnKinds`). It's tracked for removal in
-[#848](https://github.com/neilotoole/sq/issues/848); don't extend it or model
-new code on it.
+For a worked example of this rule applied, see `SQLDriver.RecordMeta`: its
+result-column kind hints are threaded as an explicit parameter rather than
+smuggled through `context.Value` (resolved in
+[#848](https://github.com/neilotoole/sq/issues/848)).
 
 ### English spelling
 

--- a/cli/cmd_sql.go
+++ b/cli/cmd_sql.go
@@ -201,7 +201,7 @@ func execSQLPrint(ctx context.Context, ru *run.Run, fromSrc *source.Source, srcM
 
 	// This is a query, use QuerySQL
 	recw := output.NewRecordWriterAdapter(ctx, ru.Writers.Record)
-	err = libsq.QuerySQL(ctx, grip, nil, recw, sql)
+	err = libsq.QuerySQL(ctx, grip, nil, recw, nil, sql)
 	if err != nil {
 		return err
 	}
@@ -259,7 +259,7 @@ func execSQLInsert(ctx context.Context, ru *run.Run,
 	)
 
 	start := time.Now()
-	err = libsq.QuerySQL(ctx, fromGrip, nil, inserter, args[0])
+	err = libsq.QuerySQL(ctx, fromGrip, nil, inserter, nil, args[0])
 	if err != nil {
 		return errz.Wrapf(err, "insert to {%s} failed", source.Target(destSrc, destTbl))
 	}

--- a/cli/output/adapter_test.go
+++ b/cli/output/adapter_test.go
@@ -52,7 +52,7 @@ func TestRecordWriterAdapter(t *testing.T) {
 
 			sink := &testh.RecordSink{}
 			recw := output.NewRecordWriterAdapter(th.Context, sink)
-			err := libsq.QuerySQL(th.Context, grip, nil, recw, tc.sqlQuery)
+			err := libsq.QuerySQL(th.Context, grip, nil, recw, nil, tc.sqlQuery)
 			require.NoError(t, err)
 			written, err := recw.Wait()
 			require.NoError(t, err)

--- a/drivers/clickhouse/clickhouse.go
+++ b/drivers/clickhouse/clickhouse.go
@@ -324,7 +324,7 @@ func (d *driveri) Renderer() *render.Renderer {
 }
 
 // RecordMeta implements driver.SQLDriver.
-func (d *driveri) RecordMeta(ctx context.Context, colTypes []*sql.ColumnType) (
+func (d *driveri) RecordMeta(ctx context.Context, colTypes []*sql.ColumnType, _ map[int]kind.Kind) (
 	record.Meta, driver.NewRecordFunc, error,
 ) {
 	recMeta, err := recordMetaFromColumnTypes(ctx, colTypes)

--- a/drivers/csv/insert.go
+++ b/drivers/csv/insert.go
@@ -131,7 +131,7 @@ func getIngestRecMeta(ctx context.Context, destGrip driver.Grip, tblDef *schema.
 		return nil, err
 	}
 
-	destMeta, _, err := drvr.RecordMeta(ctx, colTypes)
+	destMeta, _, err := drvr.RecordMeta(ctx, colTypes, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/drivers/duckdb/duckdb.go
+++ b/drivers/duckdb/duckdb.go
@@ -347,7 +347,7 @@ func (d *driveri) TableColumnTypes(ctx context.Context, db sqlz.DB, tblName stri
 // are represented as nil in the driver.Value slice. The munge function
 // converts duckdb-specific types (Decimal, Interval, *big.Int, composites)
 // to sq's canonical record types.
-func (d *driveri) RecordMeta(ctx context.Context, colTypes []*sql.ColumnType) (
+func (d *driveri) RecordMeta(ctx context.Context, colTypes []*sql.ColumnType, _ map[int]kind.Kind) (
 	record.Meta, driver.NewRecordFunc, error,
 ) {
 	ctData := make([]*record.ColumnTypeData, len(colTypes))

--- a/drivers/duckdb/insert.go
+++ b/drivers/duckdb/insert.go
@@ -19,7 +19,7 @@ func (d *driveri) getTableRecordMeta(ctx context.Context, db sqlz.DB, tblName st
 		return nil, err
 	}
 
-	destCols, _, err := d.RecordMeta(ctx, colTypes)
+	destCols, _, err := d.RecordMeta(ctx, colTypes, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/drivers/duckdb/metadata_test.go
+++ b/drivers/duckdb/metadata_test.go
@@ -195,7 +195,7 @@ func TestRecordMeta_BlobScan(t *testing.T) {
 
 	colTypes, err := rows.ColumnTypes()
 	require.NoError(t, err)
-	recMeta, newRecFn, err := grip.SQLDriver().RecordMeta(ctx, colTypes)
+	recMeta, newRecFn, err := grip.SQLDriver().RecordMeta(ctx, colTypes, nil)
 	require.NoError(t, err)
 	require.Equal(t, kind.Bytes, recMeta[1].Kind())
 
@@ -534,7 +534,7 @@ func TestRecordMeta_BasicQuery(t *testing.T) {
 	colTypes, err := rows.ColumnTypes()
 	require.NoError(t, err)
 
-	recMeta, newRecFn, err := grip.SQLDriver().RecordMeta(context.Background(), colTypes)
+	recMeta, newRecFn, err := grip.SQLDriver().RecordMeta(context.Background(), colTypes, nil)
 	require.NoError(t, err)
 	require.NotNil(t, newRecFn)
 	require.Len(t, recMeta, 4)

--- a/drivers/duckdb/value_test.go
+++ b/drivers/duckdb/value_test.go
@@ -59,7 +59,7 @@ func TestRecordMeta_TypeSpectrum(t *testing.T) {
 	colTypes, err := rows.ColumnTypes()
 	require.NoError(t, err)
 
-	recMeta, newRecFn, err := grip.SQLDriver().RecordMeta(th.Context, colTypes)
+	recMeta, newRecFn, err := grip.SQLDriver().RecordMeta(th.Context, colTypes, nil)
 	require.NoError(t, err)
 
 	require.True(t, rows.Next(), "type_test should have at least one row")
@@ -200,7 +200,7 @@ func TestRecordMeta_HugeIntPrecision(t *testing.T) {
 
 			colTypes, err := rows.ColumnTypes()
 			require.NoError(t, err)
-			recMeta, newRecFn, err := grip.SQLDriver().RecordMeta(th.Context, colTypes)
+			recMeta, newRecFn, err := grip.SQLDriver().RecordMeta(th.Context, colTypes, nil)
 			require.NoError(t, err)
 
 			require.True(t, rows.Next())

--- a/drivers/json/ingest.go
+++ b/drivers/json/ingest.go
@@ -117,7 +117,7 @@ func getRecMeta(ctx context.Context, grip driver.Grip, tblDef *schema.Table) (re
 		return nil, err
 	}
 
-	destMeta, _, err := grip.SQLDriver().RecordMeta(ctx, colTypes)
+	destMeta, _, err := grip.SQLDriver().RecordMeta(ctx, colTypes, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/drivers/mysql/db_type_test.go
+++ b/drivers/mysql/db_type_test.go
@@ -349,7 +349,7 @@ func TestDatabaseTypes(t *testing.T) { //nolint:tparallel
 
 			sink := &testh.RecordSink{}
 			recw := output.NewRecordWriterAdapter(th.Context, sink)
-			err := libsq.QuerySQL(th.Context, th.Open(src), nil, recw, "SELECT * FROM "+actualTblName)
+			err := libsq.QuerySQL(th.Context, th.Open(src), nil, recw, nil, "SELECT * FROM "+actualTblName)
 			require.NoError(t, err)
 			written, err := recw.Wait()
 			require.NoError(t, err)
@@ -420,7 +420,7 @@ func TestDatabaseTypeJSON(t *testing.T) {
 			// Query the inserted data
 			sink := &testh.RecordSink{}
 			recw := output.NewRecordWriterAdapter(th.Context, sink)
-			err = libsq.QuerySQL(th.Context, th.Open(src), nil, recw, "SELECT * FROM "+actualTblName)
+			err = libsq.QuerySQL(th.Context, th.Open(src), nil, recw, nil, "SELECT * FROM "+actualTblName)
 			require.NoError(t, err)
 			written, err := recw.Wait()
 			require.NoError(t, err)

--- a/drivers/mysql/mysql.go
+++ b/drivers/mysql/mysql.go
@@ -177,7 +177,7 @@ func (d *driveri) Renderer() *render.Renderer {
 }
 
 // RecordMeta implements driver.SQLDriver.
-func (d *driveri) RecordMeta(ctx context.Context, colTypes []*sql.ColumnType) (
+func (d *driveri) RecordMeta(ctx context.Context, colTypes []*sql.ColumnType, _ map[int]kind.Kind) (
 	record.Meta, driver.NewRecordFunc, error,
 ) {
 	recMeta, err := recordMetaFromColumnTypes(ctx, colTypes)
@@ -555,7 +555,7 @@ func (d *driveri) getTableRecordMeta(ctx context.Context, db sqlz.DB, tblName st
 		return nil, err
 	}
 
-	destCols, _, err := d.RecordMeta(ctx, colTypes)
+	destCols, _, err := d.RecordMeta(ctx, colTypes, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/drivers/oracle/oracle.go
+++ b/drivers/oracle/oracle.go
@@ -195,7 +195,7 @@ func (d *driveri) Renderer() *render.Renderer {
 	// avoid the fractional-value scan crash (issue #844). Without intervention
 	// these would surface as a decimal string ("200") instead of an integer. Pin
 	// them to kind.Int so they scan as int64 and stay numbers, matching every
-	// other driver. RecordMeta applies these hints via ResultColumnKindsFromContext.
+	// other driver. RecordMeta applies these hints via its kindHints parameter.
 	r.FunctionResultKinds[ast.FuncNameCount] = kind.Int
 	r.FunctionResultKinds[ast.FuncNameCountUnique] = kind.Int
 	r.FunctionResultKinds[ast.FuncNameRowNum] = kind.Int
@@ -603,7 +603,7 @@ ORDER BY column_id`
 
 // RecordMeta implements driver.SQLDriver.
 func (d *driveri) RecordMeta(
-	ctx context.Context, colTypes []*sql.ColumnType,
+	ctx context.Context, colTypes []*sql.ColumnType, kindHints map[int]kind.Kind,
 ) (record.Meta, driver.NewRecordFunc, error) {
 	sColTypeData := make([]*record.ColumnTypeData, len(colTypes))
 	ogColNames := make([]string, len(colTypes))
@@ -613,8 +613,6 @@ func (d *driveri) RecordMeta(
 	// column as a floating-scale NUMBER that refineBareNumberKind classifies as
 	// kind.Decimal (to avoid the fractional-value scan crash, issue #844), so
 	// without a hint these integer-valued functions would surface as decimal.
-	kindHints := render.ResultColumnKindsFromContext(ctx)
-
 	for i, colType := range colTypes {
 		knd := kindFromDBTypeName(d.log, colType.Name(), colType.DatabaseTypeName())
 		// Refine bare NUMBER using precision/scale from the column type metadata.
@@ -695,7 +693,7 @@ func (d *driveri) getTableRecordMeta(ctx context.Context, db sqlz.DB, tblName st
 		return nil, err
 	}
 
-	recMeta, _, err := d.RecordMeta(ctx, colTypes)
+	recMeta, _, err := d.RecordMeta(ctx, colTypes, nil)
 	return recMeta, err
 }
 

--- a/drivers/postgres/db_type_test.go
+++ b/drivers/postgres/db_type_test.go
@@ -450,7 +450,7 @@ func TestDatabaseTypes(t *testing.T) {
 			t.Cleanup(func() { th.DropTable(src, tablefq.From(actualTblName)) })
 			sink := &testh.RecordSink{}
 			recw := output.NewRecordWriterAdapter(th.Context, sink)
-			err := libsq.QuerySQL(th.Context, th.Open(src), nil, recw, "SELECT * FROM "+actualTblName)
+			err := libsq.QuerySQL(th.Context, th.Open(src), nil, recw, nil, "SELECT * FROM "+actualTblName)
 			require.NoError(t, err)
 			written, err := recw.Wait()
 			require.NoError(t, err)

--- a/drivers/postgres/postgres.go
+++ b/drivers/postgres/postgres.go
@@ -729,7 +729,7 @@ func (d *driveri) getTableRecordMeta(ctx context.Context, db sqlz.DB, tblName st
 		return nil, err
 	}
 
-	destCols, _, err := d.RecordMeta(ctx, colTypes)
+	destCols, _, err := d.RecordMeta(ctx, colTypes, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -778,7 +778,7 @@ func getTableColumnNames(ctx context.Context, db sqlz.DB, tblName string) ([]str
 }
 
 // RecordMeta implements driver.SQLDriver.
-func (d *driveri) RecordMeta(ctx context.Context, colTypes []*sql.ColumnType) (
+func (d *driveri) RecordMeta(ctx context.Context, colTypes []*sql.ColumnType, _ map[int]kind.Kind) (
 	record.Meta, driver.NewRecordFunc, error,
 ) {
 	// The jackc/pgx driver doesn't report nullability (sql.ColumnType)

--- a/drivers/rqlite/metadata.go
+++ b/drivers/rqlite/metadata.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/shopspring/decimal"
 
-	"github.com/neilotoole/sq/libsq/ast/render"
 	"github.com/neilotoole/sq/libsq/core/errz"
 	"github.com/neilotoole/sq/libsq/core/kind"
 	"github.com/neilotoole/sq/libsq/core/lg"
@@ -27,12 +26,11 @@ import (
 // recordMetaFromColumnTypes builds record.Meta for colTypes returned by
 // gorqlite. The shape matches the sqlite3 driver's helper: the SQL is
 // SQLite's, so the column-type names and affinity rules apply verbatim.
-func recordMetaFromColumnTypes(ctx context.Context, colTypes []*sql.ColumnType) (record.Meta, error) {
+func recordMetaFromColumnTypes(ctx context.Context, colTypes []*sql.ColumnType, kindHints map[int]kind.Kind,
+) (record.Meta, error) {
 	// kindHints carries forced result-column kinds recorded during rendering
 	// (e.g. sum() pinned to kind.Decimal). rqlite is SQLite-backed and reports
 	// no usable type for such expressions. See issue #839.
-	kindHints := render.ResultColumnKindsFromContext(ctx)
-
 	sColTypeData := make([]*record.ColumnTypeData, len(colTypes))
 	ogColNames := make([]string, len(colTypes))
 	for i, colType := range colTypes {

--- a/drivers/rqlite/rqlite.go
+++ b/drivers/rqlite/rqlite.go
@@ -702,10 +702,10 @@ func copyTableCompanionDDL(ctx context.Context, db sqlz.DB,
 }
 
 // RecordMeta implements driver.SQLDriver.
-func (d *driveri) RecordMeta(ctx context.Context, colTypes []*sql.ColumnType) (
+func (d *driveri) RecordMeta(ctx context.Context, colTypes []*sql.ColumnType, hints map[int]kind.Kind) (
 	record.Meta, driver.NewRecordFunc, error,
 ) {
-	recMeta, err := recordMetaFromColumnTypes(ctx, colTypes)
+	recMeta, err := recordMetaFromColumnTypes(ctx, colTypes, hints)
 	if err != nil {
 		return nil, nil, errw(err)
 	}
@@ -999,7 +999,7 @@ func (d *driveri) getTableRecordMeta(ctx context.Context, db sqlz.DB, tblName st
 		return nil, err
 	}
 
-	destCols, _, err := d.RecordMeta(ctx, colTypes)
+	destCols, _, err := d.RecordMeta(ctx, colTypes, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/drivers/rqlite/rqlite_test.go
+++ b/drivers/rqlite/rqlite_test.go
@@ -1607,7 +1607,7 @@ func TestColumnTypes_EmptyTable(t *testing.T) {
 	// RecordMeta should map each declared type to its expected
 	// non-Unknown kind, end-to-end. This is the assertion that ties
 	// the wrapper's DatabaseTypeName back to the rest of the driver.
-	recMeta, _, err := drvr.RecordMeta(th.Context, colTypes)
+	recMeta, _, err := drvr.RecordMeta(th.Context, colTypes, nil)
 	require.NoError(t, err)
 	require.Equal(t, []kind.Kind{
 		kind.Int,

--- a/drivers/sqlite3/datetime_robustness_test.go
+++ b/drivers/sqlite3/datetime_robustness_test.go
@@ -38,7 +38,7 @@ func TestQueryRailsDatetime(t *testing.T) {
 
 	sink := &testh.RecordSink{}
 	recw := output.NewRecordWriterAdapter(th.Context, sink)
-	err = libsq.QuerySQL(th.Context, th.Open(src), nil, recw,
+	err = libsq.QuerySQL(th.Context, th.Open(src), nil, recw, nil,
 		"SELECT id, created_at FROM "+tbl+" ORDER BY id")
 	require.NoError(t, err)
 	_, err = recw.Wait()

--- a/drivers/sqlite3/db_type_test.go
+++ b/drivers/sqlite3/db_type_test.go
@@ -177,7 +177,7 @@ func TestDatabaseTypes(t *testing.T) {
 
 	sink := &testh.RecordSink{}
 	recw := output.NewRecordWriterAdapter(th.Context, sink)
-	err := libsq.QuerySQL(th.Context, th.Open(src), nil, recw, "SELECT * FROM "+actualTblName)
+	err := libsq.QuerySQL(th.Context, th.Open(src), nil, recw, nil, "SELECT * FROM "+actualTblName)
 	require.NoError(t, err)
 	_, err = recw.Wait()
 	require.NoError(t, err)

--- a/drivers/sqlite3/metadata.go
+++ b/drivers/sqlite3/metadata.go
@@ -9,7 +9,6 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/neilotoole/sq/libsq/ast/render"
 	"github.com/neilotoole/sq/libsq/core/debugz"
 	"github.com/neilotoole/sq/libsq/core/kind"
 	"github.com/neilotoole/sq/libsq/core/lg"
@@ -23,14 +22,12 @@ import (
 )
 
 // recordMetaFromColumnTypes returns record.Meta for colTypes.
-func recordMetaFromColumnTypes(ctx context.Context, colTypes []*sql.ColumnType,
+func recordMetaFromColumnTypes(ctx context.Context, colTypes []*sql.ColumnType, kindHints map[int]kind.Kind,
 ) (record.Meta, error) {
 	// kindHints carries forced result-column kinds recorded during rendering
 	// (e.g. sum() pinned to kind.Decimal). SQLite reports no usable type for
 	// such expressions, so without a hint they would be surfaced as int/float
 	// from the scanned value. See issue #839.
-	kindHints := render.ResultColumnKindsFromContext(ctx)
-
 	sColTypeData := make([]*record.ColumnTypeData, len(colTypes))
 	ogColNames := make([]string, len(colTypes))
 	for i, colType := range colTypes {

--- a/drivers/sqlite3/metadata_test.go
+++ b/drivers/sqlite3/metadata_test.go
@@ -214,7 +214,7 @@ func TestRecordMetadata(t *testing.T) {
 			colTypes, err := rows.ColumnTypes()
 			require.NoError(t, err)
 
-			recMeta, _, err := drvr.RecordMeta(th.Context, colTypes)
+			recMeta, _, err := drvr.RecordMeta(th.Context, colTypes, nil)
 			require.NoError(t, err)
 			require.Equal(t, len(tc.colNames), len(recMeta))
 

--- a/drivers/sqlite3/sqlite3.go
+++ b/drivers/sqlite3/sqlite3.go
@@ -478,10 +478,10 @@ func copyTableCompanionDDL(ctx context.Context, db sqlz.DB,
 }
 
 // RecordMeta implements driver.SQLDriver.
-func (d *driveri) RecordMeta(ctx context.Context, colTypes []*sql.ColumnType) (
+func (d *driveri) RecordMeta(ctx context.Context, colTypes []*sql.ColumnType, hints map[int]kind.Kind) (
 	record.Meta, driver.NewRecordFunc, error,
 ) {
-	recMeta, err := recordMetaFromColumnTypes(ctx, colTypes)
+	recMeta, err := recordMetaFromColumnTypes(ctx, colTypes, hints)
 	if err != nil {
 		return nil, nil, errw(err)
 	}
@@ -1109,7 +1109,7 @@ func (d *driveri) getTableRecordMeta(ctx context.Context, db sqlz.DB, tblName st
 		return nil, err
 	}
 
-	destCols, _, err := d.RecordMeta(ctx, colTypes)
+	destCols, _, err := d.RecordMeta(ctx, colTypes, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/drivers/sqlserver/db_type_test.go
+++ b/drivers/sqlserver/db_type_test.go
@@ -303,7 +303,7 @@ func TestDatabaseTypes(t *testing.T) {
 
 			sink := &testh.RecordSink{}
 			recw := output.NewRecordWriterAdapter(th.Context, sink)
-			err := libsq.QuerySQL(th.Context, th.Open(src), nil, recw, "SELECT * FROM "+actualTblName)
+			err := libsq.QuerySQL(th.Context, th.Open(src), nil, recw, nil, "SELECT * FROM "+actualTblName)
 			require.NoError(t, err)
 			written, err := recw.Wait()
 			require.NoError(t, err)

--- a/drivers/sqlserver/sqlserver.go
+++ b/drivers/sqlserver/sqlserver.go
@@ -368,7 +368,7 @@ func (d *driveri) TableColumnTypes(ctx context.Context, db sqlz.DB, tblName stri
 }
 
 // RecordMeta implements driver.SQLDriver.
-func (d *driveri) RecordMeta(ctx context.Context, colTypes []*sql.ColumnType) (
+func (d *driveri) RecordMeta(ctx context.Context, colTypes []*sql.ColumnType, _ map[int]kind.Kind) (
 	record.Meta, driver.NewRecordFunc, error,
 ) {
 	sColTypeData := make([]*record.ColumnTypeData, len(colTypes))
@@ -787,7 +787,7 @@ func (d *driveri) getTableColsMeta(ctx context.Context, db sqlz.DB, tblName stri
 		return nil, errw(rows.Err())
 	}
 
-	destCols, _, err := d.RecordMeta(ctx, colTypes)
+	destCols, _, err := d.RecordMeta(ctx, colTypes, nil)
 	if err != nil {
 		sqlz.CloseRows(d.log, rows)
 		return nil, errw(err)

--- a/libsq/ast/render/render.go
+++ b/libsq/ast/render/render.go
@@ -2,7 +2,6 @@
 package render
 
 import (
-	"context"
 	"strconv"
 	"strings"
 	"unicode"
@@ -39,28 +38,6 @@ type Context struct {
 
 	// Dialect is the driver dialect.
 	Dialect dialect.Dialect
-}
-
-// ctxKeyResultColumnKinds is the context key for result-column kind hints.
-type ctxKeyResultColumnKinds struct{}
-
-// NewContextWithResultColumnKinds returns ctx with the result-column kind hints
-// attached, for retrieval by ResultColumnKindsFromContext in a driver's
-// RecordMeta. If kinds is empty, ctx is returned unchanged. See the doc on
-// Context.ResultColumnKinds and issue #839.
-func NewContextWithResultColumnKinds(ctx context.Context, kinds map[int]kind.Kind) context.Context {
-	if len(kinds) == 0 {
-		return ctx
-	}
-	return context.WithValue(ctx, ctxKeyResultColumnKinds{}, kinds)
-}
-
-// ResultColumnKindsFromContext returns the result-column kind hints attached to
-// ctx by NewContextWithResultColumnKinds, or nil if none. The returned map is
-// keyed by zero-based result-column position. See issue #839.
-func ResultColumnKindsFromContext(ctx context.Context) map[int]kind.Kind {
-	kinds, _ := ctx.Value(ctxKeyResultColumnKinds{}).(map[int]kind.Kind)
-	return kinds
 }
 
 // Renderer is a set of functions for rendering ast elements into SQL.

--- a/libsq/driver/driver.go
+++ b/libsq/driver/driver.go
@@ -132,7 +132,16 @@ type SQLDriver interface {
 	//
 	// RecordMeta also returns a NewRecordFunc which can be
 	// applied to the scan row from sql.Rows.
-	RecordMeta(ctx context.Context, colTypes []*sql.ColumnType) (record.Meta, NewRecordFunc, error)
+	//
+	// The hints arg carries forced result-column kinds, keyed by zero-based
+	// output position, recorded during SLQ rendering (e.g. SQLite/rqlite pinning
+	// sum() to kind.Decimal, or Oracle pinning count()/rownum() to kind.Int). A
+	// hint overrides the kind derived from colTypes, which in turn selects the
+	// scan target, so it must be applied before any row is scanned. Callers
+	// outside the SLQ query path (table metadata, ingest/copy) pass nil; drivers
+	// that surface no such hints ignore the arg.
+	RecordMeta(ctx context.Context, colTypes []*sql.ColumnType, hints map[int]kind.Kind) (
+		record.Meta, NewRecordFunc, error)
 
 	// PrepareInsertStmt prepares a statement for inserting
 	// values to destColNames in destTbl. numRows specifies

--- a/libsq/driver/driver_test.go
+++ b/libsq/driver/driver_test.go
@@ -270,7 +270,7 @@ func TestDriver_CreateTable_Minimal(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, len(colNames), len(colTypes))
 
-			recMeta, _, err := drvr.RecordMeta(th.Context, colTypes)
+			recMeta, _, err := drvr.RecordMeta(th.Context, colTypes, nil)
 			require.NoError(t, err)
 
 			gotNames := recMeta.Names()

--- a/libsq/libsq.go
+++ b/libsq/libsq.go
@@ -14,6 +14,7 @@ import (
 	"errors"
 
 	"github.com/neilotoole/sq/libsq/core/errz"
+	"github.com/neilotoole/sq/libsq/core/kind"
 	"github.com/neilotoole/sq/libsq/core/lg"
 	"github.com/neilotoole/sq/libsq/core/lg/lga"
 	"github.com/neilotoole/sq/libsq/core/lg/lgm"
@@ -297,13 +298,18 @@ func ExecSQL(ctx context.Context, grip driver.Grip, db sqlz.DB,
 // non-nil, the query is executed against it. Otherwise, the connection is
 // obtained from grip.
 //
+// The hints arg carries forced result-column kinds (keyed by zero-based output
+// position) for the driver's RecordMeta to apply; see SQLDriver.RecordMeta. The
+// SLQ pipeline supplies hints recorded during rendering; callers executing raw
+// SQL pass nil.
+//
 // Note that QuerySQL may return before recw has finished writing, thus the
 // caller may wish to wait for recw to complete.
 // The caller is responsible for closing grip (and db, if non-nil).
 //
 // See also: ExecSQL.
 func QuerySQL(ctx context.Context, grip driver.Grip, db sqlz.DB,
-	recw RecordWriter, query string, args ...any,
+	recw RecordWriter, hints map[int]kind.Kind, query string, args ...any,
 ) error {
 	log := lg.FromContext(ctx)
 	errw := grip.SQLDriver().ErrWrapFunc()
@@ -376,7 +382,7 @@ func QuerySQL(ctx context.Context, grip driver.Grip, db sqlz.DB,
 	}
 
 	drvr := grip.SQLDriver()
-	recMeta, recFromScanRowFn, err := drvr.RecordMeta(ctx, colTypes)
+	recMeta, recFromScanRowFn, err := drvr.RecordMeta(ctx, colTypes, hints)
 	if err != nil {
 		return errw(err)
 	}

--- a/libsq/pipeline.go
+++ b/libsq/pipeline.go
@@ -12,6 +12,7 @@ import (
 	"github.com/neilotoole/sq/libsq/ast"
 	"github.com/neilotoole/sq/libsq/ast/render"
 	"github.com/neilotoole/sq/libsq/core/errz"
+	"github.com/neilotoole/sq/libsq/core/kind"
 	"github.com/neilotoole/sq/libsq/core/lg"
 	"github.com/neilotoole/sq/libsq/core/lg/lga"
 	"github.com/neilotoole/sq/libsq/core/lg/lgm"
@@ -119,14 +120,15 @@ func (p *pipeline) execute(ctx context.Context, recw RecordWriter) error {
 		}
 	}
 
-	// Propagate any result-column kind hints recorded during rendering (e.g.
+	// Pass any result-column kind hints recorded during rendering (e.g.
 	// SQLite/rqlite pinning sum() to kind.Decimal) so the driver can apply them
-	// when building record metadata. See issue #839.
+	// when building record metadata. See issues #839 and #848.
+	var hints map[int]kind.Kind
 	if p.rc != nil {
-		ctx = render.NewContextWithResultColumnKinds(ctx, p.rc.ResultColumnKinds)
+		hints = p.rc.ResultColumnKinds
 	}
 
-	if err := QuerySQL(ctx, p.targetGrip, conn, recw, p.targetSQL); err != nil {
+	if err := QuerySQL(ctx, p.targetGrip, conn, recw, hints, p.targetSQL); err != nil {
 		return err
 	}
 
@@ -552,7 +554,7 @@ func execCopyTable(ctx context.Context, fromDB driver.Grip, fromTbl tablefq.T,
 	)
 
 	query := "SELECT * FROM " + fromTbl.Render(fromDB.SQLDriver().Dialect().Enquote)
-	err := QuerySQL(ctx, fromDB, nil, inserter, query)
+	err := QuerySQL(ctx, fromDB, nil, inserter, nil, query)
 	if err != nil {
 		return errz.Wrapf(err, "insert %s.%s failed", destGrip.Source().Handle, destTbl)
 	}

--- a/testh/testh.go
+++ b/testh/testh.go
@@ -647,7 +647,7 @@ func (h *Helper) QuerySQL(src *source.Source, db sqlz.DB, query string, args ...
 
 	sink := &RecordSink{}
 	recw := output.NewRecordWriterAdapter(h.Context, sink)
-	err := libsq.QuerySQL(h.Context, grip, db, recw, query, args...)
+	err := libsq.QuerySQL(h.Context, grip, db, recw, nil, query, args...)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Fixes #848.

## Summary

Result-column kind hints were passed from the renderer to a driver's
`RecordMeta` through a `context.Value`. This refactor threads them as an
explicit parameter instead. No user-visible behavior change.

The hint is core logic, not request-scoped metadata: it overrides the kind
derived from the column types, which in turn selects the scan target, so it
must reach **inside** `RecordMeta` before any row is scanned. The
`context.Value` shape hid that real data dependency behind an untyped, optional
lookup that was easy to miss when reading or implementing a driver.

## Changes

- `SQLDriver.RecordMeta` and `libsq.QuerySQL` gain a `hints map[int]kind.Kind`
  parameter (keyed by zero-based output position).
- The SLQ pipeline passes `render.Context.ResultColumnKinds` straight through
  to `QuerySQL`; the per-query `context` wrapping is gone.
- Callers outside the SLQ query path (table metadata, ingest/copy, raw SQL,
  tests) pass `nil`. The five drivers that surface no hints
  (Postgres, MySQL, SQL Server, ClickHouse, DuckDB) take `_ map[int]kind.Kind`.
- The three consumers (SQLite, rqlite, Oracle) read the parameter instead of
  the context.
- Removed `render.NewContextWithResultColumnKinds`,
  `render.ResultColumnKindsFromContext`, and the context-key plumbing.
  `render.Context.ResultColumnKinds` (where the renderer accumulates hints) is
  retained.
- `CLAUDE.md`: the `context.Value` rule no longer needs its "legacy exception"
  note; replaced with a pointer to `RecordMeta` as the worked example.

No CHANGELOG entry: internal refactor with no user-facing change.

## Verification

- `go build ./...`, `make lint`, `make lint-markdown`: clean.
- `go test -short ./...`: passes.
- Behavior preserved end-to-end through the new parameter path: SQLite
  `sum()` -> decimal (#839), and against a live Oracle source, `count()` ->
  int64 and division/`avg()` -> decimal (#844 / #847) all run and pass.

Net diff removes more than it adds: the indirection was larger than the
parameter.

## Related

- #839: introduced the context-based mechanism (SQLite/rqlite `sum()` -> decimal).
- #847 / #844: added Oracle as a third consumer (`count()`/`rownum()` pinned to int).
- #838: will thread schema / operand kinds into the render path; the natural
  next step for division portability now that hints are explicit.
