### PR TITLE
test(progress): cover io/lifecycle/group-bar; fix ReadFrom bar stop

### DIFF
--- a/libsq/core/progress/api_test.go
+++ b/libsq/core/progress/api_test.go
@@ -1,0 +1,229 @@
+package progress_test
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/neilotoole/sq/libsq/core/progress"
+)
+
+// TestNew_disabled verifies that a non-positive maxBars yields a nil Progress.
+func TestNew_disabled(t *testing.T) {
+	t.Parallel()
+
+	require.Nil(t, progress.New(context.Background(), io.Discard, 0, time.Millisecond, nil))
+	require.Nil(t, progress.New(context.Background(), io.Discard, -1, time.Millisecond, nil))
+}
+
+// TestNilProgress_safe verifies the documented contract that all exported
+// methods of Progress are safe to call on a nil Progress, and that the bars it
+// hands out are safe no-ops.
+func TestNilProgress_safe(t *testing.T) {
+	t.Parallel()
+
+	var p *progress.Progress
+	require.Nil(t, p)
+
+	require.NotPanics(t, func() {
+		buf := &bytes.Buffer{}
+		require.Same(t, buf, p.HideOnWriter(buf))
+
+		bars := []progress.Bar{
+			p.NewByteCounter("msg", -1),
+			p.NewByteCounter("msg", 100),
+			p.NewFilesizeCounter("msg", nil, "nonexistent"),
+			p.NewUnitCounter("msg", "rec"),
+			p.NewUnitTotalCounter("msg", "rec", 10),
+			p.NewWaiter("msg"),
+			p.NewTimeoutWaiter("msg", time.Now().Add(time.Minute)),
+		}
+		for _, b := range bars {
+			require.NotNil(t, b)
+			b.Incr(1)
+			b.Stop()
+		}
+
+		p.Stop()
+	})
+}
+
+// TestConstructors_smoke exercises each bar constructor against a live
+// Progress, covering both their determinate and indeterminate branches.
+func TestConstructors_smoke(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	p := progress.New(ctx, io.Discard, progress.DefaultMaxBars, time.Millisecond, nil)
+	t.Cleanup(p.Stop)
+
+	tmpFile := filepath.Join(t.TempDir(), "data.bin")
+	require.NoError(t, os.WriteFile(tmpFile, []byte("0123456789"), 0o600))
+	f, err := os.Open(tmpFile)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = f.Close() })
+
+	bars := []progress.Bar{
+		p.NewByteCounter("bytes indeterminate", -1),
+		p.NewByteCounter("bytes determinate", 1000),
+		p.NewFilesizeCounter("filesize from file", f, ""),
+		p.NewFilesizeCounter("filesize from path", nil, tmpFile),
+		p.NewFilesizeCounter("filesize missing", nil, "does-not-exist"),
+		p.NewUnitCounter("units", "rec"),
+		p.NewUnitCounter("units no unit", ""),
+		p.NewUnitTotalCounter("unit total", "sheet", 16),
+		p.NewUnitTotalCounter("unit total zero", "sheet", 0), // delegates to NewUnitCounter
+		p.NewWaiter("waiter"),
+		p.NewTimeoutWaiter("timeout future", time.Now().Add(time.Hour)),
+		p.NewTimeoutWaiter("timeout past", time.Now().Add(-time.Hour)),
+	}
+
+	for _, b := range bars {
+		require.NotNil(t, b)
+		b.Incr(3)
+		b.Stop()
+	}
+}
+
+// TestNewUnitTotalCounter_zeroTotal verifies that a non-positive total causes
+// NewUnitTotalCounter to behave like an indeterminate unit counter (i.e. it
+// still returns a usable bar).
+func TestNewUnitTotalCounter_zeroTotal(t *testing.T) {
+	t.Parallel()
+
+	p := progress.New(context.Background(), io.Discard, progress.DefaultMaxBars, time.Millisecond, nil)
+	t.Cleanup(p.Stop)
+
+	b := p.NewUnitTotalCounter("msg", "rec", 0)
+	require.NotNil(t, b)
+	b.Incr(1)
+	b.Stop()
+}
+
+// TestContext_FromContext covers the context accessors, including the nil and
+// missing-value paths.
+func TestContext_FromContext(t *testing.T) {
+	t.Parallel()
+
+	var nilCtx context.Context
+	require.Nil(t, progress.FromContext(nilCtx))
+	require.Nil(t, progress.FromContext(context.Background()))
+
+	p := progress.New(context.Background(), io.Discard, progress.DefaultMaxBars, time.Millisecond, nil)
+	t.Cleanup(p.Stop)
+
+	ctx := progress.NewContext(nilCtx, p)
+	require.Same(t, p, progress.FromContext(ctx))
+}
+
+// TestContext_Incr verifies that progress.Incr increments the Bar carried by
+// the context, and is safe on a nil context or a context without a Bar.
+func TestContext_Incr(t *testing.T) {
+	t.Parallel()
+
+	var nilCtx context.Context
+	require.NotPanics(t, func() {
+		progress.Incr(nilCtx, 1)               // nil context
+		progress.Incr(context.Background(), 1) // no bar in context
+		progress.Incr(progress.NewBarContext(nilCtx, nil), 1)
+	})
+
+	p := progress.New(context.Background(), io.Discard, progress.DefaultMaxBars, time.Hour, nil)
+	t.Cleanup(p.Stop)
+	// A long render delay keeps the background loop from creating a lifecycle,
+	// so the bar's group accounting is only mutated by this test.
+	p.SetNotBefore(time.Now().Add(time.Hour))
+
+	bar := p.NewByteCounter("msg", -1)
+	ctx := progress.NewBarContext(context.Background(), bar)
+	progress.Incr(ctx, 7)
+
+	delta, ok := progress.GroupIncrDelta(bar)
+	require.True(t, ok)
+	require.Equal(t, 7, delta)
+}
+
+// TestColors_EnableColor covers enabling and disabling color, plus the nil
+// receiver guard.
+func TestColors_EnableColor(t *testing.T) {
+	t.Parallel()
+
+	require.NotPanics(t, func() {
+		c := progress.DefaultColors()
+		c.EnableColor(true)
+		c.EnableColor(false)
+
+		var nilColors *progress.Colors
+		nilColors.EnableColor(true)
+		nilColors.EnableColor(false)
+	})
+}
+
+// TestGroupIncrDelta verifies the group-bar increment accounting: each call
+// returns only the delta accumulated since the previous call.
+func TestGroupIncrDelta(t *testing.T) {
+	t.Parallel()
+
+	p := progress.New(context.Background(), io.Discard, progress.DefaultMaxBars, time.Hour, nil)
+	t.Cleanup(p.Stop)
+	// Freeze the background loop so it never consumes the bar's deltas.
+	p.SetNotBefore(time.Now().Add(time.Hour))
+
+	bar := p.NewUnitCounter("msg", "rec")
+
+	delta, ok := progress.GroupIncrDelta(bar)
+	require.True(t, ok)
+	require.Equal(t, 0, delta, "no increments yet")
+
+	bar.Incr(10)
+	delta, _ = progress.GroupIncrDelta(bar)
+	require.Equal(t, 10, delta)
+
+	delta, _ = progress.GroupIncrDelta(bar)
+	require.Equal(t, 0, delta, "no new increments since last consume")
+
+	bar.Incr(5)
+	delta, _ = progress.GroupIncrDelta(bar)
+	require.Equal(t, 5, delta)
+}
+
+// TestGroupBar_partition drives the refresh machinery deterministically and
+// verifies that bars beyond the group threshold are routed into the invisible
+// (grouped) set. With maxBars=3 the group threshold is 2, so of 5 renderable
+// bars, 2 are visible and 3 are grouped.
+func TestGroupBar_partition(t *testing.T) {
+	t.Parallel()
+
+	const maxBars = 3
+	p := progress.New(context.Background(), io.Discard, maxBars, time.Millisecond, nil)
+	t.Cleanup(p.Stop)
+
+	const numBars = 5
+	bars := make([]progress.Bar, numBars)
+	for i := range bars {
+		bars[i] = p.NewWaiter("waiter")
+		// Make every bar immediately renderable.
+		require.True(t, progress.SetBarNotBefore(bars[i], time.Now().Add(-time.Hour)))
+		bars[i].Incr(1)
+	}
+	require.Equal(t, numBars, p.BarCount())
+
+	require.True(t, p.EnsureLife(), "lifecycle should have been established")
+
+	// A single deterministic refresh partitions the bars. Repeated background
+	// refreshes produce the same stable partition counts.
+	p.ForceRefresh(time.Now())
+
+	visible, invisible := p.ActiveBarCounts()
+	require.Equal(t, maxBars-1, visible, "visible bars capped at group threshold")
+	require.Equal(t, numBars-(maxBars-1), invisible, "overflow bars are grouped")
+
+	// The group bar's aggregate increment calculation must run without error.
+	require.GreaterOrEqual(t, p.CalculateGroupIncr(), 0)
+}

