### PR TITLE
Fix flag-value shell completion suppressed by positional cap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,17 @@ Breaking changes are annotated with ☢️, and alpha/beta features with 🐥.
 > `v0.18.2`. This typically means that there was some CI/tooling mishap. Ignore
 > those gaps.
 
+## Unreleased
+
+### Fixed
+
+- Shell completion for flag values now works even when the command already has a
+  positional argument. Previously, tab-completing values for flags such as
+  [`add --store`](https://sq.io/docs/cmd/add) (`inline | keyring`), `config get --src`,
+  `config set --src`, `--log.level`, and `--log.format` produced nothing once a
+  positional arg was present (which is the usual case). The `--error.format` flag also
+  now offers completion.
+
 ## [v0.54.0] - 2026-06-19
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,8 @@ Breaking changes are annotated with ☢️, and alpha/beta features with 🐥.
   [`add --store`](https://sq.io/docs/cmd/add) (`inline | keyring`), `config get --src`,
   `config set --src`, `--log.level`, and `--log.format` produced nothing once a
   positional arg was present (which is the usual case). The `--error.format` flag also
-  now offers completion, and `--arg` no longer suggests filenames for its free-form value.
+  now offers completion, and `--arg` no longer offers irrelevant suggestions (filenames
+  for its variable name, or table names for its value), since both are free-form.
 
 ## [v0.54.0] - 2026-06-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ Breaking changes are annotated with ☢️, and alpha/beta features with 🐥.
   [`add --store`](https://sq.io/docs/cmd/add) (`inline | keyring`), `config get --src`,
   `config set --src`, `--log.level`, and `--log.format` produced nothing once a
   positional arg was present (which is the usual case). The `--error.format` flag also
-  now offers completion.
+  now offers completion, and `--arg` no longer suggests filenames for its free-form value.
 
 ## [v0.54.0] - 2026-06-19
 

--- a/cli/cmd_add.go
+++ b/cli/cmd_add.go
@@ -189,14 +189,14 @@ More examples:
 	cmd.Flags().BoolP(flag.PasswordPrompt, flag.PasswordPromptShort, false, flag.PasswordPromptUsage)
 	cmd.Flags().String(flag.AddStore, "", flag.AddStoreUsage)
 	panicOn(cmd.RegisterFlagCompletionFunc(flag.AddStore,
-		completeStrings(1, flag.AddStoreInline, flag.AddStoreKeyring)))
+		completeStrings(flag.AddStoreInline, flag.AddStoreKeyring)))
 	cmd.Flags().Bool(flag.SkipVerify, false, flag.SkipVerifyUsage)
 	cmd.Flags().BoolP(flag.AddActive, flag.AddActiveShort, false, flag.AddActiveUsage)
 
 	addOptionFlag(cmd.Flags(), driver.OptIngestHeader)
 	addOptionFlag(cmd.Flags(), csv.OptEmptyAsNull)
 	addOptionFlag(cmd.Flags(), csv.OptDelim)
-	panicOn(cmd.RegisterFlagCompletionFunc(csv.OptDelim.Flag().Name, completeStrings(-1, csv.NamedDelims()...)))
+	panicOn(cmd.RegisterFlagCompletionFunc(csv.OptDelim.Flag().Name, completeStrings(csv.NamedDelims()...)))
 
 	return cmd
 }

--- a/cli/cmd_config_get.go
+++ b/cli/cmd_config_get.go
@@ -35,7 +35,7 @@ just for that source.`,
 	addOptionFlag(cmd.Flags(), OptCompact)
 
 	cmd.Flags().String(flag.ConfigSrc, "", flag.ConfigSrcUsage)
-	panicOn(cmd.RegisterFlagCompletionFunc(flag.ConfigSrc, completeHandle(1, true)))
+	panicOn(cmd.RegisterFlagCompletionFunc(flag.ConfigSrc, completeHandleFlag(true)))
 
 	return cmd
 }

--- a/cli/cmd_config_ls.go
+++ b/cli/cmd_config_ls.go
@@ -43,7 +43,7 @@ just for that source.`,
 	addOptionFlag(cmd.Flags(), OptCompact)
 
 	cmd.Flags().String(flag.ConfigSrc, "", flag.ConfigSrcUsage)
-	panicOn(cmd.RegisterFlagCompletionFunc(flag.ConfigSrc, completeHandle(1, true)))
+	panicOn(cmd.RegisterFlagCompletionFunc(flag.ConfigSrc, completeHandleFlag(true)))
 
 	return cmd
 }

--- a/cli/cmd_config_set.go
+++ b/cli/cmd_config_set.go
@@ -49,7 +49,7 @@ Use "sq config ls -v" to list available options.`,
 	cmd.Flags().BoolP(flag.YAML, flag.YAMLShort, false, flag.YAMLUsage)
 
 	cmd.Flags().String(flag.ConfigSrc, "", flag.ConfigSrcUsage)
-	panicOn(cmd.RegisterFlagCompletionFunc(flag.ConfigSrc, completeHandle(1, true)))
+	panicOn(cmd.RegisterFlagCompletionFunc(flag.ConfigSrc, completeHandleFlag(true)))
 
 	cmd.Flags().BoolP(flag.ConfigDelete, flag.ConfigDeleteShort, false, flag.ConfigDeleteUsage)
 

--- a/cli/cmd_diff.go
+++ b/cli/cmd_diff.go
@@ -212,7 +212,7 @@ Exit status is 0 if inputs are the same, 1 if different, 2 on any error.`,
 
 	panicOn(cmd.RegisterFlagCompletionFunc(
 		OptDiffDataFormat.Flag().Name,
-		completeStrings(-1, stringz.Strings(diffFormats)...),
+		completeStrings(stringz.Strings(diffFormats)...),
 	))
 
 	addOptionFlag(cmd.Flags(), driver.OptIngestCache)

