### PR TITLE
Keyring: orphan-aware ls, new prune command, and migrate overhaul (#715)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,27 +117,9 @@ sq-side caller, not deep inside the external code.
 Avoid `fmt.Errorf` and `errors.New` outside sentinel declarations — they
 produce stackless errors that surface upstream with no useful trace.
 
-### Shell completion
-
-Every command that accepts arguments must offer shell completion via the cobra
-command's `ValidArgsFunction`. Completion is part of the command, not an
-optional extra: a new command, or a new positional argument on an existing one,
-is not done until its arguments tab-complete.
-
-Reuse the helpers in [`cli/complete.go`](./cli/complete.go) rather than
-hand-rolling completion:
-
-- Source handles: `completeHandle(maxVals, includeActive)`, or
-  `completeHandleOrGroup` where a group is also valid.
-- Keyring entry paths: `completeKeyringPath`.
-- Other values (booleans, catalogs, schemas, drivers): the matching `complete*`
-  helper.
-
-Cap positional completion at the number of args the command takes (`maxVals`),
-and set `includeActive` by whether the `@active` shortcut is a sensible target.
-Commands with no positional arguments need no `ValidArgsFunction`. Add a
-completion test with the command, using the `testComplete` helper (see the
-existing `*_Completion` tests).
+Command-authoring conventions for the `cli` package (including the rule that
+every argument-taking command must offer shell completion) live in
+[`cli/CLAUDE.md`](./cli/CLAUDE.md).
 
 ### Passing data: prefer explicit signatures over `context.Value`
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,6 +117,28 @@ sq-side caller, not deep inside the external code.
 Avoid `fmt.Errorf` and `errors.New` outside sentinel declarations — they
 produce stackless errors that surface upstream with no useful trace.
 
+### Shell completion
+
+Every command that accepts arguments must offer shell completion via the cobra
+command's `ValidArgsFunction`. Completion is part of the command, not an
+optional extra: a new command, or a new positional argument on an existing one,
+is not done until its arguments tab-complete.
+
+Reuse the helpers in [`cli/complete.go`](./cli/complete.go) rather than
+hand-rolling completion:
+
+- Source handles: `completeHandle(maxVals, includeActive)`, or
+  `completeHandleOrGroup` where a group is also valid.
+- Keyring entry paths: `completeKeyringPath`.
+- Other values (booleans, catalogs, schemas, drivers): the matching `complete*`
+  helper.
+
+Cap positional completion at the number of args the command takes (`maxVals`),
+and set `includeActive` by whether the `@active` shortcut is a sensible target.
+Commands with no positional arguments need no `ValidArgsFunction`. Add a
+completion test with the command, using the `testComplete` helper (see the
+existing `*_Completion` tests).
+
 ### Passing data: prefer explicit signatures over `context.Value`
 
 Don't smuggle values through `context.Context` to avoid a signature or

--- a/cli/CLAUDE.md
+++ b/cli/CLAUDE.md
@@ -1,0 +1,27 @@
+# CLAUDE.md (cli package)
+
+Conventions specific to the `cli` package: cobra command construction, flags,
+shell completion, and output writers. The repo-wide rules in the root
+[`CLAUDE.md`](../CLAUDE.md) still apply here.
+
+## Shell completion
+
+Every command that accepts arguments must offer shell completion via the cobra
+command's `ValidArgsFunction`. Completion is part of the command, not an
+optional extra: a new command, or a new positional argument on an existing one,
+is not done until its arguments tab-complete.
+
+Reuse the helpers in [`complete.go`](./complete.go) rather than hand-rolling
+completion:
+
+- Source handles: `completeHandle(maxVals, includeActive)`, or
+  `completeHandleOrGroup` where a group is also valid.
+- Keyring entry paths: `completeKeyringPath`.
+- Other values (booleans, catalogs, schemas, drivers): the matching `complete*`
+  helper.
+
+Cap positional completion at the number of args the command takes (`maxVals`),
+and set `includeActive` by whether the `@active` shortcut is a sensible target.
+Commands with no positional arguments need no `ValidArgsFunction`. Add a
+completion test with the command, using the `testComplete` helper (see the
+existing `*_Completion` tests).

--- a/cli/CLAUDE.md
+++ b/cli/CLAUDE.md
@@ -22,6 +22,13 @@ completion:
 
 Cap positional completion at the number of args the command takes (`maxVals`),
 and set `includeActive` by whether the `@active` shortcut is a sensible target.
-Commands with no positional arguments need no `ValidArgsFunction`. Add a
-completion test with the command, using the `testComplete` helper (see the
-existing `*_Completion` tests).
+
+Commands with no positional arguments need no `ValidArgsFunction`. Arguments
+whose values are inherently free-form are likewise exempt, since there is
+nothing to enumerate: a new name the user invents, a literal value to store, an
+arbitrary SQL or SLQ query. For example, `config keyring create PATH` takes no
+completion for `PATH`, because it must be a new entry that does not yet exist;
+suggesting existing paths would only offer names the command rejects.
+
+Add a completion test with the command, using the `testComplete` helper (see
+the existing `*_Completion` tests).

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -290,6 +290,7 @@ func newCommandTree(ru *run.Run) (rootCmd *cobra.Command) {
 	addCmd(ru, configCmd, newConfigExportCmd())
 	configKeyringCmd := addCmd(ru, configCmd, newConfigKeyringCmd())
 	addCmd(ru, configKeyringCmd, newConfigKeyringLsCmd())
+	addCmd(ru, configKeyringCmd, newConfigKeyringPruneCmd())
 	addCmd(ru, configKeyringCmd, newConfigKeyringCreateCmd())
 	addCmd(ru, configKeyringCmd, newConfigKeyringUpdateCmd())
 	addCmd(ru, configKeyringCmd, newConfigKeyringGetCmd())

--- a/cli/cmd_config_keyring_ls.go
+++ b/cli/cmd_config_keyring_ls.go
@@ -8,6 +8,7 @@ import (
 	"github.com/neilotoole/sq/cli/flag"
 	"github.com/neilotoole/sq/cli/output"
 	"github.com/neilotoole/sq/cli/run"
+	"github.com/neilotoole/sq/libsq/core/errz"
 	"github.com/neilotoole/sq/libsq/core/secret"
 	"github.com/neilotoole/sq/libsq/core/secret/keyring"
 	"github.com/neilotoole/sq/libsq/source"
@@ -46,7 +47,10 @@ external and not listed.`,
 
 func execConfigKeyringLs(cmd *cobra.Command, _ []string) error {
 	ru := run.FromContext(cmd.Context())
-	refs := collectKeyringRefs(ru.Config.Collection.Sources())
+	refs, err := collectKeyringRefs(ru.Config.Collection.Sources())
+	if err != nil {
+		return err
+	}
 	stored, err := keyring.NewStore().List(cmd.Context())
 	if err != nil {
 		return err
@@ -118,15 +122,18 @@ func keyringStatusRank(status string) int {
 // No deduplication: a shared path yields one row per referencing source,
 // which is how sharing becomes visible in the output.
 //
-// Malformed placeholders are silently skipped here. Surfacing them
-// would require a return-error variant; in practice the same sources
-// also fail to open via "sq ping", which is the better error venue.
-func collectKeyringRefs(srcs []*source.Source) []output.KeyringRef {
+// Returns an error if any source has a malformed placeholder in its
+// Location. A malformed Location causes ExtractRefs to discard all refs
+// from that Location, so continuing silently would produce an incomplete
+// referenced set. For destructive operations such as prune, an incomplete
+// set means live, referenced entries could be misclassified as orphans
+// and deleted. Hard-failing here prevents that data loss.
+func collectKeyringRefs(srcs []*source.Source) ([]output.KeyringRef, error) {
 	var rows []output.KeyringRef
 	for _, src := range srcs {
 		refs, err := secret.ExtractRefs(src.Location)
 		if err != nil {
-			continue
+			return nil, errz.Wrapf(err, "source %s has a malformed placeholder in its location", src.Handle)
 		}
 		for _, ref := range refs {
 			if ref.Scheme != "keyring" {
@@ -145,7 +152,7 @@ func collectKeyringRefs(srcs []*source.Source) []output.KeyringRef {
 		}
 		return rows[i].Handle < rows[j].Handle
 	})
-	return rows
+	return rows, nil
 }
 
 // addKeyringFormatFlags registers the output-format + header flags

--- a/cli/cmd_config_keyring_ls.go
+++ b/cli/cmd_config_keyring_ls.go
@@ -9,6 +9,7 @@ import (
 	"github.com/neilotoole/sq/cli/output"
 	"github.com/neilotoole/sq/cli/run"
 	"github.com/neilotoole/sq/libsq/core/secret"
+	"github.com/neilotoole/sq/libsq/core/secret/keyring"
 	"github.com/neilotoole/sq/libsq/source"
 )
 
@@ -17,25 +18,26 @@ func newConfigKeyringLsCmd() *cobra.Command {
 		Use:     "ls",
 		Aliases: []string{"list"},
 		Args:    cobra.NoArgs,
-		Short:   "List keyring paths referenced by sources",
-		Long: `Walk every source's Location and print one row per ${keyring:<path>}
-placeholder it references, paired with the source's handle and driver.
-${env:...} and ${file:...} refs are not listed here — those backends are
-external; sq reads them at connect time and has nothing to manage.
+		Short:   "List keyring entries and their status",
+		Long: `List every keyring entry under the sq service, reconciled against
+the ${keyring:<path>} placeholders referenced by sources.
 
 Output columns:
+  STATUS    referenced | orphan | missing (see below).
   PATH      The keyring entry path, e.g. "j2k7m3pxtz".
-  HANDLE    The @handle that references the entry.
-  DRIVER    The source's driver type (postgres, mysql, sqlite, ...).
+  HANDLE    The @handle that references the entry (blank for orphans).
+  DRIVER    The source's driver type (blank for orphans).
 
-When the same path appears in multiple sources, each source gets its own
-row — clustered together because rows are sorted by path. A repeated
-path across rows means the underlying keyring entry is shared.
+Status values:
+  referenced  Present in the keyring and referenced by a source.
+  orphan      Present in the keyring, referenced by no source. Remove
+              with 'sq config keyring prune'.
+  missing     Referenced by a source but absent from the keyring; that
+              source will fail to resolve its secret at connect time.
 
-The listing is derived from the YAML config; no persistent index is
-maintained. Keyring entries that no source references (orphans) are
-not surfaced — that requires keyring enumeration, deferred to a
-future release.`,
+A path referenced by multiple sources yields one row per source. Only
+${keyring:...} refs are reconciled; ${env:...} and ${file:...} are
+external and not listed.`,
 		RunE: execConfigKeyringLs,
 	}
 	addKeyringFormatFlags(cmd)
@@ -45,7 +47,69 @@ future release.`,
 func execConfigKeyringLs(cmd *cobra.Command, _ []string) error {
 	ru := run.FromContext(cmd.Context())
 	refs := collectKeyringRefs(ru.Config.Collection.Sources())
-	return ru.Writers.Keyring.List(refs)
+	stored, err := keyring.NewStore().List(cmd.Context())
+	if err != nil {
+		return err
+	}
+	rows := reconcileKeyringEntries(refs, stored)
+	return ru.Writers.Keyring.List(rows)
+}
+
+// reconcileKeyringEntries builds the unified ls rows by classifying each
+// keyring path. A referenced path present in the keyring is "referenced";
+// a referenced path absent from the keyring is "missing"; a stored path
+// that no source references is an "orphan". Referenced/missing rows keep
+// their handle and driver (one row per referencing source); orphan rows
+// have neither. Rows are sorted referenced, then orphan, then missing,
+// breaking ties by path then handle.
+func reconcileKeyringEntries(refs []output.KeyringRef, stored []string) []output.KeyringRef {
+	storedSet := make(map[string]struct{}, len(stored))
+	for _, s := range stored {
+		storedSet[s] = struct{}{}
+	}
+	referencedSet := make(map[string]struct{}, len(refs))
+
+	rows := make([]output.KeyringRef, 0, len(refs)+len(stored))
+	for _, r := range refs {
+		referencedSet[r.Path] = struct{}{}
+		r.Status = output.KeyringStatusReferenced
+		if _, ok := storedSet[r.Path]; !ok {
+			r.Status = output.KeyringStatusMissing
+		}
+		rows = append(rows, r)
+	}
+	for _, s := range stored {
+		if _, ok := referencedSet[s]; ok {
+			continue
+		}
+		rows = append(rows, output.KeyringRef{Status: output.KeyringStatusOrphan, Path: s})
+	}
+
+	sort.Slice(rows, func(i, j int) bool {
+		if ri, rj := keyringStatusRank(rows[i].Status), keyringStatusRank(rows[j].Status); ri != rj {
+			return ri < rj
+		}
+		if rows[i].Path != rows[j].Path {
+			return rows[i].Path < rows[j].Path
+		}
+		return rows[i].Handle < rows[j].Handle
+	})
+	return rows
+}
+
+// keyringStatusRank orders statuses for display: referenced first (the
+// healthy common case), then orphan, then missing.
+func keyringStatusRank(status string) int {
+	switch status {
+	case output.KeyringStatusReferenced:
+		return 0
+	case output.KeyringStatusOrphan:
+		return 1
+	case output.KeyringStatusMissing:
+		return 2
+	default:
+		return 3
+	}
 }
 
 // collectKeyringRefs extracts (path, handle, driver) rows from srcs,

--- a/cli/cmd_config_keyring_migrate.go
+++ b/cli/cmd_config_keyring_migrate.go
@@ -262,6 +262,13 @@ func applyMigratePlans(ctx context.Context, ru *run.Run, plans []migratePlan) (
 		p.src.Location = "${keyring:" + id + "}"
 	}
 
+	if len(done) == 0 {
+		// Nothing was eligible (e.g. JSON mode on an all-skipped collection,
+		// where the text-mode short-circuit doesn't apply): don't rewrite
+		// sq.yml for a no-op.
+		return nil, nil
+	}
+
 	if err := ru.ConfigStore.Save(ctx, ru.Config); err != nil {
 		return failAll("save config: " + err.Error())
 	}

--- a/cli/cmd_config_keyring_migrate.go
+++ b/cli/cmd_config_keyring_migrate.go
@@ -328,9 +328,11 @@ func migrateSkipReason(loc string) string {
 		}
 		return "malformed location: " + msg
 	}
-	if u.Scheme == "" || u.Host == "" {
+	if u.Scheme == "" {
 		// Not a connection URL (a file path, document source, and so on):
-		// there are no inline credentials to relocate.
+		// there are no inline credentials to relocate. A scheme-bearing URL
+		// with an empty host still falls through to the password checks below,
+		// so one that carries a password is migrated rather than skipped.
 		return "no credentials to migrate"
 	}
 	if u.User == nil {

--- a/cli/cmd_config_keyring_migrate.go
+++ b/cli/cmd_config_keyring_migrate.go
@@ -108,6 +108,18 @@ func execConfigKeyringMigrate(cmd *cobra.Command, args []string) error {
 		return writerErr
 	}
 
+	// Nothing actionable (e.g. a collection of file sources with no inline
+	// credentials): report and stop without prompting or applying.
+	actionable := 0
+	for _, p := range plans {
+		if p.reason == "" {
+			actionable++
+		}
+	}
+	if actionable == 0 {
+		return ru.Writers.Keyring.Migrate(planRowsForReport(plans), true)
+	}
+
 	if err := ru.Writers.Keyring.Migrate(planRowsForReport(plans), true); err != nil {
 		return err
 	}

--- a/cli/cmd_config_keyring_migrate.go
+++ b/cli/cmd_config_keyring_migrate.go
@@ -332,16 +332,38 @@ func migrateSkipReason(loc string) string {
 	return ""
 }
 
-// promptYesNo writes prompt to out and reads a y/n response from in.
-// Returns true on "y"/"yes" (case-insensitive); false on anything else
-// or EOF (so just pressing Enter answers "no", matching the [y/N]
-// default).
+// promptYesNo writes prompt to out and reads a y/n response from in,
+// re-prompting until it gets a recognized answer. "y"/"yes" returns true;
+// "n"/"no" or an empty line (accepting the [y/N] default) returns false.
+// Any other input is unrecognized and triggers a re-prompt. If the input
+// stream ends (EOF) before a valid answer is given, it returns an error, so
+// the caller exits non-zero rather than treating garbage as a silent "no".
 func promptYesNo(in io.Reader, out io.Writer, prompt string) (bool, error) {
-	fmt.Fprintf(out, "%s [y/N] ", prompt)
-	line, err := bufio.NewReader(in).ReadString('\n')
-	if err != nil && !errors.Is(err, io.EOF) {
-		return false, err
+	r := bufio.NewReader(in)
+	for {
+		fmt.Fprintf(out, "%s [y/N] ", prompt)
+		line, err := r.ReadString('\n')
+		switch strings.ToLower(strings.TrimSpace(line)) {
+		case "y", "yes":
+			return true, nil
+		case "n", "no":
+			return false, nil
+		case "":
+			// An empty line (the user pressed Enter) accepts the [y/N]
+			// default of No. An empty read at EOF, though, means no answer
+			// was given at all; that's handled as an error below.
+			if !errors.Is(err, io.EOF) {
+				return false, nil
+			}
+		}
+
+		// The response was unrecognized, or the input stream ended.
+		if errors.Is(err, io.EOF) {
+			return false, errz.New("no valid response to prompt")
+		}
+		if err != nil {
+			return false, errz.Err(err)
+		}
+		// Input remains and the response was unrecognized: re-prompt.
 	}
-	resp := strings.ToLower(strings.TrimSpace(line))
-	return resp == "y" || resp == "yes", nil
 }

--- a/cli/cmd_config_keyring_migrate.go
+++ b/cli/cmd_config_keyring_migrate.go
@@ -334,38 +334,33 @@ func migrateSkipReason(loc string) string {
 	return ""
 }
 
-// promptYesNo writes prompt to out and reads a y/n response from in,
-// re-prompting until it gets a recognized answer. "y"/"yes" returns true;
-// "n"/"no" or an empty line (accepting the [y/N] default) returns false.
-// Any other input is unrecognized and triggers a re-prompt. If the input
-// stream ends (EOF) before a valid answer is given, it returns an error, so
-// the caller exits non-zero rather than treating garbage as a silent "no".
+// promptYesNo writes prompt to out and reads a single y/n response from in.
+// "y"/"yes" returns true; "n"/"no", or an empty line accepting the [y/N]
+// default, returns false. Matching is case-insensitive and trims surrounding
+// whitespace. Any other input is an error (it does not retry), as is EOF with
+// no answer given, so the caller exits non-zero rather than treating it as a
+// silent "no".
 func promptYesNo(in io.Reader, out io.Writer, prompt string) (bool, error) {
-	r := bufio.NewReader(in)
-	for {
-		fmt.Fprintf(out, "%s [y/N] ", prompt)
-		line, err := r.ReadString('\n')
-		switch strings.ToLower(strings.TrimSpace(line)) {
-		case "y", "yes":
-			return true, nil
-		case "n", "no":
-			return false, nil
-		case "":
-			// An empty line (the user pressed Enter) accepts the [y/N]
-			// default of No. An empty read at EOF, though, means no answer
-			// was given at all; that's handled as an error below.
-			if !errors.Is(err, io.EOF) {
-				return false, nil
-			}
-		}
+	fmt.Fprintf(out, "%s [y/N] ", prompt)
+	line, err := bufio.NewReader(in).ReadString('\n')
+	if err != nil && !errors.Is(err, io.EOF) {
+		return false, errz.Err(err)
+	}
 
-		// The response was unrecognized, or the input stream ended.
+	resp := strings.TrimSpace(line)
+	switch strings.ToLower(resp) {
+	case "y", "yes":
+		return true, nil
+	case "n", "no":
+		return false, nil
+	case "":
+		// An empty line (the user pressed Enter) accepts the [y/N] default
+		// of No. An empty read at EOF means no answer was given at all.
 		if errors.Is(err, io.EOF) {
-			return false, errz.New("no valid response to prompt")
+			return false, errz.New("no response to prompt")
 		}
-		if err != nil {
-			return false, errz.Err(err)
-		}
-		// Input remains and the response was unrecognized: re-prompt.
+		return false, nil
+	default:
+		return false, errz.Errorf("unrecognized response to prompt: %q", resp)
 	}
 }

--- a/cli/cmd_config_keyring_migrate.go
+++ b/cli/cmd_config_keyring_migrate.go
@@ -130,7 +130,9 @@ func execConfigKeyringMigrate(cmd *cobra.Command, args []string) error {
 			return err
 		}
 		if !ok {
-			return nil
+			// Declining is a deliberate non-success: nothing is migrated, so
+			// exit non-zero (like apt/dnf "Abort.") rather than report success.
+			return errz.New("migration cancelled")
 		}
 	}
 

--- a/cli/cmd_config_keyring_migrate.go
+++ b/cli/cmd_config_keyring_migrate.go
@@ -46,6 +46,9 @@ Sources skipped automatically:
 Use --dry-run to preview without making any changes. Use --yes to skip
 the confirmation prompt.`,
 		RunE: execConfigKeyringMigrate,
+		// migrate's optional arg is a source handle (not a keyring path),
+		// so it completes handles, like the other handle-taking commands.
+		ValidArgsFunction: completeHandle(1, true),
 		Example: `  # Preview the migration
   $ sq config keyring migrate --all --dry-run
 

--- a/cli/cmd_config_keyring_migrate.go
+++ b/cli/cmd_config_keyring_migrate.go
@@ -310,26 +310,27 @@ func migrateSkipReason(loc string) string {
 	}
 	u, err := url.Parse(loc)
 	if err != nil {
-		// A genuinely malformed DSN should not be silently classified
-		// as "not a URL" — the user needs to see WHY their source was
-		// skipped. Extract just the parse error's reason (url.Error's
-		// Err field) to avoid echoing the loc string itself, which
-		// could contain inline credentials.
+		// A genuinely malformed DSN should not be silently treated as a
+		// credential-less source. Surface the parse error's reason so the
+		// user sees why the source was skipped. Use only url.Error's Err
+		// field, not the loc string, which could contain inline credentials.
 		msg := "parse failed"
 		var ue *url.Error
 		if errors.As(err, &ue) && ue.Err != nil {
 			msg = ue.Err.Error()
 		}
-		return "not a URL: " + msg
+		return "malformed location: " + msg
 	}
 	if u.Scheme == "" || u.Host == "" {
-		return "not a URL"
+		// Not a connection URL (a file path, document source, and so on):
+		// there are no inline credentials to relocate.
+		return "no credentials to migrate"
 	}
 	if u.User == nil {
-		return "no password component"
+		return "no password to migrate"
 	}
 	if _, has := u.User.Password(); !has {
-		return "no password component"
+		return "no password to migrate"
 	}
 	return ""
 }

--- a/cli/cmd_config_keyring_migrate.go
+++ b/cli/cmd_config_keyring_migrate.go
@@ -59,6 +59,10 @@ the confirmation prompt.`,
 	cmd.Flags().Bool(flagMigrateDryRun, false, "Show planned changes, make no writes")
 	cmd.Flags().Bool(flagMigrateYes, false, "Skip the confirmation prompt")
 	addKeyringFormatFlags(cmd)
+	// migrate rewrites sq.yml (unlike the other keyring subcommands, which
+	// touch only the keyring), so it takes the config lock and runs against
+	// a freshly-reloaded config, like add/rm/mv and the other config writers.
+	cmdMarkRequiresConfigLock(cmd)
 	return cmd
 }
 
@@ -163,30 +167,69 @@ func planRowsForReport(plans []migratePlan) []output.KeyringMigrateRow {
 	return rows
 }
 
-// applyMigratePlans performs the migration and returns one row per
-// non-skipped plan describing the outcome. Skipped plans don't appear
-// in the result because they were already reported during the plan
-// phase. The returned error is non-nil if at least one source failed
-// to migrate; rows for both successes and failures are still returned.
+// applyMigratePlans performs the migration atomically. It writes every
+// eligible source's keyring entry and rewrites its Location in memory,
+// then saves the config exactly once. If any step fails (minting an ID,
+// writing the keyring, or the single config save), the whole batch is
+// rolled back: every keyring entry written this run is deleted, every
+// Location is restored, and the config is left untouched. So a run is
+// all-or-nothing; a failure migrates no sources. Skipped plans don't
+// appear in the result because they were already reported during the
+// plan phase.
 func applyMigratePlans(ctx context.Context, ru *run.Run, plans []migratePlan) (
 	[]output.KeyringMigrateRow, error,
 ) {
 	kr := keyring.NewStore()
-	rows := make([]output.KeyringMigrateRow, 0, len(plans))
-	var anyFailed bool
+
+	// done tracks each source whose keyring entry was written and Location
+	// rewritten in memory, so a later failure can roll the whole batch back.
+	type applied struct {
+		src *source.Source
+		id  string
+		old string
+	}
+	var done []applied
+
+	rollbackAll := func() {
+		for _, a := range done {
+			a.src.Location = a.old
+			if delErr := kr.Delete(ctx, a.id); delErr != nil {
+				// Rollback delete failed: the keyring entry written this
+				// run may orphan. Log it so the failure is recoverable
+				// from debug output and via 'sq config keyring prune'.
+				lg.FromContext(ctx).Warn("Failed to roll back keyring entry during migrate rollback",
+					lga.Path, a.id, lga.Handle, a.src.Handle, lga.Err, delErr)
+			}
+		}
+	}
+
+	// failAll rolls the batch back and reports every eligible source as
+	// failed (rolled back): migration is all-or-nothing, so on any failure
+	// nothing is persisted.
+	failAll := func(cause string) ([]output.KeyringMigrateRow, error) {
+		rollbackAll()
+		rows := make([]output.KeyringMigrateRow, 0, len(done))
+		for _, p := range plans {
+			if p.reason != "" {
+				continue
+			}
+			rows = append(rows, output.KeyringMigrateRow{
+				Handle: p.src.Handle,
+				Status: output.KeyringMigrateStatusFailed,
+				Error:  "rolled back: " + cause,
+			})
+		}
+		return rows, errz.Errorf(
+			"migration failed and was rolled back; no sources were changed: %s", cause)
+	}
+
 	for _, p := range plans {
 		if p.reason != "" {
 			continue
 		}
 		id, err := kr.NewID(ctx)
 		if err != nil {
-			rows = append(rows, output.KeyringMigrateRow{
-				Handle: p.src.Handle,
-				Status: output.KeyringMigrateStatusFailed,
-				Error:  "mint keyring id: " + err.Error(),
-			})
-			anyFailed = true
-			continue
+			return failAll("mint keyring id for " + p.src.Handle + ": " + err.Error())
 		}
 		// The stored Location is a placeholder template in which '$$'
 		// escapes a literal '$' (e.g. written by the v0.54.0 config
@@ -196,42 +239,23 @@ func applyMigratePlans(ctx context.Context, ru *run.Run, plans []migratePlan) (
 		// driver a wrong (still-escaped) credential. Safe because
 		// migrateSkipReason guarantees zero placeholder refs.
 		if err = kr.Set(ctx, id, secret.Unescape(p.src.Location)); err != nil {
-			rows = append(rows, output.KeyringMigrateRow{
-				Handle: p.src.Handle,
-				Status: output.KeyringMigrateStatusFailed,
-				Error:  "write keyring: " + err.Error(),
-			})
-			anyFailed = true
-			continue
+			return failAll("write keyring for " + p.src.Handle + ": " + err.Error())
 		}
-		oldLoc := p.src.Location
+		done = append(done, applied{src: p.src, id: id, old: p.src.Location})
 		p.src.Location = "${keyring:" + id + "}"
-		if err = ru.ConfigStore.Save(ctx, ru.Config); err != nil {
-			p.src.Location = oldLoc
-			if delErr := kr.Delete(ctx, id); delErr != nil {
-				// Rollback failed: the keyring entry just written may
-				// orphan, with no easy way for the user to find it
-				// (orphan-listing is pending — see #715). Log so the
-				// failure is at least recoverable from debug output.
-				lg.FromContext(ctx).Warn("Failed to roll back keyring entry on migrate save error",
-					lga.Path, id, lga.Handle, p.src.Handle, lga.Err, delErr)
-			}
-			rows = append(rows, output.KeyringMigrateRow{
-				Handle: p.src.Handle,
-				Status: output.KeyringMigrateStatusFailed,
-				Error:  "save config (rolled back): " + err.Error(),
-			})
-			anyFailed = true
-			continue
-		}
-		rows = append(rows, output.KeyringMigrateRow{
-			Handle:      p.src.Handle,
-			Status:      output.KeyringMigrateStatusMigrated,
-			NewLocation: p.src.Location,
-		})
 	}
-	if anyFailed {
-		return rows, errz.New("one or more sources failed to migrate")
+
+	if err := ru.ConfigStore.Save(ctx, ru.Config); err != nil {
+		return failAll("save config: " + err.Error())
+	}
+
+	rows := make([]output.KeyringMigrateRow, 0, len(done))
+	for _, a := range done {
+		rows = append(rows, output.KeyringMigrateRow{
+			Handle:      a.src.Handle,
+			Status:      output.KeyringMigrateStatusMigrated,
+			NewLocation: a.src.Location,
+		})
 	}
 	return rows, nil
 }

--- a/cli/cmd_config_keyring_migrate_internal_test.go
+++ b/cli/cmd_config_keyring_migrate_internal_test.go
@@ -8,9 +8,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestPromptYesNo covers the y/n prompt: recognized answers, the [y/N]
-// empty-line default, re-prompting on unrecognized input, and a non-nil
-// error when the input stream ends without a valid answer.
+// TestPromptYesNo covers the strict y/n prompt: only y/yes and n/no (plus the
+// empty-line [y/N] default) are accepted; any other input is an error, as is
+// EOF with no answer. The prompt does not retry.
 func TestPromptYesNo(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -21,13 +21,16 @@ func TestPromptYesNo(t *testing.T) {
 		{name: "y", input: "y\n", want: true},
 		{name: "yes", input: "yes\n", want: true},
 		{name: "uppercase Y", input: "Y\n", want: true},
+		{name: "uppercase YES", input: "YES\n", want: true},
+		{name: "whitespace trimmed", input: "  yes  \n", want: true},
 		{name: "y no newline (data+EOF)", input: "y", want: true},
 		{name: "n", input: "n\n", want: false},
 		{name: "no", input: "no\n", want: false},
 		{name: "empty line is the [y/N] default no", input: "\n", want: false},
-		{name: "reprompt then yes", input: "what?\ny\n", want: true},
-		{name: "reprompt then no", input: "huh\nn\n", want: false},
-		{name: "invalid then EOF errors", input: "garbage\n", wantErr: true},
+		{name: "unrecognized word errors", input: "what?\n", wantErr: true},
+		{name: "partial 'ye' errors", input: "ye\n", wantErr: true},
+		{name: "yep errors", input: "yep\n", wantErr: true},
+		{name: "numeric errors", input: "1\n", wantErr: true},
 		{name: "empty input (EOF) errors", input: "", wantErr: true},
 	}
 	for _, tc := range tests {
@@ -44,13 +47,12 @@ func TestPromptYesNo(t *testing.T) {
 	}
 }
 
-// TestPromptYesNo_RepromptsOnInvalid verifies the prompt is re-issued for
-// each unrecognized response before a valid one is accepted.
-func TestPromptYesNo_RepromptsOnInvalid(t *testing.T) {
+// TestPromptYesNo_DoesNotRetry verifies the prompt is issued exactly once: an
+// unrecognized answer errors immediately rather than re-prompting.
+func TestPromptYesNo_DoesNotRetry(t *testing.T) {
 	var out bytes.Buffer
-	got, err := promptYesNo(strings.NewReader("maybe\nsure\ny\n"), &out, "Proceed?")
-	require.NoError(t, err)
-	require.True(t, got)
-	// Three reads (maybe, sure, y) means the prompt was printed three times.
-	require.Equal(t, 3, strings.Count(out.String(), "Proceed?"))
+	// A valid "y" follows the garbage, but it must never be read.
+	_, err := promptYesNo(strings.NewReader("maybe\ny\n"), &out, "Proceed?")
+	require.Error(t, err)
+	require.Equal(t, 1, strings.Count(out.String(), "Proceed?"), "prompt must be issued once")
 }

--- a/cli/cmd_config_keyring_migrate_internal_test.go
+++ b/cli/cmd_config_keyring_migrate_internal_test.go
@@ -1,0 +1,56 @@
+package cli
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestPromptYesNo covers the y/n prompt: recognized answers, the [y/N]
+// empty-line default, re-prompting on unrecognized input, and a non-nil
+// error when the input stream ends without a valid answer.
+func TestPromptYesNo(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    bool
+		wantErr bool
+	}{
+		{name: "y", input: "y\n", want: true},
+		{name: "yes", input: "yes\n", want: true},
+		{name: "uppercase Y", input: "Y\n", want: true},
+		{name: "y no newline (data+EOF)", input: "y", want: true},
+		{name: "n", input: "n\n", want: false},
+		{name: "no", input: "no\n", want: false},
+		{name: "empty line is the [y/N] default no", input: "\n", want: false},
+		{name: "reprompt then yes", input: "what?\ny\n", want: true},
+		{name: "reprompt then no", input: "huh\nn\n", want: false},
+		{name: "invalid then EOF errors", input: "garbage\n", wantErr: true},
+		{name: "empty input (EOF) errors", input: "", wantErr: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var out bytes.Buffer
+			got, err := promptYesNo(strings.NewReader(tc.input), &out, "Proceed?")
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// TestPromptYesNo_RepromptsOnInvalid verifies the prompt is re-issued for
+// each unrecognized response before a valid one is accepted.
+func TestPromptYesNo_RepromptsOnInvalid(t *testing.T) {
+	var out bytes.Buffer
+	got, err := promptYesNo(strings.NewReader("maybe\nsure\ny\n"), &out, "Proceed?")
+	require.NoError(t, err)
+	require.True(t, got)
+	// Three reads (maybe, sure, y) means the prompt was printed three times.
+	require.Equal(t, 3, strings.Count(out.String(), "Proceed?"))
+}

--- a/cli/cmd_config_keyring_migrate_internal_test.go
+++ b/cli/cmd_config_keyring_migrate_internal_test.go
@@ -8,6 +8,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// TestConfigKeyringMigrate_RequiresConfigLock guards that migrate is marked to
+// take the config lock, since it mutates sq.yml. Dropping the marker would
+// silently make migrate non-atomic against a concurrent sq process.
+func TestConfigKeyringMigrate_RequiresConfigLock(t *testing.T) {
+	require.True(t, cmdRequiresConfigLock(newConfigKeyringMigrateCmd()))
+}
+
 // TestPromptYesNo covers the strict y/n prompt: only y/yes and n/no (plus the
 // empty-line [y/N] default) are accepted; any other input is an error, as is
 // EOF with no answer. The prompt does not retry.

--- a/cli/cmd_config_keyring_prune.go
+++ b/cli/cmd_config_keyring_prune.go
@@ -1,0 +1,93 @@
+package cli
+
+import (
+	"sort"
+
+	"github.com/spf13/cobra"
+
+	"github.com/neilotoole/sq/cli/output"
+	"github.com/neilotoole/sq/cli/run"
+	"github.com/neilotoole/sq/libsq/core/errz"
+	"github.com/neilotoole/sq/libsq/core/secret/keyring"
+)
+
+const flagPruneDryRun = "dry-run"
+
+func newConfigKeyringPruneCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "prune",
+		Args:  cobra.NoArgs,
+		Short: "Delete orphaned keyring entries",
+		Long: `Delete every keyring entry under the sq service that no source
+references. An entry is an orphan when no source Location contains a
+${keyring:PATH} placeholder naming it; hand-crafted references count, so
+an entry wired into any source is never pruned.
+
+Both sq-generated opaque IDs and user-named entries are pruned. Use
+'sq config keyring ls' to review entries first, and --dry-run to preview
+what prune would remove without deleting anything.`,
+		RunE: execConfigKeyringPrune,
+		Example: `  # Preview orphans without deleting
+  $ sq config keyring prune --dry-run
+
+  # Delete all orphaned entries
+  $ sq config keyring prune`,
+	}
+	cmd.Flags().Bool(flagPruneDryRun, false, "Show orphans that would be deleted, make no changes")
+	addKeyringFormatFlags(cmd)
+	return cmd
+}
+
+func execConfigKeyringPrune(cmd *cobra.Command, _ []string) error {
+	ru := run.FromContext(cmd.Context())
+	kr := keyring.NewStore()
+
+	stored, err := kr.List(cmd.Context())
+	if err != nil {
+		return err
+	}
+
+	referenced := make(map[string]struct{})
+	for _, ref := range collectKeyringRefs(ru.Config.Collection.Sources()) {
+		referenced[ref.Path] = struct{}{}
+	}
+
+	orphans := make([]string, 0, len(stored))
+	for _, path := range stored {
+		if _, ok := referenced[path]; !ok {
+			orphans = append(orphans, path)
+		}
+	}
+	sort.Strings(orphans)
+
+	dryRun := cmdFlagIsSetTrue(cmd, flagPruneDryRun)
+	rows := make([]output.KeyringPruneRow, 0, len(orphans))
+	var failed int
+	for _, path := range orphans {
+		row := output.KeyringPruneRow{Path: path, Kind: output.KeyringKindNamed}
+		if keyring.IsID(path) {
+			row.Kind = output.KeyringKindID
+		}
+		switch {
+		case dryRun:
+			row.Status = output.KeyringPruneStatusPlanned
+		default:
+			if delErr := kr.Delete(cmd.Context(), path); delErr != nil {
+				row.Status = output.KeyringPruneStatusFailed
+				row.Error = delErr.Error()
+				failed++
+			} else {
+				row.Status = output.KeyringPruneStatusDeleted
+			}
+		}
+		rows = append(rows, row)
+	}
+
+	if writeErr := ru.Writers.Keyring.Prune(rows, dryRun); writeErr != nil {
+		return writeErr
+	}
+	if failed > 0 {
+		return errz.Errorf("failed to delete %d of %d orphaned keyring entries", failed, len(orphans))
+	}
+	return nil
+}

--- a/cli/cmd_config_keyring_prune.go
+++ b/cli/cmd_config_keyring_prune.go
@@ -47,8 +47,12 @@ func execConfigKeyringPrune(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
+	refs, err := collectKeyringRefs(ru.Config.Collection.Sources())
+	if err != nil {
+		return err
+	}
 	referenced := make(map[string]struct{})
-	for _, ref := range collectKeyringRefs(ru.Config.Collection.Sources()) {
+	for _, ref := range refs {
 		referenced[ref.Path] = struct{}{}
 	}
 

--- a/cli/cmd_config_keyring_prune.go
+++ b/cli/cmd_config_keyring_prune.go
@@ -46,6 +46,11 @@ what prune would remove without deleting anything.`,
 	}
 	cmd.Flags().Bool(flagPruneDryRun, false, "Show orphans that would be deleted, make no changes")
 	addKeyringFormatFlags(cmd)
+	// prune decides what to delete by diffing the keyring against the config's
+	// references, so it takes the config lock and runs against a freshly
+	// reloaded config. Otherwise a concurrent writer (e.g. sq add) could make
+	// an orphan referenced after prune read the config but before it deletes.
+	cmdMarkRequiresConfigLock(cmd)
 	return cmd
 }
 

--- a/cli/cmd_config_keyring_prune.go
+++ b/cli/cmd_config_keyring_prune.go
@@ -83,11 +83,10 @@ func execConfigKeyringPrune(cmd *cobra.Command, _ []string) error {
 		rows = append(rows, row)
 	}
 
-	if writeErr := ru.Writers.Keyring.Prune(rows, dryRun); writeErr != nil {
-		return writeErr
-	}
+	writeErr := ru.Writers.Keyring.Prune(rows, dryRun)
+	var summaryErr error
 	if failed > 0 {
-		return errz.Errorf("failed to delete %d of %d orphaned keyring entries", failed, len(orphans))
+		summaryErr = errz.Errorf("failed to delete %d of %d orphaned keyring entries", failed, len(orphans))
 	}
-	return nil
+	return errz.Append(writeErr, summaryErr)
 }

--- a/cli/cmd_config_keyring_prune.go
+++ b/cli/cmd_config_keyring_prune.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"context"
 	"sort"
 
 	"github.com/spf13/cobra"
@@ -9,7 +10,17 @@ import (
 	"github.com/neilotoole/sq/cli/run"
 	"github.com/neilotoole/sq/libsq/core/errz"
 	"github.com/neilotoole/sq/libsq/core/secret/keyring"
+	"github.com/neilotoole/sq/libsq/source"
 )
+
+// keyringPruner is the subset of *keyring.Store that prune needs:
+// enumerate stored entries and delete them by path. Defining it here lets
+// tests substitute a fault-injecting fake to exercise the delete-failure
+// path, which the go-keyring mock backend cannot trigger.
+type keyringPruner interface {
+	List(ctx context.Context) ([]string, error)
+	Delete(ctx context.Context, path string) error
+}
 
 const flagPruneDryRun = "dry-run"
 
@@ -40,18 +51,38 @@ what prune would remove without deleting anything.`,
 
 func execConfigKeyringPrune(cmd *cobra.Command, _ []string) error {
 	ru := run.FromContext(cmd.Context())
-	kr := keyring.NewStore()
+	dryRun := cmdFlagIsSetTrue(cmd, flagPruneDryRun)
+	return pruneOrphans(
+		cmd.Context(),
+		keyring.NewStore(),
+		ru.Config.Collection.Sources(),
+		dryRun,
+		ru.Writers.Keyring,
+	)
+}
 
-	stored, err := kr.List(cmd.Context())
+// pruneOrphans enumerates kr's entries, treats every entry that no source in
+// srcs references as an orphan, and (unless dryRun) deletes each, reporting
+// the outcome via w. It returns a non-nil error if enumeration fails, if any
+// source Location fails to parse, or if any deletion fails (the per-entry
+// failures are also visible in the reported rows).
+func pruneOrphans(
+	ctx context.Context,
+	kr keyringPruner,
+	srcs []*source.Source,
+	dryRun bool,
+	w output.KeyringWriter,
+) error {
+	stored, err := kr.List(ctx)
 	if err != nil {
 		return err
 	}
 
-	refs, err := collectKeyringRefs(ru.Config.Collection.Sources())
+	refs, err := collectKeyringRefs(srcs)
 	if err != nil {
 		return err
 	}
-	referenced := make(map[string]struct{})
+	referenced := make(map[string]struct{}, len(refs))
 	for _, ref := range refs {
 		referenced[ref.Path] = struct{}{}
 	}
@@ -64,7 +95,6 @@ func execConfigKeyringPrune(cmd *cobra.Command, _ []string) error {
 	}
 	sort.Strings(orphans)
 
-	dryRun := cmdFlagIsSetTrue(cmd, flagPruneDryRun)
 	rows := make([]output.KeyringPruneRow, 0, len(orphans))
 	var failed int
 	for _, path := range orphans {
@@ -76,7 +106,7 @@ func execConfigKeyringPrune(cmd *cobra.Command, _ []string) error {
 		case dryRun:
 			row.Status = output.KeyringPruneStatusPlanned
 		default:
-			if delErr := kr.Delete(cmd.Context(), path); delErr != nil {
+			if delErr := kr.Delete(ctx, path); delErr != nil {
 				row.Status = output.KeyringPruneStatusFailed
 				row.Error = delErr.Error()
 				failed++
@@ -87,7 +117,7 @@ func execConfigKeyringPrune(cmd *cobra.Command, _ []string) error {
 		rows = append(rows, row)
 	}
 
-	writeErr := ru.Writers.Keyring.Prune(rows, dryRun)
+	writeErr := w.Prune(rows, dryRun)
 	var summaryErr error
 	if failed > 0 {
 		summaryErr = errz.Errorf("failed to delete %d of %d orphaned keyring entries", failed, len(orphans))

--- a/cli/cmd_config_keyring_prune_internal_test.go
+++ b/cli/cmd_config_keyring_prune_internal_test.go
@@ -33,6 +33,13 @@ func (f *fakePruner) Delete(_ context.Context, path string) error {
 	return nil
 }
 
+// TestConfigKeyringPrune_RequiresConfigLock guards that prune takes the config
+// lock, since it deletes keyring entries based on the config's references and
+// must not race a concurrent config writer.
+func TestConfigKeyringPrune_RequiresConfigLock(t *testing.T) {
+	require.True(t, cmdRequiresConfigLock(newConfigKeyringPruneCmd()))
+}
+
 // TestPruneOrphans_DeleteFailure verifies that when one entry's deletion
 // fails, prune still deletes the others, marks the failed row, and returns
 // a summary error naming the failure count.

--- a/cli/cmd_config_keyring_prune_internal_test.go
+++ b/cli/cmd_config_keyring_prune_internal_test.go
@@ -56,5 +56,5 @@ func TestPruneOrphans_DeleteFailure(t *testing.T) {
 
 	out := buf.String()
 	require.Contains(t, out, "boom123456")
-	require.Contains(t, out, "FAIL")
+	require.Contains(t, out, "failed")
 }

--- a/cli/cmd_config_keyring_prune_internal_test.go
+++ b/cli/cmd_config_keyring_prune_internal_test.go
@@ -1,0 +1,60 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/neilotoole/sq/cli/output"
+	"github.com/neilotoole/sq/cli/output/tablew"
+	"github.com/neilotoole/sq/libsq/core/errz"
+)
+
+// fakePruner is a keyringPruner whose Delete fails for any path in failOn.
+// It lets tests exercise the prune delete-failure path that the real
+// go-keyring mock backend cannot trigger (its Delete always succeeds).
+type fakePruner struct {
+	failOn  map[string]error
+	stored  []string
+	deleted []string
+}
+
+func (f *fakePruner) List(context.Context) ([]string, error) {
+	return f.stored, nil
+}
+
+func (f *fakePruner) Delete(_ context.Context, path string) error {
+	if err := f.failOn[path]; err != nil {
+		return err
+	}
+	f.deleted = append(f.deleted, path)
+	return nil
+}
+
+// TestPruneOrphans_DeleteFailure verifies that when one entry's deletion
+// fails, prune still deletes the others, marks the failed row, and returns
+// a summary error naming the failure count.
+func TestPruneOrphans_DeleteFailure(t *testing.T) {
+	kr := &fakePruner{
+		stored: []string{"keepgoing9", "boom123456"},
+		failOn: map[string]error{"boom123456": errz.New("keyring locked")},
+	}
+	buf := &bytes.Buffer{}
+	pr := output.NewPrinting()
+	pr.EnableColor(false)
+	w := tablew.NewKeyringWriter(buf, pr)
+
+	// nil sources means every stored entry is an orphan.
+	err := pruneOrphans(context.Background(), kr, nil, false, w)
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed to delete 1 of 2 orphaned keyring entries")
+	require.Equal(t, []string{"keepgoing9"}, kr.deleted,
+		"the non-failing orphan must still be deleted after the failure")
+
+	out := buf.String()
+	require.Contains(t, out, "boom123456")
+	require.Contains(t, out, "FAIL")
+}

--- a/cli/cmd_config_keyring_test.go
+++ b/cli/cmd_config_keyring_test.go
@@ -343,6 +343,15 @@ func TestCmdConfigKeyringMigrate_PerCase(t *testing.T) {
 			wantKeyring: "postgres://alice:hunter2@db/sakila",
 		},
 		{
+			// A scheme-bearing URL with a password but an empty host still
+			// carries an inline credential, so it must migrate (regression
+			// guard: the host check used to skip it, leaving the password
+			// in sq.yml).
+			name:        "url with password but empty host",
+			inLocation:  "postgres://alice:hunter2@/sakila",
+			wantKeyring: "postgres://alice:hunter2@/sakila",
+		},
+		{
 			name:           "url without password",
 			inLocation:     "postgres://alice@db/sakila",
 			wantSkipReason: "no password",

--- a/cli/cmd_config_keyring_test.go
+++ b/cli/cmd_config_keyring_test.go
@@ -65,6 +65,17 @@ type migrateJSONEnvelope struct {
 	DryRun bool             `json:"dry_run"`
 }
 
+type pruneJSONRow struct {
+	Path   string `json:"path"`
+	Kind   string `json:"kind"`
+	Status string `json:"status"`
+	Error  string `json:"error,omitempty"`
+}
+type pruneJSONEnvelope struct {
+	Rows   []pruneJSONRow `json:"rows"`
+	DryRun bool           `json:"dry_run"`
+}
+
 func TestCmdConfigKeyringCreate_ExplicitValue(t *testing.T) {
 	gokeyring.MockInit()
 	th := testh.New(t)
@@ -1126,7 +1137,7 @@ func TestCmdConfigKeyringPrune_DeletesOrphans(t *testing.T) {
 
 	kr := keyring.NewStore()
 	require.NoError(t, kr.Set(th.Context, "keep1234567", "live"))   // referenced
-	require.NoError(t, kr.Set(th.Context, "orphan23456", "stale"))  // orphan (opaque id)
+	require.NoError(t, kr.Set(th.Context, "m4n8k2pxtz", "stale"))   // orphan (valid sq-minted opaque ID)
 	require.NoError(t, kr.Set(th.Context, "named_orphan", "stale")) // orphan (named)
 
 	tr.Add(source.Source{
@@ -1137,13 +1148,18 @@ func TestCmdConfigKeyringPrune_DeletesOrphans(t *testing.T) {
 
 	require.NoError(t, tr.Exec("config", "keyring", "prune"))
 
+	out := tr.Out.String()
+	// Output must label both the opaque-ID and named-kind orphans.
+	require.Contains(t, out, "(id)")
+	require.Contains(t, out, "(named)")
+
 	// Referenced entry survives.
 	v, err := kr.Resolve(th.Context, "keep1234567")
 	require.NoError(t, err)
 	require.Equal(t, "live", v)
 
-	// Both orphans (opaque and named) are gone.
-	_, err = kr.Resolve(th.Context, "orphan23456")
+	// Both orphans (opaque-ID and named) are deleted.
+	_, err = kr.Resolve(th.Context, "m4n8k2pxtz")
 	require.ErrorIs(t, err, secret.ErrNotFound)
 	_, err = kr.Resolve(th.Context, "named_orphan")
 	require.ErrorIs(t, err, secret.ErrNotFound)
@@ -1155,16 +1171,90 @@ func TestCmdConfigKeyringPrune_DryRun(t *testing.T) {
 	tr := testrun.New(th.Context, t, nil)
 
 	kr := keyring.NewStore()
-	require.NoError(t, kr.Set(th.Context, "orphan23456", "stale"))
+	// m4n8k2pxtz is a valid sq-minted opaque ID (10-char Crockford).
+	require.NoError(t, kr.Set(th.Context, "m4n8k2pxtz", "stale"))
 
 	require.NoError(t, tr.Exec("config", "keyring", "prune", "--dry-run"))
 	out := tr.Out.String()
-	require.Contains(t, out, "orphan23456")
+	require.Contains(t, out, "m4n8k2pxtz")
 
 	// Dry-run deletes nothing.
-	v, err := kr.Resolve(th.Context, "orphan23456")
+	v, err := kr.Resolve(th.Context, "m4n8k2pxtz")
 	require.NoError(t, err)
 	require.Equal(t, "stale", v)
+}
+
+// TestCmdConfigKeyringPrune_JSON verifies the JSON envelope emitted by
+// "sq config keyring prune --json". It checks both the apply path
+// (dry_run=false, status="deleted") and the dry-run path
+// (dry_run=true, status="planned"), and that dry-run leaves entries intact.
+func TestCmdConfigKeyringPrune_JSON(t *testing.T) {
+	// --- Apply path ---
+	t.Run("apply", func(t *testing.T) {
+		gokeyring.MockInit()
+		th := testh.New(t)
+		tr := testrun.New(th.Context, t, nil)
+
+		kr := keyring.NewStore()
+		// m4n8k2pxtz is a valid sq-minted opaque ID (10-char Crockford).
+		require.NoError(t, kr.Set(th.Context, "m4n8k2pxtz", "stale"))
+		require.NoError(t, kr.Set(th.Context, "named_orphan", "stale"))
+
+		require.NoError(t, tr.Exec("config", "keyring", "prune", "--json"))
+
+		var env pruneJSONEnvelope
+		require.NoError(t, json.Unmarshal(tr.Out.Bytes(), &env))
+		require.False(t, env.DryRun)
+		require.Len(t, env.Rows, 2)
+
+		byPath := map[string]pruneJSONRow{}
+		for _, r := range env.Rows {
+			byPath[r.Path] = r
+		}
+		require.Equal(t, output.KeyringKindID, byPath["m4n8k2pxtz"].Kind)
+		require.Equal(t, output.KeyringPruneStatusDeleted, byPath["m4n8k2pxtz"].Status)
+		require.Equal(t, output.KeyringKindNamed, byPath["named_orphan"].Kind)
+		require.Equal(t, output.KeyringPruneStatusDeleted, byPath["named_orphan"].Status)
+
+		// Both entries must be gone after apply.
+		_, err := kr.Resolve(th.Context, "m4n8k2pxtz")
+		require.ErrorIs(t, err, secret.ErrNotFound)
+		_, err = kr.Resolve(th.Context, "named_orphan")
+		require.ErrorIs(t, err, secret.ErrNotFound)
+	})
+
+	// --- Dry-run path ---
+	t.Run("dry-run", func(t *testing.T) {
+		gokeyring.MockInit()
+		th := testh.New(t)
+		tr := testrun.New(th.Context, t, nil)
+
+		kr := keyring.NewStore()
+		require.NoError(t, kr.Set(th.Context, "m4n8k2pxtz", "stale"))
+		require.NoError(t, kr.Set(th.Context, "named_orphan", "stale"))
+
+		require.NoError(t, tr.Exec("config", "keyring", "prune", "--dry-run", "--json"))
+
+		var env pruneJSONEnvelope
+		require.NoError(t, json.Unmarshal(tr.Out.Bytes(), &env))
+		require.True(t, env.DryRun)
+		require.Len(t, env.Rows, 2)
+
+		byPath := map[string]pruneJSONRow{}
+		for _, r := range env.Rows {
+			byPath[r.Path] = r
+		}
+		require.Equal(t, output.KeyringPruneStatusPlanned, byPath["m4n8k2pxtz"].Status)
+		require.Equal(t, output.KeyringPruneStatusPlanned, byPath["named_orphan"].Status)
+
+		// Dry-run must not delete anything.
+		v, err := kr.Resolve(th.Context, "m4n8k2pxtz")
+		require.NoError(t, err)
+		require.Equal(t, "stale", v)
+		v, err = kr.Resolve(th.Context, "named_orphan")
+		require.NoError(t, err)
+		require.Equal(t, "stale", v)
+	})
 }
 
 // TestCmdConfigKeyringPrune_WriterError exercises the errz.Append branch

--- a/cli/cmd_config_keyring_test.go
+++ b/cli/cmd_config_keyring_test.go
@@ -1106,3 +1106,55 @@ func TestCmdConfigKeyringPrune_DryRun(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "stale", v)
 }
+
+// TestCmdConfigKeyringPrune_WriterError exercises the errz.Append branch
+// where the output writer itself fails. The command must surface the writer
+// error even when no individual deletion failed.
+//
+// The test pre-populates tr.Run.Writers with an erroring stub before calling
+// Exec. preRun skips writer initialization when Writers is non-nil (see
+// cli/run.go), so the stub is preserved through command execution. The prune
+// command accesses only ru.Writers.Keyring, so nil values in the other
+// Writers fields do not cause a panic.
+//
+// Note on Delete seam: forcing kr.Delete to fail is not cleanly testable via
+// the zalando/go-keyring mock. MockInit installs an in-memory map backend;
+// Delete on a present key always succeeds, and Store.Delete treats not-found
+// as success explicitly. Adding a seam for a forced Delete failure would
+// require production code changes purely for testing, so the partial-delete-
+// failure path is not tested at the kr.Delete level.
+func TestCmdConfigKeyringPrune_WriterError(t *testing.T) {
+	gokeyring.MockInit()
+	th := testh.New(t)
+	tr := testrun.New(th.Context, t, nil)
+
+	kr := keyring.NewStore()
+	require.NoError(t, kr.Set(th.Context, "orphan23456", "stale"))
+
+	// Pre-populate Writers with a stub so preRun skips writer
+	// initialization. Only Keyring needs to be set; the prune
+	// command touches no other writer field.
+	tr.Run.Writers = &output.Writers{Keyring: &failingKeyringWriter{}}
+
+	err := tr.Exec("config", "keyring", "prune")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "simulated prune writer failure")
+}
+
+// failingKeyringWriter is a KeyringWriter stub whose Prune always errors,
+// used by TestCmdConfigKeyringPrune_WriterError.
+type failingKeyringWriter struct{}
+
+func (w *failingKeyringWriter) List(_ []output.KeyringRef) error { return nil }
+func (w *failingKeyringWriter) Get(_, _ string, _ bool) error    { return nil }
+func (w *failingKeyringWriter) Created(_ string) error           { return nil }
+func (w *failingKeyringWriter) Updated(_ string) error           { return nil }
+func (w *failingKeyringWriter) Rm(_ string) error                { return nil }
+
+func (w *failingKeyringWriter) Migrate(_ []output.KeyringMigrateRow, _ bool) error {
+	return nil
+}
+
+func (w *failingKeyringWriter) Prune(_ []output.KeyringPruneRow, _ bool) error {
+	return errz.New("simulated prune writer failure")
+}

--- a/cli/cmd_config_keyring_test.go
+++ b/cli/cmd_config_keyring_test.go
@@ -1059,6 +1059,66 @@ func TestCmdConfigKeyringRm_Completion_TolerantOfMalformedSource(t *testing.T) {
 		"malformed source must not block completion of healthy refs")
 }
 
+// TestCmdConfigKeyringPrune_MalformedSourceAbortsWithoutDeleting verifies
+// that prune hard-fails when any source has a malformed placeholder in its
+// Location, and that no keyring entries are deleted in that case. A source
+// whose Location has both a valid ${keyring:...} ref and a malformed
+// placeholder would have its valid ref silently dropped by ExtractRefs
+// (all-or-nothing); prune would then misclassify the live entry as an
+// orphan and delete it. Hard-failing before the delete loop prevents that
+// data loss.
+func TestCmdConfigKeyringPrune_MalformedSourceAbortsWithoutDeleting(t *testing.T) {
+	gokeyring.MockInit()
+	th := testh.New(t)
+	tr := testrun.New(th.Context, t, nil)
+
+	kr := keyring.NewStore()
+	// A live entry referenced by the malformed source (must NOT be deleted).
+	require.NoError(t, kr.Set(th.Context, "keepme1234", "live"))
+	// A genuine orphan (must also NOT be deleted, because prune must abort
+	// before touching anything when the referenced set may be incomplete).
+	require.NoError(t, kr.Set(th.Context, "orphan9999", "stale"))
+
+	// Add a source whose Location contains both a valid ${keyring:...} ref
+	// and an unclosed ${ that makes ExtractRefs return an error.
+	tr.Add(source.Source{
+		Handle:   "@bad_src",
+		Type:     drivertype.Pg,
+		Location: "postgres://u:${keyring:keepme1234}@host/db?x=${env:UNCLOSED",
+	})
+
+	err := tr.Exec("config", "keyring", "prune")
+	require.Error(t, err, "prune must error when a source has a malformed Location")
+
+	// Neither entry may have been deleted.
+	v, resolveErr := kr.Resolve(th.Context, "keepme1234")
+	require.NoError(t, resolveErr)
+	require.Equal(t, "live", v, "referenced entry must survive")
+
+	v, resolveErr = kr.Resolve(th.Context, "orphan9999")
+	require.NoError(t, resolveErr)
+	require.Equal(t, "stale", v, "orphan entry must survive when prune aborts early")
+}
+
+// TestCmdConfigKeyringLs_MalformedSourceErrors verifies that ls returns a
+// non-nil error when any source has a malformed placeholder in its Location.
+// An incomplete referenced set would misclassify live entries as orphans
+// in the output, so hard-failing is correct.
+func TestCmdConfigKeyringLs_MalformedSourceErrors(t *testing.T) {
+	gokeyring.MockInit()
+	th := testh.New(t)
+	tr := testrun.New(th.Context, t, nil)
+
+	tr.Add(source.Source{
+		Handle:   "@bad_ls",
+		Type:     drivertype.Pg,
+		Location: "postgres://u:${keyring:keepme1234}@host/db?x=${env:UNCLOSED",
+	})
+
+	err := tr.Exec("config", "keyring", "ls")
+	require.Error(t, err, "ls must error when a source has a malformed Location")
+}
+
 func TestCmdConfigKeyringPrune_DeletesOrphans(t *testing.T) {
 	gokeyring.MockInit()
 	th := testh.New(t)

--- a/cli/cmd_config_keyring_test.go
+++ b/cli/cmd_config_keyring_test.go
@@ -402,7 +402,8 @@ func TestCmdConfigKeyringMigrate_PerCase(t *testing.T) {
 				Location: tc.inLocation,
 			})
 
-			require.NoError(t, tr.Exec("config", "keyring", "migrate", "--all", "--yes"))
+			// -v so skipped sources (and their reasons) appear in the output.
+			require.NoError(t, tr.Exec("config", "keyring", "migrate", "--all", "--yes", "-v"))
 
 			src, err := tr.Run.Config.Collection.Get("@h")
 			require.NoError(t, err)
@@ -961,6 +962,52 @@ func TestCmdConfigKeyringMigrate_Completion(t *testing.T) {
 	require.Empty(t, got.values)
 }
 
+// TestCmdConfigKeyringMigrate_HidesSkipsByDefault verifies that the
+// default (non-verbose) output shows only the sources that migrate, and
+// omits skipped sources and their reasons.
+func TestCmdConfigKeyringMigrate_HidesSkipsByDefault(t *testing.T) {
+	gokeyring.MockInit()
+	th := testh.New(t)
+	tr := testrun.New(th.Context, t, nil)
+	tr.Add(
+		source.Source{Handle: "@hide_pg", Type: drivertype.Pg, Location: "postgres://alice:hunter2@db/sakila"},
+		source.Source{Handle: "@hide_csv", Type: "csv", Location: "/data/file.csv"},
+		source.Source{Handle: "@hide_nopw", Type: drivertype.Pg, Location: "postgres://alice@db/sakila"},
+	)
+
+	require.NoError(t, tr.Exec("config", "keyring", "migrate", "--all", "--yes"))
+
+	out := tr.Out.String()
+	require.Contains(t, out, "@hide_pg") // the migrating source is shown
+	require.NotContains(t, out, "not a URL")
+	require.NotContains(t, out, "no password component")
+	require.NotContains(t, out, "@hide_csv")
+	require.NotContains(t, out, "@hide_nopw")
+}
+
+// TestCmdConfigKeyringMigrate_NothingToMigrate verifies that when every
+// source is skipped, migrate reports "Nothing to migrate", does not prompt,
+// and changes nothing.
+func TestCmdConfigKeyringMigrate_NothingToMigrate(t *testing.T) {
+	gokeyring.MockInit()
+	th := testh.New(t)
+	tr := testrun.New(th.Context, t, nil)
+	tr.Add(
+		source.Source{Handle: "@nm_csv", Type: "csv", Location: "/data/a.csv"},
+		source.Source{Handle: "@nm_nopw", Type: drivertype.Pg, Location: "postgres://alice@db/sakila"},
+	)
+	// "n" on stdin would cancel if a prompt fired; it must not, because the
+	// command short-circuits before prompting when nothing is actionable.
+	tr.PipeStdin("n\n")
+
+	require.NoError(t, tr.Exec("config", "keyring", "migrate", "--all"))
+
+	require.Contains(t, tr.Out.String(), "Nothing to migrate")
+	csv, err := tr.Run.Config.Collection.Get("@nm_csv")
+	require.NoError(t, err)
+	require.Equal(t, "/data/a.csv", csv.Location)
+}
+
 // TestCmdConfigKeyringMigrate_AtomicSingleSave verifies the migration is
 // atomic: a multi-source run saves the config exactly once for the whole
 // batch, not once per source. That single save is what makes a mid-batch
@@ -1276,7 +1323,8 @@ func TestCmdConfigKeyringMigrate_MixedCollection(t *testing.T) {
 		Location: fileLoc,
 	})
 
-	require.NoError(t, tr.Exec("config", "keyring", "migrate", "--all", "--yes"))
+	// -v so the skipped sources (and their reasons) appear in the output.
+	require.NoError(t, tr.Exec("config", "keyring", "migrate", "--all", "--yes", "-v"))
 
 	// The eligible source must be migrated.
 	srcEligible, err := tr.Run.Config.Collection.Get("@mc_eligible")

--- a/cli/cmd_config_keyring_test.go
+++ b/cli/cmd_config_keyring_test.go
@@ -860,6 +860,9 @@ func TestCmdConfigKeyringMigrate_JSON_Apply(t *testing.T) {
 
 	require.NoError(t, tr.Exec("config", "keyring", "migrate", "--all", "--json"))
 
+	// JSON output must stay plain: no ANSI color escapes.
+	require.NotContains(t, tr.Out.String(), "\x1b[", "JSON output must not be colorized")
+
 	type applyRow struct {
 		Handle      string `json:"handle"`
 		Status      string `json:"status"`
@@ -1006,6 +1009,21 @@ func TestCmdConfigKeyringMigrate_NothingToMigrate(t *testing.T) {
 	csv, err := tr.Run.Config.Collection.Get("@nm_csv")
 	require.NoError(t, err)
 	require.Equal(t, "/data/a.csv", csv.Location)
+}
+
+// TestCmdConfigKeyringMigrate_JSON_NothingActionable verifies that a JSON-mode
+// run with nothing eligible does not rewrite sq.yml (no no-op save), matching
+// the text-mode short-circuit.
+func TestCmdConfigKeyringMigrate_JSON_NothingActionable(t *testing.T) {
+	gokeyring.MockInit()
+	th := testh.New(t)
+	tr := testrun.New(th.Context, t, nil)
+	tr.Add(source.Source{Handle: "@js_csv", Type: "csv", Location: "/tmp/x.csv"})
+	counter := &countingConfigStore{Store: tr.Run.ConfigStore}
+	tr.Run.ConfigStore = counter
+
+	require.NoError(t, tr.Exec("config", "keyring", "migrate", "--all", "--json"))
+	require.Equal(t, 0, counter.saves, "an all-skipped JSON run must not save sq.yml")
 }
 
 // TestCmdConfigKeyringMigrate_AtomicSingleSave verifies the migration is

--- a/cli/cmd_config_keyring_test.go
+++ b/cli/cmd_config_keyring_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/neilotoole/sq/cli/testrun"
 	"github.com/neilotoole/sq/libsq/core/errz"
 	"github.com/neilotoole/sq/libsq/core/ioz/lockfile"
+	"github.com/neilotoole/sq/libsq/core/secret"
 	"github.com/neilotoole/sq/libsq/core/secret/keyring"
 	"github.com/neilotoole/sq/libsq/source"
 	"github.com/neilotoole/sq/libsq/source/drivertype"
@@ -1056,4 +1057,52 @@ func TestCmdConfigKeyringRm_Completion_TolerantOfMalformedSource(t *testing.T) {
 	got := testComplete(t, tr, "config", "keyring", "rm", "")
 	require.Contains(t, got.values, "goodid",
 		"malformed source must not block completion of healthy refs")
+}
+
+func TestCmdConfigKeyringPrune_DeletesOrphans(t *testing.T) {
+	gokeyring.MockInit()
+	th := testh.New(t)
+	tr := testrun.New(th.Context, t, nil)
+
+	kr := keyring.NewStore()
+	require.NoError(t, kr.Set(th.Context, "keep1234567", "live"))   // referenced
+	require.NoError(t, kr.Set(th.Context, "orphan23456", "stale"))  // orphan (opaque id)
+	require.NoError(t, kr.Set(th.Context, "named_orphan", "stale")) // orphan (named)
+
+	tr.Add(source.Source{
+		Handle:   "@keep_pg",
+		Type:     drivertype.Pg,
+		Location: "${keyring:keep1234567}",
+	})
+
+	require.NoError(t, tr.Exec("config", "keyring", "prune"))
+
+	// Referenced entry survives.
+	v, err := kr.Resolve(th.Context, "keep1234567")
+	require.NoError(t, err)
+	require.Equal(t, "live", v)
+
+	// Both orphans (opaque and named) are gone.
+	_, err = kr.Resolve(th.Context, "orphan23456")
+	require.ErrorIs(t, err, secret.ErrNotFound)
+	_, err = kr.Resolve(th.Context, "named_orphan")
+	require.ErrorIs(t, err, secret.ErrNotFound)
+}
+
+func TestCmdConfigKeyringPrune_DryRun(t *testing.T) {
+	gokeyring.MockInit()
+	th := testh.New(t)
+	tr := testrun.New(th.Context, t, nil)
+
+	kr := keyring.NewStore()
+	require.NoError(t, kr.Set(th.Context, "orphan23456", "stale"))
+
+	require.NoError(t, tr.Exec("config", "keyring", "prune", "--dry-run"))
+	out := tr.Out.String()
+	require.Contains(t, out, "orphan23456")
+
+	// Dry-run deletes nothing.
+	v, err := kr.Resolve(th.Context, "orphan23456")
+	require.NoError(t, err)
+	require.Equal(t, "stale", v)
 }

--- a/cli/cmd_config_keyring_test.go
+++ b/cli/cmd_config_keyring_test.go
@@ -11,6 +11,7 @@ import (
 	gokeyring "github.com/zalando/go-keyring"
 
 	"github.com/neilotoole/sq/cli/config"
+	"github.com/neilotoole/sq/cli/output"
 	"github.com/neilotoole/sq/cli/testrun"
 	"github.com/neilotoole/sq/libsq/core/errz"
 	"github.com/neilotoole/sq/libsq/core/ioz/lockfile"
@@ -583,6 +584,7 @@ func TestCmdConfigKeyringLs_HeaderRow(t *testing.T) {
 	require.Contains(t, out, "PATH")
 	require.Contains(t, out, "HANDLE")
 	require.Contains(t, out, "DRIVER")
+	require.Contains(t, out, "STATUS")
 	require.Contains(t, out, "hdr_id")
 
 	// --no-header (and the -H short form) suppresses it.
@@ -623,15 +625,19 @@ func TestCmdConfigKeyringLs_JSON(t *testing.T) {
 		Path   string `json:"path"`
 		Handle string `json:"handle"`
 		Driver string `json:"driver"`
+		Status string `json:"status"`
 	}
 	require.NoError(t, json.Unmarshal(tr.Out.Bytes(), &got))
 	require.Len(t, got, 2, "env source must not produce a row")
 	require.Equal(t, "abc1", got[0].Path)
 	require.Equal(t, "@a_js", got[0].Handle)
 	require.Equal(t, "postgres", got[0].Driver)
+	// Paths are referenced by sources but not written to the mock keyring.
+	require.Equal(t, output.KeyringStatusMissing, got[0].Status)
 	require.Equal(t, "abc2", got[1].Path)
 	require.Equal(t, "@b_js", got[1].Handle)
 	require.Equal(t, "mysql", got[1].Driver)
+	require.Equal(t, output.KeyringStatusMissing, got[1].Status)
 }
 
 // TestCmdConfigKeyringLs_JSON_Empty: empty collection emits a JSON
@@ -1013,6 +1019,13 @@ func TestCmdConfigKeyringLs_Statuses(t *testing.T) {
 	require.Contains(t, out, "ref1234567")
 	require.Contains(t, out, "orphan23456")
 	require.Contains(t, out, "gone7654321")
+
+	// Spec mandates sort order: referenced → orphan → missing.
+	idxReferenced := strings.Index(out, "ref1234567")
+	idxOrphan := strings.Index(out, "orphan23456")
+	idxMissing := strings.Index(out, "gone7654321")
+	require.Less(t, idxReferenced, idxOrphan, "referenced must appear before orphan")
+	require.Less(t, idxOrphan, idxMissing, "orphan must appear before missing")
 }
 
 // TestCmdConfigKeyringRm_Completion_TolerantOfMalformedSource verifies

--- a/cli/cmd_config_keyring_test.go
+++ b/cli/cmd_config_keyring_test.go
@@ -1167,9 +1167,11 @@ func TestCmdConfigKeyringMigrate_PromptAbort(t *testing.T) {
 
 	// Answer "no" at the prompt.
 	tr.PipeStdin("n\n")
-	require.NoError(t, tr.Exec("config", "keyring", "migrate", "--all"))
+	execErr := tr.Exec("config", "keyring", "migrate", "--all")
+	require.Error(t, execErr, "declining must exit non-zero")
+	require.Contains(t, execErr.Error(), "cancelled")
 
-	// Abort is not an error; the source Location must be unchanged.
+	// Declining changes nothing; the source Location must be unchanged.
 	src, err := tr.Run.Config.Collection.Get("@pa_src")
 	require.NoError(t, err)
 	require.Equal(t, origLoc, src.Location, "abort must not modify the Location")
@@ -1196,9 +1198,10 @@ func TestCmdConfigKeyringMigrate_PromptProceedEmptyAborts(t *testing.T) {
 		Location: origLoc,
 	})
 
-	// Empty input (just Enter) should default to "no".
+	// Empty input (just Enter) defaults to "no", which cancels (non-zero).
 	tr.PipeStdin("\n")
-	require.NoError(t, tr.Exec("config", "keyring", "migrate", "--all"))
+	execErr := tr.Exec("config", "keyring", "migrate", "--all")
+	require.Error(t, execErr, "empty Enter (default no) must exit non-zero")
 
 	src, err := tr.Run.Config.Collection.Get("@pe_src")
 	require.NoError(t, err)

--- a/cli/cmd_config_keyring_test.go
+++ b/cli/cmd_config_keyring_test.go
@@ -1503,9 +1503,9 @@ func TestCmdConfigKeyringPrune_DeletesOrphans(t *testing.T) {
 	require.NoError(t, tr.Exec("config", "keyring", "prune"))
 
 	out := tr.Out.String()
-	// Output must label both the opaque-ID and named-kind orphans.
-	require.Contains(t, out, "(id)")
-	require.Contains(t, out, "(named)")
+	// Output must label both the opaque-ID and named-kind orphans (KIND column).
+	require.Contains(t, out, "id")
+	require.Contains(t, out, "named")
 
 	// Referenced entry survives.
 	v, err := kr.Resolve(th.Context, "keep1234567")
@@ -1517,6 +1517,24 @@ func TestCmdConfigKeyringPrune_DeletesOrphans(t *testing.T) {
 	require.ErrorIs(t, err, secret.ErrNotFound)
 	_, err = kr.Resolve(th.Context, "named_orphan")
 	require.ErrorIs(t, err, secret.ErrNotFound)
+}
+
+// TestCmdConfigKeyringPrune_NothingToPrune verifies that with no orphans,
+// prune reports it rather than printing an empty table.
+func TestCmdConfigKeyringPrune_NothingToPrune(t *testing.T) {
+	gokeyring.MockInit()
+	th := testh.New(t)
+	tr := testrun.New(th.Context, t, nil)
+	// A referenced entry exists, but nothing is orphaned.
+	require.NoError(t, keyring.NewStore().Set(th.Context, "keep7654321", "live"))
+	tr.Add(source.Source{
+		Handle:   "@keep2",
+		Type:     drivertype.Pg,
+		Location: "${keyring:keep7654321}",
+	})
+
+	require.NoError(t, tr.Exec("config", "keyring", "prune"))
+	require.Contains(t, tr.Out.String(), "No orphaned entries to prune")
 }
 
 func TestCmdConfigKeyringPrune_DryRun(t *testing.T) {

--- a/cli/cmd_config_keyring_test.go
+++ b/cli/cmd_config_keyring_test.go
@@ -996,6 +996,205 @@ func TestCmdConfigKeyringMigrate_ConfigFormatJSON_SkipsPrompt(t *testing.T) {
 	require.Contains(t, src.Location, "${keyring:")
 }
 
+// TestCmdConfigKeyringMigrate_PromptAbort verifies that answering "n" at the
+// y/N confirmation leaves the source untouched and returns no error (abort is
+// not a failure).
+func TestCmdConfigKeyringMigrate_PromptAbort(t *testing.T) {
+	gokeyring.MockInit()
+	th := testh.New(t)
+	tr := testrun.New(th.Context, t, nil)
+
+	const origLoc = "postgres://alice:hunter2@db/sakila"
+	require.NoError(t, tr.Run.Config.Collection.Add(&source.Source{
+		Handle:   "@pa_src",
+		Type:     "postgres",
+		Location: origLoc,
+	}))
+
+	// Answer "no" at the prompt.
+	tr.PipeStdin("n\n")
+	require.NoError(t, tr.Exec("config", "keyring", "migrate", "--all"))
+
+	// Abort is not an error; the source Location must be unchanged.
+	src, err := tr.Run.Config.Collection.Get("@pa_src")
+	require.NoError(t, err)
+	require.Equal(t, origLoc, src.Location, "abort must not modify the Location")
+
+	// No keyring entry written: Location still lacks a ${keyring:...} placeholder.
+	require.NotContains(t, src.Location, "${keyring:")
+
+	// The plan/prompt text must appear so the user can see what would run.
+	require.Contains(t, tr.Out.String(), "@pa_src")
+}
+
+// TestCmdConfigKeyringMigrate_PromptProceedEmptyAborts verifies that pressing
+// Enter without typing confirms the [y/N] default of "no", aborting the
+// migration without error.
+func TestCmdConfigKeyringMigrate_PromptProceedEmptyAborts(t *testing.T) {
+	gokeyring.MockInit()
+	th := testh.New(t)
+	tr := testrun.New(th.Context, t, nil)
+
+	const origLoc = "postgres://alice:hunter2@db/sakila"
+	require.NoError(t, tr.Run.Config.Collection.Add(&source.Source{
+		Handle:   "@pe_src",
+		Type:     "postgres",
+		Location: origLoc,
+	}))
+
+	// Empty input (just Enter) should default to "no".
+	tr.PipeStdin("\n")
+	require.NoError(t, tr.Exec("config", "keyring", "migrate", "--all"))
+
+	src, err := tr.Run.Config.Collection.Get("@pe_src")
+	require.NoError(t, err)
+	require.Equal(t, origLoc, src.Location, "empty Enter must abort and leave Location unchanged")
+	require.NotContains(t, src.Location, "${keyring:")
+}
+
+// TestCmdConfigKeyringMigrate_PromptProceed verifies that answering "y" at the
+// confirmation prompt executes the migration.
+func TestCmdConfigKeyringMigrate_PromptProceed(t *testing.T) {
+	gokeyring.MockInit()
+	th := testh.New(t)
+	tr := testrun.New(th.Context, t, nil)
+
+	const origLoc = "postgres://alice:hunter2@db/sakila"
+	require.NoError(t, tr.Run.Config.Collection.Add(&source.Source{
+		Handle:   "@pp_src",
+		Type:     "postgres",
+		Location: origLoc,
+	}))
+
+	// Answer "yes" at the prompt.
+	tr.PipeStdin("y\n")
+	require.NoError(t, tr.Exec("config", "keyring", "migrate", "--all"))
+
+	src, err := tr.Run.Config.Collection.Get("@pp_src")
+	require.NoError(t, err)
+
+	// Location must now be a bare ${keyring:<id>} placeholder.
+	id := extractKeyringID(t, src.Location)
+
+	// The keyring entry must hold the original DSN verbatim.
+	got, err := gokeyring.Get("sq", id)
+	require.NoError(t, err)
+	require.Equal(t, origLoc, got)
+}
+
+// TestCmdConfigKeyringMigrate_SingleHandle verifies that passing a single
+// @HANDLE migrates only that source, leaving other eligible sources unchanged.
+func TestCmdConfigKeyringMigrate_SingleHandle(t *testing.T) {
+	gokeyring.MockInit()
+	th := testh.New(t)
+	tr := testrun.New(th.Context, t, nil)
+
+	const loc1 = "postgres://alice:hunter2@db/sakila"
+	const loc2 = "postgres://bob:secret99@db2/northwind"
+	require.NoError(t, tr.Run.Config.Collection.Add(&source.Source{
+		Handle:   "@h1",
+		Type:     "postgres",
+		Location: loc1,
+	}))
+	require.NoError(t, tr.Run.Config.Collection.Add(&source.Source{
+		Handle:   "@h2",
+		Type:     "postgres",
+		Location: loc2,
+	}))
+
+	require.NoError(t, tr.Exec("config", "keyring", "migrate", "@h1", "--yes"))
+
+	// @h1 must be migrated.
+	src1, err := tr.Run.Config.Collection.Get("@h1")
+	require.NoError(t, err)
+	id := extractKeyringID(t, src1.Location)
+	got, err := gokeyring.Get("sq", id)
+	require.NoError(t, err)
+	require.Equal(t, loc1, got)
+
+	// @h2 must be untouched.
+	src2, err := tr.Run.Config.Collection.Get("@h2")
+	require.NoError(t, err)
+	require.Equal(t, loc2, src2.Location, "@h2 must not be migrated when only @h1 was specified")
+}
+
+// TestCmdConfigKeyringMigrate_RequiresHandleOrAll verifies that running
+// migrate with no handle and no --all flag returns an error.
+func TestCmdConfigKeyringMigrate_RequiresHandleOrAll(t *testing.T) {
+	gokeyring.MockInit()
+	th := testh.New(t)
+	tr := testrun.New(th.Context, t, nil)
+
+	err := tr.Exec("config", "keyring", "migrate")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "specify @HANDLE or --all")
+}
+
+// TestCmdConfigKeyringMigrate_UnknownHandle verifies that migrating a handle
+// that does not exist in the collection returns an error.
+func TestCmdConfigKeyringMigrate_UnknownHandle(t *testing.T) {
+	gokeyring.MockInit()
+	th := testh.New(t)
+	tr := testrun.New(th.Context, t, nil)
+
+	err := tr.Exec("config", "keyring", "migrate", "@nonexistent", "--yes")
+	require.Error(t, err)
+}
+
+// TestCmdConfigKeyringMigrate_MixedCollection verifies that --all --yes
+// migrates only eligible sources and skips the rest with an informative
+// reason. Three sources: one eligible, one without a password, one non-URL.
+func TestCmdConfigKeyringMigrate_MixedCollection(t *testing.T) {
+	gokeyring.MockInit()
+	th := testh.New(t)
+	tr := testrun.New(th.Context, t, nil)
+
+	const eligibleLoc = "postgres://alice:hunter2@db/sakila"
+	const noPassLoc = "postgres://alice@db/sakila"
+	const fileLoc = "/data/file.xlsx"
+
+	require.NoError(t, tr.Run.Config.Collection.Add(&source.Source{
+		Handle:   "@mc_eligible",
+		Type:     "postgres",
+		Location: eligibleLoc,
+	}))
+	require.NoError(t, tr.Run.Config.Collection.Add(&source.Source{
+		Handle:   "@mc_nopass",
+		Type:     "postgres",
+		Location: noPassLoc,
+	}))
+	require.NoError(t, tr.Run.Config.Collection.Add(&source.Source{
+		Handle:   "@mc_file",
+		Type:     "xlsx",
+		Location: fileLoc,
+	}))
+
+	require.NoError(t, tr.Exec("config", "keyring", "migrate", "--all", "--yes"))
+
+	// The eligible source must be migrated.
+	srcEligible, err := tr.Run.Config.Collection.Get("@mc_eligible")
+	require.NoError(t, err)
+	id := extractKeyringID(t, srcEligible.Location)
+	got, err := gokeyring.Get("sq", id)
+	require.NoError(t, err)
+	require.Equal(t, eligibleLoc, got)
+
+	// The no-password source must be unchanged.
+	srcNoPass, err := tr.Run.Config.Collection.Get("@mc_nopass")
+	require.NoError(t, err)
+	require.Equal(t, noPassLoc, srcNoPass.Location)
+
+	// The file source must be unchanged.
+	srcFile, err := tr.Run.Config.Collection.Get("@mc_file")
+	require.NoError(t, err)
+	require.Equal(t, fileLoc, srcFile.Location)
+
+	// Skip reasons must appear in output.
+	out := tr.Out.String()
+	require.Contains(t, out, "no password")
+	require.Contains(t, out, "not a URL")
+}
+
 // TestCmdConfigKeyringLs_Statuses verifies the three-state classification:
 // referenced (in keyring + in config), orphan (in keyring, no config ref),
 // and missing (in config, absent from keyring).

--- a/cli/cmd_config_keyring_test.go
+++ b/cli/cmd_config_keyring_test.go
@@ -42,6 +42,20 @@ func (s *failingConfigStore) Lockfile() (lockfile.Lockfile, error) {
 	return s.underlying.Lockfile()
 }
 
+// countingConfigStore wraps a config.Store and counts Save invocations,
+// used to assert that migrate persists the config exactly once for the
+// whole batch (atomic) rather than once per source. Methods other than
+// Save delegate to the embedded store.
+type countingConfigStore struct {
+	config.Store
+	saves int
+}
+
+func (s *countingConfigStore) Save(ctx context.Context, cfg *config.Config) error {
+	s.saves++
+	return s.Store.Save(ctx, cfg)
+}
+
 // migrateRollbackRow / migrateRollbackEnvelope and migrateJSONRow /
 // migrateJSONEnvelope are JSON unmarshal targets for migrate-result
 // tests. Promoted to top-level types (rather than inline anonymous
@@ -382,11 +396,11 @@ func TestCmdConfigKeyringMigrate_PerCase(t *testing.T) {
 			gokeyring.MockInit()
 			th := testh.New(t)
 			tr := testrun.New(th.Context, t, nil)
-			require.NoError(t, tr.Run.Config.Collection.Add(&source.Source{
+			tr.Add(source.Source{
 				Handle:   "@h",
 				Type:     "postgres",
 				Location: tc.inLocation,
-			}))
+			})
 
 			require.NoError(t, tr.Exec("config", "keyring", "migrate", "--all", "--yes"))
 
@@ -414,11 +428,11 @@ func TestCmdConfigKeyringMigrate_DryRun(t *testing.T) {
 	gokeyring.MockInit()
 	th := testh.New(t)
 	tr := testrun.New(th.Context, t, nil)
-	require.NoError(t, tr.Run.Config.Collection.Add(&source.Source{
+	tr.Add(source.Source{
 		Handle:   "@h_dr",
 		Type:     "postgres",
 		Location: "postgres://alice:hunter2@db/sakila",
-	}))
+	})
 
 	require.NoError(t, tr.Exec("config", "keyring", "migrate", "--all", "--dry-run"))
 
@@ -792,16 +806,16 @@ func TestCmdConfigKeyringMigrate_JSON_DryRun(t *testing.T) {
 	gokeyring.MockInit()
 	th := testh.New(t)
 	tr := testrun.New(th.Context, t, nil)
-	require.NoError(t, tr.Run.Config.Collection.Add(&source.Source{
+	tr.Add(source.Source{
 		Handle:   "@m_pw",
 		Type:     "postgres",
 		Location: "postgres://alice:hunter2@db/sakila",
-	}))
-	require.NoError(t, tr.Run.Config.Collection.Add(&source.Source{
+	})
+	tr.Add(source.Source{
 		Handle:   "@m_skip",
 		Type:     "postgres",
 		Location: "postgres://alice@db/sakila", // no password -> skip
-	}))
+	})
 
 	require.NoError(t, tr.Exec("config", "keyring", "migrate", "--all", "--dry-run", "--json"))
 
@@ -837,11 +851,11 @@ func TestCmdConfigKeyringMigrate_JSON_Apply(t *testing.T) {
 	gokeyring.MockInit()
 	th := testh.New(t)
 	tr := testrun.New(th.Context, t, nil)
-	require.NoError(t, tr.Run.Config.Collection.Add(&source.Source{
+	tr.Add(source.Source{
 		Handle:   "@m_pw_apply",
 		Type:     "postgres",
 		Location: "postgres://alice:hunter2@db/sakila",
-	}))
+	})
 
 	require.NoError(t, tr.Exec("config", "keyring", "migrate", "--all", "--json"))
 
@@ -873,27 +887,27 @@ func TestCmdConfigKeyringMigrate_JSON_Apply(t *testing.T) {
 //     "rolled back" so JSON consumers can detect the path.
 //   - The command surfaces a non-nil error.
 //
-// The rollback also calls kr.Delete on the orphan keyring entry, but
+// The rollback also calls kr.Delete on the keyring entry it wrote, but
 // the test doesn't assert that directly because the minted ID isn't
-// observable from outside (orphan listing is pending — see #715).
+// observable from outside.
 func TestCmdConfigKeyringMigrate_RollbackOnSaveFailure(t *testing.T) {
 	gokeyring.MockInit()
 	th := testh.New(t)
 	tr := testrun.New(th.Context, t, nil)
 
 	const origLoc = "postgres://alice:hunter2@db/sakila"
-	require.NoError(t, tr.Run.Config.Collection.Add(&source.Source{
+	tr.Add(source.Source{
 		Handle:   "@rb_src",
 		Type:     "postgres",
 		Location: origLoc,
-	}))
+	})
 	// Swap in a failing store AFTER initial setup so the source-add
 	// Save() above still succeeds. Now any further Save errors.
 	tr.Run.ConfigStore = &failingConfigStore{underlying: tr.Run.ConfigStore}
 
 	err := tr.Exec("config", "keyring", "migrate", "--all", "--yes", "--json")
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "one or more sources failed")
+	require.Contains(t, err.Error(), "no sources were changed")
 
 	// The in-memory source must reflect the rollback: Location is the
 	// original DSN, not a ${keyring:...} placeholder.
@@ -912,6 +926,64 @@ func TestCmdConfigKeyringMigrate_RollbackOnSaveFailure(t *testing.T) {
 	require.Contains(t, env.Rows[0].Error, "rolled back")
 }
 
+// TestCmdConfigKeyringMigrate_AtomicSingleSave verifies the migration is
+// atomic: a multi-source run saves the config exactly once for the whole
+// batch, not once per source. That single save is what makes a mid-batch
+// failure all-or-nothing.
+func TestCmdConfigKeyringMigrate_AtomicSingleSave(t *testing.T) {
+	gokeyring.MockInit()
+	th := testh.New(t)
+	tr := testrun.New(th.Context, t, nil)
+	tr.Add(
+		source.Source{Handle: "@as_a", Type: "postgres", Location: "postgres://u:p1@db/a"},
+		source.Source{Handle: "@as_b", Type: "postgres", Location: "postgres://u:p2@db/b"},
+		source.Source{Handle: "@as_c", Type: "postgres", Location: "postgres://u:p3@db/c"},
+	)
+	counter := &countingConfigStore{Store: tr.Run.ConfigStore}
+	tr.Run.ConfigStore = counter
+
+	require.NoError(t, tr.Exec("config", "keyring", "migrate", "--all", "--yes"))
+
+	require.Equal(t, 1, counter.saves,
+		"atomic migrate must save the config once for the batch, not once per source")
+	for _, h := range []string{"@as_a", "@as_b", "@as_c"} {
+		src, err := tr.Run.Config.Collection.Get(h)
+		require.NoError(t, err)
+		require.Contains(t, src.Location, "${keyring:", "%s should be migrated", h)
+	}
+}
+
+// TestCmdConfigKeyringMigrate_AtomicRollbackMultiSource verifies the
+// all-or-nothing guarantee across multiple sources: when the config save
+// fails, every source is rolled back to its original inline Location, not
+// just one.
+func TestCmdConfigKeyringMigrate_AtomicRollbackMultiSource(t *testing.T) {
+	gokeyring.MockInit()
+	th := testh.New(t)
+	tr := testrun.New(th.Context, t, nil)
+
+	const locA = "postgres://alice:hunter2@db/sakila"
+	const locB = "postgres://bob:s3cr3t@db/sakila2"
+	tr.Add(
+		source.Source{Handle: "@arb_a", Type: "postgres", Location: locA},
+		source.Source{Handle: "@arb_b", Type: "postgres", Location: locB},
+	)
+	// Fail the save (after the tr.Add setup save), so the single end-of-run
+	// save fails and the whole batch must roll back.
+	tr.Run.ConfigStore = &failingConfigStore{underlying: tr.Run.ConfigStore}
+
+	err := tr.Exec("config", "keyring", "migrate", "--all", "--yes")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "no sources were changed")
+
+	a, err := tr.Run.Config.Collection.Get("@arb_a")
+	require.NoError(t, err)
+	require.Equal(t, locA, a.Location, "@arb_a must be rolled back")
+	b, err := tr.Run.Config.Collection.Get("@arb_b")
+	require.NoError(t, err)
+	require.Equal(t, locB, b.Location, "@arb_b must be rolled back")
+}
+
 // TestCmdConfigKeyringMigrate_JSON_SkipsPrompt verifies the documented
 // behavior in cmd_config_keyring_migrate.go: in --json mode the
 // y/N confirmation prompt is bypassed entirely, because JSON consumers
@@ -925,11 +997,11 @@ func TestCmdConfigKeyringMigrate_JSON_SkipsPrompt(t *testing.T) {
 	gokeyring.MockInit()
 	th := testh.New(t)
 	tr := testrun.New(th.Context, t, nil)
-	require.NoError(t, tr.Run.Config.Collection.Add(&source.Source{
+	tr.Add(source.Source{
 		Handle:   "@js_prompt",
 		Type:     "postgres",
 		Location: "postgres://alice:hunter2@db/sakila",
-	}))
+	})
 	// Pipe "n\n" so the y/N prompt — if reached — would answer "no".
 	tr.PipeStdin("n\n")
 
@@ -968,11 +1040,11 @@ func TestCmdConfigKeyringMigrate_ConfigFormatJSON_SkipsPrompt(t *testing.T) {
 	require.NoError(t, tr.Exec("config", "set", "format", "json"))
 	tr = testrun.New(th.Context, t, tr)
 
-	require.NoError(t, tr.Run.Config.Collection.Add(&source.Source{
+	tr.Add(source.Source{
 		Handle:   "@cfg_json",
 		Type:     "postgres",
 		Location: "postgres://alice:hunter2@db/sakila",
-	}))
+	})
 	// Pipe "n\n" so the y/N prompt (if reached) would answer "no".
 	tr.PipeStdin("n\n")
 
@@ -1005,11 +1077,11 @@ func TestCmdConfigKeyringMigrate_PromptAbort(t *testing.T) {
 	tr := testrun.New(th.Context, t, nil)
 
 	const origLoc = "postgres://alice:hunter2@db/sakila"
-	require.NoError(t, tr.Run.Config.Collection.Add(&source.Source{
+	tr.Add(source.Source{
 		Handle:   "@pa_src",
 		Type:     "postgres",
 		Location: origLoc,
-	}))
+	})
 
 	// Answer "no" at the prompt.
 	tr.PipeStdin("n\n")
@@ -1036,11 +1108,11 @@ func TestCmdConfigKeyringMigrate_PromptProceedEmptyAborts(t *testing.T) {
 	tr := testrun.New(th.Context, t, nil)
 
 	const origLoc = "postgres://alice:hunter2@db/sakila"
-	require.NoError(t, tr.Run.Config.Collection.Add(&source.Source{
+	tr.Add(source.Source{
 		Handle:   "@pe_src",
 		Type:     "postgres",
 		Location: origLoc,
-	}))
+	})
 
 	// Empty input (just Enter) should default to "no".
 	tr.PipeStdin("\n")
@@ -1060,11 +1132,11 @@ func TestCmdConfigKeyringMigrate_PromptProceed(t *testing.T) {
 	tr := testrun.New(th.Context, t, nil)
 
 	const origLoc = "postgres://alice:hunter2@db/sakila"
-	require.NoError(t, tr.Run.Config.Collection.Add(&source.Source{
+	tr.Add(source.Source{
 		Handle:   "@pp_src",
 		Type:     "postgres",
 		Location: origLoc,
-	}))
+	})
 
 	// Answer "yes" at the prompt.
 	tr.PipeStdin("y\n")
@@ -1091,16 +1163,16 @@ func TestCmdConfigKeyringMigrate_SingleHandle(t *testing.T) {
 
 	const loc1 = "postgres://alice:hunter2@db/sakila"
 	const loc2 = "postgres://bob:secret99@db2/northwind"
-	require.NoError(t, tr.Run.Config.Collection.Add(&source.Source{
+	tr.Add(source.Source{
 		Handle:   "@h1",
 		Type:     "postgres",
 		Location: loc1,
-	}))
-	require.NoError(t, tr.Run.Config.Collection.Add(&source.Source{
+	})
+	tr.Add(source.Source{
 		Handle:   "@h2",
 		Type:     "postgres",
 		Location: loc2,
-	}))
+	})
 
 	require.NoError(t, tr.Exec("config", "keyring", "migrate", "@h1", "--yes"))
 
@@ -1153,21 +1225,21 @@ func TestCmdConfigKeyringMigrate_MixedCollection(t *testing.T) {
 	const noPassLoc = "postgres://alice@db/sakila"
 	const fileLoc = "/data/file.xlsx"
 
-	require.NoError(t, tr.Run.Config.Collection.Add(&source.Source{
+	tr.Add(source.Source{
 		Handle:   "@mc_eligible",
 		Type:     "postgres",
 		Location: eligibleLoc,
-	}))
-	require.NoError(t, tr.Run.Config.Collection.Add(&source.Source{
+	})
+	tr.Add(source.Source{
 		Handle:   "@mc_nopass",
 		Type:     "postgres",
 		Location: noPassLoc,
-	}))
-	require.NoError(t, tr.Run.Config.Collection.Add(&source.Source{
+	})
+	tr.Add(source.Source{
 		Handle:   "@mc_file",
 		Type:     "xlsx",
 		Location: fileLoc,
-	}))
+	})
 
 	require.NoError(t, tr.Exec("config", "keyring", "migrate", "--all", "--yes"))
 

--- a/cli/cmd_config_keyring_test.go
+++ b/cli/cmd_config_keyring_test.go
@@ -926,6 +926,41 @@ func TestCmdConfigKeyringMigrate_RollbackOnSaveFailure(t *testing.T) {
 	require.Contains(t, env.Rows[0].Error, "rolled back")
 }
 
+// TestCmdConfigKeyringMigrate_Completion verifies that migrate completes
+// source handles (not keyring paths), and caps at one handle.
+func TestCmdConfigKeyringMigrate_Completion(t *testing.T) {
+	gokeyring.MockInit()
+	th := testh.New(t)
+	tr := testrun.New(th.Context, t, nil).Add(
+		source.Source{
+			Handle:   "@mig_a",
+			Type:     drivertype.Pg,
+			Location: "postgres://alice:hunter2@db/sakila",
+		},
+		source.Source{
+			Handle:   "@mig_b",
+			Type:     drivertype.Pg,
+			Location: "postgres://bob:s3cr3t@db/sakila2",
+		},
+	)
+
+	// Source handles are offered for the first arg (alongside any other
+	// handles the harness seeds).
+	got := testComplete(t, tr, "config", "keyring", "migrate", "")
+	require.Subset(t, got.values, []string{"@mig_a", "@mig_b"})
+	require.Contains(t, got.directives, cobra.ShellCompDirectiveNoFileComp)
+
+	// A prefix narrows the real handles (the "@active" shortcut token is
+	// always offered when includeActive is set, so don't assert against it).
+	got = testComplete(t, tr, "config", "keyring", "migrate", "@mig_a")
+	require.Contains(t, got.values, "@mig_a")
+	require.NotContains(t, got.values, "@mig_b")
+
+	// migrate takes at most one handle: no completions for a second arg.
+	got = testComplete(t, tr, "config", "keyring", "migrate", "@mig_a", "")
+	require.Empty(t, got.values)
+}
+
 // TestCmdConfigKeyringMigrate_AtomicSingleSave verifies the migration is
 // atomic: a multi-source run saves the config exactly once for the whole
 // batch, not once per source. That single save is what makes a mid-batch

--- a/cli/cmd_config_keyring_test.go
+++ b/cli/cmd_config_keyring_test.go
@@ -350,7 +350,7 @@ func TestCmdConfigKeyringMigrate_PerCase(t *testing.T) {
 		{
 			name:           "non-url",
 			inLocation:     "/data/file.xlsx",
-			wantSkipReason: "not a URL",
+			wantSkipReason: "no credentials",
 		},
 		{
 			name: "malformed placeholder is surfaced, not silently migrated",
@@ -386,9 +386,9 @@ func TestCmdConfigKeyringMigrate_PerCase(t *testing.T) {
 			// working via the connect-path unescape, so skipping is
 			// safe; migrating would have to unescape (see previous
 			// case).
-			name:           "escaped placeholder skipped as non-URL",
+			name:           "escaped placeholder makes a malformed URL",
 			inLocation:     "postgres://alice:$${env:HOME}@db/sakila",
-			wantSkipReason: "not a URL",
+			wantSkipReason: "malformed location",
 		},
 	}
 	for _, tc := range tests {
@@ -979,8 +979,8 @@ func TestCmdConfigKeyringMigrate_HidesSkipsByDefault(t *testing.T) {
 
 	out := tr.Out.String()
 	require.Contains(t, out, "@hide_pg") // the migrating source is shown
-	require.NotContains(t, out, "not a URL")
-	require.NotContains(t, out, "no password component")
+	require.NotContains(t, out, "no credentials")
+	require.NotContains(t, out, "no password")
 	require.NotContains(t, out, "@hide_csv")
 	require.NotContains(t, out, "@hide_nopw")
 }
@@ -1350,7 +1350,7 @@ func TestCmdConfigKeyringMigrate_MixedCollection(t *testing.T) {
 	// Skip reasons must appear in output.
 	out := tr.Out.String()
 	require.Contains(t, out, "no password")
-	require.Contains(t, out, "not a URL")
+	require.Contains(t, out, "no credentials")
 }
 
 // TestCmdConfigKeyringLs_Statuses verifies the three-state classification:

--- a/cli/cmd_config_keyring_test.go
+++ b/cli/cmd_config_keyring_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/neilotoole/sq/cli/testrun"
 	"github.com/neilotoole/sq/libsq/core/errz"
 	"github.com/neilotoole/sq/libsq/core/ioz/lockfile"
+	"github.com/neilotoole/sq/libsq/core/secret/keyring"
 	"github.com/neilotoole/sq/libsq/source"
 	"github.com/neilotoole/sq/libsq/source/drivertype"
 	"github.com/neilotoole/sq/testh"
@@ -975,6 +976,43 @@ func TestCmdConfigKeyringMigrate_ConfigFormatJSON_SkipsPrompt(t *testing.T) {
 	src, err := tr.Run.Config.Collection.Get("@cfg_json")
 	require.NoError(t, err)
 	require.Contains(t, src.Location, "${keyring:")
+}
+
+// TestCmdConfigKeyringLs_Statuses verifies the three-state classification:
+// referenced (in keyring + in config), orphan (in keyring, no config ref),
+// and missing (in config, absent from keyring).
+func TestCmdConfigKeyringLs_Statuses(t *testing.T) {
+	gokeyring.MockInit()
+	th := testh.New(t)
+	tr := testrun.New(th.Context, t, nil)
+
+	// A referenced entry: source references it AND it exists in the keyring.
+	require.NoError(t, keyring.NewStore().Set(th.Context, "ref1234567", "live-secret"))
+	// An orphan: exists in the keyring, referenced by nothing.
+	require.NoError(t, keyring.NewStore().Set(th.Context, "orphan23456", "stale-secret"))
+
+	tr.Add(
+		source.Source{
+			Handle:   "@ref_pg",
+			Type:     drivertype.Pg,
+			Location: "${keyring:ref1234567}",
+		},
+		// A missing entry: source references it, but it is NOT in the keyring.
+		source.Source{
+			Handle:   "@missing_pg",
+			Type:     drivertype.Pg,
+			Location: "${keyring:gone7654321}",
+		},
+	)
+
+	require.NoError(t, tr.Exec("config", "keyring", "ls"))
+	out := tr.Out.String()
+	require.Contains(t, out, "referenced")
+	require.Contains(t, out, "orphan")
+	require.Contains(t, out, "missing")
+	require.Contains(t, out, "ref1234567")
+	require.Contains(t, out, "orphan23456")
+	require.Contains(t, out, "gone7654321")
 }
 
 // TestCmdConfigKeyringRm_Completion_TolerantOfMalformedSource verifies

--- a/cli/output/jsonw/keyringwriter.go
+++ b/cli/output/jsonw/keyringwriter.go
@@ -71,6 +71,19 @@ func (w *keyringWriter) Rm(path string) error {
 	})
 }
 
+// Prune implements output.KeyringWriter. Emits a single JSON object with
+// the dry-run flag and the row array, matching the Migrate envelope.
+func (w *keyringWriter) Prune(rows []output.KeyringPruneRow, dryRun bool) error {
+	if rows == nil {
+		rows = []output.KeyringPruneRow{}
+	}
+	type envelope struct {
+		Rows   []output.KeyringPruneRow `json:"rows"`
+		DryRun bool                     `json:"dry_run"`
+	}
+	return writeJSON(w.out, w.pr, envelope{DryRun: dryRun, Rows: rows})
+}
+
 // Migrate implements output.KeyringWriter. Emits a single JSON object
 // with the dry-run flag and the row array so a consumer can tell the
 // modes apart from the JSON alone.

--- a/cli/output/tablew/keyringwriter.go
+++ b/cli/output/tablew/keyringwriter.go
@@ -89,7 +89,7 @@ func (w *keyringWriter) Prune(rows []output.KeyringPruneRow, _ bool) error {
 		if r.Status == output.KeyringPruneStatusFailed {
 			status = w.pr.Error.Sprint(status)
 		} else {
-			status = w.pr.Enabled.Sprint(status)
+			status = w.pr.Success.Sprint(status)
 		}
 		tblRows = append(tblRows, []string{w.pr.String.Sprint(r.Path), w.pr.Faint.Sprint(r.Kind), status})
 	}
@@ -172,7 +172,7 @@ func (w *keyringWriter) colorMigrateRow(r output.KeyringMigrateRow) (handle, sta
 	case output.KeyringMigrateStatusFailed:
 		return w.pr.Handle.Sprint(handle), w.pr.Error.Sprint(status), w.pr.Error.Sprint(detail)
 	default: // planned, migrated
-		return w.pr.Handle.Sprint(handle), w.pr.Enabled.Sprint(status), w.pr.Faint.Sprint(detail)
+		return w.pr.Handle.Sprint(handle), w.pr.Success.Sprint(status), w.pr.Faint.Sprint(detail)
 	}
 }
 

--- a/cli/output/tablew/keyringwriter.go
+++ b/cli/output/tablew/keyringwriter.go
@@ -71,6 +71,29 @@ func (w *keyringWriter) Rm(_ string) error {
 	return nil
 }
 
+// Prune implements output.KeyringWriter.
+func (w *keyringWriter) Prune(rows []output.KeyringPruneRow, _ bool) error {
+	for _, r := range rows {
+		path := w.pr.String.Sprint(r.Path)
+		kind := w.pr.Faint.Sprint("(" + r.Kind + ")")
+		var line string
+		switch r.Status {
+		case output.KeyringPruneStatusPlanned:
+			line = fmt.Sprintf("%s  %s  %s\n", w.pr.Faint.Sprint("would delete"), path, kind)
+		case output.KeyringPruneStatusDeleted:
+			line = fmt.Sprintf("%s  %s  %s\n", w.pr.Enabled.Sprint("deleted"), path, kind)
+		case output.KeyringPruneStatusFailed:
+			line = fmt.Sprintf("%s  %s  %s  %s\n", w.pr.Error.Sprint("FAIL"), path, kind, r.Error)
+		default:
+			line = path + "  " + r.Status + "\n"
+		}
+		if _, err := fmt.Fprint(w.out, line); err != nil {
+			return errz.Err(err)
+		}
+	}
+	return nil
+}
+
 // Migrate implements output.KeyringWriter.
 func (w *keyringWriter) Migrate(rows []output.KeyringMigrateRow, _ bool) error {
 	for _, r := range rows {

--- a/cli/output/tablew/keyringwriter.go
+++ b/cli/output/tablew/keyringwriter.go
@@ -71,27 +71,49 @@ func (w *keyringWriter) Rm(_ string) error {
 	return nil
 }
 
-// Prune implements output.KeyringWriter.
+// Prune implements output.KeyringWriter. It renders an aligned table of the
+// orphaned entries (PATH / KIND / STATUS). When there are none, it prints a
+// short message instead of an empty table.
 func (w *keyringWriter) Prune(rows []output.KeyringPruneRow, _ bool) error {
-	for _, r := range rows {
-		path := w.pr.String.Sprint(r.Path)
-		kind := w.pr.Faint.Sprint("(" + r.Kind + ")")
-		var line string
-		switch r.Status {
-		case output.KeyringPruneStatusPlanned:
-			line = fmt.Sprintf("%s  %s  %s\n", w.pr.Faint.Sprint("would delete"), path, kind)
-		case output.KeyringPruneStatusDeleted:
-			line = fmt.Sprintf("%s  %s  %s\n", w.pr.Enabled.Sprint("deleted"), path, kind)
-		case output.KeyringPruneStatusFailed:
-			line = fmt.Sprintf("%s  %s  %s  %s\n", w.pr.Error.Sprint("FAIL"), path, kind, r.Error)
-		default:
-			line = path + "  " + r.Status + "\n"
-		}
-		if _, err := fmt.Fprint(w.out, line); err != nil {
-			return errz.Err(err)
-		}
+	if len(rows) == 0 {
+		_, err := fmt.Fprint(w.out, w.pr.Faint.Sprint("No orphaned entries to prune.\n"))
+		return errz.Err(err)
 	}
-	return nil
+
+	w.tbl.reset()
+	tblRows := make([][]string, 0, len(rows))
+	for _, r := range rows {
+		// Pre-color per row: the action status is green, a failure is red,
+		// and the KIND is muted as supplementary info.
+		status := pruneStatusCell(r)
+		if r.Status == output.KeyringPruneStatusFailed {
+			status = w.pr.Error.Sprint(status)
+		} else {
+			status = w.pr.Enabled.Sprint(status)
+		}
+		tblRows = append(tblRows, []string{w.pr.String.Sprint(r.Path), w.pr.Faint.Sprint(r.Kind), status})
+	}
+	w.tbl.tblImpl.SetHeader([]string{"PATH", "KIND", "STATUS"})
+	return w.tbl.appendRowsAndRenderAll(context.TODO(), tblRows)
+}
+
+// pruneStatusCell returns the STATUS cell for a prune row: "delete" for a
+// dry-run plan, "deleted" for a removed entry, or "failed: <error>" for a
+// deletion that failed.
+func pruneStatusCell(r output.KeyringPruneRow) string {
+	switch r.Status {
+	case output.KeyringPruneStatusPlanned:
+		return "delete"
+	case output.KeyringPruneStatusDeleted:
+		return "deleted"
+	case output.KeyringPruneStatusFailed:
+		if r.Error != "" {
+			return "failed: " + r.Error
+		}
+		return "failed"
+	default:
+		return r.Status
+	}
 }
 
 // Migrate implements output.KeyringWriter. It renders an aligned table.
@@ -129,28 +151,28 @@ func (w *keyringWriter) Migrate(rows []output.KeyringMigrateRow, _ bool) error {
 	w.tbl.reset()
 	tblRows := make([][]string, 0, len(display))
 	for _, r := range display {
-		tblRows = append(tblRows, []string{r.Handle, migrateStatusLabel(r.Status), migrateDetail(r)})
+		handle, status, detail := w.colorMigrateRow(r)
+		tblRows = append(tblRows, []string{handle, status, detail})
 	}
 	w.tbl.tblImpl.SetHeader([]string{"HANDLE", "STATUS", "DETAIL"})
-	w.tbl.tblImpl.SetColTrans(0, w.pr.Handle.SprintFunc())
-	w.tbl.tblImpl.SetColTrans(1, w.migrateStatusTrans)
-	w.tbl.tblImpl.SetColTrans(2, w.pr.Faint.SprintFunc())
 	return w.tbl.appendRowsAndRenderAll(context.TODO(), tblRows)
 }
 
-// migrateStatusTrans colors a migrate STATUS cell by its value. Its
-// signature matches the table writer's textTransFunc (func(...any) string).
-func (w *keyringWriter) migrateStatusTrans(a ...any) string {
-	s := fmt.Sprint(a...)
-	switch s {
-	case "migrate", "migrated":
-		return w.pr.Enabled.Sprint(s)
-	case "failed":
-		return w.pr.Error.Sprint(s)
-	case "skip":
-		return w.pr.Faint.Sprint(s)
-	default:
-		return s
+// colorMigrateRow pre-colors a migrate row's cells. A skipped row is muted in
+// full (it's benign and should recede behind the actionable rows); a
+// migrate/migrated row gets a green status with a muted detail; a failed row
+// gets a red status and error. Pre-coloring (rather than a column transform)
+// is what lets the whole skip row be dimmed, and it stays aligned because the
+// table measures column width with ANSI codes stripped.
+func (w *keyringWriter) colorMigrateRow(r output.KeyringMigrateRow) (handle, status, detail string) {
+	handle, status, detail = r.Handle, migrateStatusLabel(r.Status), migrateDetail(r)
+	switch r.Status {
+	case output.KeyringMigrateStatusSkip:
+		return w.pr.Faint.Sprint(handle), w.pr.Faint.Sprint(status), w.pr.Faint.Sprint(detail)
+	case output.KeyringMigrateStatusFailed:
+		return w.pr.Handle.Sprint(handle), w.pr.Error.Sprint(status), w.pr.Error.Sprint(detail)
+	default: // planned, migrated
+		return w.pr.Handle.Sprint(handle), w.pr.Enabled.Sprint(status), w.pr.Faint.Sprint(detail)
 	}
 }
 

--- a/cli/output/tablew/keyringwriter.go
+++ b/cli/output/tablew/keyringwriter.go
@@ -32,12 +32,13 @@ func (w *keyringWriter) List(refs []output.KeyringRef) error {
 	}
 	rows := make([][]string, 0, len(refs))
 	for _, r := range refs {
-		rows = append(rows, []string{r.Path, r.Handle, r.Driver})
+		rows = append(rows, []string{r.Status, r.Path, r.Handle, r.Driver})
 	}
-	w.tbl.tblImpl.SetHeader([]string{"PATH", "HANDLE", "DRIVER"})
-	w.tbl.tblImpl.SetColTrans(0, w.pr.String.SprintFunc())
-	w.tbl.tblImpl.SetColTrans(1, w.pr.Handle.SprintFunc())
-	w.tbl.tblImpl.SetColTrans(2, w.pr.Faint.SprintFunc())
+	w.tbl.tblImpl.SetHeader([]string{"STATUS", "PATH", "HANDLE", "DRIVER"})
+	w.tbl.tblImpl.SetColTrans(0, w.pr.Faint.SprintFunc())
+	w.tbl.tblImpl.SetColTrans(1, w.pr.String.SprintFunc())
+	w.tbl.tblImpl.SetColTrans(2, w.pr.Handle.SprintFunc())
+	w.tbl.tblImpl.SetColTrans(3, w.pr.Faint.SprintFunc())
 	return w.tbl.appendRowsAndRenderAll(context.TODO(), rows)
 }
 

--- a/cli/output/tablew/keyringwriter.go
+++ b/cli/output/tablew/keyringwriter.go
@@ -94,26 +94,96 @@ func (w *keyringWriter) Prune(rows []output.KeyringPruneRow, _ bool) error {
 	return nil
 }
 
-// Migrate implements output.KeyringWriter.
+// Migrate implements output.KeyringWriter. It renders an aligned table.
+// By default only actionable rows (migrate / migrated / failed) are shown;
+// skipped sources are listed only when verbose output is enabled. When
+// nothing is actionable, a short message is printed instead of an empty
+// table.
 func (w *keyringWriter) Migrate(rows []output.KeyringMigrateRow, _ bool) error {
+	display := make([]output.KeyringMigrateRow, 0, len(rows))
+	var skipped int
 	for _, r := range rows {
-		handle := w.pr.Handle.Sprint(r.Handle)
-		var line string
-		switch r.Status {
-		case output.KeyringMigrateStatusSkip:
-			line = fmt.Sprintf("%s  %s   (%s)\n", handle, w.pr.Faint.Sprint("skip"), r.Reason)
-		case output.KeyringMigrateStatusPlanned:
-			line = fmt.Sprintf("%s  %s     %s\n", handle, w.pr.Faint.Sprint("->"), "${keyring:<new-id>}")
-		case output.KeyringMigrateStatusMigrated:
-			line = fmt.Sprintf("%s  %s   ->  %s\n", handle, w.pr.Enabled.Sprint("done"), r.NewLocation)
-		case output.KeyringMigrateStatusFailed:
-			line = fmt.Sprintf("%s  %s   %s\n", handle, w.pr.Error.Sprint("FAIL"), r.Error)
-		default:
-			line = handle + "  " + r.Status + "\n"
+		if r.Status == output.KeyringMigrateStatusSkip {
+			skipped++
+			if !w.pr.Verbose {
+				continue
+			}
 		}
-		if _, err := fmt.Fprint(w.out, line); err != nil {
-			return errz.Err(err)
-		}
+		display = append(display, r)
 	}
-	return nil
+
+	if len(display) == 0 {
+		var msg string
+		switch {
+		case skipped == 1:
+			msg = "Nothing to migrate (1 source skipped; use -v to see why).\n"
+		case skipped > 1:
+			msg = fmt.Sprintf("Nothing to migrate (%d sources skipped; use -v to see why).\n", skipped)
+		default:
+			msg = "Nothing to migrate.\n"
+		}
+		_, err := fmt.Fprint(w.out, w.pr.Faint.Sprint(msg))
+		return errz.Err(err)
+	}
+
+	w.tbl.reset()
+	tblRows := make([][]string, 0, len(display))
+	for _, r := range display {
+		tblRows = append(tblRows, []string{r.Handle, migrateStatusLabel(r.Status), migrateDetail(r)})
+	}
+	w.tbl.tblImpl.SetHeader([]string{"HANDLE", "STATUS", "DETAIL"})
+	w.tbl.tblImpl.SetColTrans(0, w.pr.Handle.SprintFunc())
+	w.tbl.tblImpl.SetColTrans(1, w.migrateStatusTrans)
+	w.tbl.tblImpl.SetColTrans(2, w.pr.Faint.SprintFunc())
+	return w.tbl.appendRowsAndRenderAll(context.TODO(), tblRows)
+}
+
+// migrateStatusTrans colors a migrate STATUS cell by its value. Its
+// signature matches the table writer's textTransFunc (func(...any) string).
+func (w *keyringWriter) migrateStatusTrans(a ...any) string {
+	s := fmt.Sprint(a...)
+	switch s {
+	case "migrate", "migrated":
+		return w.pr.Enabled.Sprint(s)
+	case "failed":
+		return w.pr.Error.Sprint(s)
+	case "skip":
+		return w.pr.Faint.Sprint(s)
+	default:
+		return s
+	}
+}
+
+// migrateStatusLabel maps a KeyringMigrateStatus* value to its display word.
+func migrateStatusLabel(status string) string {
+	switch status {
+	case output.KeyringMigrateStatusPlanned:
+		return "migrate"
+	case output.KeyringMigrateStatusMigrated:
+		return "migrated"
+	case output.KeyringMigrateStatusFailed:
+		return "failed"
+	case output.KeyringMigrateStatusSkip:
+		return "skip"
+	default:
+		return status
+	}
+}
+
+// migrateDetail returns the DETAIL cell for a migrate row: the target
+// placeholder for a plan, the new location for a success, the error for a
+// failure, or the skip reason.
+func migrateDetail(r output.KeyringMigrateRow) string {
+	switch r.Status {
+	case output.KeyringMigrateStatusPlanned:
+		return "${keyring:<new-id>}"
+	case output.KeyringMigrateStatusMigrated:
+		return r.NewLocation
+	case output.KeyringMigrateStatusFailed:
+		return r.Error
+	case output.KeyringMigrateStatusSkip:
+		return r.Reason
+	default:
+		return ""
+	}
 }

--- a/cli/output/tablew/keyringwriter_test.go
+++ b/cli/output/tablew/keyringwriter_test.go
@@ -79,6 +79,62 @@ func TestKeyringWriter_Migrate_RowFormatting(t *testing.T) {
 	}
 }
 
+// TestKeyringWriter_Prune_RowFormatting pins the text-mode output shape
+// for each KeyringPruneRow status. Without this test, a regression that
+// drops the status word or kind suffix from any branch (planned/deleted/
+// failed) would silently break the user-facing prune log.
+func TestKeyringWriter_Prune_RowFormatting(t *testing.T) {
+	tests := []struct {
+		name     string
+		row      output.KeyringPruneRow
+		dryRun   bool
+		contains []string
+	}{
+		{
+			name:   "planned",
+			dryRun: true,
+			row: output.KeyringPruneRow{
+				Path:   "m4n8k2pxtz",
+				Kind:   output.KeyringKindID,
+				Status: output.KeyringPruneStatusPlanned,
+			},
+			contains: []string{"would delete", "m4n8k2pxtz", "(id)"},
+		},
+		{
+			name:   "deleted",
+			dryRun: false,
+			row: output.KeyringPruneRow{
+				Path:   "named_orphan",
+				Kind:   output.KeyringKindNamed,
+				Status: output.KeyringPruneStatusDeleted,
+			},
+			contains: []string{"deleted", "named_orphan", "(named)"},
+		},
+		{
+			name:   "failed",
+			dryRun: false,
+			row: output.KeyringPruneRow{
+				Path:   "bad_entry",
+				Kind:   output.KeyringKindNamed,
+				Status: output.KeyringPruneStatusFailed,
+				Error:  "keychain locked",
+			},
+			contains: []string{"FAIL", "bad_entry", "(named)", "keychain locked"},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			w := tablew.NewKeyringWriter(&buf, newTestPrinting())
+			require.NoError(t, w.Prune([]output.KeyringPruneRow{tc.row}, tc.dryRun))
+			out := buf.String()
+			for _, s := range tc.contains {
+				require.Contains(t, out, s, "rendered output must contain %q; got: %s", s, out)
+			}
+		})
+	}
+}
+
 // TestKeyringWriter_List_HeaderToggle verifies that List honors
 // pr.ShowHeader: header row prints when true (with STATUS/PATH/HANDLE/DRIVER
 // labels) and is omitted when false.

--- a/cli/output/tablew/keyringwriter_test.go
+++ b/cli/output/tablew/keyringwriter_test.go
@@ -83,6 +83,33 @@ func TestKeyringWriter_Migrate_RowFormatting(t *testing.T) {
 	}
 }
 
+// TestKeyringWriter_Migrate_Colorized verifies the color scheme renders:
+// migrate is green, a failed status is red, and a skipped row is muted in
+// full (handle and status both faint).
+func TestKeyringWriter_Migrate_Colorized(t *testing.T) {
+	pr := output.NewPrinting()
+	pr.EnableColor(true)
+	pr.Verbose = true // render skip rows too
+
+	// Guard: the assertions below are meaningless unless color is actually on.
+	require.NotEqual(t, "migrate", pr.Enabled.Sprint("migrate"),
+		"color must be enabled for this test to verify anything")
+
+	var buf bytes.Buffer
+	w := tablew.NewKeyringWriter(&buf, pr)
+	require.NoError(t, w.Migrate([]output.KeyringMigrateRow{
+		{Handle: "@pg", Status: output.KeyringMigrateStatusPlanned},
+		{Handle: "@csv", Status: output.KeyringMigrateStatusSkip, Reason: "not a URL"},
+		{Handle: "@bad", Status: output.KeyringMigrateStatusFailed, Error: "boom"},
+	}, true))
+	out := buf.String()
+
+	require.Contains(t, out, pr.Enabled.Sprint("migrate"), "migrate status must be green")
+	require.Contains(t, out, pr.Error.Sprint("failed"), "failed status must be red")
+	require.Contains(t, out, pr.Faint.Sprint("skip"), "skip status must be muted")
+	require.Contains(t, out, pr.Faint.Sprint("@csv"), "skip row's handle must be muted too")
+}
+
 // TestKeyringWriter_Prune_RowFormatting pins the text-mode output shape
 // for each KeyringPruneRow status. Without this test, a regression that
 // drops the status word or kind suffix from any branch (planned/deleted/
@@ -102,7 +129,7 @@ func TestKeyringWriter_Prune_RowFormatting(t *testing.T) {
 				Kind:   output.KeyringKindID,
 				Status: output.KeyringPruneStatusPlanned,
 			},
-			contains: []string{"would delete", "m4n8k2pxtz", "(id)"},
+			contains: []string{"delete", "m4n8k2pxtz", "id"},
 		},
 		{
 			name:   "deleted",
@@ -112,7 +139,7 @@ func TestKeyringWriter_Prune_RowFormatting(t *testing.T) {
 				Kind:   output.KeyringKindNamed,
 				Status: output.KeyringPruneStatusDeleted,
 			},
-			contains: []string{"deleted", "named_orphan", "(named)"},
+			contains: []string{"deleted", "named_orphan", "named"},
 		},
 		{
 			name:   "failed",
@@ -123,7 +150,7 @@ func TestKeyringWriter_Prune_RowFormatting(t *testing.T) {
 				Status: output.KeyringPruneStatusFailed,
 				Error:  "keychain locked",
 			},
-			contains: []string{"FAIL", "bad_entry", "(named)", "keychain locked"},
+			contains: []string{"failed", "bad_entry", "named", "keychain locked"},
 		},
 	}
 	for _, tc := range tests {

--- a/cli/output/tablew/keyringwriter_test.go
+++ b/cli/output/tablew/keyringwriter_test.go
@@ -28,6 +28,7 @@ func TestKeyringWriter_Migrate_RowFormatting(t *testing.T) {
 	tests := []struct {
 		name     string
 		row      output.KeyringMigrateRow
+		verbose  bool
 		contains []string
 	}{
 		{
@@ -36,7 +37,7 @@ func TestKeyringWriter_Migrate_RowFormatting(t *testing.T) {
 				Handle: "@plan_src",
 				Status: output.KeyringMigrateStatusPlanned,
 			},
-			contains: []string{"@plan_src", "->", "${keyring:<new-id>}"},
+			contains: []string{"@plan_src", "migrate", "${keyring:<new-id>}"},
 		},
 		{
 			name: "skip",
@@ -45,6 +46,7 @@ func TestKeyringWriter_Migrate_RowFormatting(t *testing.T) {
 				Status: output.KeyringMigrateStatusSkip,
 				Reason: "no password component",
 			},
+			verbose:  true, // skipped sources render only in verbose mode
 			contains: []string{"@skip_src", "skip", "no password component"},
 		},
 		{
@@ -54,7 +56,7 @@ func TestKeyringWriter_Migrate_RowFormatting(t *testing.T) {
 				Status:      output.KeyringMigrateStatusMigrated,
 				NewLocation: "${keyring:abc1234567}",
 			},
-			contains: []string{"@done_src", "done", "${keyring:abc1234567}"},
+			contains: []string{"@done_src", "migrated", "${keyring:abc1234567}"},
 		},
 		{
 			name: "failed",
@@ -63,13 +65,15 @@ func TestKeyringWriter_Migrate_RowFormatting(t *testing.T) {
 				Status: output.KeyringMigrateStatusFailed,
 				Error:  "save config (rolled back): boom",
 			},
-			contains: []string{"@fail_src", "FAIL", "save config (rolled back): boom"},
+			contains: []string{"@fail_src", "failed", "save config (rolled back): boom"},
 		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			var buf bytes.Buffer
-			w := tablew.NewKeyringWriter(&buf, newTestPrinting())
+			pr := newTestPrinting()
+			pr.Verbose = tc.verbose
+			w := tablew.NewKeyringWriter(&buf, pr)
 			require.NoError(t, w.Migrate([]output.KeyringMigrateRow{tc.row}, false))
 			out := buf.String()
 			for _, s := range tc.contains {

--- a/cli/output/tablew/keyringwriter_test.go
+++ b/cli/output/tablew/keyringwriter_test.go
@@ -92,7 +92,7 @@ func TestKeyringWriter_Migrate_Colorized(t *testing.T) {
 	pr.Verbose = true // render skip rows too
 
 	// Guard: the assertions below are meaningless unless color is actually on.
-	require.NotEqual(t, "migrate", pr.Enabled.Sprint("migrate"),
+	require.NotEqual(t, "migrate", pr.Success.Sprint("migrate"),
 		"color must be enabled for this test to verify anything")
 
 	var buf bytes.Buffer
@@ -104,7 +104,7 @@ func TestKeyringWriter_Migrate_Colorized(t *testing.T) {
 	}, true))
 	out := buf.String()
 
-	require.Contains(t, out, pr.Enabled.Sprint("migrate"), "migrate status must be green")
+	require.Contains(t, out, pr.Success.Sprint("migrate"), "migrate status must be green")
 	require.Contains(t, out, pr.Error.Sprint("failed"), "failed status must be red")
 	require.Contains(t, out, pr.Faint.Sprint("skip"), "skip status must be muted")
 	require.Contains(t, out, pr.Faint.Sprint("@csv"), "skip row's handle must be muted too")

--- a/cli/output/tablew/keyringwriter_test.go
+++ b/cli/output/tablew/keyringwriter_test.go
@@ -80,7 +80,7 @@ func TestKeyringWriter_Migrate_RowFormatting(t *testing.T) {
 }
 
 // TestKeyringWriter_List_HeaderToggle verifies that List honors
-// pr.ShowHeader: header row prints when true (with PATH/HANDLE/DRIVER
+// pr.ShowHeader: header row prints when true (with STATUS/PATH/HANDLE/DRIVER
 // labels) and is omitted when false.
 func TestKeyringWriter_List_HeaderToggle(t *testing.T) {
 	refs := []output.KeyringRef{
@@ -94,6 +94,7 @@ func TestKeyringWriter_List_HeaderToggle(t *testing.T) {
 		w := tablew.NewKeyringWriter(&buf, pr)
 		require.NoError(t, w.List(refs))
 		out := buf.String()
+		require.Contains(t, out, "STATUS")
 		require.Contains(t, out, "PATH")
 		require.Contains(t, out, "HANDLE")
 		require.Contains(t, out, "DRIVER")
@@ -107,9 +108,31 @@ func TestKeyringWriter_List_HeaderToggle(t *testing.T) {
 		w := tablew.NewKeyringWriter(&buf, pr)
 		require.NoError(t, w.List(refs))
 		out := buf.String()
+		require.NotContains(t, out, "STATUS")
 		require.NotContains(t, out, "PATH")
 		require.NotContains(t, out, "HANDLE")
 		require.NotContains(t, out, "DRIVER")
 		require.Contains(t, out, "abc123")
 	})
+}
+
+// TestKeyringWriter_ListStatusColumn verifies that List renders the STATUS
+// column with the correct values for referenced, orphan, and missing rows.
+func TestKeyringWriter_ListStatusColumn(t *testing.T) {
+	buf := &bytes.Buffer{}
+	w := tablew.NewKeyringWriter(buf, newTestPrinting())
+
+	err := w.List([]output.KeyringRef{
+		{Status: output.KeyringStatusReferenced, Path: "j2k7m3pxtz", Handle: "@prod", Driver: "postgres"},
+		{Status: output.KeyringStatusOrphan, Path: "m4n8k2pxtz"},
+		{Status: output.KeyringStatusMissing, Path: "@stale/pw", Handle: "@stale", Driver: "mysql"},
+	})
+	require.NoError(t, err)
+
+	out := buf.String()
+	require.Contains(t, out, "STATUS")
+	require.Contains(t, out, "referenced")
+	require.Contains(t, out, "orphan")
+	require.Contains(t, out, "missing")
+	require.Contains(t, out, "m4n8k2pxtz")
 }

--- a/cli/output/writers.go
+++ b/cli/output/writers.go
@@ -301,9 +301,8 @@ type KeyringWriter interface {
 	Migrate(rows []KeyringMigrateRow, dryRun bool) error
 
 	// Prune prints the orphaned entries removed by "sq config keyring
-	// prune". When dryRun is true the rows describe a plan (status
-	// "planned"); when false they describe applied outcomes (status
-	// "deleted" or "failed").
+	// prune". When dryRun is true every row's status is "planned"; when
+	// false no row is "planned" — each is "deleted" or "failed".
 	Prune(rows []KeyringPruneRow, dryRun bool) error
 }
 

--- a/cli/output/writers.go
+++ b/cli/output/writers.go
@@ -247,6 +247,30 @@ type KeyringMigrateRow struct {
 	Error       string `json:"error,omitempty"`        // populated for "failed"
 }
 
+// KeyringPruneStatus* enumerate the status values surfaced by
+// KeyringWriter.Prune. The string forms are part of the JSON contract.
+const (
+	KeyringPruneStatusPlanned = "planned" // dry-run: entry would be deleted
+	KeyringPruneStatusDeleted = "deleted" // applied: entry was deleted
+	KeyringPruneStatusFailed  = "failed"  // applied: deletion failed
+)
+
+// KeyringKind* classify a keyring entry's path shape, for display only.
+const (
+	KeyringKindID    = "id"    // sq-minted opaque Crockford ID
+	KeyringKindNamed = "named" // user-named entry
+)
+
+// KeyringPruneRow describes one orphaned entry in a prune plan (dry-run)
+// or result (applied). Kind is informational; Status takes one of the
+// KeyringPruneStatus* constants.
+type KeyringPruneRow struct {
+	Path   string `json:"path"`
+	Kind   string `json:"kind"`
+	Status string `json:"status"`
+	Error  string `json:"error,omitempty"` // populated for "failed"
+}
+
 // KeyringWriter prints output for the "sq config keyring" command group.
 // Implementations live in cli/output/tablew (text/table) and
 // cli/output/jsonw (JSON).
@@ -275,6 +299,12 @@ type KeyringWriter interface {
 	// false the rows describe applied outcomes (statuses: "migrated",
 	// "skip", or "failed").
 	Migrate(rows []KeyringMigrateRow, dryRun bool) error
+
+	// Prune prints the orphaned entries removed by "sq config keyring
+	// prune". When dryRun is true the rows describe a plan (status
+	// "planned"); when false they describe applied outcomes (status
+	// "deleted" or "failed").
+	Prune(rows []KeyringPruneRow, dryRun bool) error
 }
 
 // NewRecordWriterFunc is a func type that returns an output.RecordWriter.

--- a/cli/output/writers.go
+++ b/cli/output/writers.go
@@ -207,13 +207,24 @@ type Writers struct {
 }
 
 // KeyringRef is one row of "sq config keyring ls" output. Each row
-// describes a single ${keyring:<path>} reference reachable from the
-// active source collection.
+// describes one keyring entry: either a ${keyring:<path>} reference
+// reachable from the active source collection, or an entry found in the
+// OS keyring. Status classifies the row.
 type KeyringRef struct {
+	Status string `json:"status"`
 	Path   string `json:"path"`
 	Handle string `json:"handle"`
 	Driver string `json:"driver"`
 }
+
+// KeyringStatus* enumerate the status values surfaced by
+// KeyringWriter.List. The string forms are part of the JSON contract
+// and must not change casually.
+const (
+	KeyringStatusReferenced = "referenced" // in config and present in the keyring
+	KeyringStatusOrphan     = "orphan"     // in the keyring, referenced by no source
+	KeyringStatusMissing    = "missing"    // referenced by a source, absent from the keyring
+)
 
 // KeyringMigrateStatus enumerates the status values surfaced by
 // KeyringWriter.Migrate. The string forms are part of the JSON

--- a/go.mod
+++ b/go.mod
@@ -85,7 +85,7 @@ require (
 require (
 	github.com/neilotoole/jsoncolor v0.9.1
 	github.com/rqlite/gorqlite v0.0.0-20260504155303-50d445fd0ab9
-	github.com/zalando/go-keyring v0.2.8
+	github.com/zalando/go-keyring v0.2.9-0.20260616202443-860ea660ec62
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -734,8 +734,8 @@ github.com/ydb-platform/ydb-go-sdk/v3 v3.128.2 h1:HVnGd4HTu0D7yI8tSgpra7BzWwTqca
 github.com/ydb-platform/ydb-go-sdk/v3 v3.128.2/go.mod h1:fPywoVkXsn1UYhmJR5QR5At+98n4lIDUyVCgu4/zk8w=
 github.com/yookoala/realpath v1.0.0 h1:7OA9pj4FZd+oZDsyvXWQvjn5oBdcHRTV44PpdMSuImQ=
 github.com/yookoala/realpath v1.0.0/go.mod h1:gJJMA9wuX7AcqLy1+ffPatSCySA1FQ2S8Ya9AIoYBpE=
-github.com/zalando/go-keyring v0.2.8 h1:6sD/Ucpl7jNq10rM2pgqTs0sZ9V3qMrqfIIy5YPccHs=
-github.com/zalando/go-keyring v0.2.8/go.mod h1:tsMo+VpRq5NGyKfxoBVjCuMrG47yj8cmakZDO5QGii0=
+github.com/zalando/go-keyring v0.2.9-0.20260616202443-860ea660ec62 h1:6O6/tNQYb5s1MXvvLwRmCAwJcue+qtLn5sKEqb4bHwQ=
+github.com/zalando/go-keyring v0.2.9-0.20260616202443-860ea660ec62/go.mod h1:tsMo+VpRq5NGyKfxoBVjCuMrG47yj8cmakZDO5QGii0=
 github.com/zeebo/assert v1.3.0 h1:g7C04CbJuIDKNPFHmsk4hwZDO5O+kntRxzaUoNXj+IQ=
 github.com/zeebo/assert v1.3.0/go.mod h1:Pq9JiuJQpG8JLJdtkwrJESF0Foym2/D9XMU5ciN/wJ0=
 github.com/zeebo/xxh3 v1.1.0 h1:s7DLGDK45Dyfg7++yxI0khrfwq9661w9EN78eP/UZVs=

--- a/libsq/core/secret/keyring/id.go
+++ b/libsq/core/secret/keyring/id.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rand"
 	"errors"
 	"io"
+	"strings"
 
 	"github.com/neilotoole/sq/libsq/core/errz"
 	"github.com/neilotoole/sq/libsq/core/secret"
@@ -32,6 +33,23 @@ const maxIDAttempts = 8
 // crypto/rand.Reader. Tests in this package override it to obtain
 // deterministic IDs.
 var randSource = rand.Reader
+
+// IsID reports whether s has the shape of an sq-minted keyring ID:
+// exactly IDLen characters, each drawn from the Crockford Base32
+// alphabet. It is a syntactic check only (it does not consult the
+// keyring) and is used to label entries as "id" versus "named" in
+// command output, not to gate any destructive action.
+func IsID(s string) bool {
+	if len(s) != IDLen {
+		return false
+	}
+	for _, r := range s {
+		if !strings.ContainsRune(crockfordAlphabet, r) {
+			return false
+		}
+	}
+	return true
+}
 
 // NewID returns a fresh Crockford Base32 ID guaranteed not to collide
 // with an existing entry under the sq keyring service. The returned

--- a/libsq/core/secret/keyring/id_test.go
+++ b/libsq/core/secret/keyring/id_test.go
@@ -140,3 +140,27 @@ func (zeroReader) Read(p []byte) (int, error) {
 	}
 	return len(p), nil
 }
+
+func TestIsID(t *testing.T) {
+	testCases := []struct {
+		in   string
+		want bool
+	}{
+		{in: "j2k7m3pxtz", want: true},   // canonical 10-char Crockford
+		{in: "0000000000", want: true},   // all-zero, still 10 valid chars
+		{in: "", want: false},            // empty
+		{in: "j2k7m3pxt", want: false},   // 9 chars
+		{in: "j2k7m3pxtzz", want: false}, // 11 chars
+		{in: "my_db_pw", want: false},    // user-named: underscore + wrong length
+		{in: "j2k7m3pxti", want: false},  // contains excluded 'i'
+		{in: "j2k7m3pxtl", want: false},  // contains excluded 'l'
+		{in: "j2k7m3pxto", want: false},  // contains excluded 'o'
+		{in: "abcdefghuz", want: false},  // contains excluded 'u'
+		{in: "J2K7M3PXTZ", want: false},  // uppercase not in lowercased alphabet
+	}
+	for _, tc := range testCases {
+		t.Run(tc.in, func(t *testing.T) {
+			require.Equal(t, tc.want, IsID(tc.in))
+		})
+	}
+}

--- a/libsq/core/secret/keyring/keyring.go
+++ b/libsq/core/secret/keyring/keyring.go
@@ -52,6 +52,22 @@ func (s *Store) Set(_ context.Context, path, value string) error {
 	return errz.Err(gokeyring.Set(Service, path, value))
 }
 
+// List returns the account names ("users") of every entry stored under
+// the sq keyring service. The result is the raw set reported by the OS
+// keyring; callers reconcile it against config to classify entries as
+// referenced or orphaned.
+//
+// Each call is an OS-keyring roundtrip. On macOS this enumerates via the
+// security(1) tool's attribute-only dump, which does not raise an auth
+// prompt.
+func (s *Store) List(_ context.Context) ([]string, error) {
+	users, err := gokeyring.ListUsers(Service)
+	if err != nil {
+		return nil, errz.Err(err)
+	}
+	return users, nil
+}
+
 // Delete removes the keyring entry at path. Deleting a non-existent
 // entry is not an error.
 //

--- a/libsq/core/secret/keyring/keyring_test.go
+++ b/libsq/core/secret/keyring/keyring_test.go
@@ -63,15 +63,8 @@ func (c *countingStore) Resolve(ctx context.Context, path string) (string, error
 	return c.inner.Resolve(ctx, path)
 }
 
-// TestStore_RegistryMemoizesKeyringResolution verifies that a
-// keyring-backed Registry hits the OS keyring once per path per run
-// (gh #779). Each Store.Resolve is an OS-keychain IPC roundtrip, so
-// repeated resolution of the same placeholder (e.g. one Grips.Open per
-// table during inspect) must be served from the Registry memo. The
-// memoization deliberately lives in secret.Registry rather than in
-// Store itself: the keyring write commands (create, update, rm,
-// migrate) use Store directly and must always read through to the
-// backend.
+// TestStore_List verifies that List enumerates stored account names and
+// returns an empty slice (not an error) for an empty keyring.
 func TestStore_List(t *testing.T) {
 	gokeyring.MockInit()
 	ctx := context.Background()
@@ -91,6 +84,15 @@ func TestStore_List(t *testing.T) {
 	require.ElementsMatch(t, []string{"j2k7m3pxtz", "my_db_pw"}, users)
 }
 
+// TestStore_RegistryMemoizesKeyringResolution verifies that a
+// keyring-backed Registry hits the OS keyring once per path per run
+// (gh #779). Each Store.Resolve is an OS-keychain IPC roundtrip, so
+// repeated resolution of the same placeholder (e.g. one Grips.Open per
+// table during inspect) must be served from the Registry memo. The
+// memoization deliberately lives in secret.Registry rather than in
+// Store itself: the keyring write commands (create, update, rm,
+// migrate) use Store directly and must always read through to the
+// backend.
 func TestStore_RegistryMemoizesKeyringResolution(t *testing.T) {
 	gokeyring.MockInit()
 	ctx := context.Background()

--- a/libsq/core/secret/keyring/keyring_test.go
+++ b/libsq/core/secret/keyring/keyring_test.go
@@ -72,6 +72,25 @@ func (c *countingStore) Resolve(ctx context.Context, path string) (string, error
 // Store itself: the keyring write commands (create, update, rm,
 // migrate) use Store directly and must always read through to the
 // backend.
+func TestStore_List(t *testing.T) {
+	gokeyring.MockInit()
+	ctx := context.Background()
+	st := keyring.NewStore()
+
+	// Empty keyring yields an empty list, not an error.
+	users, err := st.List(ctx)
+	require.NoError(t, err)
+	require.Empty(t, users)
+
+	// Populate, then enumerate.
+	require.NoError(t, st.Set(ctx, "j2k7m3pxtz", "secret-a"))
+	require.NoError(t, st.Set(ctx, "my_db_pw", "secret-b"))
+
+	users, err = st.List(ctx)
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{"j2k7m3pxtz", "my_db_pw"}, users)
+}
+
 func TestStore_RegistryMemoizesKeyringResolution(t *testing.T) {
 	gokeyring.MockInit()
 	ctx := context.Background()

--- a/site/content/en/docs/cmd/config-keyring-migrate.md
+++ b/site/content/en/docs/cmd/config-keyring-migrate.md
@@ -101,9 +101,9 @@ Proceed with migration? [y/N]
 Answer `y`/`yes` to proceed, or `n`/`no` (or just press Enter, the `[y/N]`
 default) to cancel. Cancelling touches nothing (no keyring writes, no `sq.yml`
 change) and exits non-zero, so a script can tell a declined migration from a
-completed one. An unrecognized answer re-prompts; if the input ends without a
-valid answer, migrate also exits non-zero. Pass `--yes` to skip the prompt,
-which is what you want in scripts:
+completed one. Only `y`/`yes`/`n`/`no` (case-insensitive) are accepted; any
+other answer, or no answer at all, is an error and exits non-zero without
+retrying. Pass `--yes` to skip the prompt, which is what you want in scripts:
 
 ```shell
 # Migrate one source without prompting

--- a/site/content/en/docs/cmd/config-keyring-migrate.md
+++ b/site/content/en/docs/cmd/config-keyring-migrate.md
@@ -51,14 +51,16 @@ $ sq config keyring migrate --all
 ```
 
 Sources with nothing to move are skipped automatically, each with its reason
-shown in the output:
+shown in the output (skips are hidden unless you pass `-v`):
 
-- Non-URL locations (file paths, SQLite, Excel, and so on).
-- URLs with no password component.
-- Locations that already contain a `${...}` placeholder, so re-runs are
-  idempotent.
-- Locations with malformed placeholder syntax, surfaced rather than stamped
-  into the keyring.
+- File or document sources with no embedded credentials, such as CSV, SQLite,
+  or Excel: `no credentials to migrate`.
+- A connection URL that carries no password: `no password to migrate`.
+- A location that already uses a `${...}` placeholder, so re-runs are
+  idempotent: `already has a placeholder`.
+- A malformed location or placeholder, surfaced rather than stamped into the
+  keyring: `malformed location: <reason>` or
+  `malformed placeholder syntax: <reason>`.
 
 ## Preview, then confirm
 

--- a/site/content/en/docs/cmd/config-keyring-migrate.md
+++ b/site/content/en/docs/cmd/config-keyring-migrate.md
@@ -81,12 +81,13 @@ applies directly.
 
 ## How changes are applied
 
-Sources are migrated one at a time: mint an ID, write the keyring entry,
-rewrite the source's `location`, and save `sq.yml`. If saving fails for a
-source, `migrate` rolls that source back, restoring its original `location` and
-deleting the keyring entry it just wrote, then reports the source as failed and
-continues with the rest. A run that hits a failure still reports which sources
-succeeded, and exits non-zero.
+`migrate` runs under a config lock (so it won't race another `sq` process) and
+is atomic: a `--all` run either migrates every eligible source or changes
+nothing. It writes each source's keyring entry and rewrites its `location` in
+memory, then saves `sq.yml` once for the whole batch. If any step fails, the
+run is rolled back: every keyring entry it wrote is deleted, every `location`
+is restored, `sq.yml` is left untouched, and the command exits non-zero. A
+failed migration never leaves your config half-converted.
 
 ## Reference
 

--- a/site/content/en/docs/cmd/config-keyring-migrate.md
+++ b/site/content/en/docs/cmd/config-keyring-migrate.md
@@ -11,10 +11,82 @@ toc: false
 url: /docs/cmd/config-keyring-migrate
 ---
 Part of the [`sq config keyring`](/docs/cmd/config-keyring) command group;
-see [Secrets](/docs/secrets) for the broader picture. `migrate` is a bulk operation
-that walks the source collection, writes each inline-password conn string to a
-fresh opaque keyring ID, and replaces the YAML location with a bare
-`${keyring:<id>}` placeholder. Use `--dry-run` first to preview.
+see [Secrets](/docs/secrets) for the broader picture.
+
+`migrate` is the one keyring command a typical user is likely to run. It moves
+plaintext credentials out of `sq.yml` and into the OS keyring in bulk. For each
+source it writes the source's full Location (the connection string, credentials
+and all) to a fresh opaque keyring entry, then rewrites that source's
+`location` in `sq.yml` to a bare `${keyring:<id>}` placeholder. The driver type
+stays in the `driver:` field; the keyring entry holds the whole DSN.
+
+## Back up your config first
+
+`migrate` rewrites `sq.yml` in place and keeps no backup of its own. Before a
+real run, export your current config so you can restore it if anything looks
+wrong:
+
+```shell
+$ sq config export -o sq.bak.yml
+```
+
+[`sq config export`](/docs/cmd/config-export) copies the config verbatim,
+including the inline credentials `migrate` is about to move, so the backup is a
+complete pre-migration snapshot. If you want a self-contained copy with every
+secret resolved in-line (for example, before moving to a machine whose keyring
+won't hold these entries), add `--expand`. Note that this writes every secret
+in plaintext:
+
+```shell
+$ sq config export --expand -o sq.bak.yml
+```
+
+## What gets migrated
+
+Name a single source by handle, or pass `--all` for the whole collection:
+
+```shell
+$ sq config keyring migrate @sakila
+$ sq config keyring migrate --all
+```
+
+Sources with nothing to move are skipped automatically, each with its reason
+shown in the output:
+
+- Non-URL locations (file paths, SQLite, Excel, and so on).
+- URLs with no password component.
+- Locations that already contain a `${...}` placeholder, so re-runs are
+  idempotent.
+- Locations with malformed placeholder syntax, surfaced rather than stamped
+  into the keyring.
+
+## Preview, then confirm
+
+Preview first with `--dry-run`. It mints no IDs and writes nothing:
+
+```shell
+$ sq config keyring migrate --all --dry-run
+```
+
+A real run prints the same plan and then prompts before changing anything:
+
+```text
+Proceed with migration? [y/N]
+```
+
+Anything other than `y` or `yes` (including just pressing Enter) aborts without
+touching the keyring or `sq.yml`. Pass `--yes` to skip the prompt in scripts.
+JSON output (`--json`) is non-interactive: it skips the preview and prompt and
+applies directly.
+
+## How changes are applied
+
+Sources are migrated one at a time: mint an ID, write the keyring entry,
+rewrite the source's `location`, and save `sq.yml`. If saving fails for a
+source, `migrate` rolls that source back, restoring its original `location` and
+deleting the keyring entry it just wrote, then reports the source as failed and
+continues with the rest. A run that hits a failure still reports which sources
+succeeded, and exits non-zero.
 
 ## Reference
 

--- a/site/content/en/docs/cmd/config-keyring-migrate.md
+++ b/site/content/en/docs/cmd/config-keyring-migrate.md
@@ -68,6 +68,17 @@ Preview first with `--dry-run`. It mints no IDs and writes nothing:
 $ sq config keyring migrate --all --dry-run
 ```
 
+The output is an aligned table listing only the sources that will migrate.
+Sources with nothing to move (file paths, no password, already migrated) are
+omitted to keep the list focused; pass `-v` to show them with their skip
+reason. If nothing is eligible, migrate says so and makes no changes:
+
+```text
+HANDLE            STATUS   DETAIL
+@sakila/pg        migrate  ${keyring:<new-id>}
+@sakila/local/pg  migrate  ${keyring:<new-id>}
+```
+
 A real run prints the same plan and then prompts before changing anything:
 
 ```text

--- a/site/content/en/docs/cmd/config-keyring-migrate.md
+++ b/site/content/en/docs/cmd/config-keyring-migrate.md
@@ -99,10 +99,11 @@ Proceed with migration? [y/N]
 ```
 
 Answer `y`/`yes` to proceed, or `n`/`no` (or just press Enter, the `[y/N]`
-default) to cancel without touching the keyring or `sq.yml`. An unrecognized
-answer re-prompts; if the input ends without a valid answer, migrate exits
-non-zero rather than assuming no. Pass `--yes` to skip the prompt, which is what
-you want in scripts:
+default) to cancel. Cancelling touches nothing (no keyring writes, no `sq.yml`
+change) and exits non-zero, so a script can tell a declined migration from a
+completed one. An unrecognized answer re-prompts; if the input ends without a
+valid answer, migrate also exits non-zero. Pass `--yes` to skip the prompt,
+which is what you want in scripts:
 
 ```shell
 # Migrate one source without prompting

--- a/site/content/en/docs/cmd/config-keyring-migrate.md
+++ b/site/content/en/docs/cmd/config-keyring-migrate.md
@@ -62,9 +62,20 @@ shown in the output:
 
 ## Preview, then confirm
 
-Preview first with `--dry-run`. It mints no IDs and writes nothing:
+Every run targets either a single source by handle or the whole collection with
+`--all`. Two flags control how it behaves, and both work with either target:
+
+- `--dry-run` previews the plan and changes nothing (mints no IDs, writes
+  nothing).
+- `--yes` skips the confirmation prompt, for non-interactive use.
+
+### `--dry-run`: preview without changes
 
 ```shell