--- a/libsq/core/progress/api_test.go
+++ b/libsq/core/progress/api_test.go
@@ -165,6 +165,45 @@ func TestColors_EnableColor(t *testing.T) {
 	})
 }
 
+// TestHideOnWriter verifies that writing to the HideOnWriter-wrapped writer
+// passes bytes through, kills the live lifecycle (hiding the progress), and
+// pushes the next-show checkpoint out by the render delay.
+func TestHideOnWriter(t *testing.T) {
+	t.Parallel()
+
+	// A long render delay ensures that, once hidden, the background loop won't
+	// immediately recreate the lifecycle, keeping the assertions deterministic.
+	p := progress.New(context.Background(), io.Discard, progress.DefaultMaxBars, time.Hour, nil)
+	t.Cleanup(p.Stop)
+
+	bar := p.NewWaiter("waiter")
+	bar.Incr(1)
+	require.True(t, p.EnsureLife(), "lifecycle should have been established")
+	require.True(t, p.HasLife())
+
+	before := time.Now()
+	buf := &bytes.Buffer{}
+	w := p.HideOnWriter(buf)
+
+	n, err := w.Write([]byte("main output"))
+	require.NoError(t, err)
+	require.Equal(t, len("main output"), n)
+	require.Equal(t, "main output", buf.String())
+
+	require.False(t, p.HasLife(), "lifecycle should be killed after a write")
+	require.True(t, p.NotBefore().After(before),
+		"next-show checkpoint should be pushed past the write time")
+}
+
+// TestHideOnWriter_nilWriter verifies the guard for a nil underlying writer.
+func TestHideOnWriter_nilWriter(t *testing.T) {
+	t.Parallel()
+
+	p := progress.New(context.Background(), io.Discard, progress.DefaultMaxBars, time.Millisecond, nil)
+	t.Cleanup(p.Stop)
+	require.Nil(t, p.HideOnWriter(nil))
+}
+
 // TestGroupIncrDelta verifies the group-bar increment accounting: each call
 // returns only the delta accumulated since the previous call.
 func TestGroupIncrDelta(t *testing.T) {

--- a/libsq/core/progress/export_test.go
+++ b/libsq/core/progress/export_test.go
@@ -1,0 +1,109 @@
+package progress
+
+import "time"
+
+// This file exposes internals to the progress_test package (white-box tests)
+// so that the lifecycle, refresh, and group-bar machinery can be driven
+// deterministically without relying on real-time ticker behavior.
+
+// Export pure formatter functions for direct testing.
+var (
+	GroupBarCounterText  = groupBarCounterText
+	UnitCounterText      = unitCounterText
+	UnitTotalCounterText = unitTotalCounterText
+	TimeoutText          = timeoutText
+	MsgWidth             = msgWidth
+)
+
+// MsgMaxLen is the maximum message width, exported for tests.
+const MsgMaxLen = msgMaxLen
+
+// BarCount returns the number of non-destroyed bars tracked by p.
+func (p *Progress) BarCount() int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return len(p.allBars)
+}
+
+// EnsureLife blocks until the Progress has a live lifecycle, or returns false
+// if one couldn't be established within a reasonable number of attempts. It's
+// used by tests that need the refresh machinery to be active.
+func (p *Progress) EnsureLife() bool {
+	for range 200 {
+		p.mu.Lock()
+		life := p.life
+		p.mu.Unlock()
+		if life != nil && life.alive() {
+			return true
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	return false
+}
+
+// ForceRefresh synchronously runs one state-refresh iteration at time t,
+// bypassing the ticker. It requires a live lifecycle (see EnsureLife). It
+// returns true if the refresh loop signaled that it should stop.
+func (p *Progress) ForceRefresh(t time.Time) (stop bool) {
+	p.mu.Lock()
+	life := p.life
+	p.mu.Unlock()
+	if life == nil {
+		return true
+	}
+	return life.refreshState(t)
+}
+
+// ActiveBarCounts returns the number of visible and invisible (grouped) bars as
+// recorded by the most recent refresh.
+func (p *Progress) ActiveBarCounts() (visible, invisible int) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return len(p.activeVisibleBars), len(p.activeInvisibleBars)
+}
+
+// SetNotBefore sets the Progress's notBefore checkpoint, allowing tests to make
+// bars immediately renderable.
+func (p *Progress) SetNotBefore(t time.Time) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.notBefore = t
+}
+
+// BarNotBefore exposes a bar's render-delay checkpoint for tests.
+func BarNotBefore(b Bar) (time.Time, bool) {
+	vb, ok := b.(*virtualBar)
+	if !ok {
+		return time.Time{}, false
+	}
+	vb.mu.Lock()
+	defer vb.mu.Unlock()
+	return vb.notBefore, true
+}
+
+// SetBarNotBefore overrides a bar's render-delay checkpoint, making it
+// immediately renderable when set to the past.
+func SetBarNotBefore(b Bar, t time.Time) bool {
+	vb, ok := b.(*virtualBar)
+	if !ok {
+		return false
+	}
+	vb.mu.Lock()
+	defer vb.mu.Unlock()
+	vb.notBefore = t
+	return true
+}
+
+// GroupIncrDelta exposes virtualBar.groupIncrDelta for tests.
+func GroupIncrDelta(b Bar) (int, bool) {
+	vb, ok := b.(*virtualBar)
+	if !ok {
+		return 0, false
+	}
+	return vb.groupIncrDelta(), true
+}
+
+// CalculateGroupIncr exposes the group bar's aggregate increment calculation.
+func (p *Progress) CalculateGroupIncr() int {
+	return p.groupBar.calculateIncr()
+}

