### PR TITLE
refactor(secret): pass secret.Registry explicitly, not via context

### DIFF
--- a/cli/cmd_add.go
+++ b/cli/cmd_add.go
@@ -828,7 +828,10 @@ func detectConnParamsForAdd(ctx context.Context, cmd *cobra.Command,
 		return nil
 	}
 
-	probeSrc, err := driver.ResolveSourceSecrets(ctx, run.FromContext(ctx).SecretRegistry, src)
+	// len(refs) == 0 is guaranteed by the early return above, so
+	// ResolveSourceSecrets only unescapes "$$" and never consults the
+	// registry: pass nil rather than reaching back into the context.
+	probeSrc, err := driver.ResolveSourceSecrets(ctx, nil, src)
 	if err != nil {
 		return err
 	}

--- a/cli/cmd_add.go
+++ b/cli/cmd_add.go
@@ -376,7 +376,7 @@ func execSrcAdd(cmd *cobra.Command, args []string) (err error) {
 		// string. Same expansion is needed for ${env:...}, ${file:...},
 		// or any composition form.
 		var pingSrc *source.Source
-		pingSrc, err = driver.ResolveSourceSecrets(ctx, src)
+		pingSrc, err = driver.ResolveSourceSecrets(ctx, ru.SecretRegistry, src)
 		if err != nil {
 			return err
 		}
@@ -828,7 +828,7 @@ func detectConnParamsForAdd(ctx context.Context, cmd *cobra.Command,
 		return nil
 	}
 
-	probeSrc, err := driver.ResolveSourceSecrets(ctx, src)
+	probeSrc, err := driver.ResolveSourceSecrets(ctx, run.FromContext(ctx).SecretRegistry, src)
 	if err != nil {
 		return err
 	}

--- a/cli/cmd_add_test.go
+++ b/cli/cmd_add_test.go
@@ -878,8 +878,8 @@ func TestCmdAdd_InlinePassword_EscapesDollar(t *testing.T) {
 		"literal password must be stored in escaped (template) form")
 
 	// Round-trip: the driver must receive the literal password. Zero
-	// refs, so no secret.Registry is needed on the context.
-	resolved, err := driver.ResolveSourceSecrets(context.Background(), src)
+	// refs, so a nil secret.Registry suffices.
+	resolved, err := driver.ResolveSourceSecrets(context.Background(), nil, src)
 	require.NoError(t, err)
 	require.Equal(t, "postgres://alice:pa$$word@localhost:5432/sakila", resolved.Location)
 }
