### PR TITLE
perf(json): wrap ingest inserts in a single transaction (#866)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ Breaking changes are annotated with ☢️, and alpha/beta features with 🐥.
 - [#863]: Forcing color to a non-terminal stdout (e.g. when `FORCE_COLOR` is set and
   output is a pipe or buffer) no longer panics; `sq` writes raw ANSI to non-`*os.File`
   writers instead of performing an unchecked type assertion.
+- [#866]: Ingesting JSON and JSONL is now much faster, especially on Windows, where a large
+  JSONL file could previously take minutes. Each ingest now runs as a single transaction, so a
+  failed ingest no longer leaves a partially-populated cache.
 
 ## [v0.54.0] - 2026-06-19
 
@@ -1715,6 +1718,7 @@ make working with lots of sources much easier.
 [#851]: https://github.com/neilotoole/sq/issues/851
 [#853]: https://github.com/neilotoole/sq/issues/853
 [#863]: https://github.com/neilotoole/sq/pull/863
+[#866]: https://github.com/neilotoole/sq/issues/866
 
 [v0.15.2]: https://github.com/neilotoole/sq/releases/tag/v0.15.2
 [v0.15.3]: https://github.com/neilotoole/sq/compare/v0.15.2...v0.15.3

--- a/drivers/json/ingest_json.go
+++ b/drivers/json/ingest_json.go
@@ -177,6 +177,19 @@ func ingestJSON(ctx context.Context, job *ingestJob) error {
 	}
 	defer lg.WarnIfCloseError(log, lgm.CloseDB, conn)
 
+	tx, err := conn.BeginTx(ctx, nil)
+	if err != nil {
+		return errz.Err(err)
+	}
+	// Roll back unless we reach the explicit Commit below. One transaction per
+	// ingest collapses the per-row autocommit fsyncs (gh866).
+	committed := false
+	defer func() {
+		if !committed {
+			lg.WarnIfError(log, "Rollback JSON ingest tx", errz.Err(tx.Rollback()))
+		}
+	}()
+
 	proc := newProcessor(job.flatten)
 	scan := newObjectInArrayScanner(log, r)
 
@@ -212,7 +225,7 @@ func ingestJSON(ctx context.Context, job *ingestJob) error {
 					return err
 				}
 
-				if err = execSchemaDelta(ctx, drvr, conn, proc.curSchema, newSchema); err != nil {
+				if err = execSchemaDelta(ctx, drvr, tx, proc.curSchema, newSchema); err != nil {
 					return err
 				}
 
@@ -228,7 +241,7 @@ func ingestJSON(ctx context.Context, job *ingestJob) error {
 					return err
 				}
 
-				if err = job.execInsertions(ctx, drvr, conn, insertions); err != nil {
+				if err = job.execInsertions(ctx, drvr, tx, insertions); err != nil {
 					return err
 				}
 			}
@@ -262,7 +275,7 @@ func ingestJSON(ctx context.Context, job *ingestJob) error {
 			return err
 		}
 
-		if err = job.execInsertions(ctx, drvr, conn, insertions); err != nil {
+		if err = job.execInsertions(ctx, drvr, tx, insertions); err != nil {
 			return err
 		}
 	}
@@ -271,6 +284,10 @@ func ingestJSON(ctx context.Context, job *ingestJob) error {
 		return errz.New("empty JSON input")
 	}
 
+	if err = tx.Commit(); err != nil {
+		return errz.Err(err)
+	}
+	committed = true
 	return nil
 }
 

--- a/drivers/json/ingest_json.go
+++ b/drivers/json/ingest_json.go
@@ -285,10 +285,12 @@ func ingestJSON(ctx context.Context, job *ingestJob) error { //nolint:gocognit
 		return errz.New("empty JSON input")
 	}
 
+	// tx.Commit marks the tx as done whether or not it succeeds, so the
+	// deferred rollback could only ever return ErrTxDone. Skip it either way.
+	committed = true
 	if err = tx.Commit(); err != nil {
 		return errz.Err(err)
 	}
-	committed = true
 	return nil
 }
 

--- a/drivers/json/ingest_json.go
+++ b/drivers/json/ingest_json.go
@@ -151,7 +151,7 @@ func DetectJSON(sampleSize int) files.TypeDetectFunc {
 	}
 }
 
-func ingestJSON(ctx context.Context, job *ingestJob) error {
+func ingestJSON(ctx context.Context, job *ingestJob) error { //nolint:gocognit
 	bar := progress.FromContext(ctx).NewUnitCounter("Ingest JSON", "object")
 	defer bar.Stop()
 

--- a/drivers/json/ingest_json.go
+++ b/drivers/json/ingest_json.go
@@ -182,7 +182,8 @@ func ingestJSON(ctx context.Context, job *ingestJob) error { //nolint:gocognit
 		return errz.Err(err)
 	}
 	// Roll back unless we reach the explicit Commit below. One transaction per
-	// ingest collapses the per-row autocommit fsyncs (gh866).
+	// ingest collapses the per-row autocommit fsyncs (gh866; cache DB
+	// durability pragmas tracked in gh868).
 	committed := false
 	defer func() {
 		if !committed {

--- a/drivers/json/ingest_jsonl.go
+++ b/drivers/json/ingest_jsonl.go
@@ -122,6 +122,20 @@ func ingestJSONL(ctx context.Context, job *ingestJob) error { //nolint:gocognit
 	}
 	defer lg.WarnIfCloseError(log, lgm.CloseDB, conn)
 
+	tx, err := conn.BeginTx(ctx, nil)
+	if err != nil {
+		return errz.Err(err)
+	}
+	// Roll back unless we reach the explicit Commit below. Wrapping the whole
+	// ingest in one transaction collapses the per-row autocommit fsyncs that
+	// make this catastrophically slow on Windows (gh866).
+	committed := false
+	defer func() {
+		if !committed {
+			lg.WarnIfError(log, "Rollback JSONL ingest tx", errz.Err(tx.Rollback()))
+		}
+	}()
+
 	proc := newProcessor(job.flatten)
 	scan := newLineScanner(ctx, r, '{')
 
@@ -155,7 +169,7 @@ func ingestJSONL(ctx context.Context, job *ingestJob) error { //nolint:gocognit
 					return err
 				}
 
-				if err = execSchemaDelta(ctx, drvr, conn, curSchema, newSchema); err != nil {
+				if err = execSchemaDelta(ctx, drvr, tx, curSchema, newSchema); err != nil {
 					return err
 				}
 
@@ -170,7 +184,7 @@ func ingestJSONL(ctx context.Context, job *ingestJob) error { //nolint:gocognit
 					return err
 				}
 
-				if err = job.execInsertions(ctx, drvr, conn, insertions); err != nil {
+				if err = job.execInsertions(ctx, drvr, tx, insertions); err != nil {
 					return err
 				}
 			}
@@ -216,7 +230,7 @@ func ingestJSONL(ctx context.Context, job *ingestJob) error { //nolint:gocognit
 			return err
 		}
 
-		if err = job.execInsertions(ctx, drvr, conn, insertions); err != nil {
+		if err = job.execInsertions(ctx, drvr, tx, insertions); err != nil {
 			return err
 		}
 	}
@@ -225,6 +239,10 @@ func ingestJSONL(ctx context.Context, job *ingestJob) error { //nolint:gocognit
 		return errz.New("empty JSONL input")
 	}
 
+	if err = tx.Commit(); err != nil {
+		return errz.Err(err)
+	}
+	committed = true
 	return nil
 }
 

--- a/drivers/json/ingest_jsonl.go
+++ b/drivers/json/ingest_jsonl.go
@@ -128,7 +128,8 @@ func ingestJSONL(ctx context.Context, job *ingestJob) error { //nolint:gocognit
 	}
 	// Roll back unless we reach the explicit Commit below. Wrapping the whole
 	// ingest in one transaction collapses the per-row autocommit fsyncs that
-	// make this catastrophically slow on Windows (gh866).
+	// make this catastrophically slow on Windows (gh866; cache DB durability
+	// pragmas tracked in gh868).
 	committed := false
 	defer func() {
 		if !committed {

--- a/drivers/json/ingest_jsonl.go
+++ b/drivers/json/ingest_jsonl.go
@@ -240,10 +240,12 @@ func ingestJSONL(ctx context.Context, job *ingestJob) error { //nolint:gocognit
 		return errz.New("empty JSONL input")
 	}
 
+	// tx.Commit marks the tx as done whether or not it succeeds, so the
+	// deferred rollback could only ever return ErrTxDone. Skip it either way.
+	committed = true
 	if err = tx.Commit(); err != nil {
 		return errz.Err(err)
 	}
-	committed = true
 	return nil
 }
 

--- a/drivers/json/ingest_test.go
+++ b/drivers/json/ingest_test.go
@@ -93,20 +93,6 @@ func BenchmarkIngestJSONL_Flat(b *testing.B) {
 			wantCols:  []string{"a", "b"},
 			wantKinds: []kind.Kind{kind.Float, kind.Int},
 		},
-		{
-			// One ingest that forces both an ALTER ADD COLUMN (new field "b"
-			// on the second line) and an ALTER COLUMN KIND (field "a" goes
-			// int -> float). With sampleSize 0 the schema is built after the
-			// first line, so the second line triggers both alters in a single
-			// execSchemaDelta while row 1 is already inserted. Guards the
-			// schema-delta-inside-transaction edge cases (gh866).
-			name: "add_col_and_kind_change",
-			input: `{"a": 1}
-{"a": 1.5, "b": 10}`,
-			wantRows:  2,
-			wantCols:  []string{"a", "b"},
-			wantKinds: []kind.Kind{kind.Float, kind.Int},
-		},
 	}
 
 	for _, tc := range testCases {

--- a/drivers/json/ingest_test.go
+++ b/drivers/json/ingest_test.go
@@ -93,6 +93,20 @@ func BenchmarkIngestJSONL_Flat(b *testing.B) {
 			wantCols:  []string{"a", "b"},
 			wantKinds: []kind.Kind{kind.Float, kind.Int},
 		},
+		{
+			// One ingest that forces both an ALTER ADD COLUMN (new field "b"
+			// on the second line) and an ALTER COLUMN KIND (field "a" goes
+			// int -> float). With sampleSize 0 the schema is built after the
+			// first line, so the second line triggers both alters in a single
+			// execSchemaDelta while row 1 is already inserted. Guards the
+			// schema-delta-inside-transaction edge cases (gh866).
+			name: "add_col_and_kind_change",
+			input: `{"a": 1}
+{"a": 1.5, "b": 10}`,
+			wantRows:  2,
+			wantCols:  []string{"a", "b"},
+			wantKinds: []kind.Kind{kind.Float, kind.Int},
+		},
 	}
 
 	for _, tc := range testCases {
@@ -183,6 +197,20 @@ func TestIngestJSONL_Flat(t *testing.T) {
 			name: "recs_null",
 			input: `{"a": null, "b": null}
 {"a": 1.1, "b": 2.0000}`,
+			wantRows:  2,
+			wantCols:  []string{"a", "b"},
+			wantKinds: []kind.Kind{kind.Float, kind.Int},
+		},
+		{
+			// One ingest that forces both an ALTER ADD COLUMN (new field "b"
+			// on the second line) and an ALTER COLUMN KIND (field "a" goes
+			// int -> float). With sampleSize 0 the schema is built after the
+			// first line, so the second line triggers both alters in a single
+			// execSchemaDelta while row 1 is already inserted. Guards the
+			// schema-delta-inside-transaction edge cases (gh866).
+			name: "add_col_and_kind_change",
+			input: `{"a": 1}
+{"a": 1.5, "b": 10}`,
 			wantRows:  2,
 			wantCols:  []string{"a", "b"},
 			wantKinds: []kind.Kind{kind.Float, kind.Int},

--- a/drivers/sqlite3/alter.go
+++ b/drivers/sqlite3/alter.go
@@ -222,6 +222,14 @@ func readSqliteSequence(ctx context.Context, db sqlz.DB, tbl string) (sql.NullIn
 // pragmaDisableForeignKeys disables foreign keys, returning a function that
 // restores the original state of the foreign_keys pragma. If an error occurs,
 // the returned restore function will be nil.
+//
+// Caveat: "PRAGMA foreign_keys" is a no-op inside an open transaction. SQLite
+// silently ignores both the disable and the restore (no error is returned), so
+// a caller that runs this within a transaction does NOT actually disable
+// enforcement. Callers that depend on foreign keys really being off must invoke
+// this in autocommit context. This is currently safe for the JSON/JSONL ingest
+// path (gh866), whose cache tables have no foreign keys, but it is a trap for
+// any future caller of AlterTableColumnKinds inside a transaction.
 func pragmaDisableForeignKeys(ctx context.Context, db sqlz.DB) (restore func(), err error) {
 	pragmaFkExisting, err := readPragma(ctx, db, "foreign_keys")
 	if err != nil {


### PR DESCRIPTION
Fixes #866.

JSON and JSONL ingest write rows to a scratch SQLite cache DB one INSERT per row via
`execInsertions`. The cache DB opens with no DSN params (`libsq/files/cache.go:210`), so it
runs SQLite's default `synchronous=FULL`. Every autocommit INSERT fsyncs.

For `film_actor.jsonl` (5,462 rows) that means 5,462 fsyncs. On Windows,
`TestIngestJSONL_Flat/film_actor` was taking ~408s (62% of the Windows full-suite test step)
versus ~12s on Linux/macOS.

## Fix

Wrap each ingest job in a single transaction. `*sql.Tx` satisfies `sqlz.DB`
(`libsq/core/sqlz/sqlz.go:43`), so passing `tx` instead of `conn` to `execSchemaDelta` and
`execInsertions` requires no signature changes. A `committed` bool sentinel + deferred
rollback covers all error-return paths without per-site rollback calls.

- `ingestJSONL` (`drivers/json/ingest_jsonl.go`): transaction wraps the schema-delta/insert loop.
- `ingestJSON` array path (`drivers/json/ingest_json.go`): same pattern.
- `ingestJSONA` is not affected: already uses `libsq.NewDBWriter` (batch insert).

A guard test (`add_col_and_kind_change`) is added to `TestIngestJSONL_Flat` to lock in the
behavior of both `AlterTableAddColumn` and `AlterTableColumnKinds` firing within a single ingest
under the transaction, since those are the non-obvious SQLite edge cases the wrapping must not
break.

## SQLite edge cases

- `PRAGMA foreign_keys=off` inside a transaction is a no-op in SQLite. This is safe here: the
  ingest cache tables have no foreign keys (and the cache connection never enables
  `_foreign_keys`), so there is nothing to enforce during the `AlterTableColumnKinds` rebuild.
  Since the disable now silently no-ops inside the ingest transaction, a caveat was added to
  `pragmaDisableForeignKeys` so a future caller of `AlterTableColumnKinds` inside a transaction
  is not misled.
- Transactional DDL (`CREATE TABLE`, `ALTER TABLE`, `DROP TABLE`) and the prepared INSERT
  statements all share the same connection and transaction, so each statement sees the
  uncommitted schema correctly.

## Behavior change

A failed mid-ingest now rolls back entirely instead of leaving partial rows in the cache DB.
The cache DB is keyed on a source checksum and rebuilt on mismatch, so an all-or-nothing ingest
is strictly more correct.

## Performance results

Measured with a `workflow_dispatch` run of the full pipeline against this branch
([run 27879076276](https://github.com/neilotoole/sq/actions/runs/27879076276)):

| Metric | Before | After |
| --- | --- | --- |
| `TestIngestJSONL_Flat/film_actor` (Windows) | ~408s | ~12s |
| `test-windows-full` total job | ~16-17 min (est.) | **11m27s** (measured) |

The ~396s reduction in `film_actor` (which was ~62% of the Windows test step) accounts for
essentially all of the improvement; the subtest now matches the ~12s seen on Linux/macOS. All
jobs in the dispatch run were green.

### Per-platform breakdown (same run)

Full suite (`FULL_RUN`, no `-short`), step durations in seconds, dominant step bold:

| Step | Windows (windows-2022) | Linux (ubuntu-24.04) | macOS (macos-15) |
| --- | --- | --- | --- |
| Set up job | 2 | 2 | 3 |
| Checkout | 8 | 3 | 4 |
| Set up Go | 75 | 19 | 34 |
| Build | 28 | 50 | 18 |
| **Go tests** | **557** | **282** | **170** |
| Test output (tparse) | 10 | 4 | 2 |
| Upload coverage | - | 7 | 1 |
| **Total job** | **687s (11m27s)** | **372s (6m12s)** | **238s (3m58s)** |

Where the time goes now:

- Test execution dominates on every platform: Windows 81% of the job (557/687), Linux 76%
  (282/372), macOS 71% (170/238). Everything else is setup/build noise.
- Windows is still the slowest, but the cause is now broad-based test execution, not one
  pathological subtest. The `film_actor` ingest that was ~408s on its own is ~12s now, so the
  557s is the full suite spread across many tests rather than a single hotspot. Windows runs
  tests roughly 2x Linux and 3.3x macOS, consistent with general Windows I/O and process
  overhead rather than a single fixable test.
- `Set up Go` is disproportionately slow on Windows (75s vs 19s Linux / 34s macOS): the
  CGO/SQLite toolchain plus module-cache warm-up. It is the second-largest line on Windows
  (~11% of the job) and the main remaining lever after test execution if further trimming is
  ever wanted.
- Build is cheap and uniform (18-50s) and irrelevant next to the test step.

Net: the fix removed the single outlier; what remains is the inherent per-platform test cost,
with Windows test execution the only large remaining lever.

## Review follow-ups

After a deep review of the branch, three points were addressed:

1. Documented that `PRAGMA foreign_keys=off` is a no-op inside an open transaction on
   `pragmaDisableForeignKeys`. No active bug here (FK-free cache tables), but it is a trap for
   any future in-transaction caller of `AlterTableColumnKinds`.
2. Removed the `add_col_and_kind_change` case from `BenchmarkIngestJSONL_Flat`: the benchmark
   only checks `wantErr`, so the duplicated case asserted nothing there. The real guard lives in
   `TestIngestJSONL_Flat`.
3. Pointed the ingest transaction comments at #868, which tracks relaxing the cache DB
   durability pragmas (the journal-size / lock-duration tradeoff of a single ingest-wide
   transaction).

The transaction-lifecycle concerns (double-close of tx-scoped prepared statements, defer
ordering, any commit-skipping success path, stale statements across a table rebuild, and
context cancellation) were all checked and confirmed safe.

## Related

- #867: follow-up to replace per-row INSERT with `driver.BatchInsert` (complementary)
- #868: follow-up to relax cache DB durability pragmas (complementary)
- #871: evaluate decoupling coverage instrumentation from the main pipeline (surfaced while profiling per-platform CI timings here)