### PR TITLE
test(debugz): add coverage and honor ctx cancellation in DebugSleep

### DIFF
--- a/libsq/core/debugz/debugz.go
+++ b/libsq/core/debugz/debugz.go
@@ -31,12 +31,20 @@ progress is not enabled. This is useful for testing the progress impl.`,
 )
 
 // DebugSleep sleeps for a period of time to facilitate testing the
-// progress impl. It uses the value from OptProgressDebugSleep. This function
-// (and OptProgressDebugSleep) should be removed when the progress impl is
-// stable.
+// progress impl. It uses the value from OptProgressDebugSleep. The sleep is
+// interrupted if ctx is canceled. This function (and OptProgressDebugSleep)
+// should be removed when the progress impl is stable.
 func DebugSleep(ctx context.Context) {
 	sleep := OptProgressDebugSleep.Get(options.FromContext(ctx))
-	if sleep > 0 {
-		time.Sleep(sleep)
+	if sleep <= 0 {
+		return
+	}
+
+	t := time.NewTimer(sleep)
+	defer t.Stop()
+
+	select {
+	case <-ctx.Done():
+	case <-t.C:
 	}
 }

--- a/libsq/core/debugz/debugz_test.go
+++ b/libsq/core/debugz/debugz_test.go
@@ -41,6 +41,11 @@ func TestOptProgressDebugForce(t *testing.T) {
 	require.True(t, opt.Get(o))
 }
 
+// TestDebugSleep covers the DebugSleep branches. Its subtests measure short
+// wall-clock intervals, so they deliberately don't run in parallel: scheduler
+// jitter would make the timing assertions flaky.
+//
+//nolint:tparallel // Subtests are timing-sensitive; see the doc comment above.
 func TestDebugSleep(t *testing.T) {
 	t.Parallel()
 
@@ -57,9 +62,10 @@ func TestDebugSleep(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+		// Note: these subtests deliberately don't call t.Parallel(). They
+		// measure short wall-clock intervals, and parallel scheduler delays
+		// can push a no-sleep case past its upper bound, causing flakiness.
 		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-
 			ctx := context.Background()
 			if tc.setOpt {
 				ctx = options.NewContext(ctx,
@@ -73,7 +79,10 @@ func TestDebugSleep(t *testing.T) {
 			if tc.wantSleep {
 				require.GreaterOrEqual(t, elapsed, tc.sleep)
 			} else {
-				require.Less(t, elapsed, 50*time.Millisecond)
+				// Generous upper bound: we only need to prove DebugSleep
+				// didn't block for the configured duration, without being
+				// sensitive to scheduler jitter under -race or loaded CI.
+				require.Less(t, elapsed, 5*time.Second)
 			}
 		})
 	}
@@ -85,6 +94,7 @@ func TestDebugSleep_canceled(t *testing.T) {
 	t.Parallel()
 
 	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	ctx = options.NewContext(ctx,
 		options.Options{debugz.OptProgressDebugSleep.Key(): 30 * time.Second})
 

--- a/libsq/core/debugz/debugz_test.go
+++ b/libsq/core/debugz/debugz_test.go
@@ -1,0 +1,100 @@
+package debugz_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/neilotoole/sq/libsq/core/debugz"
+	"github.com/neilotoole/sq/libsq/core/options"
+)
+
+func TestOptProgressDebugSleep(t *testing.T) {
+	opt := debugz.OptProgressDebugSleep
+	require.Equal(t, "debug.progress.sleep", opt.Key())
+	require.Equal(t, time.Duration(0), opt.Default())
+	require.NotEmpty(t, opt.Usage())
+	require.NotEmpty(t, opt.Help())
+
+	// Default (nil options) is zero.
+	require.Equal(t, time.Duration(0), opt.Get(nil))
+
+	// Explicit value is returned.
+	o := options.Options{opt.Key(): time.Second}
+	require.Equal(t, time.Second, opt.Get(o))
+}
+
+func TestOptProgressDebugForce(t *testing.T) {
+	opt := debugz.OptProgressDebugForce
+	require.Equal(t, "debug.progress.force", opt.Key())
+	require.False(t, opt.Default())
+	require.NotEmpty(t, opt.Usage())
+	require.NotEmpty(t, opt.Help())
+
+	// Default (nil options) is false.
+	require.False(t, opt.Get(nil))
+
+	// Explicit value is returned.
+	o := options.Options{opt.Key(): true}
+	require.True(t, opt.Get(o))
+}
+
+func TestDebugSleep(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name      string
+		sleep     time.Duration
+		setOpt    bool
+		wantSleep bool
+	}{
+		{name: "no_options", setOpt: false, wantSleep: false},
+		{name: "zero", sleep: 0, setOpt: true, wantSleep: false},
+		{name: "negative", sleep: -time.Second, setOpt: true, wantSleep: false},
+		{name: "positive", sleep: 50 * time.Millisecond, setOpt: true, wantSleep: true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := context.Background()
+			if tc.setOpt {
+				ctx = options.NewContext(ctx,
+					options.Options{debugz.OptProgressDebugSleep.Key(): tc.sleep})
+			}
+
+			start := time.Now()
+			debugz.DebugSleep(ctx)
+			elapsed := time.Since(start)
+
+			if tc.wantSleep {
+				require.GreaterOrEqual(t, elapsed, tc.sleep)
+			} else {
+				require.Less(t, elapsed, 50*time.Millisecond)
+			}
+		})
+	}
+}
+
+// TestDebugSleep_canceled verifies that a canceled context interrupts the
+// sleep rather than blocking for the full duration.
+func TestDebugSleep_canceled(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	ctx = options.NewContext(ctx,
+		options.Options{debugz.OptProgressDebugSleep.Key(): 30 * time.Second})
+
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		cancel()
+	}()
+
+	start := time.Now()
+	debugz.DebugSleep(ctx)
+	require.Less(t, time.Since(start), 5*time.Second,
+		"DebugSleep should return promptly when ctx is canceled")
+}


### PR DESCRIPTION
## What

The `debugz` package had **no tests** despite `DebugSleep` being called from ~40 sites across every SQL driver. This PR adds `debugz_test.go` reaching **100% statement coverage**, and fixes a latent bug found during review.

## Changes

- **Tests:** cover the `OptProgressDebugSleep` / `OptProgressDebugForce` option declarations and all `DebugSleep` branches (no options, zero, negative, positive, and cancellation). Passes under `-race`.
- **Fix:** `DebugSleep` now honors context cancellation. It previously used a bare `time.Sleep` that ignored `ctx`, so a canceled operation would keep sleeping for the full configured duration. Replaced with a `time.Timer` plus a `select` on `ctx.Done()`.

## Notes

`debugz` is debug-only scaffolding slated for removal once the progress impl stabilizes, so no CHANGELOG entry (no user-visible behavior change).

Verified: `go test -race -cover` → 100.0%, `golangci-lint` → 0 issues.