### PR TITLE
perf(ingest): relax durability on disposable cache DB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@ Breaking changes are annotated with ☢️, and alpha/beta features with 🐥.
 - [#866]: Ingesting JSON and JSONL is now much faster, especially on Windows, where a large
   JSONL file could previously take minutes. Each ingest now runs as a single transaction, so a
   failed ingest no longer leaves a partially-populated cache.
+- [#868]: Ingesting any document source (CSV, Excel, JSON, etc.) is now faster, especially on
+  Windows and other slow filesystems. The disposable ingest cache DB is opened with relaxed
+  durability, so writes no longer pay a per-row disk sync. The cache is rebuilt from the source
+  if it is ever missing or corrupt, so there is no loss of correctness.
 - Shell completion for flag values now works even when the command already has a
   positional argument. Previously, tab-completing values for flags such as
   [`add --store`](https://sq.io/docs/cmd/add) (`inline | keyring`), `config get --src`,
@@ -1726,6 +1730,7 @@ make working with lots of sources much easier.
 [#853]: https://github.com/neilotoole/sq/issues/853
 [#863]: https://github.com/neilotoole/sq/pull/863
 [#866]: https://github.com/neilotoole/sq/issues/866
+[#868]: https://github.com/neilotoole/sq/issues/868
 
 [v0.15.2]: https://github.com/neilotoole/sq/releases/tag/v0.15.2
 [v0.15.3]: https://github.com/neilotoole/sq/compare/v0.15.2...v0.15.3

--- a/drivers/sqlite3/sqlite3.go
+++ b/drivers/sqlite3/sqlite3.go
@@ -1119,7 +1119,7 @@ func (d *driveri) getTableRecordMeta(ctx context.Context, db sqlz.DB, tblName st
 
 var _ driver.ScratchSrcFunc = NewScratchSource
 
-// ScratchConnParams is the "?key=val&..." connection-string suffix appended
+// scratchConnParams is the "?key=val&..." connection-string suffix appended
 // to scratch (disposable) SQLite DB locations: the ingest cache DB for
 // document sources (CSV, Excel, JSON, etc.), join work DBs, and ephemeral
 // DBs. These DBs are never authoritative: each is rebuilt from its source if
@@ -1148,7 +1148,7 @@ var _ driver.ScratchSrcFunc = NewScratchSource
 // switch to synchronous=NORMAL + journal_mode=WAL, whose journal is on disk).
 //
 // See gh #868.
-const ScratchConnParams = "?_synchronous=OFF&_journal_mode=MEMORY"
+const scratchConnParams = "?_synchronous=OFF&_journal_mode=MEMORY"
 
 // NewScratchSource returns a new scratch src. The supplied fpath
 // must be the absolute path to the location to create the SQLite DB file,
@@ -1159,7 +1159,7 @@ func NewScratchSource(ctx context.Context, fpath string) (src *source.Source, cl
 	src = &source.Source{
 		Type:     drivertype.SQLite,
 		Handle:   source.ScratchHandle,
-		Location: Prefix + fpath + ScratchConnParams,
+		Location: Prefix + fpath + scratchConnParams,
 		// The path is an internally constructed literal, not a
 		// placeholder template: mark it so resolution is a no-op.
 		SecretsResolved: true,
@@ -1168,7 +1168,7 @@ func NewScratchSource(ctx context.Context, fpath string) (src *source.Source, cl
 	clnup = func() error {
 		// SQLite's rollback journal for "<fpath>" is the sibling file
 		// "<fpath>-journal", not a "<fpath>/.db-journal" child path. Under
-		// ScratchConnParams' journal_mode=MEMORY no on-disk journal is
+		// scratchConnParams' journal_mode=MEMORY no on-disk journal is
 		// normally created, but remove a stale one defensively (e.g. left by
 		// an earlier abnormal exit before this DB's mode was applied).
 		if journal := fpath + "-journal"; ioz.FileAccessible(journal) {

--- a/drivers/sqlite3/sqlite3.go
+++ b/drivers/sqlite3/sqlite3.go
@@ -1119,6 +1119,37 @@ func (d *driveri) getTableRecordMeta(ctx context.Context, db sqlz.DB, tblName st
 
 var _ driver.ScratchSrcFunc = NewScratchSource
 
+// ScratchConnParams is the "?key=val&..." connection-string suffix appended
+// to scratch (disposable) SQLite DB locations: the ingest cache DB for
+// document sources (CSV, Excel, JSON, etc.), join work DBs, and ephemeral
+// DBs. These DBs are never authoritative: each is rebuilt from its source if
+// it is missing, stale, or corrupt, so durability buys nothing.
+//
+// synchronous=OFF + journal_mode=MEMORY drops the per-write fsync that
+// otherwise dominates large ingests: with SQLite's defaults (synchronous=FULL,
+// rollback journal) every autocommit INSERT performs a full fsync. On a slow
+// filesystem that cost is brutal (gh #866: a 5,462-row JSONL ingest took ~408s
+// on Windows vs ~12s on Linux/macOS, one fsync per row). MEMORY is chosen over
+// WAL because the latter leaves -wal/-shm sidecar files that the scratch
+// cleanup would have to track, whereas an in-memory journal needs no on-disk
+// state. The only durability downside, a torn DB after a hard crash or power
+// loss, is self-healing: the cache is regenerated from source on next use.
+//
+// An in-memory rollback journal can in principle grow large enough to OOM,
+// but not for the ingest workload: ingest always targets a freshly-created
+// (empty) cache DB and the document drivers build no secondary indexes, so
+// inserts only append to the table's rowid b-tree. SQLite does not journal
+// pages allocated beyond the database's size at transaction start (rollback
+// just truncates), so the in-memory journal holds only the constant handful
+// of pre-existing pages that get modified, regardless of row count. CAVEAT:
+// if a future change maintains a secondary index (or otherwise rewrites many
+// pre-existing pages) inside a single ingest transaction, the in-memory
+// journal would grow with the data and this choice should be revisited (e.g.
+// switch to synchronous=NORMAL + journal_mode=WAL, whose journal is on disk).
+//
+// See gh #868.
+const ScratchConnParams = "?_synchronous=OFF&_journal_mode=MEMORY"
+
 // NewScratchSource returns a new scratch src. The supplied fpath
 // must be the absolute path to the location to create the SQLite DB file,
 // typically in the user cache dir.
@@ -1128,14 +1159,19 @@ func NewScratchSource(ctx context.Context, fpath string) (src *source.Source, cl
 	src = &source.Source{
 		Type:     drivertype.SQLite,
 		Handle:   source.ScratchHandle,
-		Location: Prefix + fpath,
+		Location: Prefix + fpath + ScratchConnParams,
 		// The path is an internally constructed literal, not a
 		// placeholder template: mark it so resolution is a no-op.
 		SecretsResolved: true,
 	}
 
 	clnup = func() error {
-		if journal := filepath.Join(fpath, ".db-journal"); ioz.FileAccessible(journal) {
+		// SQLite's rollback journal for "<fpath>" is the sibling file
+		// "<fpath>-journal", not a "<fpath>/.db-journal" child path. Under
+		// ScratchConnParams' journal_mode=MEMORY no on-disk journal is
+		// normally created, but remove a stale one defensively (e.g. left by
+		// an earlier abnormal exit before this DB's mode was applied).
+		if journal := fpath + "-journal"; ioz.FileAccessible(journal) {
 			lg.WarnIfError(log, "Delete sqlite3 db journal file", os.Remove(journal))
 		}
 

--- a/drivers/sqlite3/sqlite3_test.go
+++ b/drivers/sqlite3/sqlite3_test.go
@@ -1336,6 +1336,58 @@ func TestNewScratchSource_SecretsResolved(t *testing.T) {
 		"resolution must not alter the literal scratch path")
 }
 
+// TestNewScratchSource_RelaxedDurability verifies gh868: the scratch
+// (disposable) cache DB is opened with relaxed durability pragmas, so
+// large document ingests don't pay a per-INSERT fsync. The params must
+// be both present in the Location and actually applied on the connection
+// by the underlying driver.
+func TestNewScratchSource_RelaxedDurability(t *testing.T) {
+	th := testh.New(t)
+	fpath := filepath.Join(t.TempDir(), "scratch.sqlite")
+
+	src, clnup, err := sqlite3.NewScratchSource(th.Context, fpath)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = clnup() })
+
+	require.True(t, strings.HasSuffix(src.Location, sqlite3.ScratchConnParams),
+		"scratch location must carry the relaxed-durability params")
+
+	grip := th.Open(src)
+	db, err := grip.DB(th.Context)
+	require.NoError(t, err)
+
+	// PRAGMA synchronous reports the numeric level: 0 == OFF.
+	var sync int
+	require.NoError(t, db.QueryRowContext(th.Context, `PRAGMA synchronous`).Scan(&sync))
+	require.Zero(t, sync, "synchronous must be OFF (0)")
+
+	var journalMode string
+	require.NoError(t, db.QueryRowContext(th.Context, `PRAGMA journal_mode`).Scan(&journalMode))
+	require.Equal(t, "memory", strings.ToLower(journalMode), "journal_mode must be MEMORY")
+}
+
+// TestNewScratchSource_CleanupRemovesJournal verifies that the scratch
+// cleanup func targets SQLite's rollback journal sibling file
+// ("<fpath>-journal"), not the bogus "<fpath>/.db-journal" child path it
+// used previously. journal_mode=MEMORY means no journal is normally
+// created, so this guards the corrected path against regression (gh868).
+func TestNewScratchSource_CleanupRemovesJournal(t *testing.T) {
+	th := testh.New(t)
+	fpath := filepath.Join(t.TempDir(), "scratch.sqlite")
+
+	// Simulate an on-disk scratch DB plus a stale rollback journal.
+	require.NoError(t, os.WriteFile(fpath, []byte("db"), 0o600))
+	journal := fpath + "-journal"
+	require.NoError(t, os.WriteFile(journal, []byte("journal"), 0o600))
+
+	_, clnup, err := sqlite3.NewScratchSource(th.Context, fpath)
+	require.NoError(t, err)
+
+	require.NoError(t, clnup())
+	require.NoFileExists(t, fpath, "scratch DB file must be removed")
+	require.NoFileExists(t, journal, "scratch DB journal sibling must be removed")
+}
+
 // TestDriveri_CopyTable_CopiesIndexesAndTriggers verifies gh758:
 // CopyTable carries the source table's companion objects (indexes and
 // triggers, separate sqlite_master rows) across to the destination,

--- a/drivers/sqlite3/sqlite3_test.go
+++ b/drivers/sqlite3/sqlite3_test.go
@@ -1364,6 +1364,13 @@ func TestNewScratchSource_RelaxedDurability(t *testing.T) {
 	var journalMode string
 	require.NoError(t, db.QueryRowContext(th.Context, `PRAGMA journal_mode`).Scan(&journalMode))
 	require.Equal(t, "memory", strings.ToLower(journalMode), "journal_mode must be MEMORY")
+
+	// Close the grip before the test returns so t.TempDir()'s cleanup can
+	// delete the DB file: Windows cannot remove a file that still has an open
+	// handle, and the testh Helper otherwise closes the grip only after
+	// t.TempDir()'s RemoveAll runs. grip.Close is idempotent (closeOnce), so
+	// the Helper's later close is a harmless no-op.
+	require.NoError(t, grip.Close())
 }
 
 // TestNewScratchSource_CleanupRemovesJournal verifies that the scratch

--- a/drivers/sqlite3/sqlite3_test.go
+++ b/drivers/sqlite3/sqlite3_test.go
@@ -1349,7 +1349,7 @@ func TestNewScratchSource_RelaxedDurability(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = clnup() })
 
-	require.True(t, strings.HasSuffix(src.Location, sqlite3.ScratchConnParams),
+	require.True(t, strings.HasSuffix(src.Location, "?_synchronous=OFF&_journal_mode=MEMORY"),
 		"scratch location must carry the relaxed-durability params")
 
 	grip := th.Open(src)


### PR DESCRIPTION
Closes #868. Follow-up to #866.

## Problem

The document-source ingest cache DB (CSV, Excel, JSON, etc.) was opened with SQLite's defaults (`synchronous=FULL`, rollback journal), so every autocommit write performed a full fsync. During ingest this is paid per INSERT, the root cause behind the slow Windows JSONL ingest in #866 (5,462 rows = 5,462 fsyncs; ~408s on Windows vs ~12s on Linux/macOS).

The cache DB is disposable: it's keyed on a checksum of the source and rebuilt whenever it's missing, stale, or corrupt. Durability buys nothing here, so the full-fsync default is pure cost.

## Change

Open the disposable cache DB with `synchronous=OFF` + `journal_mode=MEMORY`, eliminating the per-write fsync. This benefits every document ingest path, not just JSON.

### Where the fix landed

The issue cited `libsq/files/cache.go:210`, but that location is the cache-**hit reopen**, which only ever reads (queries against a document source never write back), so its pragmas are inert. The fsync-heavy ingest **writes** go through `NewScratchSource` (`drivers/sqlite3/sqlite3.go`) on the cache-**miss** path, where the rows are actually INSERTed. The params are applied there via a new exported `ScratchConnParams`, which also covers join and ephemeral scratch DBs (all disposable). The cache-hit reopen is left unchanged.

### Why MEMORY over WAL

WAL leaves `-wal`/`-shm` sidecar files that the scratch cleanup would have to track; an in-memory journal needs no on-disk state. The only durability downside, a torn DB after a hard crash, is self-healing (the cache is rebuilt from source on next use).

### OOM safety

An in-memory rollback journal can in principle grow large, but not for this workload: ingest always targets a freshly-created (empty) cache DB and the document drivers build no secondary indexes, so inserts only append to the rowid b-tree. SQLite doesn't journal pages allocated beyond the file's size at transaction start (rollback just truncates), so the journal holds only a constant handful of pre-existing pages regardless of row count. The const comment documents this, with a caveat to revisit if a future change maintains a secondary index inside the ingest transaction.

`cache_size` was considered and left at the default: benchmarking 2M-row append-only inserts with cache sizes from 2 MB to 256 MB showed no reliable speedup (the working set for sequential appends is just the rightmost b-tree path), and raising it would only increase per-connection RAM.

### Also: latent cleanup bug

Fixed an unrelated latent bug in `NewScratchSource`'s cleanup func: it looked for the rollback journal at `<fpath>/.db-journal` (a child of the DB file) instead of the sibling `<fpath>-journal`, so it never matched. Moot in normal operation now that `journal_mode=MEMORY` creates no on-disk journal, but corrected and covered by a test.

## Measured performance (Windows)

Measured by dispatching the full Windows suite (`test-windows-full`, no `-short`) via `workflow_dispatch` on `master` vs this branch. The branch figures below are from the run on the merged tip, and reproduced to within tenths of a second across three independent branch runs, so they are signal, not CI variance.

| Test (`test-windows-full`) | master | this PR | delta | delta % |
| --- | ---: | ---: | ---: | ---: |
| `driver TestDriver_Open/@sakila_xlsx` | 71.9s | 3.7s | -68.3s | -95% |
| `xmlud TestIngest_RSS` (XML) | 14.8s | 0.10s | -14.7s | -99% |
| `libsq TestQuerySQL_Smoke/@sakila_xlsx` | 16.4s | 2.2s | -14.2s | -87% |
| `cli StdinQuery/sakila_subset.xlsx` | 12.3s | 0.32s | -12.0s | -97% |

These are XLSX/XML ingests, which #866 (JSON-only) did not cover. JSON ingest is flat (`drivers/json` within noise), as expected since #866 already wraps it in a single transaction.

Package- and wall-clock totals are intentionally omitted: they are dominated by unrelated CI runner variance (e.g. the long DuckDB `TestCmdInspect_json_yaml` tests, which never touch the SQLite ingest cache, swung 10-14s between runs). The per-test ingest numbers above isolate the actual change.

## Validation

- `TestNewScratchSource_RelaxedDurability` asserts the params are present in the location **and** actually applied on the live connection (`PRAGMA synchronous` -> 0, `PRAGMA journal_mode` -> memory).
- `TestNewScratchSource_CleanupRemovesJournal` guards the corrected journal path.
- Full test run across the document drivers (`csv`, `json`, `xlsx`), plus `sqlite3`, `libsq/files`, `libsq/driver`: pass.
- End-to-end `cli/...` + `libsq` (real ingest+cache path): pass.
- Full pipeline green on `workflow_dispatch`, including the complete Windows suite (`test-windows-full`) on ubuntu + macOS + Windows.
- Pinned `golangci-lint`: 0 issues. `markdownlint`: 0 errors.
