### PR TITLE
runtimez: fix mem-stats data race and stale exit values, add tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -86,6 +86,7 @@ require (
 	github.com/neilotoole/jsoncolor v0.9.1
 	github.com/rqlite/gorqlite v0.0.0-20260504155303-50d445fd0ab9
 	github.com/zalando/go-keyring v0.2.9-0.20260616202443-860ea660ec62
+	go.uber.org/goleak v1.3.0
 )
 
 require (

--- a/libsq/core/runtimez/runtimez.go
+++ b/libsq/core/runtimez/runtimez.go
@@ -46,9 +46,9 @@ func MemStats() *runtime.MemStats {
 // StartMemStatsTracker starts a goroutine that tracks memory stats, returning
 // the peak values of [runtime.MemStats.Sys], [runtime.MemStats.Alloc],
 // [runtime.MemStats.TotalAlloc] and [runtime.MemStats.PauseTotalNs]. The
-// goroutine samples every [MemStatsRefresh] and exits when ctx is done.
-//
-//nolint:revive // datarace
+// goroutine wakes on each [MemStatsRefresh] tick and reads the cached
+// [MemStats], so its effective sampling resolution is bounded by
+// [MemStatsRefresh]. It exits when ctx is done.
 func StartMemStatsTracker(ctx context.Context) (sys, curAllocs, totalAllocs, gcPauseNs *atomic.Uint64) {
 	lg.FromContext(ctx).Info("Starting memory stats tracker", lga.Freq, MemStatsRefresh)
 
@@ -57,23 +57,29 @@ func StartMemStatsTracker(ctx context.Context) (sys, curAllocs, totalAllocs, gcP
 	totalAllocs = &atomic.Uint64{}
 	gcPauseNs = &atomic.Uint64{}
 
+	// record updates the peak atomics (sys, curAllocs) and the latest-value
+	// atomics (totalAllocs, gcPauseNs) from a single stats sample. Shared by
+	// the sampling loop and the final exit pass so the two can't drift.
+	record := func(stats *runtime.MemStats) {
+		if stats.Sys > sys.Load() {
+			sys.Store(stats.Sys)
+		}
+
+		if stats.Alloc > curAllocs.Load() {
+			curAllocs.Store(stats.Alloc)
+		}
+
+		totalAllocs.Store(stats.TotalAlloc)
+		gcPauseNs.Store(stats.PauseTotalNs)
+	}
+
 	go func() {
 		ticker := time.NewTicker(MemStatsRefresh)
 		defer ticker.Stop()
 
 		for {
 			// Use our (cached) MemStats, which is updated periodically.
-			stats := MemStats()
-			if stats.Sys > sys.Load() {
-				sys.Store(stats.Sys)
-			}
-
-			if stats.Alloc > curAllocs.Load() {
-				curAllocs.Store(stats.Alloc)
-			}
-
-			totalAllocs.Store(stats.TotalAlloc)
-			gcPauseNs.Store(stats.PauseTotalNs)
+			record(MemStats())
 
 			select {
 			case <-ctx.Done():
@@ -81,16 +87,7 @@ func StartMemStatsTracker(ctx context.Context) (sys, curAllocs, totalAllocs, gcP
 				// runtime.ReadMemStats, just so we have fresh values on exit.
 				var ms runtime.MemStats
 				runtime.ReadMemStats(&ms)
-				if ms.Sys > sys.Load() {
-					sys.Store(ms.Sys)
-				}
-
-				if ms.Alloc > curAllocs.Load() {
-					curAllocs.Store(ms.Alloc)
-				}
-
-				totalAllocs.Store(ms.TotalAlloc)
-				gcPauseNs.Store(ms.PauseTotalNs)
+				record(&ms)
 				return
 			case <-ticker.C:
 			}

--- a/libsq/core/runtimez/runtimez.go
+++ b/libsq/core/runtimez/runtimez.go
@@ -35,15 +35,18 @@ func MemStats() *runtime.MemStats {
 		memStats = &ms
 		memStatsNextRefresh = now.Add(MemStatsRefresh)
 	}
+	// Capture the pointer while holding the lock; reading the package-level
+	// memStats after Unlock would race a concurrent refresh.
+	ms := memStats
 	memStatsMu.Unlock()
 
-	return memStats
+	return ms
 }
 
 // StartMemStatsTracker starts a goroutine that tracks memory stats, returning
-// the peak values of [runtime.MemStats.Sys], [runtime.MemStats.TotalAlloc] and
-// [runtime.MemStats.PauseTotalNs]. The goroutine sleeps for sampleFreq between
-// each sample and exits when ctx is done.
+// the peak values of [runtime.MemStats.Sys], [runtime.MemStats.Alloc],
+// [runtime.MemStats.TotalAlloc] and [runtime.MemStats.PauseTotalNs]. The
+// goroutine samples every [MemStatsRefresh] and exits when ctx is done.
 //
 //nolint:revive // datarace
 func StartMemStatsTracker(ctx context.Context) (sys, curAllocs, totalAllocs, gcPauseNs *atomic.Uint64) {
@@ -79,7 +82,11 @@ func StartMemStatsTracker(ctx context.Context) (sys, curAllocs, totalAllocs, gcP
 				var ms runtime.MemStats
 				runtime.ReadMemStats(&ms)
 				if ms.Sys > sys.Load() {
-					sys.Store(stats.Sys)
+					sys.Store(ms.Sys)
+				}
+
+				if ms.Alloc > curAllocs.Load() {
+					curAllocs.Store(ms.Alloc)
 				}
 
 				totalAllocs.Store(ms.TotalAlloc)

--- a/libsq/core/runtimez/runtimez_test.go
+++ b/libsq/core/runtimez/runtimez_test.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"runtime"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
 )
 
 // resetMemStatsState restores the package-level mem-stats cache to its zero
@@ -71,6 +73,11 @@ func TestMemStats_Concurrent(t *testing.T) {
 	resetMemStatsState(t)
 	MemStatsRefresh = time.Nanosecond
 
+	// Record a nil result rather than asserting inside the worker goroutines:
+	// require.* calls t.FailNow (runtime.Goexit), which must run on the test
+	// goroutine, so the workers flag failure and the test goroutine asserts.
+	var sawNil atomic.Bool
+
 	const goroutines = 16
 	var wg sync.WaitGroup
 	wg.Add(goroutines)
@@ -78,18 +85,24 @@ func TestMemStats_Concurrent(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			for range 1000 {
-				require.NotNil(t, MemStats())
+				if MemStats() == nil {
+					sawNil.Store(true)
+					return
+				}
 			}
 		}()
 	}
 	wg.Wait()
+	require.False(t, sawNil.Load(), "MemStats must never return nil")
 }
 
 func TestStartMemStatsTracker(t *testing.T) {
 	resetMemStatsState(t)
 	MemStatsRefresh = time.Millisecond
 
-	baseline := runtime.NumGoroutine()
+	// Snapshot pre-existing goroutines so goleak only flags the tracker if it
+	// fails to exit after cancel.
+	ignoreExisting := goleak.IgnoreCurrent()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	sys, curAllocs, totalAllocs, gcPauseNs := StartMemStatsTracker(ctx)
@@ -98,32 +111,29 @@ func TestStartMemStatsTracker(t *testing.T) {
 	require.NotNil(t, totalAllocs)
 	require.NotNil(t, gcPauseNs)
 
-	// Allocate some garbage so the tracker observes non-zero values.
+	// Allocate live heap so the tracker observes non-trivial Alloc/Sys, and
+	// force a GC so PauseTotalNs becomes non-zero.
 	sink := make([][]byte, 0, 128)
 	for range 128 {
 		sink = append(sink, make([]byte, 1<<16))
 	}
+	runtime.GC() //nolint:revive // explicit GC populates PauseTotalNs for the gcPauseNs assertion
 	runtime.KeepAlive(sink)
 
+	// All four peaks must be populated, including curAllocs and gcPauseNs,
+	// which are the values the exit-branch refresh fix targets.
 	require.Eventually(t, func() bool {
-		return sys.Load() > 0 && totalAllocs.Load() > 0
-	}, 2*time.Second, time.Millisecond, "tracker should populate sys and totalAllocs")
+		return sys.Load() > 0 && curAllocs.Load() > 0 &&
+			totalAllocs.Load() > 0 && gcPauseNs.Load() > 0
+	}, 2*time.Second, time.Millisecond, "tracker should populate all four peak values")
 
-	// Cancel and confirm the tracker goroutine exits (no leak). Its final
-	// pass does an uncached ReadMemStats, so values must remain sensible. Poll
-	// in this goroutine (not via require.Eventually, whose own poller goroutine
-	// would skew the count) until the goroutine total returns to baseline.
+	// Cancel and confirm the tracker goroutine exits (no leak). goleak retries
+	// with backoff, so it absorbs the goroutine's shutdown latency.
 	cancel()
-	var exited bool
-	for deadline := time.Now().Add(2 * time.Second); time.Now().Before(deadline); {
-		if runtime.NumGoroutine() <= baseline {
-			exited = true
-			break
-		}
-		time.Sleep(5 * time.Millisecond)
-	}
-	require.True(t, exited, "tracker goroutine should exit when ctx is done")
+	goleak.VerifyNone(t, ignoreExisting)
 
 	require.Positive(t, sys.Load())
+	require.Positive(t, curAllocs.Load())
 	require.Positive(t, totalAllocs.Load())
+	require.Positive(t, gcPauseNs.Load())
 }

--- a/libsq/core/runtimez/runtimez_test.go
+++ b/libsq/core/runtimez/runtimez_test.go
@@ -1,0 +1,129 @@
+package runtimez
+
+import (
+	"context"
+	"runtime"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// resetMemStatsState restores the package-level mem-stats cache to its zero
+// state and restores MemStatsRefresh when the test completes. Tests that touch
+// the global cache must call this and must not run in parallel with each other.
+func resetMemStatsState(t *testing.T) {
+	t.Helper()
+	prevRefresh := MemStatsRefresh
+	memStatsMu.Lock()
+	memStats = nil
+	memStatsNextRefresh = time.Time{}
+	memStatsMu.Unlock()
+	t.Cleanup(func() {
+		MemStatsRefresh = prevRefresh
+		memStatsMu.Lock()
+		memStats = nil
+		memStatsNextRefresh = time.Time{}
+		memStatsMu.Unlock()
+	})
+}
+
+func TestMemStats_NonNil(t *testing.T) {
+	resetMemStatsState(t)
+	require.NotNil(t, MemStats())
+}
+
+func TestMemStats_Caches(t *testing.T) {
+	resetMemStatsState(t)
+	// A long refresh window means the second call must return the cached
+	// instance, i.e. the identical pointer.
+	MemStatsRefresh = time.Hour
+
+	p1 := MemStats()
+	require.NotNil(t, p1)
+	p2 := MemStats()
+	require.Same(t, p1, p2, "stats should be cached within the refresh window")
+}
+
+func TestMemStats_Refresh(t *testing.T) {
+	resetMemStatsState(t)
+	MemStatsRefresh = time.Hour
+
+	p1 := MemStats()
+	require.NotNil(t, p1)
+
+	// Force the next-refresh deadline into the past; the next call must
+	// re-read, yielding a fresh (different) instance.
+	memStatsMu.Lock()
+	memStatsNextRefresh = time.Now().Add(-time.Hour)
+	memStatsMu.Unlock()
+
+	p2 := MemStats()
+	require.NotNil(t, p2)
+	require.NotSame(t, p1, p2, "stats should be refreshed after the window elapses")
+}
+
+// TestMemStats_Concurrent hammers MemStats from many goroutines with a tiny
+// refresh window so refreshes interleave with reads. Run under -race, this
+// guards against an unsynchronized read of the shared memStats pointer.
+func TestMemStats_Concurrent(t *testing.T) {
+	resetMemStatsState(t)
+	MemStatsRefresh = time.Nanosecond
+
+	const goroutines = 16
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for range goroutines {
+		go func() {
+			defer wg.Done()
+			for range 1000 {
+				require.NotNil(t, MemStats())
+			}
+		}()
+	}
+	wg.Wait()
+}
+
+func TestStartMemStatsTracker(t *testing.T) {
+	resetMemStatsState(t)
+	MemStatsRefresh = time.Millisecond
+
+	baseline := runtime.NumGoroutine()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	sys, curAllocs, totalAllocs, gcPauseNs := StartMemStatsTracker(ctx)
+	require.NotNil(t, sys)
+	require.NotNil(t, curAllocs)
+	require.NotNil(t, totalAllocs)
+	require.NotNil(t, gcPauseNs)
+
+	// Allocate some garbage so the tracker observes non-zero values.
+	sink := make([][]byte, 0, 128)
+	for range 128 {
+		sink = append(sink, make([]byte, 1<<16))
+	}
+	runtime.KeepAlive(sink)
+
+	require.Eventually(t, func() bool {
+		return sys.Load() > 0 && totalAllocs.Load() > 0
+	}, 2*time.Second, time.Millisecond, "tracker should populate sys and totalAllocs")
+
+	// Cancel and confirm the tracker goroutine exits (no leak). Its final
+	// pass does an uncached ReadMemStats, so values must remain sensible. Poll
+	// in this goroutine (not via require.Eventually, whose own poller goroutine
+	// would skew the count) until the goroutine total returns to baseline.
+	cancel()
+	var exited bool
+	for deadline := time.Now().Add(2 * time.Second); time.Now().Before(deadline); {
+		if runtime.NumGoroutine() <= baseline {
+			exited = true
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	require.True(t, exited, "tracker goroutine should exit when ctx is done")
+
+	require.Positive(t, sys.Load())
+	require.Positive(t, totalAllocs.Load())
+}


### PR DESCRIPTION
Deep review of the previously untested `runtimez` package, with fixes for the bugs it surfaced.

## Fixes

- **Data race in `MemStats()`** — the shared `memStats` pointer was read after the mutex was released, racing a concurrent refresh. It's now captured into a local under the lock. `MemStats()` is called from the progress-bar widget goroutine while the tracker goroutine refreshes, so this was reachable.
- **Stale-store on exit in `StartMemStatsTracker`** — the `ctx.Done()` branch tested the fresh `ms.Sys` but stored the stale cached `stats.Sys`, defeating the "fresh values on exit" intent. It now stores `ms.Sys`, and also refreshes `curAllocs` on exit for consistency with the other peak values.
- **Stale godoc** — `StartMemStatsTracker` referenced a nonexistent `sampleFreq` parameter. Corrected to describe sampling via `MemStatsRefresh`, and documented `Alloc` among the tracked peaks.

## Tests

The package had no tests. `runtimez_test.go` adds:

- `MemStats` lazy init, caching within the refresh window (`require.Same`), and refresh after it elapses.
- A `-race` concurrency guard (16 goroutines x 1000 calls) — confirmed to trip `WARNING: DATA RACE` when the `MemStats` fix is reverted.
- `StartMemStatsTracker` lifecycle: non-nil atomics, populated values, and a no-leak shutdown check on `ctx` cancel.

A `resetMemStatsState` helper saves/restores the global `MemStatsRefresh` and resets the cache around each test, since the package state is global (tests are intentionally non-parallel).

Verified: `go test -race` passes, stable over `-count=5`, `golangci-lint` reports 0 issues.