+# Preview a single source
+$ sq config keyring migrate @sakila --dry-run
+
+# Preview the whole collection
 $ sq config keyring migrate --all --dry-run
 ```
 
@@ -79,16 +90,28 @@ HANDLE            STATUS   DETAIL
 @sakila/local/pg  migrate  ${keyring:<new-id>}
 ```
 
-A real run prints the same plan and then prompts before changing anything:
+### The confirmation prompt and `--yes`
+
+A real run prints the same plan, then prompts before changing anything:
 
 ```text
 Proceed with migration? [y/N]
 ```
 
 Anything other than `y` or `yes` (including just pressing Enter) aborts without
-touching the keyring or `sq.yml`. Pass `--yes` to skip the prompt in scripts.
-JSON output (`--json`) is non-interactive: it skips the preview and prompt and
-applies directly.
+touching the keyring or `sq.yml`. Pass `--yes` to skip the prompt, which is what
+you want in scripts:
+
+```shell
+# Migrate one source without prompting
+$ sq config keyring migrate @sakila --yes
+
+# Migrate everything without prompting
+$ sq config keyring migrate --all --yes
+```
+
+JSON output (`--json`) is non-interactive: it skips both the preview and the
+prompt and applies directly, so `--yes` is implied.
 
 ## How changes are applied
 

