### PR TITLE
docs: add Cursor Cloud env setup notes to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -221,3 +221,48 @@ is present.
 
 Optional: set `DISABLE_TELEMETRY=1` to opt out of anonymous Skills CLI
 telemetry ([docs](https://skills.sh/docs/cli)).
+
+## Cursor Cloud specific instructions
+
+These notes apply to the Cursor Cloud agent VM. The standard build/test/lint
+commands live in [Common commands](#common-commands); only the non-obvious
+caveats are captured here.
+
+### Run Go tests with `NO_COLOR` and `FORCE_COLOR` cleared
+
+The VM preseeds `NO_COLOR=1`, `FORCE_COLOR=0`, and `TERM=dumb` in the
+environment. These break color-sensitive Go tests, so clear the first two
+before running the suite:
+
+```bash
+env -u NO_COLOR -u FORCE_COLOR make test-short
+```
+
+Why: `libsq/core/colorz` tests fail under `NO_COLOR=1`, and the CLI
+`*Roundtrip` / `TestDiff_*` tests panic because `termz.IsColorTerminal`
+treats any non-empty `FORCE_COLOR` (including `FORCE_COLOR=0`) as "force color
+on", then asserts stdout is an `*os.File`. CI runs with none of these set, so
+clearing them matches CI behavior. `make lint` and `make lint-markdown` are
+unaffected.
+
+### Build needs CGO + ICU headers
+
+`make build` / `make test` pass `sqlite_icu` (among other SQLite build tags),
+so a C compiler and the ICU dev headers (`libicu-dev`, providing
+`unicode/utypes.h`) must be present. These are installed in the VM snapshot.
+The CI workflow omits `sqlite_icu`, but the `Makefile` includes it.
+
+### Tooling locations
+
+`bun` (used by `make lint-markdown` and the `site/` product) is installed at
+`~/.bun/bin`. The Go toolchain auto-downloads the version pinned in `go.mod`
+(currently 1.26.3) on first use.
+
+### SQL driver integration tests need Docker
+
+Postgres/MySQL/SQL Server/ClickHouse/Oracle driver tests require the
+`sakiladb/*` Docker images and `SQ_TEST_SRC__SAKILA_*` env vars (see
+[`CONTRIBUTING.md`](./CONTRIBUTING.md)). Docker is not installed in the VM, so
+use `make test-short` (or `go test -short`), which skips them. SQLite, CSV,
+JSON, and XLSX drivers run against checked-in testdata with no external
+service.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -228,23 +228,6 @@ These notes apply to the Cursor Cloud agent VM. The standard build/test/lint
 commands live in [Common commands](#common-commands); only the non-obvious
 caveats are captured here.
 
-### Run Go tests with `NO_COLOR` and `FORCE_COLOR` cleared
-
-The VM preseeds `NO_COLOR=1`, `FORCE_COLOR=0`, and `TERM=dumb` in the
-environment. These break color-sensitive Go tests, so clear the first two
-before running the suite:
-
-```bash
-env -u NO_COLOR -u FORCE_COLOR make test-short
-```
-
-Why: `libsq/core/colorz` tests fail under `NO_COLOR=1`, and the CLI
-`*Roundtrip` / `TestDiff_*` tests panic because `termz.IsColorTerminal`
-treats any non-empty `FORCE_COLOR` (including `FORCE_COLOR=0`) as "force color
-on", then asserts stdout is an `*os.File`. CI runs with none of these set, so
-clearing them matches CI behavior. `make lint` and `make lint-markdown` are
-unaffected.
-
 ### Build needs CGO + ICU headers
 
 `make build` / `make test` pass `sqlite_icu` (among other SQLite build tags),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the Cursor Cloud development environment for the `sq` CLI and records
the non-obvious caveats discovered during setup in `AGENTS.md` under a new
`## Cursor Cloud specific instructions` section. No application code changed.

## What was set up

- Go toolchain 1.26.3 (auto-downloaded per `go.mod`) + CGO via system `gcc`.
- System deps installed in the VM: `libicu-dev` (required for the `sqlite_icu`
  build tag the `Makefile` passes), `shellcheck` (for `make lint`), and `bun`
  (for `make lint-markdown` / the `site/` product).

## AGENTS.md notes

The `## Cursor Cloud specific instructions` section documents the ICU build
requirement, tooling locations (`bun`), and that Docker-backed SQL driver
integration tests are skipped via `make test-short`.

Note: the original `NO_COLOR`/`FORCE_COLOR` test workaround has been removed
from this section because the underlying issue is now fixed in code in
neilotoole/sq#863. Recommend merging #863 first (or together) so master is never
in a state without either the workaround note or the fix.

## Verification

- `make build` → `dist/sq` (`sq v0.54.0`)
- `make lint` → 0 issues
- `make lint-markdown` → 0 errors
- `make test-short` → all packages ok
- Hello-world: added a CSV source and ran SLQ + SQL queries via `dist/sq`

[sq_hello_world_demo.log](https://cursor.com/agents/bc-2cf2fc8f-cdc4-4e06-a2cf-8bafd7906ce0/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsq_hello_world_demo.log)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2cf2fc8f-cdc4-4e06-a2cf-8bafd7906ce0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2cf2fc8f-cdc4-4e06-a2cf-8bafd7906ce0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

