### PR TITLE
test(langz): reach 100% coverage and clarify docs

### DIFF
--- a/libsq/core/langz/langz.go
+++ b/libsq/core/langz/langz.go
@@ -29,7 +29,7 @@ func Apply[T any](collection []T, fn func(item T) T) []T {
 
 // MustTypedSlice calls TypedSlice, but panics if the conversion fails.
 func MustTypedSlice[T, S any](in ...S) []T {
-	out, ok := TypedSlice[T, S](in...)
+	out, ok := TypedSlice[T](in...)
 	if !ok {
 		var s S
 		var t T
@@ -189,7 +189,7 @@ func ZeroIfNil[T comparable](t *T) T {
 // from ch, or false otherwise. This is useful for a succinct
 // "if done" idiom, e.g.:
 //
-//	if someCondition && loz.Take(doneCh) {
+//	if someCondition && langz.Take(doneCh) {
 //		return
 //	}
 //
@@ -211,6 +211,10 @@ func Take[C any](ch <-chan C) bool {
 
 // Remove returns a slice without v, preserving order. If order is not
 // important, use RemoveUnordered instead, as it's faster.
+//
+// The input slice a is modified in place: its backing array is shifted to
+// close the gap, leaving a stale element at the old tail. Callers must use
+// the returned slice and not retain references to a.
 func Remove[T any](a []*T, v *T) []*T {
 	// https://stackoverflow.com/a/37335777/6004734
 	for i := range a {
@@ -223,6 +227,10 @@ func Remove[T any](a []*T, v *T) []*T {
 
 // RemoveUnordered returns a slice without v, but order is not
 // guaranteed to preserved. If order is important, use Remove instead.
+//
+// The input slice a is modified in place: the removed element is overwritten
+// with the tail element, leaving a stale element at the old tail. Callers must
+// use the returned slice and not retain references to a.
 func RemoveUnordered[T any](a []*T, v *T) []*T {
 	// https://stackoverflow.com/a/37335777/6004734
 	for i := range a {

--- a/libsq/core/langz/langz.go
+++ b/libsq/core/langz/langz.go
@@ -226,7 +226,7 @@ func Remove[T any](a []*T, v *T) []*T {
 }
 
 // RemoveUnordered returns a slice without v, but order is not
-// guaranteed to preserved. If order is important, use Remove instead.
+// guaranteed to be preserved. If order is important, use Remove instead.
 //
 // The input slice a is modified in place: the removed element is overwritten
 // with the tail element, leaving a stale element at the old tail. Callers must

--- a/libsq/core/langz/langz_test.go
+++ b/libsq/core/langz/langz_test.go
@@ -47,6 +47,29 @@ func TestTypedSlice(t *testing.T) {
 	require.True(t, ok)
 	require.Len(t, strs, 2)
 	require.Equal(t, []string{"hello", "world"}, strs)
+
+	// Empty input yields an empty (non-nil) slice and ok=true.
+	got, ok := langz.TypedSlice[string, any]()
+	require.True(t, ok)
+	require.NotNil(t, got)
+	require.Empty(t, got)
+
+	// A failed conversion returns nil, false.
+	mixed := []any{"hello", 42}
+	got, ok = langz.TypedSlice[string](mixed...)
+	require.False(t, ok)
+	require.Nil(t, got)
+}
+
+func TestMustTypedSlice(t *testing.T) {
+	bufs := []*bytes.Buffer{new(bytes.Buffer), new(bytes.Buffer)}
+	rdrs := langz.MustTypedSlice[io.Reader](bufs...)
+	require.Len(t, rdrs, 2)
+
+	require.Panics(t, func() {
+		mixed := []any{"hello", 42}
+		_ = langz.MustTypedSlice[string](mixed...)
+	}, "should panic when a conversion fails")
 }
 
 func TestApply(t *testing.T) {
@@ -109,6 +132,134 @@ func TestIsSliceZeroed(t *testing.T) {
 	require.False(t, langz.IsSliceZeroed([]int{0, 1}))
 	require.True(t, langz.IsSliceZeroed([]string{"", ""}))
 	require.False(t, langz.IsSliceZeroed([]string{"", "a"}))
+}
+
+func TestJoinSlices(t *testing.T) {
+	// Always returns a new, non-nil slice, even for all-nil input.
+	got := langz.JoinSlices[int](nil)
+	require.NotNil(t, got)
+	require.Empty(t, got)
+
+	got = langz.JoinSlices[int](nil, nil, nil)
+	require.NotNil(t, got)
+	require.Empty(t, got)
+
+	// Order is preserved across the input slices.
+	got = langz.JoinSlices([]int{1, 2}, []int{3}, []int{4, 5})
+	require.Equal(t, []int{1, 2, 3, 4, 5}, got)
+
+	// No others; result is a copy, not the same backing array.
+	a := []int{1, 2, 3}
+	got = langz.JoinSlices(a)
+	require.Equal(t, a, got)
+	got[0] = 99
+	require.Equal(t, []int{1, 2, 3}, a, "input slice must not be modified")
+}
+
+func TestMake(t *testing.T) {
+	require.Equal(t, []int{}, langz.Make(0, 7))
+	require.Equal(t, []int{7, 7, 7}, langz.Make(3, 7))
+	require.Equal(t, []string{"x", "x"}, langz.Make(2, "x"))
+}
+
+func TestNilIfZero(t *testing.T) {
+	require.Nil(t, langz.NilIfZero(0))
+	require.Nil(t, langz.NilIfZero(""))
+
+	got := langz.NilIfZero(42)
+	require.NotNil(t, got)
+	require.Equal(t, 42, *got)
+
+	gotStr := langz.NilIfZero("hello")
+	require.NotNil(t, gotStr)
+	require.Equal(t, "hello", *gotStr)
+}
+
+func TestZeroIfNil(t *testing.T) {
+	require.Equal(t, 0, langz.ZeroIfNil[int](nil))
+	require.Equal(t, "", langz.ZeroIfNil[string](nil))
+
+	v := 42
+	require.Equal(t, 42, langz.ZeroIfNil(&v))
+	s := "hello"
+	require.Equal(t, "hello", langz.ZeroIfNil(&s))
+}
+
+func TestTake(t *testing.T) {
+	// Nil channel returns false.
+	var nilCh chan struct{}
+	require.False(t, langz.Take(nilCh))
+
+	// Open channel with no value available returns false.
+	openCh := make(chan struct{})
+	require.False(t, langz.Take(openCh))
+
+	// Buffered channel with a value available returns true.
+	bufCh := make(chan int, 1)
+	bufCh <- 1
+	require.True(t, langz.Take(bufCh))
+	// Value was consumed, so a second take returns false.
+	require.False(t, langz.Take(bufCh))
+
+	// Closed channel always returns true.
+	closedCh := make(chan struct{})
+	close(closedCh)
+	require.True(t, langz.Take(closedCh))
+}
+
+func TestRemove(t *testing.T) {
+	// Distinct underlying values so testify's reflect.DeepEqual-based
+	// matchers don't treat the pointers as equal.
+	v1, v2, v3, v4 := 1, 2, 3, 4
+	a, b, c, d := &v1, &v2, &v3, &v4
+
+	// Removes the element, preserving order.
+	got := langz.Remove([]*int{a, b, c}, b)
+	require.Equal(t, []*int{a, c}, got)
+
+	// Element not present: slice returned unchanged.
+	got = langz.Remove([]*int{a, c}, d)
+	require.Equal(t, []*int{a, c}, got)
+
+	// Empty slice.
+	got = langz.Remove([]*int{}, a)
+	require.Empty(t, got)
+}
+
+func TestRemoveUnordered(t *testing.T) {
+	v1, v2, v3, v4 := 1, 2, 3, 4
+	a, b, c, d := &v1, &v2, &v3, &v4
+
+	// Removes the element (order not guaranteed).
+	got := langz.RemoveUnordered([]*int{a, b, c}, b)
+	require.Len(t, got, 2)
+	require.NotContains(t, got, b)
+	require.Contains(t, got, a)
+	require.Contains(t, got, c)
+
+	// Element not present: slice returned unchanged.
+	got = langz.RemoveUnordered([]*int{a, c}, d)
+	require.Equal(t, []*int{a, c}, got)
+
+	// Empty slice.
+	got = langz.RemoveUnordered([]*int{}, a)
+	require.Empty(t, got)
+}
+
+func TestCond(t *testing.T) {
+	require.Equal(t, "yes", langz.Cond(true, "yes", "no"))
+	require.Equal(t, "no", langz.Cond(false, "yes", "no"))
+	require.Equal(t, 1, langz.Cond(true, 1, 2))
+	require.Equal(t, 2, langz.Cond(false, 1, 2))
+}
+
+func TestNonEmptyOf(t *testing.T) {
+	require.Equal(t, "a", langz.NonEmptyOf("a", "b"))
+	require.Equal(t, "b", langz.NonEmptyOf("", "b"))
+	require.Equal(t, 1, langz.NonEmptyOf(1, 2))
+	require.Equal(t, 2, langz.NonEmptyOf(0, 2))
+	// Both zero: returns b (also zero).
+	require.Equal(t, 0, langz.NonEmptyOf(0, 0))
 }
 
 func TestNewErrorAfterNReader_Read(t *testing.T) {


### PR DESCRIPTION
Deep review of `libsq/core/langz`, focused on closing test gaps.

## Tests
Added coverage for the previously untested functions (`JoinSlices`, `Make`,
`NilIfZero`, `ZeroIfNil`, `Take`, `Remove`, `RemoveUnordered`, `Cond`,
`NonEmptyOf`) plus the panic path of `MustTypedSlice` and the empty-input /
failed-conversion branches of `TypedSlice`. Statement coverage goes from
**56% to 100%**.

## Doc and code fixes
- Fix a wrong package prefix in the `Take` example (`loz.Take` -> `langz.Take`).
- Document that `Remove` and `RemoveUnordered` modify the input slice in place,
  leaving a stale element at the old tail. This is the one real footgun in the
  package; callers must use the returned slice and not retain the input.
- Drop a redundant type argument in `MustTypedSlice` (`infertypeargs`).

No behavior change; internal package, so no CHANGELOG entry.