--- a/site/content/en/docs/cmd/config-keyring-migrate.md
+++ b/site/content/en/docs/cmd/config-keyring-migrate.md
@@ -98,8 +98,10 @@ A real run prints the same plan, then prompts before changing anything:
 Proceed with migration? [y/N]
 ```
 
-Anything other than `y` or `yes` (including just pressing Enter) aborts without
-touching the keyring or `sq.yml`. Pass `--yes` to skip the prompt, which is what
+Answer `y`/`yes` to proceed, or `n`/`no` (or just press Enter, the `[y/N]`
+default) to cancel without touching the keyring or `sq.yml`. An unrecognized
+answer re-prompts; if the input ends without a valid answer, migrate exits
+non-zero rather than assuming no. Pass `--yes` to skip the prompt, which is what
 you want in scripts:
 
 ```shell

--- a/site/content/en/docs/cmd/config-keyring-prune.help.txt
+++ b/site/content/en/docs/cmd/config-keyring-prune.help.txt
@@ -1,35 +1,29 @@
-List every keyring entry under the sq service, reconciled against
-the ${keyring:<path>} placeholders referenced by sources.
+Delete every keyring entry under the sq service that no source
+references. An entry is an orphan when no source Location contains a
+${keyring:PATH} placeholder naming it; hand-crafted references count, so
+an entry wired into any source is never pruned.
 
