### PR TITLE
Fix YAML/JSON output rendering: Unknown-kind color, BLOB base64, muted punctuation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,8 @@ Breaking changes are annotated with ☢️, and alpha/beta features with 🐥.
 
 ### Changed
 
+- [#851]: In colored output, structured-format punctuation (JSON braces, brackets, commas,
+  and colons) is now rendered muted rather than bold, so values stand out.
 - [#846]: YAML now renders decimal values as quoted strings by default, matching
   JSON and keeping precision for values beyond float64 range. Set
   `format.decimal=number` to restore bare numbers.
@@ -129,6 +131,13 @@ Breaking changes are annotated with ☢️, and alpha/beta features with 🐥.
 
 ### Fixed
 
+- [#851]: Two fixes to [`yaml`](https://sq.io/docs/output#yaml) output, aligning it with
+  `json`:
+  - A numeric value from an untyped column (such as the result of `avg()`) is now colorized,
+    matching `json` and the writer's own handling of typed numeric columns. Previously it
+    rendered without color.
+  - A `BLOB` value is now encoded as a base64 string (e.g. `aGk=`) instead of a sequence of
+    raw byte numbers, which produced malformed YAML.
 - [#844]: On [Oracle](https://sq.io/docs/drivers/oracle), a query whose result is a
   computed `NUMBER` with a fractional value (e.g. a division like `.actor_id / 8`, or a
   native `AVG`) no longer fails with a scan error. Oracle reports no usable precision or
@@ -1771,6 +1780,7 @@ make working with lots of sources much easier.
 [#839]: https://github.com/neilotoole/sq/issues/839
 [#844]: https://github.com/neilotoole/sq/issues/844
 [#846]: https://github.com/neilotoole/sq/issues/846
+[#851]: https://github.com/neilotoole/sq/issues/851
 
 [v0.15.2]: https://github.com/neilotoole/sq/releases/tag/v0.15.2
 [v0.15.3]: https://github.com/neilotoole/sq/compare/v0.15.2...v0.15.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,8 +52,9 @@ Breaking changes are annotated with ☢️, and alpha/beta features with 🐥.
 
 ### Changed
 
-- [#851]: In colored output, structured-format punctuation (JSON braces, brackets, commas,
-  and colons) is now rendered muted rather than bold, so values stand out.
+- [#851]: In colored output, structural punctuation is now rendered muted rather than bold,
+  so values stand out. This is most visible in JSON (braces, brackets, commas, colons) and
+  also applies to SQL syntax highlighting and other colorized output.
 - [#846]: YAML now renders decimal values as quoted strings by default, matching
   JSON and keeping precision for values beyond float64 range. Set
   `format.decimal=number` to restore bare numbers.

--- a/cli/output/jsonw/jsonw_bytes_test.go
+++ b/cli/output/jsonw/jsonw_bytes_test.go
@@ -1,0 +1,63 @@
+package jsonw_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/neilotoole/sq/cli/output"
+	"github.com/neilotoole/sq/cli/output/jsonw"
+	"github.com/neilotoole/sq/cli/output/jsonw/internal"
+	"github.com/neilotoole/sq/libsq/core/kind"
+	"github.com/neilotoole/sq/libsq/core/record"
+	"github.com/neilotoole/sq/testh"
+)
+
+// TestRecordWriter_BytesColor verifies the JSON record writer encodes a []byte
+// value as a base64 string in both the colored and monochrome paths. The
+// monochrome path is also covered by TestRecordWriters; this test asserts the
+// colored path explicitly (the Bytes color wraps the base64 string), mirroring
+// the YAML writer's coverage.
+func TestRecordWriter_BytesColor(t *testing.T) {
+	ctx := context.Background()
+	hi := []byte("hi")
+	wantB64 := `"` + base64.StdEncoding.EncodeToString(hi) + `"` // "aGk="
+
+	render := func(t *testing.T, enableColor bool) string {
+		t.Helper()
+		recMeta := testh.NewRecordMeta([]string{"c"}, []kind.Kind{kind.Bytes})
+		recs := []record.Record{{hi}}
+
+		buf := &bytes.Buffer{}
+		pr := output.NewPrinting()
+		pr.EnableColor(enableColor)
+		pr.Compact = true
+
+		w := jsonw.NewStdRecordWriter(buf, pr)
+		require.NoError(t, w.Open(ctx, recMeta))
+		require.NoError(t, w.WriteRecords(ctx, recs))
+		require.NoError(t, w.Close(ctx))
+		return buf.String()
+	}
+
+	t.Run("color", func(t *testing.T) {
+		pr := output.NewPrinting()
+		pr.EnableColor(true)
+		clrs := internal.NewColors(pr)
+		wantColored := string(clrs.Bytes.Prefix) + wantB64 + string(clrs.Bytes.Suffix)
+
+		got := render(t, true)
+		require.Contains(t, got, wantColored)
+	})
+
+	t.Run("monochrome", func(t *testing.T) {
+		got := render(t, false)
+		require.Contains(t, got, `"c":`+wantB64)
+		require.NotContains(t, got, "\x1b")
+		require.True(t, json.Valid([]byte(got)))
+	})
+}

--- a/cli/output/printing.go
+++ b/cli/output/printing.go
@@ -34,7 +34,7 @@ type Printing struct {
 	// Active is the color for an active handle (or group, etc).
 	Active *color.Color
 
-	// Bold is the color for bold elements. Frequently Punc will just be color.Bold.
+	// Bold is the color for bold elements.
 	Bold *color.Color
 
 	// Bool is the color for boolean values.
@@ -225,7 +225,7 @@ func NewPrinting() *Printing {
 		Normal:                 color.New(),
 		Null:                   color.New(color.Faint),
 		Number:                 color.New(color.FgCyan),
-		Punc:                   color.New(color.Bold),
+		Punc:                   color.New(color.Faint),
 		String:                 color.New(color.FgGreen),
 		Subdued:                color.New(color.Faint, color.Italic),
 		Stack:                  color.New(color.Faint),

--- a/cli/output/yamlw/recordwriter.go
+++ b/cli/output/yamlw/recordwriter.go
@@ -3,6 +3,7 @@ package yamlw
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"io"
 	"strconv"
 	"sync"
@@ -11,6 +12,7 @@ import (
 	"github.com/fatih/color"
 	goccy "github.com/goccy/go-yaml"
 	"github.com/goccy/go-yaml/ast"
+	"github.com/shopspring/decimal"
 
 	"github.com/neilotoole/sq/cli/output"
 	"github.com/neilotoole/sq/libsq/core/errz"
@@ -37,6 +39,7 @@ type recordWriter struct {
 	recMeta    record.Meta
 	fieldNames []string
 	clrs       []*color.Color
+	byValue    []bool
 	keys       []string
 	mu         sync.Mutex
 }
@@ -48,6 +51,7 @@ func (w *recordWriter) Open(_ context.Context, recMeta record.Meta) error {
 	w.buf = &bytes.Buffer{}
 	w.enc = goccy.NewEncoder(io.Discard, newDecimalMarshaler(w.pr.DecimalAsNumber))
 	w.clrs = make([]*color.Color, len(w.recMeta))
+	w.byValue = make([]bool, len(w.recMeta))
 	w.keys = make([]string, len(w.recMeta))
 	w.null = w.pr.Null.Sprint("null")
 
@@ -85,13 +89,37 @@ func (w *recordWriter) Open(_ context.Context, recMeta record.Meta) error {
 		case kind.Int, kind.Float, kind.Decimal:
 			w.clrs[i] = w.pr.Number
 		case kind.Unknown:
+			// The declared kind doesn't determine the color; resolve it from
+			// the Go value type at write time, mirroring the JSON encoder. See #851.
 			w.clrs[i] = w.pr.Normal
+			w.byValue[i] = true
 		default:
 			w.clrs[i] = w.pr.Normal
 		}
 	}
 
 	return nil
+}
+
+// colorForValue returns the color to apply to val, dispatching on the Go value
+// type. It mirrors the JSON encoder's value-type dispatch (see jsonw.encodeAny)
+// and is used for columns whose declared kind is kind.Unknown, where the column
+// color can't be determined from metadata alone. See #851.
+func colorForValue(pr *output.Printing, val any) *color.Color {
+	switch val.(type) {
+	case int64, float64, decimal.Decimal:
+		return pr.Number
+	case bool:
+		return pr.Bool
+	case []byte:
+		return pr.Bytes
+	case string:
+		return pr.String
+	default:
+		// time.Time is intercepted before this point, and nil is rendered as
+		// null; anything else falls back to no color.
+		return pr.Normal
+	}
 }
 
 // WriteRecords implements output.RecordWriter.
@@ -107,9 +135,10 @@ func (w *recordWriter) WriteRecords(ctx context.Context, recs []record.Record) e
 		err  error
 		node ast.Node
 
-		buf  = w.buf
-		clrs = w.clrs
-		keys = w.keys
+		buf     = w.buf
+		clrs    = w.clrs
+		byValue = w.byValue
+		keys    = w.keys
 	)
 
 	for i, rec := range recs {
@@ -148,6 +177,12 @@ func (w *recordWriter) WriteRecords(ctx context.Context, recs []record.Record) e
 				continue
 			}
 
+			// goccy renders a []byte as a YAML sequence of byte ints. Instead
+			// encode it as a base64 string, matching the JSON output. See #851.
+			if b, ok := val.([]byte); ok {
+				val = base64.StdEncoding.EncodeToString(b)
+			}
+
 			node, err = w.enc.EncodeToNode(val)
 			if err != nil {
 				return errz.Wrapf(err, "yaml: failed to encode result: [%d].%s",
@@ -158,7 +193,13 @@ func (w *recordWriter) WriteRecords(ctx context.Context, recs []record.Record) e
 				// Shouldn't happen
 				buf.WriteString(w.null)
 			} else {
-				buf.WriteString(clrs[j].Sprint(node.String()))
+				clr := clrs[j]
+				if byValue[j] {
+					// Resolve the color from the original record value, which
+					// may have been transformed above (e.g. []byte to base64).
+					clr = colorForValue(w.pr, rec[j])
+				}
+				buf.WriteString(clr.Sprint(node.String()))
 			}
 		}
 

--- a/cli/output/yamlw/recordwriter.go
+++ b/cli/output/yamlw/recordwriter.go
@@ -178,8 +178,15 @@ func (w *recordWriter) WriteRecords(ctx context.Context, recs []record.Record) e
 			}
 
 			// goccy renders a []byte as a YAML sequence of byte ints. Instead
-			// encode it as a base64 string, matching the JSON output. See #851.
+			// encode it as a base64 string, matching the JSON output. A nil
+			// slice is a NULL value, rendered as null like the JSON encoder
+			// (a typed-nil []byte does not satisfy the val == nil check above).
+			// See #851.
 			if b, ok := val.([]byte); ok {
+				if b == nil {
+					buf.WriteString(w.null)
+					continue
+				}
 				val = base64.StdEncoding.EncodeToString(b)
 			}
 

--- a/cli/output/yamlw/recordwriter.go
+++ b/cli/output/yamlw/recordwriter.go
@@ -116,8 +116,10 @@ func colorForValue(pr *output.Printing, val any) *color.Color {
 	case string:
 		return pr.String
 	default:
-		// time.Time is intercepted before this point, and nil is rendered as
-		// null; anything else falls back to no color.
+		// Values that WriteRecords renders as null never reach here: an
+		// interface-nil is caught by its val == nil check, and a typed-nil
+		// []byte short-circuits in its []byte branch. A time.Time is rendered
+		// by renderTime upstream. Anything else falls back to no color.
 		return pr.Normal
 	}
 }

--- a/cli/output/yamlw/yamlw_bytes_test.go
+++ b/cli/output/yamlw/yamlw_bytes_test.go
@@ -1,0 +1,53 @@
+package yamlw_test
+
+import (
+	"encoding/base64"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/neilotoole/sq/cli/output"
+	"github.com/neilotoole/sq/libsq/core/kind"
+)
+
+// TestRecordWriter_Bytes verifies that the YAML record writer encodes a []byte
+// value as a base64 string (matching the JSON output) rather than goccy's
+// default YAML sequence of byte ints. See #851.
+func TestRecordWriter_Bytes(t *testing.T) {
+	hi := []byte("hi")
+	wantHi := base64.StdEncoding.EncodeToString(hi) // "aGk="
+
+	// These bytes base64-encode to the all-digit group "1234", which must stay
+	// quoted in YAML so it round-trips as a string rather than the int 1234.
+	numericB64 := []byte{0xd7, 0x6d, 0xf8}
+	wantNumeric := base64.StdEncoding.EncodeToString(numericB64) // "1234"
+
+	t.Run("bytes_kind", func(t *testing.T) {
+		pr := output.NewPrinting()
+		pr.EnableColor(true)
+		got := renderColorYAML(t, pr, kind.Bytes, hi)
+		require.Contains(t, got, pr.Bytes.Sprint(wantHi))
+	})
+
+	t.Run("unknown_kind", func(t *testing.T) {
+		pr := output.NewPrinting()
+		pr.EnableColor(true)
+		got := renderColorYAML(t, pr, kind.Unknown, hi)
+		require.Contains(t, got, pr.Bytes.Sprint(wantHi))
+	})
+
+	t.Run("numeric_base64_is_quoted", func(t *testing.T) {
+		pr := output.NewPrinting()
+		pr.EnableColor(false)
+		got := renderColorYAML(t, pr, kind.Bytes, numericB64)
+		require.Equal(t, "- c: \""+wantNumeric+"\"\n", got)
+	})
+
+	t.Run("monochrome", func(t *testing.T) {
+		pr := output.NewPrinting()
+		pr.EnableColor(false)
+		got := renderColorYAML(t, pr, kind.Bytes, hi)
+		require.Equal(t, "- c: "+wantHi+"\n", got)
+		require.NotContains(t, got, "\x1b")
+	})
+}

--- a/cli/output/yamlw/yamlw_bytes_test.go
+++ b/cli/output/yamlw/yamlw_bytes_test.go
@@ -50,4 +50,23 @@ func TestRecordWriter_Bytes(t *testing.T) {
 		require.Equal(t, "- c: "+wantHi+"\n", got)
 		require.NotContains(t, got, "\x1b")
 	})
+
+	// A typed-nil []byte is a NULL value and must render as null, matching the
+	// JSON encoder, rather than as the base64 of an empty slice (""). It does
+	// not satisfy the writer's val == nil check, so it reaches the []byte path.
+	t.Run("nil_renders_null", func(t *testing.T) {
+		pr := output.NewPrinting()
+		pr.EnableColor(false)
+		got := renderColorYAML(t, pr, kind.Bytes, []byte(nil))
+		require.Equal(t, "- c: null\n", got)
+	})
+
+	// An empty but non-nil []byte is distinct from NULL: it round-trips as an
+	// empty string, matching the JSON encoder.
+	t.Run("empty_renders_quoted_empty", func(t *testing.T) {
+		pr := output.NewPrinting()
+		pr.EnableColor(false)
+		got := renderColorYAML(t, pr, kind.Bytes, []byte{})
+		require.Equal(t, "- c: \"\"\n", got)
+	})
 }

--- a/cli/output/yamlw/yamlw_bytes_test.go
+++ b/cli/output/yamlw/yamlw_bytes_test.go
@@ -69,4 +69,13 @@ func TestRecordWriter_Bytes(t *testing.T) {
 		got := renderColorYAML(t, pr, kind.Bytes, []byte{})
 		require.Equal(t, "- c: \"\"\n", got)
 	})
+
+	// A typed-nil []byte in a kind.Unknown column takes the byValue path but
+	// must still short-circuit to null before color resolution.
+	t.Run("unknown_nil_renders_null", func(t *testing.T) {
+		pr := output.NewPrinting()
+		pr.EnableColor(false)
+		got := renderColorYAML(t, pr, kind.Unknown, []byte(nil))
+		require.Equal(t, "- c: null\n", got)
+	})
 }

--- a/cli/output/yamlw/yamlw_color_test.go
+++ b/cli/output/yamlw/yamlw_color_test.go
@@ -1,0 +1,95 @@
+package yamlw_test
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/fatih/color"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/require"
+
+	"github.com/neilotoole/sq/cli/output"
+	"github.com/neilotoole/sq/cli/output/yamlw"
+	"github.com/neilotoole/sq/libsq/core/kind"
+	"github.com/neilotoole/sq/libsq/core/record"
+	"github.com/neilotoole/sq/testh"
+)
+
+// TestRecordWriter_Color verifies that the YAML record writer colorizes values
+// consistently with the JSON encoder, including numeric values in columns whose
+// declared kind is kind.Unknown (e.g. aggregate results such as avg()). See #851.
+func TestRecordWriter_Color(t *testing.T) {
+	testCases := []struct {
+		name    string
+		k       kind.Kind
+		val     any
+		wantClr func(pr *output.Printing) *color.Color
+		wantVal string
+	}{
+		// Unknown-kind columns resolve color from the Go value type.
+		{"unknown_float", kind.Unknown, float64(100.5), func(pr *output.Printing) *color.Color { return pr.Number }, "100.5"},
+		{"unknown_int", kind.Unknown, int64(42), func(pr *output.Printing) *color.Color { return pr.Number }, "42"},
+		{
+			"unknown_decimal",
+			kind.Unknown,
+			decimal.RequireFromString("100.5"),
+			func(pr *output.Printing) *color.Color { return pr.Number },
+			`"100.5"`,
+		},
+		{"unknown_bool", kind.Unknown, true, func(pr *output.Printing) *color.Color { return pr.Bool }, "true"},
+		{"unknown_string", kind.Unknown, "hello", func(pr *output.Printing) *color.Color { return pr.String }, "hello"},
+
+		// Columns with a concrete kind keep their kind-based color.
+		{"int_kind", kind.Int, int64(42), func(pr *output.Printing) *color.Color { return pr.Number }, "42"},
+		{"text_kind", kind.Text, "hello", func(pr *output.Printing) *color.Color { return pr.String }, "hello"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			pr := output.NewPrinting()
+			pr.EnableColor(true)
+
+			got := renderColorYAML(t, pr, tc.k, tc.val)
+			require.Contains(t, got, tc.wantClr(pr).Sprint(tc.wantVal))
+		})
+	}
+}
+
+// TestRecordWriter_Color_UnknownNotNormal guards against the #851 regression:
+// a numeric value in a kind.Unknown column must not fall back to the Normal
+// (no-color) path.
+func TestRecordWriter_Color_UnknownNotNormal(t *testing.T) {
+	pr := output.NewPrinting()
+	pr.EnableColor(true)
+
+	got := renderColorYAML(t, pr, kind.Unknown, float64(100.5))
+	require.Contains(t, got, pr.Number.Sprint("100.5"))
+	require.NotContains(t, got, pr.Normal.Sprint("100.5"))
+}
+
+// TestRecordWriter_Color_Monochrome verifies no escape codes are emitted when
+// color is disabled, including for the kind.Unknown value-type path.
+func TestRecordWriter_Color_Monochrome(t *testing.T) {
+	pr := output.NewPrinting()
+	pr.EnableColor(false)
+
+	got := renderColorYAML(t, pr, kind.Unknown, float64(100.5))
+	require.Equal(t, "- c: 100.5\n", got)
+	require.NotContains(t, got, "\x1b")
+}
+
+func renderColorYAML(t *testing.T, pr *output.Printing, k kind.Kind, val any) string {
+	t.Helper()
+	ctx := context.Background()
+	recMeta := testh.NewRecordMeta([]string{"c"}, []kind.Kind{k})
+	recs := []record.Record{{val}}
+
+	buf := &bytes.Buffer{}
+	w := yamlw.NewRecordWriter(buf, pr)
+	require.NoError(t, w.Open(ctx, recMeta))
+	require.NoError(t, w.WriteRecords(ctx, recs))
+	require.NoError(t, w.Flush(ctx))
+	require.NoError(t, w.Close(ctx))
+	return buf.String()
+}

--- a/cli/output/yamlw/yamlw_color_test.go
+++ b/cli/output/yamlw/yamlw_color_test.go
@@ -63,9 +63,10 @@ func TestRecordWriter_Color_UnknownNotNormal(t *testing.T) {
 	pr := output.NewPrinting()
 	pr.EnableColor(true)
 
+	// The Number-colored form is the guard: had the value fallen back to the
+	// Normal path it would be wrapped in pr.Normal's codes, not pr.Number's.
 	got := renderColorYAML(t, pr, kind.Unknown, float64(100.5))
 	require.Contains(t, got, pr.Number.Sprint("100.5"))
-	require.NotContains(t, got, pr.Normal.Sprint("100.5"))
 }
 
 // TestRecordWriter_Color_Monochrome verifies no escape codes are emitted when


### PR DESCRIPTION
Fixes #851. Three minor output-formatting fixes, all about how already-correct data is
displayed. None change query results.

### 1. YAML: colorize Unknown-kind numeric values

A numeric value from an untyped column (e.g. `avg()`, which resolves to `kind.Unknown`)
rendered without color in YAML, while the same value was colored in JSON. The YAML record
writer colored by declared column kind; it now resolves the color from the Go value type
when the kind is `kind.Unknown`, mirroring the JSON encoder's value-type dispatch.

```
sq '@sakila.actor | avg(.actor_id)' -y   # 100.5 now colored (Number), matching -j
```

### 2. YAML: encode BLOB values as base64

A `BLOB`/`[]byte` value rendered as goccy's default sequence of raw byte integers, which
also broke indentation. It is now base64-encoded, matching JSON. goccy quotes ambiguous
base64 (e.g. an all-digit group like `1234`) so it round-trips as a string.

```
sq sql --src @sakila "SELECT CAST('hi' AS BLOB) AS pic" -y
# before:  - pic: - 104
#          - 105
# after:   - pic: aGk=
```

### 3. Muted punctuation

Colored structured output rendered punctuation (`{ } [ ] : ,`) in bold, which read as
bright white and competed with the values. The default punctuation color is now faint, so
values stand out. The punctuation color is shared, so this applies to the JSON record
writer and generic JSON (`sq inspect`), plus SQL highlighting, Mermaid ERD diagrams, and
parse-error rendering.

### Tests

- `yamlw_color_test.go`: value-type color dispatch for `kind.Unknown` (float/int/decimal/
  bool/string), concrete-kind regressions, an Unknown-numeric-not-Normal guard, and a
  monochrome case.
- `yamlw_bytes_test.go`: base64 encoding for `kind.Bytes` and `kind.Unknown`, quoting of
  numeric base64, colored and monochrome paths.
- `jsonw_bytes_test.go`: JSON colored-bytes parity (the colored record-writer bytes path
  was previously untested).

### Verification

`make lint`, `make lint-markdown` clean; `go test -short ./cli/...` passes. Colored output
confirmed end-to-end via pty capture.