@@ -1283,7 +1283,7 @@ func TestCmdAdd_CwdDollarDir_CSV(t *testing.T) {
 			require.NoError(t, err, "stored template must parse cleanly")
 			require.Empty(t, refs, "filesystem-derived bytes must not form placeholder refs")
 
-			resolvedSrc, err := driver.ResolveSourceSecrets(th.Context, src)
+			resolvedSrc, err := driver.ResolveSourceSecrets(th.Context, nil, src)
 			require.NoError(t, err)
 			require.Equal(t, filepath.Join(cwd, "actor.csv"), resolvedSrc.Location,
 				"resolved location must be the true filesystem path")
@@ -1341,7 +1341,7 @@ func TestCmdAdd_CwdDollarDir_FileDB(t *testing.T) {
 				require.NoError(t, err, "stored template must parse cleanly")
 				require.Empty(t, refs, "filesystem-derived bytes must not form placeholder refs")
 
-				resolvedSrc, err := driver.ResolveSourceSecrets(th.Context, src)
+				resolvedSrc, err := driver.ResolveSourceSecrets(th.Context, nil, src)
 				require.NoError(t, err)
 				wantLit := drvr.prefix + filepath.ToSlash(filepath.Join(cwd, drvr.fname))
 				require.Equal(t, wantLit, resolvedSrc.Location,

--- a/cli/cmd_db.go
+++ b/cli/cmd_db.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"github.com/spf13/cobra"
 
+	"github.com/neilotoole/sq/cli/run"
 	"github.com/neilotoole/sq/libsq/driver"
 	"github.com/neilotoole/sq/libsq/source"
 )
@@ -28,5 +29,6 @@ func newDBCmd() *cobra.Command {
 // tool command builder: forgetting it hands the tool the literal
 // placeholder text.
 func resolveToolCmdSource(cmd *cobra.Command, src *source.Source) (*source.Source, error) {
-	return driver.ResolveSourceSecrets(cmd.Context(), src)
+	ru := run.FromContext(cmd.Context())
+	return driver.ResolveSourceSecrets(cmd.Context(), ru.SecretRegistry, src)
 }

--- a/cli/cmd_ping.go
+++ b/cli/cmd_ping.go
@@ -16,6 +16,7 @@ import (
 	"github.com/neilotoole/sq/libsq/core/lg"
 	"github.com/neilotoole/sq/libsq/core/lg/lga"
 	"github.com/neilotoole/sq/libsq/core/options"
+	"github.com/neilotoole/sq/libsq/core/secret"
 	"github.com/neilotoole/sq/libsq/driver"
 	"github.com/neilotoole/sq/libsq/source"
 )
@@ -130,7 +131,7 @@ func execPing(cmd *cobra.Command, args []string) error {
 	// already-expanded clone a second time would unescape '$$' again,
 	// corrupting literal locations (e.g. those escaped by the v0.54.0
 	// config upgrade, or a resolved secret value containing '$$').
-	err = pingSources(cmd.Context(), ru.DriverRegistry, srcs, ru.Writers.Ping, timeout)
+	err = pingSources(cmd.Context(), ru.DriverRegistry, ru.SecretRegistry, srcs, ru.Writers.Ping, timeout)
 	if errors.Is(err, context.Canceled) {
 		// It's common to cancel "sq ping". We don't want to print the cancel message.
 		return errz.ErrNoMsg
@@ -146,7 +147,7 @@ func execPing(cmd *cobra.Command, args []string) error {
 // NOTE: This ping code has an ancient lineage, in that it was
 // originally laid down before context.Context was a thing. Thus,
 // the entire thing could probably be rewritten for simplicity.
-func pingSources(ctx context.Context, dp driver.Provider, srcs []*source.Source,
+func pingSources(ctx context.Context, dp driver.Provider, reg *secret.Registry, srcs []*source.Source,
 	w output.PingWriter, timeout time.Duration,
 ) error {
 	if err := w.Open(srcs); err != nil {
@@ -164,7 +165,7 @@ func pingSources(ctx context.Context, dp driver.Provider, srcs []*source.Source,
 	var pingErrExists bool
 
 	for _, src := range srcs {
-		go pingSource(ctx, dp, src, timeout, resultCh)
+		go pingSource(ctx, dp, reg, src, timeout, resultCh)
 	}
 
 	// This func doesn't check for context.Canceled itself; instead
@@ -209,8 +210,8 @@ func pingSources(ctx context.Context, dp driver.Provider, srcs []*source.Source,
 // resolution below), and what pingResult carries to the output
 // writers; the writer layer's expand decorator handles the --expand
 // display view.
-func pingSource(ctx context.Context, dp driver.Provider, src *source.Source, timeout time.Duration,
-	resultCh chan<- pingResult,
+func pingSource(ctx context.Context, dp driver.Provider, reg *secret.Registry,
+	src *source.Source, timeout time.Duration, resultCh chan<- pingResult,
 ) {
 	drvr, err := dp.DriverFor(src.Type)
 	if err != nil {
@@ -225,7 +226,7 @@ func pingSource(ctx context.Context, dp driver.Provider, src *source.Source, tim
 	// the stored src to output writers, which serialize src.Location
 	// verbatim. We must not leak the resolved plaintext unless the
 	// user opted in via --expand.
-	resolved, err := driver.ResolveSourceSecrets(ctx, src)
+	resolved, err := driver.ResolveSourceSecrets(ctx, reg, src)
 	if err != nil {
 		resultCh <- pingResult{src: src, err: err}
 		return

--- a/cli/cmd_ping_internal_test.go
+++ b/cli/cmd_ping_internal_test.go
@@ -79,7 +79,7 @@ func TestPingSource_TimeoutDoesNotLeakGoroutine(t *testing.T) {
 	}
 	resultCh := make(chan pingResult, 1)
 
-	pingSource(context.Background(), dp, src, 20*time.Millisecond, resultCh)
+	pingSource(context.Background(), dp, nil, src, 20*time.Millisecond, resultCh)
 
 	res := <-resultCh
 	require.ErrorIs(t, res.err, context.DeadlineExceeded,

--- a/cli/cmd_x.go
+++ b/cli/cmd_x.go
@@ -57,7 +57,7 @@ func execXLockSrcCmd(cmd *cobra.Command, args []string) error {
 	// The cache lock path is derived from a hash that includes the
 	// resolved location; ingest locks the resolved leaf, so this
 	// command must too, or it locks a dir nothing else uses.
-	if src, err = driver.ResolveSourceSecrets(ctx, src); err != nil {
+	if src, err = driver.ResolveSourceSecrets(ctx, ru.SecretRegistry, src); err != nil {
 		return err
 	}
 

--- a/cli/expand_test.go
+++ b/cli/expand_test.go
@@ -203,7 +203,7 @@ func TestMaybeExpandSource_ZeroRefs_AgreesWithConnect(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "postgres://alice:pa$wd@db/sakila", got.Location)
 
-	resolved, err := driver.ResolveSourceSecrets(context.Background(), src)
+	resolved, err := driver.ResolveSourceSecrets(context.Background(), nil, src)
 	require.NoError(t, err)
 	require.Equal(t, resolved.Location, got.Location,
 		"display expansion and connect-time resolution must agree")

--- a/cli/run.go
+++ b/cli/run.go
@@ -215,16 +215,19 @@ func preRun(cmd *cobra.Command, ru *run.Run) error {
 			lga.Cmd, ru.Cmd.CommandPath())
 	}
 
-	if err = FinishRunInit(ctx, ru); err != nil {
-		return err
-	}
-
+	// Build the secret registry before FinishRunInit, which constructs
+	// ru.Grips: Grips captures the registry at construction time to
+	// resolve ${scheme:path} placeholders in source Locations.
 	ru.SecretRegistry = secret.NewRegistry()
 	ru.SecretRegistry.Register("keyring", keyring.NewStore())
 	ru.SecretRegistry.Register("env", env.NewResolver())
 	ru.SecretRegistry.Register("file", file.NewResolver())
 	ru.SecretRegistry.Register("op", op.NewResolver())
-	ctx = secret.NewContext(ctx, ru.SecretRegistry)
+
+	if err = FinishRunInit(ctx, ru); err != nil {
+		return err
+	}
+
 	cmd.SetContext(ctx)
 
 	var outCfg *outputConfig
@@ -312,7 +315,7 @@ func FinishRunInit(ctx context.Context, ru *run.Run) error {
 	ru.DriverRegistry = driver.NewRegistry(log)
 	dr := ru.DriverRegistry
 
-	ru.Grips = driver.NewGrips(dr, ru.Files, scratchSrcFunc)
+	ru.Grips = driver.NewGrips(dr, ru.Files, ru.SecretRegistry, scratchSrcFunc)
 	ru.Cleanup.AddC(ru.Grips)
 	ru.MDCache = mdcache.New(log, cfg.Collection, ru.Grips)
 	ru.Cleanup.AddC(ru.MDCache)

--- a/cli/source.go
+++ b/cli/source.go
@@ -180,7 +180,7 @@ func verifySourceCatalogSchema(ctx context.Context, ru *run.Run, src *source.Sou
 	// Bypassing Grips also bypasses the ${scheme:path} placeholder
 	// resolution that Grips.doOpen performs, so resolve here before
 	// handing src to the driver.
-	openSrc, err := driver.ResolveSourceSecrets(ctx, src)
+	openSrc, err := driver.ResolveSourceSecrets(ctx, ru.SecretRegistry, src)
 	if err != nil {
 		return err
 	}

--- a/drivers/sqlite3/sqlite3_test.go
+++ b/drivers/sqlite3/sqlite3_test.go
@@ -356,7 +356,7 @@ func TestPlaceholderLocation_Connect(t *testing.T) {
 	reg.Register("env", env.NewResolver())
 
 	th := testh.New(t)
-	ctx := secret.NewContext(th.Context, reg)
+	ctx := th.Context
 
 	src := &source.Source{
 		Handle:   "@gh798",
@@ -364,7 +364,7 @@ func TestPlaceholderLocation_Connect(t *testing.T) {
 		Location: "${env:SQ_TEST_GH798_DB_PATH}",
 	}
 
-	resolved, err := driver.ResolveSourceSecrets(ctx, src)
+	resolved, err := driver.ResolveSourceSecrets(ctx, reg, src)
 	require.NoError(t, err)
 	require.Equal(t, "sqlite3://"+filepath.ToSlash(dbPath), resolved.Location)
 
@@ -1330,7 +1330,7 @@ func TestNewScratchSource_SecretsResolved(t *testing.T) {
 	require.True(t, src.SecretsResolved,
 		"internally constructed literal locations must be marked resolved")
 
-	resolved, err := driver.ResolveSourceSecrets(ctx, src)
+	resolved, err := driver.ResolveSourceSecrets(ctx, nil, src)
 	require.NoError(t, err)
 	require.Equal(t, src.Location, resolved.Location,
 		"resolution must not alter the literal scratch path")

--- a/libsq/core/secret/secret.go
+++ b/libsq/core/secret/secret.go
@@ -164,16 +164,3 @@ func (r *Registry) ResolveScheme(ctx context.Context, scheme, path string) (stri
 		return "", errz.Err(ctx.Err())
 	}
 }
-
-type ctxKey struct{}
-
-// NewContext returns a context carrying reg.
-func NewContext(parent context.Context, reg *Registry) context.Context {
-	return context.WithValue(parent, ctxKey{}, reg)
-}
-
-// FromContext returns the Registry carried by ctx, or nil if none.
-func FromContext(ctx context.Context) *Registry {
-	r, _ := ctx.Value(ctxKey{}).(*Registry)
-	return r
-}

--- a/libsq/core/secret/secret_test.go
+++ b/libsq/core/secret/secret_test.go
@@ -32,12 +32,3 @@ func TestRegistry_RegisterAndLookup(t *testing.T) {
 	_, err = reg.ResolveScheme(context.Background(), "unknown", "x")
 	require.ErrorIs(t, err, secret.ErrUnknownScheme)
 }
-
-func TestContextRoundTrip(t *testing.T) {
-	reg := secret.NewRegistry()
-	ctx := secret.NewContext(context.Background(), reg)
-	require.Same(t, reg, secret.FromContext(ctx))
-
-	// No registry on plain context → nil.
-	require.Nil(t, secret.FromContext(context.Background()))
-}

--- a/libsq/driver/grips.go
+++ b/libsq/driver/grips.go
@@ -70,7 +70,7 @@ func gripCacheKey(mode AccessMode, handle string) string {
 	return handle + "\x00" + mode.suffix()
 }
 
-// NewGrips returns a Grips instances. secretReg resolves secret
+// NewGrips returns a Grips instance. secretReg resolves secret
 // placeholders in source Locations at open time; it may be nil if no
 // source uses placeholders.
 func NewGrips(drvrs Provider, fs *files.Files, secretReg *secret.Registry,

--- a/libsq/driver/grips.go
+++ b/libsq/driver/grips.go
@@ -41,7 +41,8 @@ type Grips struct {
 
 	// secretReg resolves ${scheme:path} placeholders in source Locations
 	// at open time (see ResolveSourceSecrets). It may be nil, in which
-	// case opening a source whose Location contains placeholders fails.
+	// case the first (uncached) open of a source whose Location contains
+	// placeholders fails; cache hits are served before resolution runs.
 	secretReg *secret.Registry
 
 	// grips caches open Grip instances, keyed by gripCacheKey: the source
@@ -197,7 +198,7 @@ func ResolveSourceSecrets(ctx context.Context, reg *secret.Registry,
 		}
 	} else {
 		if reg == nil {
-			return nil, errz.Errorf("resolve placeholders for %s: no secret registry", src.Handle)
+			return nil, errz.Errorf("resolve placeholders for %s: no secret registry provided", src.Handle)
 		}
 		if resolved, err = reg.Expand(ctx, src.Location); err != nil {
 			return nil, errz.Wrapf(err, "resolve secrets for %s", src.Handle)

--- a/libsq/driver/grips.go
+++ b/libsq/driver/grips.go
@@ -39,6 +39,11 @@ type Grips struct {
 
 	files *files.Files
 
+	// secretReg resolves ${scheme:path} placeholders in source Locations
+	// at open time (see ResolveSourceSecrets). It may be nil, in which
+	// case opening a source whose Location contains placeholders fails.
+	secretReg *secret.Registry
+
 	// grips caches open Grip instances, keyed by gripCacheKey: the source
 	// handle plus the access mode (read-write, implicit read-only, or
 	// explicit read-only) passed to Open. Keying on the mode means a
@@ -65,13 +70,18 @@ func gripCacheKey(mode AccessMode, handle string) string {
 	return handle + "\x00" + mode.suffix()
 }
 
-// NewGrips returns a Grips instances.
-func NewGrips(drvrs Provider, fs *files.Files, scratchSrcFn ScratchSrcFunc) *Grips {
+// NewGrips returns a Grips instances. secretReg resolves secret
+// placeholders in source Locations at open time; it may be nil if no
+// source uses placeholders.
+func NewGrips(drvrs Provider, fs *files.Files, secretReg *secret.Registry,
+	scratchSrcFn ScratchSrcFunc,
+) *Grips {
 	return &Grips{
 		drvrs:        drvrs,
 		mu:           sync.Mutex{},
 		scratchSrcFn: scratchSrcFn,
 		files:        fs,
+		secretReg:    secretReg,
 		grips:        map[string]Grip{},
 		clnup:        cleanup.New(),
 	}
@@ -134,17 +144,16 @@ func (gs *Grips) IsSQLSource(src *source.Source) bool {
 }
 
 // ResolveSourceSecrets returns a clone of src with any ${scheme:path}
-// placeholders in src.Location resolved via the secret.Registry on ctx,
-// and any $$ escapes reduced to a literal $. If src.Location contains
-// no well-formed placeholders, the $$ escape is still honored (a clone
-// is returned when the location changes; no Registry is needed, since
-// nothing resolves). This is what lets a literal location be stored
-// escaped, e.g. by the v0.54.0 config upgrade, and reach the driver
-// byte-identically. If placeholders are present but no Registry is
-// bound to ctx, an error is returned: a placeholder on a source that
-// has reached this point is always meant to be resolved, and a silent
-// passthrough would surface later as a confusing "connection refused"
-// or DSN-parse error from the driver.
+// placeholders in src.Location resolved via reg, and any $$ escapes
+// reduced to a literal $. If src.Location contains no well-formed
+// placeholders, the $$ escape is still honored (a clone is returned
+// when the location changes; reg may be nil, since nothing resolves).
+// This is what lets a literal location be stored escaped, e.g. by the
+// v0.54.0 config upgrade, and reach the driver byte-identically. If
+// placeholders are present but reg is nil, an error is returned: a
+// placeholder on a source that has reached this point is always meant
+// to be resolved, and a silent passthrough would surface later as a
+// confusing "connection refused" or DSN-parse error from the driver.
 //
 // Detection uses secret.ExtractRefs rather than a `${`-substring scan
 // so that literal "${" sequences (e.g. an escaped "$${env:X}" or a
@@ -167,7 +176,9 @@ func (gs *Grips) IsSQLSource(src *source.Source) bool {
 // Exposed (rather than unexported) so callers and tests can drive the
 // resolution directly. Grips.doOpen calls it once at entry; drivers do
 // not need to call it themselves.
-func ResolveSourceSecrets(ctx context.Context, src *source.Source) (*source.Source, error) {
+func ResolveSourceSecrets(ctx context.Context, reg *secret.Registry,
+	src *source.Source,
+) (*source.Source, error) {
 	if src == nil || src.SecretsResolved {
 		// Already-resolved Locations hold literal bytes, not template
 		// bytes; running them through resolution again would corrupt
@@ -185,9 +196,8 @@ func ResolveSourceSecrets(ctx context.Context, src *source.Source) (*source.Sour
 			return src, nil
 		}
 	} else {
-		reg := secret.FromContext(ctx)
 		if reg == nil {
-			return nil, errz.Errorf("resolve placeholders for %s: no secret registry bound to context", src.Handle)
+			return nil, errz.Errorf("resolve placeholders for %s: no secret registry", src.Handle)
 		}
 		if resolved, err = reg.Expand(ctx, src.Location); err != nil {
 			return nil, errz.Wrapf(err, "resolve secrets for %s", src.Handle)
@@ -232,7 +242,7 @@ func (gs *Grips) doOpen(ctx context.Context, src *source.Source, mode AccessMode
 	}
 
 	var err error
-	if src, err = ResolveSourceSecrets(ctx, src); err != nil {
+	if src, err = ResolveSourceSecrets(ctx, gs.secretReg, src); err != nil {
 		return nil, err
 	}
 

--- a/libsq/driver/grips_cache_test.go
+++ b/libsq/driver/grips_cache_test.go
@@ -108,9 +108,9 @@ func (g *fakeGrip) isClosed() bool {
 	return g.closed
 }
 
-func newFakeGrips() (*driver.Grips, *fakeDriver) {
+func newFakeGrips(reg *secret.Registry) (*driver.Grips, *fakeDriver) {
 	drvr := &fakeDriver{}
-	return driver.NewGrips(&fakeProvider{drvr: drvr}, nil, nil), drvr
+	return driver.NewGrips(&fakeProvider{drvr: drvr}, nil, reg, nil), drvr
 }
 
 // TestGrips_Open_ReadOnlyModeKeysCache verifies that the Grips cache
@@ -130,7 +130,7 @@ func TestGrips_Open_ReadOnlyModeKeysCache(t *testing.T) {
 	}
 
 	t.Run("ro then rw", func(t *testing.T) {
-		gs, drvr := newFakeGrips()
+		gs, drvr := newFakeGrips(nil)
 		ctx := context.Background()
 
 		gripRO, err := gs.Open(ctx, newSrc(), driver.ModeReadOnly)
@@ -162,7 +162,7 @@ func TestGrips_Open_ReadOnlyModeKeysCache(t *testing.T) {
 	})
 
 	t.Run("rw then ro", func(t *testing.T) {
-		gs, drvr := newFakeGrips()
+		gs, drvr := newFakeGrips(nil)
 		ctx := context.Background()
 
 		gripRW, err := gs.Open(ctx, newSrc(), driver.ModeReadWrite)
@@ -188,7 +188,7 @@ func TestGrips_Open_ReadOnlyModeKeysCache(t *testing.T) {
 		// the implicit hint (it overrides access_mode=AUTOMATIC on the
 		// location, see gh #803), so the two hints can produce different
 		// connections and must not share a cache entry.
-		gs, drvr := newFakeGrips()
+		gs, drvr := newFakeGrips(nil)
 		ctx := context.Background()
 
 		gripImplicit, err := gs.Open(ctx, newSrc(), driver.ModeReadOnly)
@@ -209,40 +209,35 @@ func TestGrips_Open_ReadOnlyModeKeysCache(t *testing.T) {
 // cache hit returns before secret resolution runs (gh #779). Previously
 // doOpen resolved secrets before consulting the cache, so every Open of
 // an already-open source (e.g. one call per table during inspect) paid
-// for resolution again. The second Open below carries a fresh
-// secret.Registry whose resolver must never be invoked: a cache hit
-// needs only the handle and the read-only hint, not the resolved
-// location.
+// for resolution again. The second Open below must not invoke the
+// resolver again: a cache hit needs only the handle and the read-only
+// hint, not the resolved location.
 func TestGrips_Open_CacheHitSkipsSecretResolution(t *testing.T) {
-	gs, drvr := newFakeGrips()
+	resolver := &captureResolver{value: "hunter2"}
+	reg := secret.NewRegistry()
+	reg.Register("keyring", resolver)
+
+	gs, drvr := newFakeGrips(reg)
 	src := &source.Source{
 		Handle:   "@fake",
 		Type:     drivertype.Pg,
 		Location: "postgres://alice:${keyring:pw}@db/sakila",
 	}
 
-	resolverA := &captureResolver{value: "hunter2"}
-	regA := secret.NewRegistry()
-	regA.Register("keyring", resolverA)
-	ctxA := secret.NewContext(context.Background(), regA)
+	ctx := context.Background()
 
-	grip1, err := gs.Open(ctxA, src, driver.ModeReadWrite)
+	grip1, err := gs.Open(ctx, src, driver.ModeReadWrite)
 	require.NoError(t, err)
-	require.Equal(t, []string{"pw"}, resolverA.calls)
+	require.Equal(t, []string{"pw"}, resolver.calls)
 	require.Equal(t, 1, drvr.openCount())
 	require.Equal(t, "postgres://alice:hunter2@db/sakila", drvr.opens[0].loc,
 		"driver must receive the resolved location")
 
-	resolverB := &captureResolver{value: "hunter2"}
-	regB := secret.NewRegistry()
-	regB.Register("keyring", resolverB)
-	ctxB := secret.NewContext(context.Background(), regB)
-
-	grip2, err := gs.Open(ctxB, src, driver.ModeReadWrite)
+	grip2, err := gs.Open(ctx, src, driver.ModeReadWrite)
 	require.NoError(t, err)
 	require.Same(t, grip1, grip2)
-	require.Empty(t, resolverB.calls,
-		"cache hit must not invoke secret resolution")
+	require.Equal(t, []string{"pw"}, resolver.calls,
+		"cache hit must not invoke secret resolution again")
 	require.Equal(t, 1, drvr.openCount())
 
 	require.NoError(t, gs.Close())
@@ -253,7 +248,7 @@ func TestGrips_Open_CacheHitSkipsSecretResolution(t *testing.T) {
 // than replaying the earlier error. (The secret layer tests the analogous
 // "failures not cached" property; this pins it for the grip cache.)
 func TestGrips_Open_ErrorNotCached(t *testing.T) {
-	gs, drvr := newFakeGrips()
+	gs, drvr := newFakeGrips(nil)
 	drvr.failOpens = 1 // fail the first Open, succeed thereafter.
 	ctx := context.Background()
 	newSrc := func() *source.Source {

--- a/libsq/driver/grips_test.go
+++ b/libsq/driver/grips_test.go
@@ -27,14 +27,14 @@ func (c *captureResolver) Resolve(_ context.Context, path string) (string, error
 func TestGrips_ResolveSourceSecrets(t *testing.T) {
 	reg := secret.NewRegistry()
 	reg.Register("keyring", &captureResolver{value: "hunter2"})
-	ctx := secret.NewContext(context.Background(), reg)
+	ctx := context.Background()
 
 	src := &source.Source{
 		Handle:   "@sakila",
 		Location: "postgres://alice:${keyring:my_db_pw}@db/sakila",
 	}
 
-	resolved, err := driver.ResolveSourceSecrets(ctx, src)
+	resolved, err := driver.ResolveSourceSecrets(ctx, reg, src)
 	require.NoError(t, err)
 	require.NotSame(t, src, resolved, "must return a clone")
 	require.Equal(t,
@@ -47,12 +47,12 @@ func TestGrips_ResolveSourceSecrets(t *testing.T) {
 
 func TestGrips_ResolveSourceSecrets_NoPlaceholder(t *testing.T) {
 	reg := secret.NewRegistry()
-	ctx := secret.NewContext(context.Background(), reg)
+	ctx := context.Background()
 	src := &source.Source{
 		Handle:   "@sakila",
 		Location: "postgres://alice:hunter2@db/sakila",
 	}
-	resolved, err := driver.ResolveSourceSecrets(ctx, src)
+	resolved, err := driver.ResolveSourceSecrets(ctx, reg, src)
 	require.NoError(t, err)
 	require.Same(t, src, resolved, "no placeholder => return input unchanged")
 }
@@ -62,8 +62,8 @@ func TestGrips_ResolveSourceSecrets_NoPlaceholder(t *testing.T) {
 // refs: the driver must receive the literal form. This is what makes
 // the v0.54.0 config upgrade's escaping of legacy locations (which
 // never contain intentional placeholders) connect byte-identically.
-// No secret.Registry is bound to the context: unescaping must not
-// require one, since a ref-free location resolves nothing.
+// A nil secret.Registry is passed: unescaping must not require one,
+// since a ref-free location resolves nothing.
 func TestGrips_ResolveSourceSecrets_NoRefs_Unescape(t *testing.T) {
 	tests := []struct {
 		name string
@@ -90,7 +90,7 @@ func TestGrips_ResolveSourceSecrets_NoRefs_Unescape(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			src := &source.Source{Handle: "@sakila", Location: tc.loc}
-			resolved, err := driver.ResolveSourceSecrets(context.Background(), src)
+			resolved, err := driver.ResolveSourceSecrets(context.Background(), nil, src)
 			require.NoError(t, err)
 			require.NotSame(t, src, resolved, "must return a clone when location changes")
 			require.Equal(t, tc.want, resolved.Location)
@@ -109,7 +109,7 @@ func TestGrips_ResolveSourceSecrets_NoRefs_Unescape(t *testing.T) {
 func TestGrips_ResolveSourceSecrets_AgreesWithExpand(t *testing.T) {
 	reg := secret.NewRegistry()
 	reg.Register("keyring", &captureResolver{value: "hunter2"})
-	ctx := secret.NewContext(context.Background(), reg)
+	ctx := context.Background()
 
 	tests := []struct {
 		name string
@@ -143,7 +143,7 @@ func TestGrips_ResolveSourceSecrets_AgreesWithExpand(t *testing.T) {
 				Type:     drivertype.Pg,
 				Location: tc.loc,
 			}
-			resolved, err := driver.ResolveSourceSecrets(ctx, src)
+			resolved, err := driver.ResolveSourceSecrets(ctx, reg, src)
 			require.NoError(t, err)
 			require.Equal(t, expanded, resolved.Location,
 				"connect-time bytes must equal Expand output")
@@ -165,11 +165,11 @@ func TestGrips_ResolveSourceSecrets_Idempotent(t *testing.T) {
 			Handle:   "@sakila",
 			Location: "postgres://alice:p$$$$wd@db/sakila",
 		}
-		r1, err := driver.ResolveSourceSecrets(context.Background(), src)
+		r1, err := driver.ResolveSourceSecrets(context.Background(), nil, src)
 		require.NoError(t, err)
 		require.Equal(t, "postgres://alice:p$$wd@db/sakila", r1.Location)
 
-		r2, err := driver.ResolveSourceSecrets(context.Background(), r1)
+		r2, err := driver.ResolveSourceSecrets(context.Background(), nil, r1)
 		require.NoError(t, err)
 		require.Same(t, r1, r2, "second resolution must be a no-op")
 		require.Equal(t, "postgres://alice:p$$wd@db/sakila", r2.Location)
@@ -178,18 +178,18 @@ func TestGrips_ResolveSourceSecrets_Idempotent(t *testing.T) {
 	t.Run("resolved secret value containing dollars", func(t *testing.T) {
 		reg := secret.NewRegistry()
 		reg.Register("keyring", &captureResolver{value: "p$$wd"})
-		ctx := secret.NewContext(context.Background(), reg)
+		ctx := context.Background()
 
 		src := &source.Source{
 			Handle:   "@sakila",
 			Location: "postgres://alice:${keyring:my_db_pw}@db/sakila",
 		}
-		r1, err := driver.ResolveSourceSecrets(ctx, src)
+		r1, err := driver.ResolveSourceSecrets(ctx, reg, src)
 		require.NoError(t, err)
 		require.Equal(t, "postgres://alice:p$$wd@db/sakila", r1.Location)
 
 		// Without the marker, this second pass would halve '$$' to '$'.
-		r2, err := driver.ResolveSourceSecrets(ctx, r1)
+		r2, err := driver.ResolveSourceSecrets(ctx, reg, r1)
 		require.NoError(t, err)
 		require.Same(t, r1, r2, "second resolution must be a no-op")
 		require.Equal(t, "postgres://alice:p$$wd@db/sakila", r2.Location)
@@ -277,7 +277,7 @@ func TestGrips_ResolveSourceSecrets_MungeFileDB(t *testing.T) {
 			t.Setenv("SQ_TEST_GH798_DB_PATH", tc.envVal)
 			reg := secret.NewRegistry()
 			reg.Register("env", env.NewResolver())
-			ctx := secret.NewContext(context.Background(), reg)
+			ctx := context.Background()
 
 			src := &source.Source{
 				Handle:   "@gh798",
@@ -285,7 +285,7 @@ func TestGrips_ResolveSourceSecrets_MungeFileDB(t *testing.T) {
 				Location: "${env:SQ_TEST_GH798_DB_PATH}",
 			}
 
-			resolved, err := driver.ResolveSourceSecrets(ctx, src)
+			resolved, err := driver.ResolveSourceSecrets(ctx, reg, src)
 			if tc.wantErr {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), "@gh798")
@@ -316,7 +316,7 @@ func TestGrips_ResolveSourceSecrets_MungeFileDB_NoChange(t *testing.T) {
 			Type:     drivertype.SQLite,
 			Location: "/data/sakila.db",
 		}
-		resolved, err := driver.ResolveSourceSecrets(context.Background(), src)
+		resolved, err := driver.ResolveSourceSecrets(context.Background(), nil, src)
 		require.NoError(t, err)
 		require.Same(t, src, resolved, "no change => return input unchanged")
 		require.Equal(t, "/data/sakila.db", resolved.Location,
@@ -328,14 +328,14 @@ func TestGrips_ResolveSourceSecrets_MungeFileDB_NoChange(t *testing.T) {
 		t.Setenv("SQ_TEST_GH798_DB_PATH", tmpl)
 		reg := secret.NewRegistry()
 		reg.Register("env", env.NewResolver())
-		ctx := secret.NewContext(context.Background(), reg)
+		ctx := context.Background()
 
 		src := &source.Source{
 			Handle:   "@gh798",
 			Type:     drivertype.SQLite,
 			Location: tmpl,
 		}
-		resolved, err := driver.ResolveSourceSecrets(ctx, src)
+		resolved, err := driver.ResolveSourceSecrets(ctx, reg, src)
 		require.NoError(t, err)
 		require.Equal(t, tmpl, resolved.Location,
 			"placeholder-shaped resolved value must not be munged into a file path")
@@ -349,7 +349,7 @@ func TestGrips_ResolveSourceSecrets_MungeFileDB_NoChange(t *testing.T) {
 func TestGrips_ResolveSourceSecrets_MungeFileDB_NonFileDriver(t *testing.T) {
 	reg := secret.NewRegistry()
 	reg.Register("keyring", &captureResolver{value: "hunter2"})
-	ctx := secret.NewContext(context.Background(), reg)
+	ctx := context.Background()
 
 	src := &source.Source{
 		Handle:   "@sakila",
@@ -357,7 +357,7 @@ func TestGrips_ResolveSourceSecrets_MungeFileDB_NonFileDriver(t *testing.T) {
 		Location: "postgres://alice:${keyring:my_db_pw}@db/sakila",
 	}
 
-	resolved, err := driver.ResolveSourceSecrets(ctx, src)
+	resolved, err := driver.ResolveSourceSecrets(ctx, reg, src)
 	require.NoError(t, err)
 	require.Equal(t, "postgres://alice:hunter2@db/sakila", resolved.Location)
 }
@@ -367,19 +367,19 @@ func TestGrips_ResolveSourceSecrets_NoRegistry(t *testing.T) {
 		Handle:   "@sakila",
 		Location: "postgres://alice:${keyring:my_db_pw}@db/sakila",
 	}
-	// Placeholders present but no secret.Registry on context: must
-	// return an explicit error rather than silently passing the
-	// unresolved Location through to the driver, where it would
-	// surface as a confusing DSN-parse or connection error.
-	resolved, err := driver.ResolveSourceSecrets(context.Background(), src)
+	// Placeholders present but a nil secret.Registry: must return an
+	// explicit error rather than silently passing the unresolved
+	// Location through to the driver, where it would surface as a
+	// confusing DSN-parse or connection error.
+	resolved, err := driver.ResolveSourceSecrets(context.Background(), nil, src)
 	require.Error(t, err)
 	require.Nil(t, resolved)
 	require.Contains(t, err.Error(), "@sakila")
-	require.Contains(t, err.Error(), "no secret registry bound to context")
+	require.Contains(t, err.Error(), "no secret registry")
 }
 
 func TestGrips_ResolveSourceSecrets_NilSource(t *testing.T) {
-	got, err := driver.ResolveSourceSecrets(context.Background(), nil)
+	got, err := driver.ResolveSourceSecrets(context.Background(), nil, nil)
 	require.NoError(t, err)
 	require.Nil(t, got)
 }

--- a/testh/testh.go
+++ b/testh/testh.go
@@ -179,7 +179,10 @@ func (h *Helper) init() {
 			assert.NoError(h.T, err)
 		})
 
-		h.grips = driver.NewGrips(h.registry, h.files, sqlite3.NewScratchSource)
+		// nil secret registry: test sources don't use ${scheme:path}
+		// placeholders. Tests that exercise secret resolution call
+		// driver.ResolveSourceSecrets directly with their own registry.
+		h.grips = driver.NewGrips(h.registry, h.files, nil, sqlite3.NewScratchSource)
 		h.Cleanup.AddC(h.grips)
 
 		h.registry.AddProvider(drivertype.SQLite, &sqlite3.Provider{Log: h.Log()})


### PR DESCRIPTION
## Summary

Threads `secret.Registry` as an explicit parameter rather than smuggling it through `context.Value`, per the "prefer explicit signatures over `context.Value`" convention added to `CLAUDE.md`.

`secret.FromContext` had exactly one production read site (`ResolveSourceSecrets`), with the registry set once at startup. This makes the dependency explicit and removes the context channel entirely.

## Changes

- `ResolveSourceSecrets(ctx, reg, src)` now takes the registry as a parameter.
- `Grips` captures the registry at construction (`NewGrips`), the same way it already holds `drvrs` and `files`, and passes it from `doOpen`.
- Deleted `secret.NewContext`, `secret.FromContext`, and `ctxKey` — the context value channel is gone.
- The CLI builds the registry before `FinishRunInit` (which constructs `Grips`) and passes `ru.SecretRegistry` to the remaining call sites. The ping path threads the registry alongside its existing explicit `driver.Provider` argument.

## Behavior

Unchanged. Paths that never injected a registry into the context (`testh`, shell completion, `testrun`, benchmarks) now receive a `nil` registry, which matches the prior `FromContext`-returns-nil behavior. Sources in those paths have no `${scheme:path}` placeholders, so resolution takes the no-refs passthrough exactly as before.

## Verification

- `make lint` — 0 issues
- Full test suite (incl. Docker SQL drivers) — green. One Postgres completion test (`TestCompleteFlagActiveSchema_query_cmds`) flaked under concurrent container load (empty schema list); it passes in isolation and on a `cli`-package re-run, and is unrelated to this change.