-Output columns:
-  STATUS    referenced | orphan | missing (see below).
-  PATH      The keyring entry path, e.g. "j2k7m3pxtz".
-  HANDLE    The @handle that references the entry (blank for orphans).
-  DRIVER    The source's driver type (blank for orphans).
-
-Status values:
-  referenced  Present in the keyring and referenced by a source.
-  orphan      Present in the keyring, referenced by no source. Remove
-              with 'sq config keyring prune'.
-  missing     Referenced by a source but absent from the keyring; that
-              source will fail to resolve its secret at connect time.
-
-A path referenced by multiple sources yields one row per source. Only
-${keyring:...} refs are reconciled; ${env:...} and ${file:...} are
-external and not listed.
+Both sq-generated opaque IDs and user-named entries are pruned. Use
+'sq config keyring ls' to review entries first, and --dry-run to preview
+what prune would remove without deleting anything.
 
 Usage:
-  sq config keyring ls
+  sq config keyring prune
 
-Aliases:
-  ls, list
+Examples:
+  # Preview orphans without deleting
+  $ sq config keyring prune --dry-run
+
+  # Delete all orphaned entries
+  $ sq config keyring prune
 
 Flags:
+      --dry-run     Show orphans that would be deleted, make no changes
   -t, --text        Output text
   -j, --json        Output JSON
   -h, --header      Print header row (default true)
   -H, --no-header   Don't print header row