--- a/cli/cmd_inspect.go
+++ b/cli/cmd_inspect.go
@@ -107,7 +107,7 @@ render a schema document that includes a Mermaid entity-relationship diagram;
 	// offering e.g. csv/xlsx/xml here would imply support that doesn't exist.
 	panicOn(cmd.RegisterFlagCompletionFunc(
 		OptFormat.Flag().Name,
-		completeStrings(-1,
+		completeStrings(
 			format.Text.String(),
 			format.JSON.String(),
 			format.YAML.String(),

--- a/cli/cmd_root.go
+++ b/cli/cmd_root.go
@@ -139,7 +139,6 @@ See docs and more: https://sq.io`,
 	addOptionFlag(cmd.PersistentFlags(), OptVerbose)
 	addOptionFlag(cmd.PersistentFlags(), pprofile.OptMode)
 	panicOn(cmd.RegisterFlagCompletionFunc(pprofile.OptMode.Flag().Name, completeStrings(
-		-1,
 		pprofile.Modes()...,
 	)))
 
@@ -156,7 +155,6 @@ See docs and more: https://sq.io`,
 
 	addOptionFlag(cmd.PersistentFlags(), OptLogLevel)
 	panicOn(cmd.RegisterFlagCompletionFunc(OptLogLevel.Flag().Name, completeStrings(
-		1,
 		slog.LevelDebug.String(),
 		slog.LevelInfo.String(),
 		slog.LevelWarn.String(),
@@ -165,12 +163,15 @@ See docs and more: https://sq.io`,
 
 	addOptionFlag(cmd.PersistentFlags(), OptLogFormat)
 	panicOn(cmd.RegisterFlagCompletionFunc(OptLogFormat.Flag().Name, completeStrings(
-		1,
 		string(format.Text),
 		string(format.JSON),
 	)))
 
 	addOptionFlag(cmd.PersistentFlags(), OptErrorFormat)
+	panicOn(cmd.RegisterFlagCompletionFunc(OptErrorFormat.Flag().Name, completeStrings(
+		string(format.Text),
+		string(format.JSON),
+	)))
 	addOptionFlag(cmd.PersistentFlags(), OptErrorStack)
 
 	return cmd

--- a/cli/cmd_slq.go
+++ b/cli/cmd_slq.go
@@ -422,11 +422,11 @@ func addQueryCmdFlags(cmd *cobra.Command) {
 	addOptionFlag(cmd.Flags(), OptFormatDecimal)
 	panicOn(cmd.RegisterFlagCompletionFunc(
 		OptFormat.Flag().Name,
-		completeStrings(-1, stringz.Strings(format.All())...),
+		completeStrings(stringz.Strings(format.All())...),
 	))
 	panicOn(cmd.RegisterFlagCompletionFunc(
 		OptFormatDecimal.Flag().Name,
-		completeStrings(-1, "string", "number"),
+		completeStrings("string", "number"),
 	))
 	addResultFormatFlags(cmd)
 	cmd.MarkFlagsMutuallyExclusive(append(
@@ -446,7 +446,7 @@ func addQueryCmdFlags(cmd *cobra.Command) {
 		(&handleTableCompleter{onlySQL: true, handleRequired: true}).complete))
 
 	cmd.Flags().String(flag.ActiveSrc, "", flag.ActiveSrcUsage)
-	panicOn(cmd.RegisterFlagCompletionFunc(flag.ActiveSrc, completeHandle(0, false)))
+	panicOn(cmd.RegisterFlagCompletionFunc(flag.ActiveSrc, completeHandleFlag(false)))
 
 	cmd.Flags().String(flag.ActiveSchema, "", flag.ActiveSchemaUsage)
 	panicOn(cmd.RegisterFlagCompletionFunc(flag.ActiveSchema,
@@ -459,7 +459,7 @@ func addQueryCmdFlags(cmd *cobra.Command) {
 	addOptionFlag(cmd.Flags(), driver.OptIngestHeader)
 	addOptionFlag(cmd.Flags(), driver.OptIngestCache)
 	addOptionFlag(cmd.Flags(), csv.OptDelim)
-	panicOn(cmd.RegisterFlagCompletionFunc(csv.OptDelim.Key(), completeStrings(-1, csv.NamedDelims()...)))
+	panicOn(cmd.RegisterFlagCompletionFunc(csv.OptDelim.Key(), completeStrings(csv.NamedDelims()...)))
 	addOptionFlag(cmd.Flags(), csv.OptEmptyAsNull)
 }
 

--- a/cli/cmd_slq.go
+++ b/cli/cmd_slq.go
@@ -42,6 +42,10 @@ func newSLQCmd() *cobra.Command {
 	cmd.Flags().Bool(flag.RenderSQL, false, flag.RenderSQLUsage)
 
 	cmd.Flags().StringArray(flag.Arg, nil, flag.ArgUsage)
+	// The --arg value is a free-form variable name (and then a literal value),
+	// so there's nothing to suggest; register completeNone to at least suppress
+	// cobra's default filename completion.
+	panicOn(cmd.RegisterFlagCompletionFunc(flag.Arg, completeNone))
 
 	// Explicitly add flagVersion because people like to do "sq --version"
 	// as much as "sq version".

--- a/cli/complete.go
+++ b/cli/complete.go
@@ -67,14 +67,14 @@ var (
 	_ completionFunc = (*handleTableCompleter)(nil).complete
 )
 
-// completeStrings completes from a slice of string.
-func completeStrings(maxVals int, a ...string) completionFunc {
-	return func(_ *cobra.Command, args []string, _ string) ([]string, cobra.ShellCompDirective) {
-		if maxVals > 0 && len(args) >= maxVals {
-			return nil, cobra.ShellCompDirectiveNoFileComp
-		}
-
-		return a, cobra.ShellCompDirectiveNoFileComp & cobra.ShellCompDirectiveKeepOrder
+// completeStrings completes a flag value from a fixed slice of strings. It is
+// for flag values only, not positional args: a flag takes a single value
+// regardless of how many positional args precede it, so there's no positional
+// cap to apply (cf. completeHandle, whose maxVals cap is meaningful only for
+// positional completion). The candidates are returned in the given order.
+func completeStrings(a ...string) completionFunc {
+	return func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+		return a, cobra.ShellCompDirectiveNoFileComp | cobra.ShellCompDirectiveKeepOrder
 	}
 }
 
@@ -108,6 +108,16 @@ func completeHandle(maxVals int, includeActive bool) completionFunc {
 
 		return handles, cobra.ShellCompDirectiveNoFileComp
 	}
+}
+
+// completeHandleFlag is the flag-value counterpart to completeHandle. It
+// suggests source handles for a flag value (e.g. --src), with no positional
+// cap: completeHandle's maxVals gates on len(args), the positional args, which
+// is correct for positional completion but would wrongly suppress a flag's
+// value once enough positionals are present. A flag takes a single value
+// regardless of preceding positionals.
+func completeHandleFlag(includeActive bool) completionFunc {
+	return completeHandle(0, includeActive)
 }
 
 // completeCatalog is a completionFunc that suggests catalogs.

--- a/cli/complete.go
+++ b/cli/complete.go
@@ -83,9 +83,11 @@ func completeBool(_ *cobra.Command, _ []string, _ string) ([]string, cobra.Shell
 	return []string{"true", "false"}, cobra.ShellCompDirectiveNoFileComp
 }
 
-// completeHandle is a completionFunc that suggests handles.
-// The max arg is the maximum number of completions. Set to 0
-// for no limit.
+// completeHandle is a completionFunc that suggests handles. It is for
+// positional completion: maxVals caps the number of positional args the
+// command takes, and completion is suppressed once that many are present
+// (set to 0 for no cap). For flag-value completion use completeHandleFlag,
+// which has no positional cap.
 func completeHandle(maxVals int, includeActive bool) completionFunc {
 	return func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if maxVals > 0 && len(args) >= maxVals {

--- a/cli/complete.go
+++ b/cli/complete.go
@@ -240,13 +240,19 @@ func completeSLQ(cmd *cobra.Command, args []string, toComplete string) ([]string
 
 	// --arg takes a "NAME VALUE" pair, but that pairing is a pre-parse hack
 	// (preprocessFlagArgVars) that doesn't run during completion, so cobra
-	// sees --arg as a single-value flag: after "--arg NAME" it consumes NAME
-	// as the flag value and treats the next word as a positional, landing us
-	// here with args empty. That word is actually the free-form arg VALUE, so
+	// sees --arg as a single-value flag. After the space form "--arg NAME" it
+	// consumes NAME as the flag value and treats the next word as a positional,
+	// landing us here with args empty; that word is the free-form arg VALUE, so
 	// suppress suggestions rather than offering query/table completions. (When
 	// the query is typed first, args is non-empty and we already returned
 	// above.)
-	if cmdFlagChanged(cmd, flag.Arg) {
+	//
+	// The "=" form "--arg=NAME:VALUE" is a single self-contained token, so the
+	// next word is a real query positional that must still complete. Tell the
+	// two apart by the trailing ":" that a joined NAME:VALUE always has and a
+	// dangling NAME (a plain identifier, per stringz.ValidIdent) never does.
+	if vals, _ := cmd.Flags().GetStringArray(flag.Arg); len(vals) > 0 &&
+		!strings.Contains(vals[len(vals)-1], ":") {
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
 

--- a/cli/complete.go
+++ b/cli/complete.go
@@ -234,30 +234,46 @@ func completeHandleOrGroup(cmd *cobra.Command, args []string, toComplete string)
 // completes the "table select" segment (that is, the @HANDLE.NAME)
 // segment.
 func completeSLQ(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-	if len(args) != 0 {
-		return nil, cobra.ShellCompDirectiveError
+	// Space-form --arg pairs ("--arg NAME VALUE") leave VALUE as a fake
+	// positional because preprocessFlagArgVars doesn't run during completion,
+	// so cobra treats the next word as a positional instead of the pair's
+	// VALUE. Count those fake positionals so we can skip them.
+	//
+	// The "=" form ("--arg=NAME:VALUE") is consumed by pflag as a single token,
+	// so it contributes no fake positionals. A joined NAME:VALUE always contains
+	// ":", a dangling NAME (a valid identifier) never does.
+	//
+	// Cobra traverses the arg list once per positional during completion (to
+	// check each intermediate word), and StringArray is cumulative, so vals
+	// may contain duplicate entries. Deduplicate before counting.
+	spaceFormArgCount := 0
+	if vals, _ := cmd.Flags().GetStringArray(flag.Arg); len(vals) > 0 {
+		seen := make(map[string]struct{}, len(vals))
+		for _, v := range vals {
+			if _, dup := seen[v]; dup {
+				continue
+			}
+			seen[v] = struct{}{}
+			if !strings.Contains(v, ":") {
+				spaceFormArgCount++
+			}
+		}
 	}
 
-	// --arg takes a "NAME VALUE" pair, but that pairing is a pre-parse hack
-	// (preprocessFlagArgVars) that doesn't run during completion, so cobra
-	// sees --arg as a single-value flag. After the space form "--arg NAME" it
-	// consumes NAME as the flag value and treats the next word as a positional,
-	// landing us here with args empty; that word is the free-form arg VALUE, so
-	// suppress suggestions rather than offering query/table completions. (When
-	// the query is typed first, args is non-empty and we already returned
-	// above.)
-	//
-	// The "=" form "--arg=NAME:VALUE" is a single self-contained token, so the
-	// next word is a real query positional that must still complete. Tell the
-	// two apart by the ":" that a joined NAME:VALUE always contains and a
-	// dangling NAME (a plain identifier, per stringz.ValidIdent) never does.
-	if vals, _ := cmd.Flags().GetStringArray(flag.Arg); len(vals) > 0 &&
-		!strings.Contains(vals[len(vals)-1], ":") {
+	// Fewer positionals than expected VALUEs: we're still in the VALUE slot.
+	if len(args) < spaceFormArgCount {
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
 
+	// Strip the fake positionals. If any real args remain, there is already a
+	// complete query positional and nothing more to suggest.
+	realArgs := args[spaceFormArgCount:]
+	if len(realArgs) != 0 {
+		return nil, cobra.ShellCompDirectiveError
+	}
+
 	c := &handleTableCompleter{}
-	return c.complete(cmd, args, toComplete)
+	return c.complete(cmd, realArgs, toComplete)
 }
 
 // completeDriverType is a completionFunc that suggests drivers.

--- a/cli/complete.go
+++ b/cli/complete.go
@@ -249,7 +249,7 @@ func completeSLQ(cmd *cobra.Command, args []string, toComplete string) ([]string
 	//
 	// The "=" form "--arg=NAME:VALUE" is a single self-contained token, so the
 	// next word is a real query positional that must still complete. Tell the
-	// two apart by the trailing ":" that a joined NAME:VALUE always has and a
+	// two apart by the ":" that a joined NAME:VALUE always contains and a
 	// dangling NAME (a plain identifier, per stringz.ValidIdent) never does.
 	if vals, _ := cmd.Flags().GetStringArray(flag.Arg); len(vals) > 0 &&
 		!strings.Contains(vals[len(vals)-1], ":") {

--- a/cli/complete.go
+++ b/cli/complete.go
@@ -238,6 +238,18 @@ func completeSLQ(cmd *cobra.Command, args []string, toComplete string) ([]string
 		return nil, cobra.ShellCompDirectiveError
 	}
 
+	// --arg takes a "NAME VALUE" pair, but that pairing is a pre-parse hack
+	// (preprocessFlagArgVars) that doesn't run during completion, so cobra
+	// sees --arg as a single-value flag: after "--arg NAME" it consumes NAME
+	// as the flag value and treats the next word as a positional, landing us
+	// here with args empty. That word is actually the free-form arg VALUE, so
+	// suppress suggestions rather than offering query/table completions. (When
+	// the query is typed first, args is non-empty and we already returned
+	// above.)
+	if cmdFlagChanged(cmd, flag.Arg) {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+
 	c := &handleTableCompleter{}
 	return c.complete(cmd, args, toComplete)
 }

--- a/cli/complete.go
+++ b/cli/complete.go
@@ -83,6 +83,15 @@ func completeBool(_ *cobra.Command, _ []string, _ string) ([]string, cobra.Shell
 	return []string{"true", "false"}, cobra.ShellCompDirectiveNoFileComp
 }
 
+// completeNone is a completionFunc for a flag whose value is inherently
+// free-form, so there's nothing to enumerate (e.g. a variable name the user
+// invents, an arbitrary literal). It offers no candidates but, unlike leaving
+// the flag without a completion func, suppresses cobra's default filename
+// completion, which would be meaningless noise for such a value.
+func completeNone(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+	return nil, cobra.ShellCompDirectiveNoFileComp
+}
+
 // completeHandle is a completionFunc that suggests handles. It is for
 // positional completion: maxVals caps the number of positional args the
 // command takes, and completion is suppressed once that many are present

--- a/cli/complete.go
+++ b/cli/complete.go
@@ -240,12 +240,18 @@ func completeSLQ(cmd *cobra.Command, args []string, toComplete string) ([]string
 	// VALUE. Count those fake positionals so we can skip them.
 	//
 	// The "=" form ("--arg=NAME:VALUE") is consumed by pflag as a single token,
-	// so it contributes no fake positionals. A joined NAME:VALUE always contains
-	// ":", a dangling NAME (a valid identifier) never does.
+	// so it contributes no fake positionals. We tell the two apart by ":": a
+	// joined NAME:VALUE always contains one, a dangling NAME never does. This
+	// assumes valid input (NAME is a bare identifier, per stringz.ValidIdent);
+	// malformed input like "--arg fo:o" or "--arg=foo" is misclassified, but
+	// such input is rejected at exec time, so the cost is only stray completion.
 	//
 	// Cobra traverses the arg list once per positional during completion (to
-	// check each intermediate word), and StringArray is cumulative, so vals
-	// may contain duplicate entries. Deduplicate before counting.
+	// check each intermediate word), and StringArray is cumulative, so vals may
+	// contain duplicate entries. Deduplicate before counting. This relies on
+	// each space-form pair having a distinct NAME; genuinely duplicate keys
+	// (e.g. "--arg x A --arg x B", itself a misuse warned about at exec time)
+	// undercount, at worst suppressing completion of a following query word.
 	spaceFormArgCount := 0
 	if vals, _ := cmd.Flags().GetStringArray(flag.Arg); len(vals) > 0 {
 		seen := make(map[string]struct{}, len(vals))

--- a/cli/complete_test.go
+++ b/cli/complete_test.go
@@ -539,40 +539,54 @@ func TestCompleteFlagValues_afterPositional(t *testing.T) {
 	tu.SkipIssueWindows(t, tu.GH372ShellCompletionWin)
 	t.Parallel()
 
+	// completeStrings flags suppress file completion and keep the listed order;
+	// the &-vs-| regression (NoFileComp & KeepOrder == 0 == Default) would
+	// re-enable file completion and drop order, so assert the directive too.
+	const stringsDirective = cobra.ShellCompDirectiveNoFileComp | cobra.ShellCompDirectiveKeepOrder
+	// completeHandleFlag suppresses file completion but sorts handles.
+	const handleDirective = cobra.ShellCompDirectiveNoFileComp
+
 	testCases := []struct {
-		name         string
-		args         []string
-		wantContains []string
+		name          string
+		args          []string
+		wantContains  []string
+		wantDirective cobra.ShellCompDirective
 	}{
 		{
-			name:         "add_store",
-			args:         []string{"add", "postgres://x", "--" + flag.AddStore, ""},
-			wantContains: []string{flag.AddStoreInline, flag.AddStoreKeyring},
+			name:          "add_store",
+			args:          []string{"add", "postgres://x", "--" + flag.AddStore, ""},
+			wantContains:  []string{flag.AddStoreInline, flag.AddStoreKeyring},
+			wantDirective: stringsDirective,
 		},
 		{
-			name:         "log_level",
-			args:         []string{".data", "--log.level", ""},
-			wantContains: []string{"DEBUG", "INFO", "WARN", "ERROR"},
+			name:          "log_level",
+			args:          []string{".data", "--log.level", ""},
+			wantContains:  []string{"DEBUG", "INFO", "WARN", "ERROR"},
+			wantDirective: stringsDirective,
 		},
 		{
-			name:         "log_format",
-			args:         []string{".data", "--log.format", ""},
-			wantContains: []string{"text", "json"},
+			name:          "log_format",
+			args:          []string{".data", "--log.format", ""},
+			wantContains:  []string{"text", "json"},
+			wantDirective: stringsDirective,
 		},
 		{
-			name:         "error_format",
-			args:         []string{".data", "--error.format", ""},
-			wantContains: []string{"text", "json"},
+			name:          "error_format",
+			args:          []string{".data", "--error.format", ""},
+			wantContains:  []string{"text", "json"},
+			wantDirective: stringsDirective,
 		},
 		{
-			name:         "config_get_src",
-			args:         []string{"config", "get", "format", "--" + flag.ConfigSrc, ""},
-			wantContains: []string{sakila.Pg},
+			name:          "config_get_src",
+			args:          []string{"config", "get", "format", "--" + flag.ConfigSrc, ""},
+			wantContains:  []string{sakila.Pg},
+			wantDirective: handleDirective,
 		},
 		{
-			name:         "config_set_src",
-			args:         []string{"config", "set", "format", "json", "--" + flag.ConfigSrc, ""},
-			wantContains: []string{sakila.Pg},
+			name:          "config_set_src",
+			args:          []string{"config", "set", "format", "json", "--" + flag.ConfigSrc, ""},
+			wantContains:  []string{sakila.Pg},
+			wantDirective: handleDirective,
 		},
 	}
 
@@ -585,7 +599,10 @@ func TestCompleteFlagValues_afterPositional(t *testing.T) {
 			tr.Add(*th.Source(sakila.Pg))
 
 			got := testComplete(t, tr, tc.args...)
-			require.NotEqual(t, cobra.ShellCompDirectiveError, got.result)
+			assert.Equal(t, tc.wantDirective, got.result,
+				"wanted: %v\ngot   : %v",
+				cobraz.MarshalDirective(tc.wantDirective),
+				cobraz.MarshalDirective(got.result))
 			for j := range tc.wantContains {
 				assert.Contains(t, got.values, tc.wantContains[j])
 			}

--- a/cli/complete_test.go
+++ b/cli/complete_test.go
@@ -553,6 +553,7 @@ func TestCompleteFlagValues_afterPositional(t *testing.T) {
 		name          string
 		args          []string
 		wantContains  []string
+		wantEmpty     bool // assert no candidates at all (free-form value)
 		wantDirective cobra.ShellCompDirective
 	}{
 		{
@@ -592,11 +593,21 @@ func TestCompleteFlagValues_afterPositional(t *testing.T) {
 			wantDirective: handleDirective,
 		},
 		{
-			// --arg is free-form (a variable name): no candidates, but file
-			// completion is suppressed rather than left as the default.
-			name:          "arg",
+			// --arg NAME slot is free-form (a variable name): no candidates,
+			// but file completion is suppressed rather than left as default.
+			name:          "arg_name",
 			args:          []string{".actor", "--" + flag.Arg, ""},
-			wantContains:  nil,
+			wantEmpty:     true,
+			wantDirective: cobra.ShellCompDirectiveNoFileComp,
+		},
+		{
+			// --arg VALUE slot ("sq --arg first <TAB>"): cobra consumes the
+			// name as the flag value and would otherwise offer query/table
+			// completions for the trailing positional. The value is free-form,
+			// so suppress them.
+			name:          "arg_value",
+			args:          []string{"--" + flag.Arg, "first", ""},
+			wantEmpty:     true,
 			wantDirective: cobra.ShellCompDirectiveNoFileComp,
 		},
 	}
@@ -614,6 +625,9 @@ func TestCompleteFlagValues_afterPositional(t *testing.T) {
 				"wanted: %v\ngot   : %v",
 				cobraz.MarshalDirective(tc.wantDirective),
 				cobraz.MarshalDirective(got.result))
+			if tc.wantEmpty {
+				assert.Empty(t, got.values)
+			}
 			for j := range tc.wantContains {
 				assert.Contains(t, got.values, tc.wantContains[j])
 			}

--- a/cli/complete_test.go
+++ b/cli/complete_test.go
@@ -629,6 +629,23 @@ func TestCompleteFlagValues_afterPositional(t *testing.T) {
 			wantContains:  []string{sakila.Pg},
 			wantDirective: cobra.ShellCompDirectiveNoFileComp | cobra.ShellCompDirectiveNoSpace,
 		},
+		{
+			// Two space-form pairs, second one mid-VALUE ("--arg a A --arg b
+			// <TAB>"): the second VALUE slot is still open, so suppress.
+			name:          "arg_two_pairs_mid_value",
+			args:          []string{"--" + flag.Arg, "a", "A", "--" + flag.Arg, "b", ""},
+			wantEmpty:     true,
+			wantDirective: cobra.ShellCompDirectiveNoFileComp,
+		},
+		{
+			// Two complete space-form pairs ("--arg a A --arg b B @<TAB>"): both
+			// VALUE slots are filled, so the current word is a real query
+			// positional that must still complete.
+			name:          "arg_two_pairs_complete_completes_query",
+			args:          []string{"--" + flag.Arg, "a", "A", "--" + flag.Arg, "b", "B", "@"},
+			wantContains:  []string{sakila.Pg},
+			wantDirective: cobra.ShellCompDirectiveNoFileComp | cobra.ShellCompDirectiveNoSpace,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/cli/complete_test.go
+++ b/cli/complete_test.go
@@ -529,6 +529,70 @@ func TestCompleteAllCobraRequestCmds(t *testing.T) {
 	}
 }
 
+// TestCompleteFlagValues_afterPositional is a regression test for flag value
+// completion being suppressed once the command already has a positional arg.
+// The completeStrings / completeHandle helpers cap on len(args) (the positional
+// args), which is correct for positional completion but must not gate flag value
+// completion: a flag takes a single value regardless of how many positionals
+// precede it. See the broken --store / --src / --log.* / --error.format cases.
+func TestCompleteFlagValues_afterPositional(t *testing.T) {
+	tu.SkipIssueWindows(t, tu.GH372ShellCompletionWin)
+	t.Parallel()
+
+	testCases := []struct {
+		name         string
+		args         []string
+		wantContains []string
+	}{
+		{
+			name:         "add_store",
+			args:         []string{"add", "postgres://x", "--" + flag.AddStore, ""},
+			wantContains: []string{flag.AddStoreInline, flag.AddStoreKeyring},
+		},
+		{
+			name:         "log_level",
+			args:         []string{".data", "--log.level", ""},
+			wantContains: []string{"DEBUG", "INFO", "WARN", "ERROR"},
+		},
+		{
+			name:         "log_format",
+			args:         []string{".data", "--log.format", ""},
+			wantContains: []string{"text", "json"},
+		},
+		{
+			name:         "error_format",
+			args:         []string{".data", "--error.format", ""},
+			wantContains: []string{"text", "json"},
+		},
+		{
+			name:         "config_get_src",
+			args:         []string{"config", "get", "format", "--" + flag.ConfigSrc, ""},
+			wantContains: []string{sakila.Pg},
+		},
+		{
+			name:         "config_set_src",
+			args:         []string{"config", "set", "format", "json", "--" + flag.ConfigSrc, ""},
+			wantContains: []string{sakila.Pg},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			th := testh.New(t)
+			tr := testrun.New(th.Context, t, nil)
+			tr.Add(*th.Source(sakila.Pg))
+
+			got := testComplete(t, tr, tc.args...)
+			require.NotEqual(t, cobra.ShellCompDirectiveError, got.result)
+			for j := range tc.wantContains {
+				assert.Contains(t, got.values, tc.wantContains[j])
+			}
+		})
+	}
+}
+
 func enableCompletionLog(ctx context.Context) context.Context {
 	o := options.FromContext(ctx)
 	if o == nil {

--- a/cli/complete_test.go
+++ b/cli/complete_test.go
@@ -591,6 +591,14 @@ func TestCompleteFlagValues_afterPositional(t *testing.T) {
 			wantContains:  []string{sakila.Pg},
 			wantDirective: handleDirective,
 		},
+		{
+			// --arg is free-form (a variable name): no candidates, but file
+			// completion is suppressed rather than left as the default.
+			name:          "arg",
+			args:          []string{".actor", "--" + flag.Arg, ""},
+			wantContains:  nil,
+			wantDirective: cobra.ShellCompDirectiveNoFileComp,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/cli/complete_test.go
+++ b/cli/complete_test.go
@@ -619,6 +619,16 @@ func TestCompleteFlagValues_afterPositional(t *testing.T) {
 			wantContains:  []string{sakila.Pg},
 			wantDirective: cobra.ShellCompDirectiveNoFileComp | cobra.ShellCompDirectiveNoSpace,
 		},
+		{
+			// Space form with both NAME and VALUE present: cobra sees VALUE as a
+			// positional, so args is non-empty. The current word is a real query
+			// positional that must still complete. Use "@" prefix (handle
+			// completion) so no live DB is needed for this short test.
+			name:          "arg_space_form_complete_pair_completes_query",
+			args:          []string{"--" + flag.Arg, "first", "TOM", "@"},
+			wantContains:  []string{sakila.Pg},
+			wantDirective: cobra.ShellCompDirectiveNoFileComp | cobra.ShellCompDirectiveNoSpace,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/cli/complete_test.go
+++ b/cli/complete_test.go
@@ -610,6 +610,15 @@ func TestCompleteFlagValues_afterPositional(t *testing.T) {
 			wantEmpty:     true,
 			wantDirective: cobra.ShellCompDirectiveNoFileComp,
 		},
+		{
+			// The "=" form "--arg=NAME:VALUE" is a self-contained token, so the
+			// next word is a real query positional that must still complete (it
+			// is not the dangling VALUE slot of the space form).
+			name:          "arg_equals_form_completes_query",
+			args:          []string{"--" + flag.Arg + "=name:TOM", "@"},
+			wantContains:  []string{sakila.Pg},
+			wantDirective: cobra.ShellCompDirectiveNoFileComp | cobra.ShellCompDirectiveNoSpace,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/cli/complete_test.go
+++ b/cli/complete_test.go
@@ -531,10 +531,13 @@ func TestCompleteAllCobraRequestCmds(t *testing.T) {
 
 // TestCompleteFlagValues_afterPositional is a regression test for flag value
 // completion being suppressed once the command already has a positional arg.
-// The completeStrings / completeHandle helpers cap on len(args) (the positional
-// args), which is correct for positional completion but must not gate flag value
-// completion: a flag takes a single value regardless of how many positionals
-// precede it. See the broken --store / --src / --log.* / --error.format cases.
+// The bug: completion helpers capped on len(args) (the positional args), which
+// is correct for positional completion but wrongly gated flag value completion,
+// since a flag takes a single value regardless of how many positionals precede
+// it. The fix split the helpers: completeStrings no longer caps (flag-only), and
+// completeHandle's positional cap is used only via the positional ValidArgsFunc,
+// with completeHandleFlag for flag values. See the formerly broken --store /
+// --src / --log.* / --error.format cases.
 func TestCompleteFlagValues_afterPositional(t *testing.T) {
 	tu.SkipIssueWindows(t, tu.GH372ShellCompletionWin)
 	t.Parallel()

--- a/cli/options.go
+++ b/cli/options.go
@@ -339,23 +339,22 @@ func addOptionFlag(flags *pflag.FlagSet, opt options.Opt) (key string) {
 // excelw.OptDatetimeFormat, excelw.OptDateFormat, excelw.OptTimeFormat.
 func addTimeFormatOptsFlags(cmd *cobra.Command) {
 	key := addOptionFlag(cmd.Flags(), OptDatetimeFormat)
-	panicOn(cmd.RegisterFlagCompletionFunc(key, completeStrings(-1, timez.NamedLayouts()...)))
+	panicOn(cmd.RegisterFlagCompletionFunc(key, completeStrings(timez.NamedLayouts()...)))
 	key = addOptionFlag(cmd.Flags(), OptDatetimeFormatAsNumber)
 	panicOn(cmd.RegisterFlagCompletionFunc(key, completeBool))
 
 	key = addOptionFlag(cmd.Flags(), OptDateFormat)
-	panicOn(cmd.RegisterFlagCompletionFunc(key, completeStrings(-1, timez.NamedLayouts()...)))
+	panicOn(cmd.RegisterFlagCompletionFunc(key, completeStrings(timez.NamedLayouts()...)))
 	key = addOptionFlag(cmd.Flags(), OptDateFormatAsNumber)
 	panicOn(cmd.RegisterFlagCompletionFunc(key, completeBool))
 
 	key = addOptionFlag(cmd.Flags(), OptTimeFormat)
-	panicOn(cmd.RegisterFlagCompletionFunc(key, completeStrings(-1, timez.NamedLayouts()...)))
+	panicOn(cmd.RegisterFlagCompletionFunc(key, completeStrings(timez.NamedLayouts()...)))
 	key = addOptionFlag(cmd.Flags(), OptTimeFormatAsNumber)
 	panicOn(cmd.RegisterFlagCompletionFunc(key, completeBool))
 
 	key = addOptionFlag(cmd.Flags(), xlsxw.OptDatetimeFormat)
 	panicOn(cmd.RegisterFlagCompletionFunc(key, completeStrings(
-		-1,
 		"yyyy-mm-dd hh:mm",
 		"dd/mm/yy h:mm am/pm",
 		"dd-mmm-yy h:mm:ss AM/PM",
@@ -363,7 +362,6 @@ func addTimeFormatOptsFlags(cmd *cobra.Command) {
 
 	key = addOptionFlag(cmd.Flags(), xlsxw.OptDateFormat)
 	panicOn(cmd.RegisterFlagCompletionFunc(key, completeStrings(
-		-1,
 		"yyyy-mm-dd",
 		"dd/mm/yy",
 		"dd-mmm-yy",
@@ -371,7 +369,6 @@ func addTimeFormatOptsFlags(cmd *cobra.Command) {
 
 	key = addOptionFlag(cmd.Flags(), xlsxw.OptTimeFormat)
 	panicOn(cmd.RegisterFlagCompletionFunc(key, completeStrings(
-		-1,
 		"hh:mm:ss",
 		"h:mm am/pm",
 		"h:mm:ss AM/PM",


### PR DESCRIPTION
## Problem

Tab-completion of flag *values* silently produced nothing once a command already had a positional arg, which is the usual case. The reported symptom was `sq add LOCATION --store ` offering nothing for `inline | keyring`.

## Root cause

`completeStrings` and `completeHandle` cap completion against `len(args)` (the command's positional args). That cap is correct for positional completion (`ValidArgsFunction`) but wrong when the same helpers are reused as flag-value completers: a flag takes a single value regardless of how many positionals precede it, so the cap suppressed the flag's completion as soon as enough positionals were present.

Affected flags (all reproduced via `__complete`):

| Flag | Broke when |
| --- | --- |
| `add --store` (`inline\|keyring`) | a LOCATION positional present (normal case) |
| `config get --src` | KEY positional present (normal case) |
| `config set --src` | KEY positional present (normal case) |
| `--log.level` | any positional present |
| `--log.format` | any positional present |

`--error.format` had no completion registered at all.

## Fix

Split the helpers so the bug class can't recur:

- **`completeStrings`** drops the `maxVals` parameter (every caller is a flag completer, none positional). This also fixes a latent directive bug on the same line: `NoFileComp & KeepOrder` was a bitwise *AND* evaluating to `0` (`Default`), which enabled spurious filename completion and dropped order preservation. It is now `NoFileComp | KeepOrder`.
- **`completeHandle`** keeps its `maxVals` cap for positional completion (`ValidArgsFunction`).
- **`completeHandleFlag`** is a new wrapper over `completeHandle` with no cap, for flag use; the `--src` callers now use it.
- **`completeNone`** is a new helper returning `nil, NoFileComp` for free-form flag values that have nothing to enumerate.

Now the completer you pick encodes intent: `completeStrings` / `completeHandleFlag` for flag values (no cap possible), `completeHandle` for positionals.

Also adds `--error.format` completion and a `TestCompleteFlagValues_afterPositional` regression test covering every affected flag with a positional arg present.

## Behavior change to note

Fixing the `&`→`|` directive means enum-value flags (`--store`, `--log.level`, `--format`, `--mode`, `--driver.csv.delim`, datetime layouts, etc.) no longer *also* offer filename completion and now preserve their listed order.

## `--arg` completion fixes

`--arg` takes a `NAME VALUE` pair, but that pairing is a pre-parse hack (`preprocessFlagArgVars`) that rewrites `--arg NAME VALUE` into `--arg NAME:VALUE` before pflag runs. That hack does **not** run in the completion path, so cobra sees `--arg` as an ordinary single-value flag, which led to three wrong completions:

1. **Filename completion in the NAME slot.** `sq --arg ` offered filenames. `completeNone` is now registered on `--arg`, suppressing cobra's default filename completion for this free-form value.

2. **Query/table completion in the VALUE slot.** `sq --arg first ` offered `.actor`, `.address`, etc. Because the hack hasn't run, cobra consumes `first` as the flag value and treats the next word as a positional, so the SLQ `ValidArgsFunction` fired on what is really the free-form VALUE. `completeSLQ` now counts the space-form `--arg` pairs and, while the current word is still a pending VALUE slot, returns `NoFileComp` with no candidates.

3. **Completion after a complete pair.** The counting has to be robust to two cobra quirks. First, the `=` form (`--arg=NAME:VALUE`) is a single self-contained token that consumes no positional, so it's distinguished from the space form by the `:` it always contains (a dangling NAME, a bare identifier, never does). Second, cobra walks the arg list once per positional during completion and `StringArray` is cumulative, so the flag values must be deduplicated before counting. With the true pair count in hand, the fake VALUE positionals are skipped: if a real query positional remains, completion stays suppressed; otherwise normal query/table completion runs. So `sq --arg first TOM .ac<TAB>` and `sq --arg=name:TOM @<TAB>` both complete the query as expected.

The heuristic assumes valid input (identifier NAMEs, distinct keys per pair); the only inputs it misclassifies are ones rejected at exec time anyway, so the cost is at most a stray or suppressed completion.

## Verification

- `go build ./...`
- `go test -short ./cli/` (full short suite, passes)
- All `*_Completion` tests + the new `TestCompleteFlagValues_afterPositional` regression test pass (covering each affected flag, both `--arg` forms, and multi-pair `--arg` cases)
- Behavior confirmed end-to-end against a built binary
- `make lint-markdown` clean; no new Go lint findings on changed lines