--- a/libsq/core/progress/export_test.go
+++ b/libsq/core/progress/export_test.go
@@ -1,6 +1,9 @@
 package progress
 
-import "time"
+import (
+	"io"
+	"time"
+)
 
 // This file exposes internals to the progress_test package (white-box tests)
 // so that the lifecycle, refresh, and group-bar machinery can be driven
@@ -106,4 +109,48 @@ func GroupIncrDelta(b Bar) (int, bool) {
 // CalculateGroupIncr exposes the group bar's aggregate increment calculation.
 func (p *Progress) CalculateGroupIncr() int {
 	return p.groupBar.calculateIncr()
+}
+
+// HasLife reports whether the Progress currently has a live lifecycle.
+func (p *Progress) HasLife() bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.life != nil
+}
+
+// NotBefore exposes the Progress's next-show checkpoint for tests.
+func (p *Progress) NotBefore() time.Time {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.notBefore
+}
+
+// WriterBar returns the underlying Bar driven by a progress.Writer, or false if
+// w isn't backed by one (e.g. the no-progress delegation adapter).
+func WriterBar(w Writer) (Bar, bool) {
+	if pc, ok := w.(*progCopier); ok {
+		return pc.b, true
+	}
+	return nil, false
+}
+
+// ReaderBar returns the underlying Bar driven by a progress reader, or false if
+// r isn't backed by one.
+func ReaderBar(r io.Reader) (Bar, bool) {
+	if pr, ok := r.(*progReader); ok {
+		return pr.b, true
+	}
+	return nil, false
+}
+
+// BarIsDestroyed reports whether b is a virtualBar that has been destroyed
+// (i.e. stopped). Returns false for any other Bar implementation.
+func BarIsDestroyed(b Bar) bool {
+	vb, ok := b.(*virtualBar)
+	if !ok {
+		return false
+	}
+	vb.mu.Lock()
+	defer vb.mu.Unlock()
+	return vb.destroyed
 }