-      --help        help for ls
+      --help        help for prune
 
 Global Flags:
       --config string         Load config from here

--- a/site/content/en/docs/cmd/config-keyring-prune.md
+++ b/site/content/en/docs/cmd/config-keyring-prune.md
@@ -1,0 +1,18 @@
+---
+title: "sq config keyring prune"
+description: "Delete orphaned keyring entries"
+group: config
+draft: false
+images: []
+menu:
+  docs:
+    parent: "cmd"
+toc: false
+url: /docs/cmd/config-keyring-prune
+---
+Part of the [`sq config keyring`](/docs/cmd/config-keyring) command group;
+see [Secrets](/docs/secrets) for the broader picture.
+
+## Reference
+
+{{< readfile file="config-keyring-prune.help.txt" code="true" lang="text" >}}

--- a/site/content/en/docs/cmd/config-keyring.help.txt
+++ b/site/content/en/docs/cmd/config-keyring.help.txt
@@ -43,7 +43,8 @@ Examples:
   $ sq config keyring migrate --all
 
 Available Commands:
-  ls          List keyring paths referenced by sources
+  ls          List keyring entries and their status
+  prune       Delete orphaned keyring entries
   create      Create a new keyring entry
   update      Update an existing keyring entry
   get         Get a keyring secret

