### PR TITLE
Fix DuckDB sum() over a DOUBLE/FLOAT column to surface as decimal (#853)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,8 +72,7 @@ Breaking changes are annotated with ☢️, and alpha/beta features with 🐥.
     (~15-17 significant digits). Callers needing lossless decimal can fall back to
     native SQL via [`sq sql`](https://sq.io/docs/cmd/sql).
 - ☢️ [#839]: [`sum()`](https://sq.io/docs/query#sum) over an integer or decimal
-  column now returns a consistent `decimal` on every SQL driver (the one
-  exception is a `DOUBLE`/`FLOAT` column on DuckDB, noted below). Previously the
+  column now returns a consistent `decimal` on every SQL driver. Previously the
   result type varied by backend (an integer on most, a decimal on MySQL and
   DuckDB, a float on Oracle), so a `sum()` value could not be consumed portably
   across sources. Unlike
@@ -96,10 +95,11 @@ Breaking changes are annotated with ☢️, and alpha/beta features with 🐥.
     maximum scale of 30, which no column can exceed) preserve the full scale, so
     for such columns the value can differ across drivers. The common integer and
     currency cases are unaffected.
-  - [DuckDB](https://sq.io/docs/drivers/duckdb) is not cast: its native `sum()`
-    is already a decimal for integer (`HUGEINT`) and decimal columns, and is left
-    lossless rather than narrowed to `DECIMAL(38, 6)`. As a result, `sum()` over
-    a `DOUBLE` column on DuckDB stays a float rather than a decimal.
+  - [#853]: [DuckDB](https://sq.io/docs/drivers/duckdb) is not given a SQL cast:
+    its native `sum()` is already a decimal for integer (`HUGEINT`) and decimal
+    columns, and is left lossless rather than narrowed to `DECIMAL(38, 6)`. A
+    `sum()` over a `DOUBLE` column is computed in float and surfaced as a
+    decimal, so like SQLite it can still carry that float drift.
   - Decimal values are now rendered with trailing fractional zeros trimmed (e.g.
     `100.50` displays as `100.5`) consistently across all drivers and output
     formats, so the same value reads identically regardless of the scale a
@@ -1782,6 +1782,7 @@ make working with lots of sources much easier.
 [#844]: https://github.com/neilotoole/sq/issues/844
 [#846]: https://github.com/neilotoole/sq/issues/846
 [#851]: https://github.com/neilotoole/sq/issues/851
+[#853]: https://github.com/neilotoole/sq/issues/853
 
 [v0.15.2]: https://github.com/neilotoole/sq/releases/tag/v0.15.2
 [v0.15.3]: https://github.com/neilotoole/sq/compare/v0.15.2...v0.15.3

--- a/drivers/duckdb/duckdb.go
+++ b/drivers/duckdb/duckdb.go
@@ -548,8 +548,8 @@ func newRecordFuncForDuckDB(log *slog.Logger, recMeta record.Meta) driver.NewRec
 // column; see #853), the float is promoted to a decimal.Decimal so the surfaced
 // value matches the surfaced kind, mirroring sum()'s decimal harmonization on
 // the other drivers. DuckDB still computed the value in float, so it can carry
-// float drift, the same tradeoff accepted for sqlite3/rqlite. Otherwise the
-// column defaults to float and the value is returned unchanged.
+// float drift; this is the same tradeoff accepted for sqlite3/rqlite. Otherwise
+// the column defaults to float and the value is returned unchanged.
 func coerceDuckDBFloat(recMeta record.Meta, i int, v float64) any {
 	if recMeta[i].Kind() == kind.Decimal {
 		return decimal.NewFromFloat(v)

--- a/drivers/duckdb/duckdb.go
+++ b/drivers/duckdb/duckdb.go
@@ -347,7 +347,7 @@ func (d *driveri) TableColumnTypes(ctx context.Context, db sqlz.DB, tblName stri
 // are represented as nil in the driver.Value slice. The munge function
 // converts duckdb-specific types (Decimal, Interval, *big.Int, composites)
 // to sq's canonical record types.
-func (d *driveri) RecordMeta(ctx context.Context, colTypes []*sql.ColumnType, _ map[int]kind.Kind) (
+func (d *driveri) RecordMeta(ctx context.Context, colTypes []*sql.ColumnType, kindHints map[int]kind.Kind) (
 	record.Meta, driver.NewRecordFunc, error,
 ) {
 	ctData := make([]*record.ColumnTypeData, len(colTypes))
@@ -355,6 +355,14 @@ func (d *driveri) RecordMeta(ctx context.Context, colTypes []*sql.ColumnType, _ 
 	for i, ct := range colTypes {
 		dbTypeName := ct.DatabaseTypeName()
 		knd := kindFromDBTypeName(dbTypeName)
+		if hint, ok := kindHints[i]; ok {
+			// A renderer-pinned kind (e.g. sum() forced to decimal; see #853)
+			// overrides the kind derived from the DB type name. The munge
+			// coerces the scanned value to match the pinned kind. Setting the
+			// kind here also takes it out of the Unknown state, so the later
+			// SetKindIfUnknown calls in the munge leave it alone.
+			knd = hint
+		}
 		colTypeData := record.NewColumnTypeData(ct, knd)
 		// Always use *any as the scan target. go-duckdb delivers native Go
 		// values (int32, float32, string, time.Time, duckdb.Decimal, etc.)
@@ -455,11 +463,9 @@ func newRecordFuncForDuckDB(log *slog.Logger, recMeta record.Meta) driver.NewRec
 
 			// ---- floats ----
 			case float32:
-				record.SetKindIfUnknown(recMeta, i, kind.Float)
-				rec[i] = float64(v)
+				rec[i] = coerceDuckDBFloat(recMeta, i, float64(v))
 			case float64:
-				record.SetKindIfUnknown(recMeta, i, kind.Float)
-				rec[i] = v
+				rec[i] = coerceDuckDBFloat(recMeta, i, v)
 
 			// ---- DECIMAL (duckdb.Decimal → shopspring decimal.Decimal) ----
 			case duckdbdriver.Decimal:
@@ -535,6 +541,21 @@ func newRecordFuncForDuckDB(log *slog.Logger, recMeta record.Meta) driver.NewRec
 		}
 		return rec, nil
 	}
+}
+
+// coerceDuckDBFloat normalizes a float value scanned from DuckDB for column i.
+// If that column's kind has been pinned to decimal (e.g. sum() over a DOUBLE
+// column; see #853), the float is promoted to a decimal.Decimal so the surfaced
+// value matches the surfaced kind, mirroring sum()'s decimal harmonization on
+// the other drivers. DuckDB still computed the value in float, so it can carry
+// float drift, the same tradeoff accepted for sqlite3/rqlite. Otherwise the
+// column defaults to float and the value is returned unchanged.
+func coerceDuckDBFloat(recMeta record.Meta, i int, v float64) any {
+	if recMeta[i].Kind() == kind.Decimal {
+		return decimal.NewFromFloat(v)
+	}
+	record.SetKindIfUnknown(recMeta, i, kind.Float)
+	return v
 }
 
 // CreateTable implements driver.SQLDriver.

--- a/drivers/duckdb/render.go
+++ b/drivers/duckdb/render.go
@@ -7,6 +7,7 @@ import (
 	"github.com/neilotoole/sq/libsq/ast"
 	"github.com/neilotoole/sq/libsq/ast/render"
 	"github.com/neilotoole/sq/libsq/core/jointype"
+	"github.com/neilotoole/sq/libsq/core/kind"
 	"github.com/neilotoole/sq/libsq/core/stringz"
 	"github.com/neilotoole/sq/libsq/driver"
 	"github.com/neilotoole/sq/libsq/driver/dialect"
@@ -58,13 +59,17 @@ func (d *driveri) Renderer() *render.Renderer {
 	// DuckDB uses the same schema/catalog function names as Postgres.
 	r.FunctionNames[ast.FuncNameSchema] = "current_schema"
 	r.FunctionNames[ast.FuncNameCatalog] = "current_database"
-	// sum() is deliberately not overridden here (issue #839). DuckDB already
-	// returns sum() over an integer column as HUGEINT (surfaced as decimal) and
-	// over a decimal column as DECIMAL, both lossless. sum() over a DOUBLE column
-	// returns DOUBLE (kind.Float); a DECIMAL cast would unify that as decimal but
-	// DuckDB's DECIMAL caps at precision 38, so the cast would regress the native
-	// HUGEINT integer range and round high-scale decimal sums. A float column's
-	// sum staying float is the lesser cost, so it is left as-is.
+	// sum() is not given a SQL cast (unlike most drivers). DuckDB's native sum()
+	// is already lossless for integer columns (widened to HUGEINT, surfaced as
+	// decimal) and decimal columns (DECIMAL); a DECIMAL cast caps at precision 38
+	// and would regress the HUGEINT integer range and round high-scale decimal
+	// sums. But sum() over a DOUBLE column natively returns DOUBLE (kind.Float),
+	// the lone non-decimal sum() across drivers. Pin the surfaced kind to decimal
+	// instead of casting, so it matches every other driver: RecordMeta applies
+	// the hint and the record munge coerces the float value to a decimal. The
+	// value is still computed in float by DuckDB, so it can carry drift, the same
+	// tradeoff accepted for sqlite3/rqlite. See #853 (and #839).
+	r.FunctionResultKinds[ast.FuncNameSum] = kind.Decimal
 	render.RegisterILikeFamily(r)
 	return r
 }

--- a/drivers/duckdb/render.go
+++ b/drivers/duckdb/render.go
@@ -67,8 +67,8 @@ func (d *driveri) Renderer() *render.Renderer {
 	// the lone non-decimal sum() across drivers. Pin the surfaced kind to decimal
 	// instead of casting, so it matches every other driver: RecordMeta applies
 	// the hint and the record munge coerces the float value to a decimal. The
-	// value is still computed in float by DuckDB, so it can carry drift, the same
-	// tradeoff accepted for sqlite3/rqlite. See #853 (and #839).
+	// value is still computed in float by DuckDB, so it can carry drift; this is
+	// the same tradeoff accepted for sqlite3/rqlite. See #853 (and #839).
 	r.FunctionResultKinds[ast.FuncNameSum] = kind.Decimal
 	render.RegisterILikeFamily(r)
 	return r

--- a/libsq/query_sum_test.go
+++ b/libsq/query_sum_test.go
@@ -103,6 +103,12 @@ func TestQuery_sum_floatColumn_duckDBDrift(t *testing.T) {
 	// 0.1 + 0.2 is not exactly representable in float64; the sum drifts to
 	// 0.30000000000000004. DuckDB computes it in float, and we surface that
 	// drifted value as a decimal without correcting it.
+	//
+	// Keep this to exactly two addends: with two values there is no summation
+	// reordering freedom, so DuckDB's SUM matches Go's left-to-right fold bit for
+	// bit. With three or more inexact addends, DuckDB could fold in a different
+	// order (or in parallel) and produce a different float64 than fa + fb below,
+	// breaking the exact-match assertion.
 	for _, v := range []float64{0.1, 0.2} {
 		rec := []any{v}
 		require.NoError(t, execer.Munge(rec))

--- a/libsq/query_sum_test.go
+++ b/libsq/query_sum_test.go
@@ -17,13 +17,14 @@ import (
 )
 
 // TestQuery_sum_floatColumn verifies that sum() over a FLOAT/DOUBLE column
-// surfaces as kind.Decimal (issue #839). Sakila has no float column, so a
+// surfaces as kind.Decimal (issues #839, #853). Sakila has no float column, so a
 // one-column float table is created per driver. This is the regression guard
 // for MySQL, whose native sum() over a float column returns DOUBLE (kind.Float)
 // and which needed an explicit cast override; the other cast-based drivers
-// coerce via their result cast. ClickHouse and DuckDB are skipped (see below):
-// ClickHouse for an insert-pipeline limitation, DuckDB because it intentionally
-// has no override and leaves sum(float) as a float.
+// coerce via their result cast. DuckDB takes a different path: a DECIMAL cast
+// would regress its native HUGEINT integer range, so it kind-pins sum() to
+// decimal and coerces the float value in its record munge (#853). ClickHouse is
+// skipped (see below) for an insert-pipeline limitation.
 func TestQuery_sum_floatColumn(t *testing.T) {
 	for _, handle := range sakila.SQLLatest() {
 		t.Run(handle, func(t *testing.T) {
@@ -39,13 +40,6 @@ func TestQuery_sum_floatColumn(t *testing.T) {
 			// decimal regardless of the operand type.
 			tu.SkipIf(t, src.Type == drivertype.ClickHouse,
 				"ClickHouse needs the batch-insert pipeline; sum(float) is covered via its result cast")
-
-			// DuckDB deliberately keeps sum() over a DOUBLE column as a float (it
-			// has no sum() override; see drivers/duckdb/render.go), so it would
-			// fail the decimal assertion below. That float-stays-float behavior is
-			// intentional, so DuckDB is excluded here.
-			tu.SkipIf(t, src.Type == drivertype.DuckDB,
-				"DuckDB intentionally leaves sum(float) as float (no override)")
 
 			tblName := stringz.UniqTableName("sum_float")
 			tblDef := schema.NewTable(tblName, []string{"col_float"}, []kind.Kind{kind.Float})
@@ -75,7 +69,7 @@ func TestQuery_sum_floatColumn(t *testing.T) {
 			require.NoError(t, err)
 			require.Len(t, sink.Recs, 1)
 			// sum(float) must surface as decimal on every driver reached here
-			// (DuckDB and ClickHouse are skipped above), value 3.75.
+			// (ClickHouse is skipped above), value 3.75.
 			assertSinkColDecimal(0, "3.75", nil)(t, sink)
 		})
 	}

--- a/libsq/query_sum_test.go
+++ b/libsq/query_sum_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	_ "github.com/mattn/go-sqlite3"
+	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/require"
 
 	"github.com/neilotoole/sq/libsq/core/kind"
@@ -73,4 +74,55 @@ func TestQuery_sum_floatColumn(t *testing.T) {
 			assertSinkColDecimal(0, "3.75", nil)(t, sink)
 		})
 	}
+}
+
+// TestQuery_sum_floatColumn_duckDBDrift verifies that DuckDB's sum() over a
+// DOUBLE column, which the kind-pin surfaces as a decimal without a SQL cast
+// (#853), faithfully preserves the float drift rather than presenting a rounded
+// value. Unlike TestQuery_sum_floatColumn, which uses exactly-representable
+// inputs, this picks inputs whose float64 sum is inexact, so it exercises the
+// "computed in float, can carry drift" path. DuckDB is embedded, so this runs
+// without Docker.
+func TestQuery_sum_floatColumn_duckDBDrift(t *testing.T) {
+	tu.SkipShort(t, true)
+
+	th, src, drvr, _, db := testh.NewWith(t, sakila.Duck)
+
+	tblName := stringz.UniqTableName("sum_drift")
+	tblDef := schema.NewTable(tblName, []string{"col_float"}, []kind.Kind{kind.Float})
+	require.NoError(t, drvr.CreateTable(th.Context, db, tblDef))
+	t.Cleanup(func() { th.DropTable(src, tablefq.From(tblName)) })
+
+	conn, err := db.Conn(th.Context)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, conn.Close()) }()
+
+	execer, err := drvr.PrepareInsertStmt(th.Context, conn, tblName, []string{"col_float"}, 1)
+	require.NoError(t, err)
+
+	// 0.1 + 0.2 is not exactly representable in float64; the sum drifts to
+	// 0.30000000000000004. DuckDB computes it in float, and we surface that
+	// drifted value as a decimal without correcting it.
+	for _, v := range []float64{0.1, 0.2} {
+		rec := []any{v}
+		require.NoError(t, execer.Munge(rec))
+		_, err = execer.Exec(th.Context, rec...)
+		require.NoError(t, err)
+	}
+	require.NoError(t, execer.Close())
+
+	sink, err := th.QuerySLQ(src.Handle+" | ."+tblName+" | sum(.col_float)", nil)
+	require.NoError(t, err)
+	require.Len(t, sink.Recs, 1)
+
+	// Expected value, derived the same way the munge derives it: the float64 sum
+	// passed through decimal.NewFromFloat. Use variables so Go computes the sum
+	// at runtime in float64; the untyped constant 0.1 + 0.2 would fold to an
+	// exact 0.3 at compile time and hide the drift. The result must differ from
+	// the exact "0.3", proving the drift is preserved rather than silently
+	// rounded, and must surface as kind.Decimal.
+	fa, fb := 0.1, 0.2
+	want := stringz.FormatDecimal(decimal.NewFromFloat(fa + fb))
+	require.NotEqual(t, "0.3", want, "test premise: 0.1+0.2 must drift in float64")
+	assertSinkColDecimal(0, want, nil)(t, sink)
 }

--- a/libsq/query_sum_test.go
+++ b/libsq/query_sum_test.go
@@ -76,14 +76,14 @@ func TestQuery_sum_floatColumn(t *testing.T) {
 	}
 }
 
-// TestQuery_sum_floatColumn_duckDBDrift verifies that DuckDB's sum() over a
+// TestQuery_sum_floatColumn_DuckDBDrift verifies that DuckDB's sum() over a
 // DOUBLE column, which the kind-pin surfaces as a decimal without a SQL cast
 // (#853), faithfully preserves the float drift rather than presenting a rounded
 // value. Unlike TestQuery_sum_floatColumn, which uses exactly-representable
 // inputs, this picks inputs whose float64 sum is inexact, so it exercises the
 // "computed in float, can carry drift" path. DuckDB is embedded, so this runs
 // without Docker.
-func TestQuery_sum_floatColumn_duckDBDrift(t *testing.T) {
+func TestQuery_sum_floatColumn_DuckDBDrift(t *testing.T) {
 	tu.SkipShort(t, true)
 
 	th, src, drvr, _, db := testh.NewWith(t, sakila.Duck)

--- a/site/content/en/docs/query/index.md
+++ b/site/content/en/docs/query/index.md
@@ -1029,7 +1029,6 @@ driver, so its type is consistent regardless of source. Unlike [`avg`](#avg),
 `sum` is not cast to a float: the sum of integers or of exact decimals is itself
 exact, and a float would lose precision. In JSON output a decimal is rendered as
 a quoted string, so `sum(.actor_id)` is `"20100"` rather than a bare number.
-(The one exception is a `DOUBLE`/`FLOAT` column on DuckDB, noted below.)
 
 {{< alert icon="👉" >}}
 SQLite (and rqlite) compute a sum over a non-integer column in floating point

--- a/site/content/en/docs/query/index.md
+++ b/site/content/en/docs/query/index.md
@@ -896,7 +896,7 @@ Result kind by function:
 | Function | Result kind | Notes |
 | --- | --- | --- |
 | [`avg`](#avg) | `float` | Always floating-point, for portability. Can lose precision beyond roughly 15 to 17 significant digits. |
-| [`sum`](#sum) | `decimal` | Exact for integer and decimal columns. A sum over a float column is computed in float (so it can carry small drift) but is still surfaced as `decimal`. |
+| [`sum`](#sum) | `decimal` | Exact for integer and decimal columns. A float column's sum is surfaced as `decimal` too, with precision that depends on the driver (see below). |
 | [`count`](#count), [`count_unique`](#count_unique) | `int` | Row and value counts are always integers. |
 | [`max`](#max), [`min`](#min) | same as the column | No cast; the result kind is inherited from the operand column. |
 

--- a/site/content/en/docs/query/index.md
+++ b/site/content/en/docs/query/index.md
@@ -896,7 +896,7 @@ Result kind by function:
 | Function | Result kind | Notes |
 | --- | --- | --- |
 | [`avg`](#avg) | `float` | Always floating-point, for portability. Can lose precision beyond roughly 15 to 17 significant digits. |
-| [`sum`](#sum) | `decimal` | Exact for integer and decimal columns. The one exception is a `DOUBLE`/`FLOAT` column on DuckDB, which stays `float`. |
+| [`sum`](#sum) | `decimal` | Exact for integer and decimal columns. A sum over a float column is computed in float (so it can carry small drift) but is still surfaced as `decimal`. |
 | [`count`](#count), [`count_unique`](#count_unique) | `int` | Row and value counts are always integers. |
 | [`max`](#max), [`min`](#min) | same as the column | No cast; the result kind is inherited from the operand column. |
 
@@ -917,18 +917,15 @@ The mechanism and any fidelity caveat vary by driver:
 | [`sqlserver`](/docs/drivers/sqlserver) | cast operand to `FLOAT` | cast operand to `DECIMAL(38, 6)` | Operand cast avoids integer-division truncation and overflow; the sum rounds per row at 6 places. |
 | [`clickhouse`](/docs/drivers/clickhouse) | native (float) | cast result to `Nullable(Decimal(38, 6))` | Rounds to 6 fractional places; overflows beyond 32 integer digits. |
 | [`oracle`](/docs/drivers/oracle) | cast result to `BINARY_DOUBLE` | cast result to `NUMBER(38, 6)` | Rounds to 6 fractional places; overflows beyond 32 integer digits. `count`, `count_unique`, and `rownum` are pinned to `int`. |
-| [`duckdb`](/docs/drivers/duckdb) | native (float) | native, not cast | The native sum is already a lossless decimal; a `DOUBLE` column's sum stays `float`. |
+| [`duckdb`](/docs/drivers/duckdb) | native (float) | kind pinned, no SQL cast | Native sum over integer (HUGEINT) and decimal columns is lossless; a `DOUBLE` column's sum is computed in float, so small drift is possible. |
 
 {{< alert icon="👉" >}}
 How `sq` harmonizes numeric types is still evolving. Proposed changes, including
 config options such as `result.numeric.type`, portable cast functions like
 `decimal(x)`, `int(x)`, and `float(x)`, and normalizing the `/` division
 operator, are under discussion in
-[#845](https://github.com/neilotoole/sq/discussions/845). One known gap, a
-[`sum`](#sum) over a `DOUBLE`/`FLOAT` column on `duckdb` surfacing as `float`
-rather than `decimal`, is tracked in
-[#853](https://github.com/neilotoole/sq/issues/853). The details described here
-may change in future versions.
+[#845](https://github.com/neilotoole/sq/discussions/845). The details described
+here may change in future versions.
 {{< /alert >}}
 
 ### `avg`
@@ -1049,11 +1046,10 @@ rounded to 6 places, and a sum whose integer part needs more than 32 digits
 overflows (a query error). On SQL Server the operand is cast before summing, so
 that rounding is applied per row. Postgres (unconstrained `NUMERIC`) and MySQL
 (its maximum scale of 30) preserve the full scale. DuckDB is not cast (its
-native sum is already a lossless decimal for integer and decimal columns), so a
-sum over a `DOUBLE` column on DuckDB stays a float. That last point is a
-portability gap (every other driver surfaces `sum` as a decimal), tracked in
-[#853](https://github.com/neilotoole/sq/issues/853). The common integer and
-currency cases are unaffected.
+native sum is already a lossless decimal for integer and decimal columns); a sum
+over a `DOUBLE` column is computed in float and surfaced as a decimal, so it can
+carry the same small drift as SQLite. The common integer and currency cases are
+unaffected.
 {{< /alert >}}
 
 ## String functions


### PR DESCRIPTION
Closes #853.

## Problem

`sum()` surfaces as `decimal` on every SQL driver except DuckDB, where a `sum`
over a `DOUBLE`/`FLOAT` column came back as `float`. This was the lone remaining
type inconsistency in the aggregate-harmonization work (#839): the same query
against the same data returned a different result kind depending on the backend.

## Fix

Use the kind-pin mechanism already used by `sqlite3`/`rqlite`, **not** a SQL
cast. A `DECIMAL` cast would regress DuckDB's native `HUGEINT` integer range
(DuckDB `DECIMAL` caps at precision 38), so the SQL stays `sum(col)` and only the
surfaced kind is forced to `decimal`:

- `render.go` pins `FunctionResultKinds[sum] = kind.Decimal`.
- `RecordMeta` now applies the `kindHints` param (it had been discarded as `_`),
  so the pinned kind reaches the column metadata. DuckDB scans into `*any` and
  munges by raw Go type, so a pin alone would leave a `float64` value under a
  `decimal` kind.
- The record munge coerces a scanned float to `decimal.Decimal` when the
  column's kind is decimal (new `coerceDuckDBFloat` helper).

The native `HUGEINT` and `DECIMAL` sum paths are untouched and stay lossless;
`avg()` is unaffected and remains `float`.

## Tradeoff

DuckDB still computes the sum in `float64`, so the surfaced `decimal` can carry
float drift (e.g. `67416.51000000001`). This is the same documented, accepted
behavior as `sqlite3`/`rqlite`: the type is unified, but a value already computed
in float is not recovered. After this change the `sum` result kind is uniformly
`decimal` across all drivers.

## Tests

- `TestQuery_sum_floatColumn` previously **skipped** DuckDB precisely because of
  this behavior. The skip is removed, so the test now asserts `sum(.col_float)`
  surfaces as `decimal` `"3.75"` on DuckDB. Confirmed red before the fix
  (kind `Float`), green after.
- Full DuckDB driver package and all libsq DuckDB subtests pass; `avg` stays
  `float`, `sum` over integer/decimal columns is unchanged.
- DuckDB is embedded, so these run without Docker.

## Docs / CHANGELOG

- Updates the aggregate-functions query docs (tables + `sum` caveat) to reflect
  the fix and removes the now-resolved `#853` gap cross-links.
- Folds the change into the unreleased #839 CHANGELOG entry (no churn entry for
  behavior that never shipped).