### PR TITLE
ci: move coverage to a dedicated nightly workflow

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,71 @@
+name: Coverage
+
+# Dedicated coverage workflow, decoupled from the main pipeline (see #871).
+#
+# Coverage is purely informational (codecov.yml marks the project and patch
+# checks "informational", so they never block a merge). Instrumenting the main
+# pipeline's `test-nix` job with whole-tree coverage only slowed it down, and
+# because `test-nix` gates `publish` and `docker-publish`, that cost sat on the
+# release critical path. This workflow runs the full suite once with coverage
+# on ubuntu and uploads to Codecov, on its own nightly schedule, independent of
+# the main pipeline's timing and of releases.
+on:
+  schedule:
+    - cron: '37 9 * * *' # Nightly; offset from the main pipeline's 09:17 run.
+
+  # Allows this workflow to be manually triggered from the Actions tab.
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  TPARSE_VERSION: v0.18.0
+  BUILD_TAGS: 'sqlite_vtable sqlite_stat4 sqlite_fts5 sqlite_introspect sqlite_json sqlite_math_functions'
+
+jobs:
+  coverage:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+
+      - name: Build
+        run: go build -tags '${{ env.BUILD_TAGS }}' -v ./...
+
+      - name: 'Go tests (with coverage)'
+        shell: bash
+        run: |
+          # pipefail so a `go test` failure isn't masked by the `| tee` below.
+          set -eo pipefail
+
+          # Full suite (no -short) with whole-tree coverage. "-coverpkg=./..."
+          # attributes coverage across all packages (e.g. integration tests
+          # exercising other packages).
+          go test -tags '${{ env.BUILD_TAGS }}' -timeout 20m -v -json \
+            -cover -coverpkg=./... -coverprofile=coverage.out ./... | tee gotest.out.json
+
+      - name: 'Test output'
+        if: always()
+        shell: bash
+        run: |
+          set -e
+          go install github.com/mfridman/tparse@${{ env.TPARSE_VERSION }}
+          tparse -all -sort=elapsed -file gotest.out.json
+
+      - name: Upload coverage to Codecov
+        if: always()
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+        with:
+          files: ./coverage.out
+          flags: nightly
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,9 +37,10 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     env:
-      # Full run (no -short, with coverage) nightly, on release tags, and on
-      # manual dispatch. The PR/master dev loop runs -short without coverage,
-      # skipping long-running tests (e.g. large-fixture JSON/XLSX ingest).
+      # Full run (no -short) nightly, on release tags, and on manual dispatch.
+      # The PR/master dev loop runs -short, skipping long-running tests (e.g.
+      # large-fixture JSON/XLSX ingest). Coverage is no longer instrumented
+      # here; it runs in the dedicated coverage workflow (see coverage.yml, #871).
       FULL_RUN: ${{ github.event_name == 'schedule' || startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch' }}
 
     steps:
@@ -64,23 +65,14 @@ jobs:
           set -eo pipefail
 
           test_args=()
-          cover_args=()
-          if [ "${FULL_RUN}" = "true" ]; then
-            # Full run: instrument coverage on the ubuntu-24.04 runner only
-            # (uploaded to Codecov below); macOS runs without coverage.
-            # "-coverpkg=./..." attributes coverage across all packages (e.g.
-            # integration tests exercising other packages).
-            if [ "${{ matrix.os }}" = "ubuntu-24.04" ]; then
-              cover_args=(-cover -coverpkg=./... -coverprofile=coverage.out)
-            fi
-          else
+          if [ "${FULL_RUN}" != "true" ]; then
             # Dev loop (PRs, master merges): skip long-running tests. The full
             # suite runs nightly and on release tags.
             test_args=(-short)
           fi
 
           go test -tags '${{ env.BUILD_TAGS }}' -timeout 20m -v -json \
-            "${test_args[@]}" "${cover_args[@]}" ./... | tee gotest.out.json
+            "${test_args[@]}" ./... | tee gotest.out.json
 
       - name: 'Test output'
         if: always()
@@ -89,15 +81,6 @@ jobs:
           set -e
           go install github.com/mfridman/tparse@${{ env.TPARSE_VERSION }}
           tparse -all -sort=elapsed -file gotest.out.json
-
-      - name: Upload coverage to Codecov
-        if: always() && matrix.os == 'ubuntu-24.04' && env.FULL_RUN == 'true'
-        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
-        with:
-          files: ./coverage.out
-          flags: ${{ matrix.os }}
-          token: ${{ secrets.CODECOV_TOKEN }}
-          fail_ci_if_error: false
 
 
   test-windows-smoke:

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,9 +1,10 @@
 # Codecov configuration.
 # See https://docs.codecov.com/docs/codecov-yaml for all options.
 #
-# Coverage is uploaded from the test-nix matrix (ubuntu + macos) in
-# .github/workflows/main.yml, tagged per-OS via flags. Checks are
-# informational so they report status without blocking PR merges.
+# Coverage is uploaded from the dedicated coverage workflow
+# (.github/workflows/coverage.yml), which runs the full suite on ubuntu nightly
+# and tags the upload with the "nightly" flag. Checks are informational so
+# they report status without blocking PR merges.
 
 coverage:
   status:


### PR DESCRIPTION
Closes #871.

Implements Option 1 from #871: decouple coverage instrumentation from the main pipeline's `test-nix` job.

## Why

Coverage is purely informational (`codecov.yml` marks the project and patch checks `informational`, so they never block a merge), but instrumenting `test-nix` with whole-tree `-coverpkg=./...` slowed the ubuntu full run by 1.8x-3.3x per package. Because `test-nix` is in `needs:` for both `publish` and `docker-publish`, that cost sat on the release critical path, not just the nightly.

## What changed

- **New `.github/workflows/coverage.yml`** — a dedicated `Coverage` workflow that runs the full suite once on ubuntu with `-cover -coverpkg=./... -coverprofile=coverage.out` and uploads to Codecov. Triggers on `schedule` (nightly, offset from the main pipeline) and `workflow_dispatch` only. It's not referenced in any `needs:`, so it's off the release path entirely.
- **`main.yml` `test-nix`** — removed the coverage instrumentation block and the Codecov upload step. Both `ubuntu-24.04` and `macos-15` now run identically, with no coverage overhead. Ubuntu full runs (and tag releases) speed up accordingly.
- **`codecov.yml`** — reconciled the stale comment that claimed coverage came from the `test-nix` ubuntu+macos matrix; it now describes the dedicated workflow. The upload flag is renamed `ubuntu-24.04` -> `nightly` to reflect the source (continuity intentionally not preserved).

Cross-package attribution is unchanged: the new job keeps `-coverpkg=./...`, so the full-tree coverage number is the same as before, only relocated.

CI-only change, so no `CHANGELOG.md` entry. Validated with actionlint 1.7.12.