--- a/libsq/core/progress/format_test.go
+++ b/libsq/core/progress/format_test.go
@@ -1,0 +1,117 @@
+package progress_test
+
+import (
+	"strings"
+	"testing"
+	"time"
+	"unicode/utf8"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/neilotoole/sq/libsq/core/progress"
+)
+
+func TestGroupBarCounterText(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		current int64
+		want    string
+	}{
+		{0, ""},
+		{1, "1 item"},
+		{2, "2 items"},
+		{42, "42 items"},
+		{1000, "1,000 items"},
+		{1234567, "1,234,567 items"},
+	}
+
+	for _, tc := range testCases {
+		require.Equal(t, tc.want, progress.GroupBarCounterText(tc.current))
+	}
+}
+
+func TestUnitCounterText(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		current int64
+		unit    string
+		want    string
+	}{
+		{0, "rec", "0 recs"},
+		{1, "rec", "1 rec"},
+		{2, "rec", "2 recs"},
+		{1000, "rec", "1,000 recs"},
+		{5, "", "5"},
+		{0, "", "0"},
+		{1234567, "row", "1,234,567 rows"},
+	}
+
+	for _, tc := range testCases {
+		require.Equal(t, tc.want, progress.UnitCounterText(tc.current, tc.unit))
+	}
+}
+
+func TestUnitTotalCounterText(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		current int64
+		total   int64
+		unit    string
+		want    string
+	}{
+		{4, 16, "sheet", "4 / 16 sheets"},
+		{1, 1, "sheet", "1 / 1 sheet"},
+		{0, 0, "", "0 / 0"},
+		{1000, 2000, "row", "1,000 / 2,000 rows"},
+		{0, 10, "rec", "0 / 10 recs"},
+	}
+
+	for _, tc := range testCases {
+		require.Equal(t, tc.want, progress.UnitTotalCounterText(tc.current, tc.total, tc.unit))
+	}
+}
+
+func TestTimeoutText(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		remaining time.Duration
+		want      string
+	}{
+		{7 * time.Second, "timeout in 7s"},
+		{90 * time.Second, "timeout in 1m30s"},
+		{1500 * time.Millisecond, "timeout in 2s"},
+		{0, "timeout in 0s"},
+		{-500 * time.Millisecond, "timeout in 0s"},
+		{-2 * time.Second, "timed out"},
+		{-time.Hour, "timed out"},
+	}
+
+	for _, tc := range testCases {
+		require.Equal(t, tc.want, progress.TimeoutText(tc.remaining),
+			"remaining=%s", tc.remaining)
+	}
+}
+
+func TestMsgWidth(t *testing.T) {
+	t.Parallel()
+
+	// Shorter than max: padded with spaces to exactly msgMaxLen bytes.
+	got := progress.MsgWidth("hello")
+	require.Equal(t, progress.MsgMaxLen, len(got))
+	require.True(t, strings.HasPrefix(got, "hello"))
+	require.Equal(t, "hello", strings.TrimRight(got, " "))
+
+	// Exactly msgMaxLen: returned unchanged.
+	exact := strings.Repeat("x", progress.MsgMaxLen)
+	require.Equal(t, exact, progress.MsgWidth(exact))
+
+	// Longer than max: ellipsified to msgMaxLen runes (visual width).
+	long := strings.Repeat("y", progress.MsgMaxLen*2)
+	gotLong := progress.MsgWidth(long)
+	require.Equal(t, progress.MsgMaxLen, utf8.RuneCountInString(gotLong))
+	require.Contains(t, gotLong, "…")
+}

--- a/libsq/core/progress/groupbar.go
+++ b/libsq/core/progress/groupbar.go
@@ -40,14 +40,7 @@ func newGroupBar(p *Progress) *groupBar {
 	}
 
 	fn := func(statistics decor.Statistics) string {
-		switch statistics.Current {
-		case 0:
-			return ""
-		case 1:
-			return "1 item"
-		default:
-			return humanize.Comma(statistics.Current) + " items"
-		}
+		return groupBarCounterText(statistics.Current)
 	}
 	cfg.counterWidget = colorize(decor.Any(fn, p.align.counter), p.colors.Size)
 
@@ -76,6 +69,19 @@ func newGroupBar(p *Progress) *groupBar {
 	// make it visible when appropriate.
 	gb.vb.markHidden()
 	return gb
+}
+
+// groupBarCounterText returns the counter text for the groupBar, given the
+// current aggregate item count.
+func groupBarCounterText(current int64) string {
+	switch current {
+	case 0:
+		return ""
+	case 1:
+		return "1 item"
+	default:
+		return humanize.Comma(current) + " items"
+	}
 }
 
 // refresh refreshes the groupBar.

--- a/libsq/core/progress/internal_test.go
+++ b/libsq/core/progress/internal_test.go
@@ -1,0 +1,17 @@
+package progress
+
+import (
+	"testing"
+	"time"
+)
+
+// TestNopBar exercises the no-op bar, including its unexported methods, which
+// are otherwise unreachable from the external test package.
+func TestNopBar(_ *testing.T) {
+	var b Bar = nopBar{}
+	b.Incr(1)
+	b.markShown()
+	b.markHidden()
+	b.refresh(time.Now())
+	b.Stop()
+}

--- a/libsq/core/progress/io.go
+++ b/libsq/core/progress/io.go
@@ -230,7 +230,14 @@ func (w *progCopier) ReadFrom(r io.Reader) (n int64, err error) {
 			b:   w.b,
 		}
 