--- a/site/content/en/docs/cmd/config-keyring.md
+++ b/site/content/en/docs/cmd/config-keyring.md
@@ -10,12 +10,21 @@ menu:
 toc: false
 url: /docs/cmd/config-keyring
 ---
+{{< alert icon="🐥" >}}
+You should rarely, if ever, need this command group directly. `sq config
+keyring` is a thin, platform-independent wrapper over your OS keychain (macOS
+Keychain, Windows Credential Manager, the Secret Service on Linux); `sq` reads
+and writes these entries for you, and the secret handling is meant to stay
+invisible. Reach in here only to inspect, rotate, or clean up entries by hand.
+
+This keyring support is beta and may change in a future release.
+{{< /alert >}}
+
 The `sq config keyring` command group manages keyring entries directly.
-Most users never need it: [`sq add --store keyring`](/docs/cmd/add) and the
-[`secrets.store`](/docs/config#secretsstore) option write entries
-automatically. Reach for these subcommands when you need to rotate a
-credential, migrate inline passwords in bulk, or inspect what's already
-stored.
+[`sq add --store keyring`](/docs/cmd/add) and the
+[`secrets.store`](/docs/config#secretsstore) option write entries automatically;
+reach for these subcommands to rotate a credential, migrate inline passwords in
+bulk, or inspect (or prune) what's already stored.
 
 See [Secrets](/docs/secrets) for an overview of how `sq` handles secrets
 and how the keyring scheme fits in.
@@ -24,17 +33,19 @@ and how the keyring scheme fits in.
 
 | Command                                                         | What it does                                                   |
 |-----------------------------------------------------------------|----------------------------------------------------------------|
-| [`sq config keyring ls`](/docs/cmd/config-keyring-ls)           | List `${keyring:<path>}` references found in source locations. |
+| [`sq config keyring ls`](/docs/cmd/config-keyring-ls)           | List every entry, tagged referenced, orphan, or missing.       |
+| [`sq config keyring prune`](/docs/cmd/config-keyring-prune)     | Delete orphaned entries (those no source references).          |
 | [`sq config keyring create`](/docs/cmd/config-keyring-create)   | Create a new entry at `PATH`. Errors if `PATH` already exists. |
 | [`sq config keyring update`](/docs/cmd/config-keyring-update)   | Rotate the value at an existing `PATH`.                        |
 | [`sq config keyring get`](/docs/cmd/config-keyring-get)         | Check an entry exists; with `--reveal`, print its value.       |
 | [`sq config keyring rm`](/docs/cmd/config-keyring-rm)           | Delete an entry. Does not touch sources that reference it.     |
 | [`sq config keyring migrate`](/docs/cmd/config-keyring-migrate) | Move inline-password sources to the keyring in bulk.           |
 
-`sq config keyring ls` walks the YAML config; it lists only `keyring`
-placeholders that some source references. Orphan entries (entries in the
-keyring that no source uses) are not surfaced. Enumerating them requires
-keyring-wide iteration, which is deferred to a future release.
+`sq config keyring ls` reconciles the keyring against your config: it tags each
+entry a source references as `referenced`, each entry no source uses as
+`orphan`, and each reference whose entry is absent from the keyring as
+`missing`. Use [`sq config keyring prune`](/docs/cmd/config-keyring-prune) to
+delete the orphans.
 
 `sq config keyring rm` deletes the keyring entry only; any remaining
 `${keyring:PATH}` reference in `sq.yml` will fail to resolve on the next

--- a/site/content/en/docs/cmd/config-keyring.md
+++ b/site/content/en/docs/cmd/config-keyring.md
@@ -10,6 +10,15 @@ menu:
 toc: false
 url: /docs/cmd/config-keyring
 ---
+The `sq config keyring` command group manages keyring entries directly.
+[`sq add --store keyring`](/docs/cmd/add) and the
+[`secrets.store`](/docs/config#secretsstore) option write entries automatically;
+reach for these subcommands to rotate a credential, migrate inline passwords in
+bulk, or inspect (or prune) what's already stored.
+
+See [Secrets](/docs/secrets) for an overview of how `sq` handles secrets
+and how the keyring scheme fits in.
+
 {{< alert icon="🐥" >}}
 You should rarely, if ever, need this command group directly. `sq config
 keyring` is a thin, platform-independent wrapper over your OS keychain (macOS
@@ -20,16 +29,10 @@ invisible. Reach in here only to inspect, rotate, or clean up entries by hand.
 This keyring support is beta and may change in a future release.
 {{< /alert >}}
 
-The `sq config keyring` command group manages keyring entries directly.
-[`sq add --store keyring`](/docs/cmd/add) and the
-[`secrets.store`](/docs/config#secretsstore) option write entries automatically;
-reach for these subcommands to rotate a credential, migrate inline passwords in
-bulk, or inspect (or prune) what's already stored.
-
-See [Secrets](/docs/secrets) for an overview of how `sq` handles secrets
-and how the keyring scheme fits in.
-
 ## Commands
+
+`sq config keyring` is a command group rather than a command itself: run
+on its own, it just prints help. Use one of its subcommands:
 
 | Command                                                         | What it does                                                   |
 |-----------------------------------------------------------------|----------------------------------------------------------------|

--- a/site/content/en/docs/cmd/generate-cmd-help.sh
+++ b/site/content/en/docs/cmd/generate-cmd-help.sh
@@ -30,6 +30,7 @@ cmds=(
   "config export"
   "config keyring"
   "config keyring ls"
+  "config keyring prune"
   "config keyring create"
   "config keyring update"
   "config keyring get"


### PR DESCRIPTION
Closes #715.

Adds OS-keyring entry enumeration (the `ls`/`prune` ask of #715) and, while in
the keyring command group, overhauls `config keyring migrate` for safety and
UX. Builds on `zalando/go-keyring`'s new `ListUsers` (PR #135), pinned via a
master pseudo-version since no tagged release contains it yet.

## `config keyring ls`: unified inventory

Enumerates the keyring on every call and reconciles it against the
`${keyring:...}` references in the config, adding a `STATUS` column:

- `referenced`: present in the keyring and referenced by a source.
- `orphan`: present in the keyring, referenced by no source.
- `missing`: referenced by a source but absent from the keyring.

Enumeration failures hard-fail rather than print a partial listing.

## `config keyring prune` (new)

Deletes every orphaned entry and reports what it removed, like `sq rm`. It is
permissive (opaque IDs and user-named entries alike, since an orphan is by
definition referenced by nothing). `--dry-run` previews. The logic sits behind
a small `keyringPruner` interface so the delete-failure path is testable.

## `config keyring migrate`: overhaul

- **Atomic and locked.** Writes every eligible source's keyring entry and
  rewrites its location in memory, then saves `sq.yml` once for the whole
  batch; any failure rolls the whole batch back, leaving `sq.yml` untouched. It
  now takes the config lock, since it mutates `sq.yml` like `add`/`rm`/`mv`.
- **Focused, aligned output.** Renders an aligned `HANDLE/STATUS/DETAIL` table.
  The default view shows only the sources that will migrate; skips appear with
  `-v`. "Nothing to migrate" is reported rather than printing an empty table,
  and does not prompt.
- **Clearer skip reasons:** `no credentials to migrate`, `no password to
  migrate`, `malformed location: ...`, instead of the old `not a URL`.
- **Strict confirmation prompt.** Only `y`/`yes`/`n`/`no` (and Enter for the
  `[y/N]` default) are accepted; any other input is an error with no retry, as
  is EOF. Declining exits non-zero (the migration did not happen); "nothing to
  migrate" still exits 0.
- **Handle completion** for the `[@HANDLE]` argument.

## Output and color

`migrate` and `prune` render through the table writer (aligned columns, like
`ls`). On a color terminal the action status is green, a failure red, and a
skipped migrate row is muted in full; red is reserved for genuine failures.

## Dev convention

Adds a `cli/CLAUDE.md` rule that every command taking arguments must offer shell
completion (with a free-form-argument exemption), prompted by `migrate` having
shipped without it.

## Notes

- `go-keyring` is pinned to a master pseudo-version; swap to a tag once upstream
  cuts a release.
- No `CHANGELOG.md` entry: the keyring command group is part of the
  still-unreleased secrets work (#441).
- A malformed `${...}` placeholder in a source location aborts `ls`/`prune`/
  `migrate` rather than silently dropping that source's references, so a
  referenced entry can never be misclassified as a prunable orphan.

## Testing

Unit and command-level tests across the new and changed behavior:
`keyring.Store.List`/`IsID`; the three-state `ls` reconciliation (text and
JSON, shared paths, sort order); `prune` (delete, dry-run, writer error,
nothing-to-prune); `migrate` (atomic single-save, multi-source rollback, the
strict prompt, decline exit code, single-handle, mixed collection, skips hidden
by default); colorized rendering; and handle completion. `make lint` clean;
`go test -short ./...` passes.
