### PR TITLE
ioz/scannerz: fix LineCount error handling; tests to 100% coverage

### DIFF
--- a/libsq/core/ioz/scannerz/lines.go
+++ b/libsq/core/ioz/scannerz/lines.go
@@ -91,23 +91,16 @@ func LineCount(ctx context.Context, r io.Reader, skipEmpty bool) int {
 
 	sc := NewScanner(ctx, r)
 	var i int
-
-	if skipEmpty {
-		for sc.Scan() {
-			if len(sc.Bytes()) > 0 {
-				i++
-			}
+	for sc.Scan() {
+		if !skipEmpty || len(sc.Bytes()) > 0 {
+			i++
 		}
-
-		if sc.Err() != nil {
-			return -1
-		}
-
-		return i
 	}
 
-	for i = 0; sc.Scan(); i++ { //nolint:revive
-		// no-op
+	// Honor the doc contract: -1 on any scan error (e.g. a line exceeding the
+	// scan buffer limit, or an underlying read error), for both modes.
+	if sc.Err() != nil {
+		return -1
 	}
 
 	return i

--- a/libsq/core/ioz/scannerz/lines_test.go
+++ b/libsq/core/ioz/scannerz/lines_test.go
@@ -2,6 +2,7 @@ package scannerz_test
 
 import (
 	"context"
+	"errors"
 	"strconv"
 	"strings"
 	"testing"
@@ -60,6 +61,43 @@ func TestLineCount(t *testing.T) {
 			require.Equal(t, tc.skipEmpty, count)
 		})
 	}
+}
+
+func TestLineCount_readError(t *testing.T) {
+	ctx := context.Background()
+	sentinel := errors.New("read boom")
+
+	// An immediate read error yields -1 in both modes.
+	for _, skipEmpty := range []bool{false, true} {
+		require.Equal(t, -1, scannerz.LineCount(ctx, errReader{err: sentinel}, skipEmpty))
+	}
+
+	// A read error partway through must also yield -1, not a partial count.
+	// (Regression guard: the non-skipEmpty path previously ignored sc.Err().)
+	for _, skipEmpty := range []bool{false, true} {
+		r := &readThenErr{p: []byte("one\ntwo\n"), err: sentinel}
+		require.Equal(t, -1, scannerz.LineCount(ctx, r, skipEmpty))
+	}
+}
+
+// errReader always fails Read with err.
+type errReader struct{ err error }
+
+func (r errReader) Read([]byte) (int, error) { return 0, r.err }
+
+// readThenErr yields p on the first Read, then fails with err.
+type readThenErr struct {
+	p    []byte
+	err  error
+	done bool
+}
+
+func (r *readThenErr) Read(b []byte) (int, error) {
+	if r.done {
+		return 0, r.err
+	}
+	r.done = true
+	return copy(b, r.p), nil
 }
 
 func TestVisitLines(t *testing.T) {


### PR DESCRIPTION
Fourth in the `ioz` sub-package review series (after #889 lockfile, #890
contextio, #892 checksum). The `scannerz` package was at 98% coverage.

## Fix

`LineCount`'s doc says *"If r is nil or any error occurs, -1 is returned"*, but
only the `skipEmpty=true` path checked `sc.Err()`. The `skipEmpty=false` path
ran `for i = 0; sc.Scan(); i++ {}` and returned `i` without ever checking the
scanner error, so a scan failure (a line exceeding the scan-buffer limit ->
`bufio.ErrTooLong`, or an underlying read error) returned a **partial count**
instead of `-1`, violating the contract.

Both paths are now unified to always check `sc.Err()` after the loop (which also
removes the duplicated scan loop):

```go
for sc.Scan() {
    if !skipEmpty || len(sc.Bytes()) > 0 {
        i++
    }
}
if sc.Err() != nil {
    return -1
}
return i
```

## Tests (98% -> 100%)

- `LineCount` error handling for both modes: an immediate read error, and a
  mid-stream read error (the latter guards the regression the `skipEmpty=false`
  path previously had).

The existing table tests already covered the empty/non-empty counting and the
nil-reader case; `Head1`, `TrimHead`, `VisitLines`, and `IndentLines` were
already fully covered.

## Verification

`go test -race ./libsq/core/ioz/scannerz/` passes at 100% coverage; downstream
consumers (`diffdoc`, `cli/output/...`) pass; `go build ./...`, `go vet`,
`golangci-lint` clean.