### PR TITLE
test(termz): reach 100% coverage and dedup IsTerminal

### DIFF
--- a/libsq/core/termz/termz.go
+++ b/libsq/core/termz/termz.go
@@ -1,5 +1,3 @@
-//go:build !windows
-
 // Package termz contains a handful of terminal utilities.
 package termz
 
@@ -18,26 +16,4 @@ func IsTerminal(w io.Writer) bool {
 	default:
 		return false
 	}
-}
-
-// IsColorTerminal returns true if w is a colorable terminal.
-// It respects [NO_COLOR], [FORCE_COLOR] and TERM=dumb environment variables.
-//
-// [NO_COLOR]: https://no-color.org/
-// [FORCE_COLOR]: https://force-color.org/
-func IsColorTerminal(w io.Writer) bool {
-	if enabled, ok := colorEnvOverride(); ok {
-		return enabled
-	}
-
-	if w == nil {
-		return false
-	}
-
-	f, ok := w.(*os.File)
-	if !ok {
-		return false
-	}
-
-	return term.IsTerminal(int(f.Fd()))
 }

--- a/libsq/core/termz/termz_test.go
+++ b/libsq/core/termz/termz_test.go
@@ -2,10 +2,45 @@ package termz
 
 import (
 	"bytes"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
+
+// TestIsTerminal verifies IsTerminal for the non-terminal cases. A non-*os.File
+// writer hits the default branch, and a regular file is an *os.File that is not
+// a terminal. A real terminal cannot be synthesized here, so the true path is
+// only exercised by interactive use.
+func TestIsTerminal(t *testing.T) {
+	// Non-*os.File writer hits the default branch.
+	require.False(t, IsTerminal(&bytes.Buffer{}))
+
+	// A regular file is an *os.File, but not a terminal.
+	f, err := os.CreateTemp(t.TempDir(), "termz")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = f.Close() })
+	require.False(t, IsTerminal(f))
+
+	// A nil writer must not panic, and is not a terminal.
+	require.False(t, IsTerminal(nil))
+}
+
+// TestIsColorTerminal_FileWriter verifies that, absent any env override, a
+// regular *os.File (not a terminal) is not reported as a color terminal. This
+// exercises the terminal-detection fall-through that the buffer-based cases in
+// TestIsColorTerminal_EnvOverrides never reach.
+func TestIsColorTerminal_FileWriter(t *testing.T) {
+	t.Setenv("NO_COLOR", "")
+	t.Setenv("FORCE_COLOR", "")
+	t.Setenv("TERM", "")
+
+	f, err := os.CreateTemp(t.TempDir(), "termz")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = f.Close() })
+
+	require.False(t, IsColorTerminal(f))
+}
 
 // TestIsColorTerminal_EnvOverrides verifies that IsColorTerminal honors the
 // NO_COLOR, FORCE_COLOR, and TERM environment variables. A bytes.Buffer (not an

--- a/libsq/core/termz/termz_test.go
+++ b/libsq/core/termz/termz_test.go
@@ -24,6 +24,11 @@ func TestIsTerminal(t *testing.T) {
 
 	// A nil writer must not panic, and is not a terminal.
 	require.False(t, IsTerminal(nil))
+
+	// A typed-nil *os.File must not panic either: (*os.File).Fd() is nil-safe
+	// (it returns ^uintptr(0)), so this resolves to a non-terminal fd.
+	var nilFile *os.File
+	require.NotPanics(t, func() { require.False(t, IsTerminal(nilFile)) })
 }
 
 // TestIsColorTerminal_FileWriter verifies that, absent any env override, a
@@ -40,6 +45,11 @@ func TestIsColorTerminal_FileWriter(t *testing.T) {
 	t.Cleanup(func() { _ = f.Close() })
 
 	require.False(t, IsColorTerminal(f))
+
+	// A typed-nil *os.File must not panic: the nil-interface guard does not
+	// catch it, but (*os.File).Fd() is nil-safe and resolves to a non-terminal.
+	var nilFile *os.File
+	require.NotPanics(t, func() { require.False(t, IsColorTerminal(nilFile)) })
 }
 
 // TestIsColorTerminal_EnvOverrides verifies that IsColorTerminal honors the

--- a/libsq/core/termz/termz_unix.go
+++ b/libsq/core/termz/termz_unix.go
@@ -1,0 +1,32 @@
+//go:build !windows
+
+package termz
+
+import (
+	"io"
+	"os"
+
+	"golang.org/x/term"
+)
+
+// IsColorTerminal returns true if w is a colorable terminal.
+// It respects [NO_COLOR], [FORCE_COLOR] and TERM=dumb environment variables.
+//
+// [NO_COLOR]: https://no-color.org/
+// [FORCE_COLOR]: https://force-color.org/
+func IsColorTerminal(w io.Writer) bool {
+	if enabled, ok := colorEnvOverride(); ok {
+		return enabled
+	}
+
+	if w == nil {
+		return false
+	}
+
+	f, ok := w.(*os.File)
+	if !ok {
+		return false
+	}
+
+	return term.IsTerminal(int(f.Fd()))
+}

--- a/libsq/core/termz/termz_windows.go
+++ b/libsq/core/termz/termz_windows.go
@@ -5,18 +5,7 @@ import (
 	"os"
 
 	"golang.org/x/sys/windows"
-	"golang.org/x/term"
 )
-
-// IsTerminal returns true if w is a terminal.
-func IsTerminal(w io.Writer) bool {
-	switch v := w.(type) {
-	case *os.File:
-		return term.IsTerminal(int(v.Fd()))
-	default:
-		return false
-	}
-}
 
 // IsColorTerminal returns true if w is a colorable terminal.
 // It respects [NO_COLOR], [FORCE_COLOR] and TERM=dumb environment variables.


### PR DESCRIPTION
## Summary

Brings `libsq/core/termz` to 100% statement coverage and removes a duplicated function.

### Testing gaps closed
- `IsTerminal` had **no test at all** (0% coverage). Added `TestIsTerminal` covering the default (non-`*os.File`) branch, an `*os.File`-but-not-a-terminal branch (temp file), and a `nil` writer (which must not panic).
- `IsColorTerminal` was at 87.5%: every existing case used a `bytes.Buffer` or `nil`, so the result was always decided by an env override or the non-file branch. Added `TestIsColorTerminal_FileWriter` to exercise the `*os.File` terminal-detection fall-through.

Coverage on non-Windows is now **100.0%** of statements.

### Dedup refactor
`IsTerminal` was byte-for-byte identical in `termz.go` (`!windows`) and `termz_windows.go`, even though `term.IsTerminal` is cross-platform. The two copies could silently drift. Layout now:

- `termz.go` (no build tag) — package doc + `IsTerminal` (single cross-platform impl).
- `termz_unix.go` (`!windows`) — `IsColorTerminal` (term-detection version).
- `termz_windows.go` (`windows`) — `IsColorTerminal` (console-mode version); dropped the duplicate `IsTerminal` and its now-unused `golang.org/x/term` import.
- `termz_color.go` — `colorEnvOverride`, unchanged.

`TestIsTerminal` now guards the one shared implementation on every platform.

### Verification
- `go test ./libsq/core/termz/` — pass, 100.0% coverage.
- `GOOS=windows go build ./libsq/core/termz/` — OK.
- `golangci-lint run` on both unix and `GOOS=windows` — 0 issues.

### Known residual gaps (inherent, not closable with portable tests)
- The Windows `IsColorTerminal` console-mode path (`GetConsoleMode`/`SetConsoleMode`) has no coverage without a Windows CI runner.
- The "true" return of both functions can't be exercised without a real TTY.