-		return io.Copy(w.w, rdr)
+		n, err = io.Copy(w.w, rdr)
+		if err != nil {
+			// Stop the bar on error. The progReader stops it on a read-side
+			// error, but a write-side error from w.w would otherwise leave the
+			// bar running, unlike the non-ReaderFrom branch below.
+			w.b.Stop()
+		}
+		return n, err
 	}
 	select {
 	case <-w.ctx.Done():

--- a/libsq/core/progress/io_test.go
+++ b/libsq/core/progress/io_test.go
@@ -49,6 +49,16 @@ type plainWriter struct {
 
 func (w plainWriter) Write(p []byte) (int, error) { return w.buf.Write(p) }
 
+// errReaderFrom implements both io.Writer and io.ReaderFrom, returning wantErr
+// from ReadFrom, to exercise the destination-error path of the ReaderFrom
+// branch of progCopier.ReadFrom.
+type errReaderFrom struct {
+	wantErr error
+}
+
+func (e errReaderFrom) Write(p []byte) (int, error)       { return len(p), nil }
+func (e errReaderFrom) ReadFrom(io.Reader) (int64, error) { return 0, e.wantErr }
+
 func TestWriter_Write(t *testing.T) {
 	t.Parallel()
 
@@ -243,6 +253,23 @@ func TestCopier_ReadFrom_readerFrom(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, int64(7), n)
 	require.Equal(t, "payload", dst.String())
+}
+
+// TestCopier_ReadFrom_readerFrom_destErr exercises the ReaderFrom branch of
+// progCopier.ReadFrom when the destination writer errors, verifying the error
+// propagates (and, as the fix ensures, the bar is stopped).
+func TestCopier_ReadFrom_readerFrom_destErr(t *testing.T) {
+	t.Parallel()
+
+	wantErr := io.ErrShortWrite
+	ctx := newTestProgress(t, context.Background())
+	w := progress.NewWriter(ctx, "copy", -1, errReaderFrom{wantErr: wantErr})
+
+	rf, ok := w.(io.ReaderFrom)
+	require.True(t, ok)
+	n, err := rf.ReadFrom(strings.NewReader("payload"))
+	require.ErrorIs(t, err, wantErr)
+	require.Zero(t, n)
 }
 
 // TestCopier_ReadFrom_notReaderFrom exercises the non-ReaderFrom branch of

--- a/libsq/core/progress/io_test.go
+++ b/libsq/core/progress/io_test.go
@@ -1,0 +1,279 @@
+package progress_test
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/neilotoole/sq/libsq/core/progress"
+)
+
+// newTestProgress returns a context carrying a Progress that writes to
+// io.Discard. The Progress is stopped via t.Cleanup.
+func newTestProgress(t *testing.T, ctx context.Context) context.Context {
+	t.Helper()
+	pb := progress.New(ctx, io.Discard, progress.DefaultMaxBars, time.Millisecond, nil)
+	t.Cleanup(pb.Stop)
+	return progress.NewContext(ctx, pb)
+}
+
+// errReadWriter returns wantErr on every Read/Write.
+type errReadWriter struct {
+	wantErr error
+}
+
+func (e errReadWriter) Write([]byte) (int, error) { return 0, e.wantErr }
+func (e errReadWriter) Read([]byte) (int, error)  { return 0, e.wantErr }
+
+// trackCloser records whether Close was called.
+type trackCloser struct {
+	io.Writer
+	closed bool
+}
+
+func (c *trackCloser) Close() error {
+	c.closed = true
+	return nil
+}
+
+// plainWriter implements io.Writer but deliberately NOT io.ReaderFrom, to
+// exercise the non-ReaderFrom branch of progCopier.ReadFrom.
+type plainWriter struct {
+	buf *bytes.Buffer
+}
+
+func (w plainWriter) Write(p []byte) (int, error) { return w.buf.Write(p) }
+
+func TestWriter_Write(t *testing.T) {
+	t.Parallel()
+
+	ctx := newTestProgress(t, context.Background())
+	buf := &bytes.Buffer{}
+	w := progress.NewWriter(ctx, "write", -1, buf)
+
+	n, err := w.Write([]byte("hello"))
+	require.NoError(t, err)
+	require.Equal(t, 5, n)
+	require.Equal(t, "hello", buf.String())
+
+	require.NoError(t, w.Close())
+}
+
+func TestWriter_Write_ctxCanceled(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	ctx = newTestProgress(t, ctx)
+	w := progress.NewWriter(ctx, "write", -1, &bytes.Buffer{})
+
+	cancel()
+	n, err := w.Write([]byte("hello"))
+	require.Error(t, err)
+	require.ErrorIs(t, err, context.Canceled)
+	require.Zero(t, n)
+}
+
+func TestWriter_Write_underlyingErr(t *testing.T) {
+	t.Parallel()
+
+	wantErr := io.ErrShortWrite
+	ctx := newTestProgress(t, context.Background())
+	w := progress.NewWriter(ctx, "write", -1, errReadWriter{wantErr: wantErr})
+
+	_, err := w.Write([]byte("hello"))
+	require.ErrorIs(t, err, wantErr)
+}
+
+func TestWriter_Close_underlyingCloser(t *testing.T) {
+	t.Parallel()
+
+	ctx := newTestProgress(t, context.Background())
+	tc := &trackCloser{Writer: &bytes.Buffer{}}
+	w := progress.NewWriter(ctx, "write", -1, tc)
+
+	require.NoError(t, w.Close())
+	require.True(t, tc.closed, "underlying closer should have been closed")
+}
+
+func TestWriter_Close_ctxCanceled(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	ctx = newTestProgress(t, ctx)
+	w := progress.NewWriter(ctx, "write", -1, &bytes.Buffer{})
+
+	cancel()
+	err := w.Close()
+	require.ErrorIs(t, err, context.Canceled)
+}
+
+func TestWriter_Stop(t *testing.T) {
+	t.Parallel()
+
+	ctx := newTestProgress(t, context.Background())
+	buf := &bytes.Buffer{}
+	w := progress.NewWriter(ctx, "write", -1, buf)
+
+	// Stop should remove the bar but not prevent further writing.
+	w.Stop()
+	n, err := w.Write([]byte("after stop"))
+	require.NoError(t, err)
+	require.Equal(t, 10, n)
+}
+
+func TestWriter_idempotentWrap(t *testing.T) {
+	t.Parallel()
+
+	ctx := newTestProgress(t, context.Background())
+	w := progress.NewWriter(ctx, "write", -1, &bytes.Buffer{})
+
+	// Wrapping the same writer with the same ctx should return it unchanged.
+	w2 := progress.NewWriter(ctx, "write", -1, w)
+	require.Same(t, w, w2)
+}
+
+func TestWriter_noProgressInContext(t *testing.T) {
+	t.Parallel()
+
+	// No Progress in context: NewWriter delegates to contextio, but the result
+	// must still be a functional progress.Writer (io.WriteCloser + Stop).
+	buf := &bytes.Buffer{}
+	w := progress.NewWriter(context.Background(), "write", -1, buf)
+
+	n, err := w.Write([]byte("delegated"))
+	require.NoError(t, err)
+	require.Equal(t, 9, n)
+	require.Equal(t, "delegated", buf.String())
+
+	w.Stop() // no-op, must not panic
+	require.NoError(t, w.Close())
+}
+
+func TestWriter_noProgressInContext_underlyingCloser(t *testing.T) {
+	t.Parallel()
+
+	tc := &trackCloser{Writer: &bytes.Buffer{}}
+	w := progress.NewWriter(context.Background(), "write", -1, tc)
+	require.NoError(t, w.Close())
+	require.True(t, tc.closed)
+}
+
+func TestReader_Read(t *testing.T) {
+	t.Parallel()
+
+	ctx := newTestProgress(t, context.Background())
+	r := progress.NewReader(ctx, "read", 5, strings.NewReader("hello"))
+
+	got, err := io.ReadAll(r)
+	require.NoError(t, err)
+	require.Equal(t, "hello", string(got))
+}
+
+func TestReader_Read_ctxCanceled(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	ctx = newTestProgress(t, ctx)
+	r := progress.NewReader(ctx, "read", -1, strings.NewReader("hello"))
+
+	cancel()
+	n, err := r.Read(make([]byte, 8))
+	require.ErrorIs(t, err, context.Canceled)
+	require.Zero(t, n)
+}
+
+func TestReader_Read_underlyingErr(t *testing.T) {
+	t.Parallel()
+
+	wantErr := io.ErrUnexpectedEOF
+	ctx := newTestProgress(t, context.Background())
+	r := progress.NewReader(ctx, "read", -1, errReadWriter{wantErr: wantErr})
+
+	_, err := r.Read(make([]byte, 8))
+	require.ErrorIs(t, err, wantErr)
+}
+
+func TestReader_Close_underlyingCloser(t *testing.T) {
+	t.Parallel()
+
+	ctx := newTestProgress(t, context.Background())
+	rc := io.NopCloser(strings.NewReader("hello"))
+	r := progress.NewReader(ctx, "read", -1, rc)
+
+	rcloser, ok := r.(io.ReadCloser)
+	require.True(t, ok)
+	require.NoError(t, rcloser.Close())
+}
+
+func TestReader_idempotentWrap(t *testing.T) {
+	t.Parallel()
+
+	ctx := newTestProgress(t, context.Background())
+	r := progress.NewReader(ctx, "read", -1, strings.NewReader("hello"))
+
+	r2 := progress.NewReader(ctx, "read", -1, r)
+	require.Same(t, r, r2)
+}
+
+func TestReader_noProgressInContext(t *testing.T) {
+	t.Parallel()
+
+	r := progress.NewReader(context.Background(), "read", -1, strings.NewReader("delegated"))
+	got, err := io.ReadAll(r)
+	require.NoError(t, err)
+	require.Equal(t, "delegated", string(got))
+}
+
+// TestCopier_ReadFrom_readerFrom exercises the io.ReaderFrom branch of
+// progCopier.ReadFrom, where the destination is itself an io.ReaderFrom
+// (bytes.Buffer is).
+func TestCopier_ReadFrom_readerFrom(t *testing.T) {
+	t.Parallel()
+
+	ctx := newTestProgress(t, context.Background())
+	dst := &bytes.Buffer{}
+	w := progress.NewWriter(ctx, "copy", int64(len("payload")), dst)
+
+	n, err := io.Copy(w, strings.NewReader("payload"))
+	require.NoError(t, err)
+	require.Equal(t, int64(7), n)
+	require.Equal(t, "payload", dst.String())
+}
+
+// TestCopier_ReadFrom_notReaderFrom exercises the non-ReaderFrom branch of
+// progCopier.ReadFrom, where the destination only implements io.Writer.
+func TestCopier_ReadFrom_notReaderFrom(t *testing.T) {
+	t.Parallel()
+
+	ctx := newTestProgress(t, context.Background())
+	buf := &bytes.Buffer{}
+	w := progress.NewWriter(ctx, "copy", -1, plainWriter{buf: buf})
+
+	n, err := io.Copy(w, strings.NewReader("payload"))
+	require.NoError(t, err)
+	require.Equal(t, int64(7), n)
+	require.Equal(t, "payload", buf.String())
+}
+
+// TestCopier_ReadFrom_ctxCanceled exercises the context-cancellation path of
+// the non-ReaderFrom branch of progCopier.ReadFrom.
+func TestCopier_ReadFrom_ctxCanceled(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	ctx = newTestProgress(t, ctx)
+	buf := &bytes.Buffer{}
+	w := progress.NewWriter(ctx, "copy", -1, plainWriter{buf: buf})
+
+	cancel()
+	rf, ok := w.(io.ReaderFrom)
+	require.True(t, ok)
+	n, err := rf.ReadFrom(strings.NewReader("payload"))
+	require.ErrorIs(t, err, context.Canceled)
+	require.Zero(t, n)
+}

--- a/libsq/core/progress/io_test.go
+++ b/libsq/core/progress/io_test.go
@@ -97,6 +97,10 @@ func TestWriter_Write_underlyingErr(t *testing.T) {
 
 	_, err := w.Write([]byte("hello"))
 	require.ErrorIs(t, err, wantErr)
+
+	bar, ok := progress.WriterBar(w)
+	require.True(t, ok)
+	require.True(t, progress.BarIsDestroyed(bar), "bar should be stopped on write error")
 }
 
 func TestWriter_Close_underlyingCloser(t *testing.T) {
@@ -206,6 +210,10 @@ func TestReader_Read_underlyingErr(t *testing.T) {
 
 	_, err := r.Read(make([]byte, 8))
 	require.ErrorIs(t, err, wantErr)
+
+	bar, ok := progress.ReaderBar(r)
+	require.True(t, ok)
+	require.True(t, progress.BarIsDestroyed(bar), "bar should be stopped on read error")
 }
 
 func TestReader_Close_underlyingCloser(t *testing.T) {
@@ -270,6 +278,11 @@ func TestCopier_ReadFrom_readerFrom_destErr(t *testing.T) {
 	n, err := rf.ReadFrom(strings.NewReader("payload"))
 	require.ErrorIs(t, err, wantErr)
 	require.Zero(t, n)
+
+	// The fix: a destination error in the ReaderFrom branch must stop the bar.
+	bar, ok := progress.WriterBar(w)
+	require.True(t, ok)
+	require.True(t, progress.BarIsDestroyed(bar), "bar should be stopped on destination error")
 }
 
 // TestCopier_ReadFrom_notReaderFrom exercises the non-ReaderFrom branch of

--- a/libsq/core/progress/newbars.go
+++ b/libsq/core/progress/newbars.go
@@ -167,16 +167,22 @@ func (p *Progress) NewUnitCounter(msg, unit string, opts ...BarOpt) Bar {
 	}
 
 	fn := func(statistics decor.Statistics) string {
-		s := humanize.Comma(statistics.Current)
-		if unit != "" {
-			s += " " + english.PluralWord(int(statistics.Current), unit, "")
-		}
-		return s
+		return unitCounterText(statistics.Current, unit)
 	}
 
 	cfg.counterWidget = colorize(decor.Any(fn, p.align.counter), p.colors.Size)
 
 	return p.createBar(cfg, opts)
+}
+
+// unitCounterText returns the counter text for an indeterminate unit counter,
+// given the current count and an optional unit (which is pluralized).
+func unitCounterText(current int64, unit string) string {
+	s := humanize.Comma(current)
+	if unit != "" {
+		s += " " + english.PluralWord(int(current), unit, "")
+	}
+	return s
 }
 
 // NewWaiter returns a generic indeterminate spinner with a timer. This produces
@@ -233,15 +239,21 @@ func (p *Progress) NewUnitTotalCounter(msg, unit string, total int64, opts ...Ba
 	}
 
 	fn := func(statistics decor.Statistics) string {
-		s := humanize.Comma(statistics.Current) + " / " + humanize.Comma(statistics.Total)
-		if unit != "" {
-			s += " " + english.PluralWord(int(statistics.Current), unit, "")
-		}
-		return s
+		return unitTotalCounterText(statistics.Current, statistics.Total, unit)
 	}
 
 	cfg.counterWidget = colorize(decor.Any(fn, p.align.counter), p.colors.Size)
 	return p.createBar(cfg, opts)
+}
+
+// unitTotalCounterText returns the counter text for a determinate unit counter,
+// given the current and total counts and an optional unit (which is pluralized).
+func unitTotalCounterText(current, total int64, unit string) string {
+	s := humanize.Comma(current) + " / " + humanize.Comma(total)
+	if unit != "" {
+		s += " " + english.PluralWord(int(current), unit, "")
+	}
+	return s
 }
 
 // NewTimeoutWaiter returns a new indeterminate bar whose label is the
@@ -263,19 +275,7 @@ func (p *Progress) NewTimeoutWaiter(msg string, expires time.Time, opts ...BarOp
 	}
 
 	fn := func(_ decor.Statistics) string {
-		remaining := time.Until(expires)
-		switch {
-		case remaining > 0:
-			return fmt.Sprintf("timeout in %s", remaining.Round(time.Second))
-		case remaining > -time.Second:
-			// We do the extra second to prevent a "flash" of the timeout message,
-			// and it also prevents "timeout in -1s" etc. This situation should be
-			// rare; the caller should have already called Stop() on the Progress
-			// when the timeout happened, but we'll play it safe.
-			return "timeout in 0s"
-		default:
-			return "timed out"
-		}
+		return timeoutText(time.Until(expires))
 	}
 
 	cfg.counterWidget = decor.Meta(decor.Any(fn, p.align.counter), func(s string) string {
@@ -291,4 +291,21 @@ func (p *Progress) NewTimeoutWaiter(msg string, expires time.Time, opts ...BarOp
 	defer p.mu.Unlock()
 
 	return p.createBar(cfg, opts)
+}
+
+// timeoutText returns the counter text for a timeout waiter, given the time
+// remaining until the timeout expires.
+func timeoutText(remaining time.Duration) string {
+	switch {
+	case remaining > 0:
+		return fmt.Sprintf("timeout in %s", remaining.Round(time.Second))
+	case remaining > -time.Second:
+		// We do the extra second to prevent a "flash" of the timeout message,
+		// and it also prevents "timeout in -1s" etc. This situation should be
+		// rare; the caller should have already called Stop() on the Progress
+		// when the timeout happened, but we'll play it safe.
+		return "timeout in 0s"
+	default:
+		return "timed out"
+	}
 }

--- a/libsq/core/progress/progress.go
+++ b/libsq/core/progress/progress.go
@@ -479,8 +479,6 @@ func (lf *pcLifecycle) startStateRefreshLoop() {
 	}
 
 	go func() {
-		p := lf.p
-
 		defer func() {
 			if r := recover(); r != nil {
 				err := errz.Errorf("%v", r)
@@ -490,47 +488,56 @@ func (lf *pcLifecycle) startStateRefreshLoop() {
 		}()
 
 		for lf.next() {
-			t := time.Now()
-
-			p.mu.Lock()
-
-			if t.Before(p.notBefore) {
-				p.mu.Unlock()
-				continue
+			if lf.refreshState(time.Now()) {
+				return
 			}
-
-			allBars := slices.Clone(p.allBars)
-			p.activeVisibleBars = make([]*virtualBar, 0, p.groupThreshold)
-			p.activeInvisibleBars = make([]*virtualBar, 0)
-
-			for i := range allBars {
-				bar := allBars[i]
-				if !bar.isRenderable(t) {
-					continue
-				}
-
-				if len(p.activeVisibleBars) < p.groupThreshold {
-					bar.wantShow = true
-					p.activeVisibleBars = append(p.activeVisibleBars, bar)
-					continue
-				}
-
-				bar.wantShow = false
-				p.activeInvisibleBars = append(p.activeInvisibleBars, bar)
-			}
-
-			for i := range allBars {
-				if !lf.alive() {
-					p.mu.Unlock()
-					return
-				}
-				p.allBars[i].refresh(t)
-			}
-			p.groupBar.refresh(t)
-
-			p.mu.Unlock()
 		}
 	}()
+}
+
+// refreshState performs a single iteration of the state refresh loop at time t:
+// it partitions the renderable bars into Progress.activeVisibleBars and
+// Progress.activeInvisibleBars (overflow beyond Progress.groupThreshold), then
+// refreshes each bar and the group bar. It returns true if the caller should
+// stop the refresh loop, which happens when the lifecycle is no longer alive.
+func (lf *pcLifecycle) refreshState(t time.Time) (stop bool) {
+	p := lf.p
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if t.Before(p.notBefore) {
+		return false
+	}
+
+	allBars := slices.Clone(p.allBars)
+	p.activeVisibleBars = make([]*virtualBar, 0, p.groupThreshold)
+	p.activeInvisibleBars = make([]*virtualBar, 0)
+
+	for i := range allBars {
+		bar := allBars[i]
+		if !bar.isRenderable(t) {
+			continue
+		}
+
+		if len(p.activeVisibleBars) < p.groupThreshold {
+			bar.wantShow = true
+			p.activeVisibleBars = append(p.activeVisibleBars, bar)
+			continue
+		}
+
+		bar.wantShow = false
+		p.activeInvisibleBars = append(p.activeInvisibleBars, bar)
+	}
+
+	for i := range allBars {
+		if !lf.alive() {
+			return true
+		}
+		p.allBars[i].refresh(t)
+	}
+	p.groupBar.refresh(t)
+
+	return false
 }
 
 var _ Bar = nopBar{}


### PR DESCRIPTION
Raises coverage of `libsq/core/progress` from ~47% to ~84%, focusing on the previously untested core behavior. Race-clean, lint-clean.

## Production changes (behavior-preserving, for testability)

- Extract the bar widget-formatting closures into named pure functions (`groupBarCounterText`, `unitCounterText`, `unitTotalCounterText`, `timeoutText`). These previously only ran when mpb rendered to a real terminal, so their logic was unreachable from tests.
- Extract the state-refresh loop body into `pcLifecycle.refreshState`, so a single refresh iteration (the visible/invisible bar partition) can be driven synchronously instead of waiting on the 333ms ticker.

## Bug fix

- `progCopier.ReadFrom`'s `io.ReaderFrom` branch wrapped only the source reader, so a write-side error from the destination propagated correctly but left the progress bar running, unlike the non-ReaderFrom branch which stops it on error. The branch now applies the same stop-on-error handling. The covering test asserts the bar is actually stopped (not just that the error propagates) and was confirmed to fail without the fix.

## New tests

- **io wrappers**: the documented context-cancellation contract (`Read`/`Write`/`Close` return `ctx.Err()` and stop the bar), underlying-error paths (asserting the bar is stopped), idempotent re-wrap, the no-progress delegation path, and both `ReadFrom` branches (incl. the destination-error and cancel paths).
- **lifecycle**: `HideOnWriter` hides the progress (passes bytes through, kills the live lifecycle, and pushes out the next-show checkpoint), plus its nil-writer guard.
- **group bar**: the increment-delta accounting (`groupIncrDelta`) and the threshold partition (5 bars, maxBars=3 -> 2 visible / 3 grouped).
- **API surface**: nil-`Progress` safety contract, `New(maxBars<=0)==nil`, every bar constructor (incl. determinate/indeterminate branches and `NewUnitTotalCounter` zero-total delegation), context `Incr`/`NewBarContext`, and `Colors.EnableColor`.
- **nopBar**: white-box coverage of its unexported methods.

An `export_test.go` seam exposes the internals needed to drive the lifecycle and group machinery deterministically.