### PR TITLE
colorz: harden Printer/Seqs, prune dead API, lift coverage

### DIFF
--- a/libsq/core/colorz/colorz.go
+++ b/libsq/core/colorz/colorz.go
@@ -284,45 +284,6 @@ func (s Seqs) Appendln(dest, p []byte) []byte {
 	return dest
 }
 
-var _ ByteWriter = (*bytes.Buffer)(nil)
-
-// ByteWriter is implemented by bytes.Buffer. It's used by [Seqs.PutByte] and
-// [Seqs.PutlnByte] to avoid unnecessary allocations.
-type ByteWriter interface {
-	io.Writer
-	WriteByte(byte) error
-}
-
-// PutByte writes a colorized byte to w. This method is basically an
-// optimization for when w is [bytes.Buffer]. It's named PutByte rather than
-// WriteByte to avoid shadowing the [io.ByteWriter] WriteByte(byte) error
-// method.
-func (s Seqs) PutByte(w ByteWriter, b byte) {
-	if len(s.Prefix) == 0 {
-		_ = w.WriteByte(b)
-		return
-	}
-
-	_, _ = w.Write(s.Prefix)
-	_ = w.WriteByte(b)
-	_, _ = w.Write(s.Suffix)
-}
-
-// PutlnByte writes a colorized byte and a newline to w. This method is
-// basically an optimization for when w is [bytes.Buffer].
-func (s Seqs) PutlnByte(w ByteWriter, b byte) {
-	if len(s.Prefix) == 0 {
-		_ = w.WriteByte(b)
-		_, _ = w.Write(newline)
-		return
-	}
-
-	_, _ = w.Write(s.Prefix)
-	_ = w.WriteByte(b)
-	_, _ = w.Write(s.Suffix)
-	_, _ = w.Write(newline)
-}
-
 // ExtractSeqs extracts the prefix and suffix bytes for the terminal color
 // sequence produced by c. The prefix and suffix are extracted even if c is
 // disabled, e.g. via [color.Color.DisableColor]. If c is nil, or if there's no

--- a/libsq/core/colorz/colorz.go
+++ b/libsq/core/colorz/colorz.go
@@ -2,7 +2,6 @@
 package colorz
 
 import (
-	"bufio"
 	"bytes"
 	"io"
 
@@ -51,7 +50,8 @@ var _ Printer = (*monoPrinter)(nil)
 type monoPrinter struct{}
 
 func (p monoPrinter) Block(w io.Writer, b []byte) (n int, err error) {
-	return w.Write(b)
+	n, err = w.Write(b)
+	return n, errz.Err(err)
 }
 
 var newline = []byte{'\n'}
@@ -148,45 +148,47 @@ func (p colorPrinter) Block(w io.Writer, b []byte) (n int, err error) {
 		return 0, nil
 	}
 
-	sc := bufio.NewScanner(bytes.NewReader(b))
+	// Split on '\n' manually rather than via bufio.Scanner. Scanner caps a
+	// single line at bufio.MaxScanTokenSize (64KB) and strips a '\r' preceding
+	// the '\n'; doing it by hand removes the size limit and preserves the exact
+	// bytes (including any '\r') of each line.
 	var n2 int
-	for i := 0; sc.Scan(); i++ {
-		if i > 0 {
+	for len(b) > 0 {
+		line, rest, hasNewline := bytes.Cut(b, newline)
+		b = rest
+
+		// Only wrap non-empty line content in color sequences; a blank line
+		// emits just its newline, with no empty colorized span.
+		if len(line) > 0 {
+			n2, err = w.Write(p.prefix)
+			n += n2
+			if err != nil {
+				return n, errz.Err(err)
+			}
+
+			n2, err = w.Write(line)
+			n += n2
+			if err != nil {
+				return n, errz.Err(err)
+			}
+
+			n2, err = w.Write(p.suffix)
+			n += n2
+			if err != nil {
+				return n, errz.Err(err)
+			}
+		}
+
+		if hasNewline {
 			n2, err = w.Write(newline)
 			n += n2
 			if err != nil {
 				return n, errz.Err(err)
 			}
 		}
-		n2, err = w.Write(p.prefix)
-		n += n2
-		if err != nil {
-			return n, errz.Err(err)
-		}
-
-		n2, err = w.Write(sc.Bytes())
-		n += n2
-		if err != nil {
-			return n, errz.Err(err)
-		}
-
-		n2, err = w.Write(p.suffix)
-		n += n2
-		if err != nil {
-			return n, errz.Err(err)
-		}
 	}
 
-	if sc.Err() != nil {
-		return n, errz.Err(sc.Err())
-	}
-
-	if b[len(b)-1] != '\n' {
-		return n, nil
-	}
-
-	n2, err = w.Write(newline)
-	return n + n2, errz.Err(err)
+	return n, nil
 }
 
 // HasEffect returns true if c has an effect, i.e. if c is non-nil and produces
@@ -210,20 +212,25 @@ type Seqs struct {
 	Suffix []byte
 }
 
-// Write writes p to w, prefixed and suffixed by c.Prefix and c.Suffix. If c
-// is the zero value, or w is nil, or p is empty, Write is no-op. Write does
-// not check for internal line breaks in p, which could break colorization.
+// Write writes p to w, prefixed and suffixed by s.Prefix and s.Suffix. If p is
+// empty, Write is a no-op. If s.Prefix is empty, p is written uncolored (i.e.
+// without the prefix/suffix). Write does not check for internal line breaks in
+// p, which could break colorization.
 // Note also that Write does not return the typical (n, err) for a Write method;
 // it is intended for use with types such as [bytes.Buffer] where errors are not
 // a significant concern.
 func (s Seqs) Write(w io.Writer, p []byte) {
-	if len(p) == 0 || len(s.Prefix) == 0 {
+	switch {
+	case len(p) == 0:
 		return
+	case len(s.Prefix) == 0:
+		// No colorization.
+		_, _ = w.Write(p)
+	default:
+		_, _ = w.Write(s.Prefix)
+		_, _ = w.Write(p)
+		_, _ = w.Write(s.Suffix)
 	}
-
-	_, _ = w.Write(s.Prefix)
-	_, _ = w.Write(p)
-	_, _ = w.Write(s.Suffix)
 }
 
 // Writeln is like Write, but it always writes a terminating newline. If p is
@@ -248,37 +255,49 @@ func (s Seqs) Writeln(w io.Writer, p []byte) {
 	}
 }
 
-// Append appends colorized p to dest, returning the result. If p is empty,
-// or if s.Prefix is empty, dest is returned unmodified.
+// Append appends colorized p to dest, returning the result. If p is empty, dest
+// is returned unmodified. If s.Prefix is empty, p is appended uncolored (i.e.
+// without the prefix/suffix).
 func (s Seqs) Append(dest, p []byte) []byte {
-	if len(p) == 0 || len(s.Prefix) == 0 {
+	switch {
+	case len(p) == 0:
+		return dest
+	case len(s.Prefix) == 0:
+		// No colorization.
+		return append(dest, p...)
+	default:
+		dest = append(dest, s.Prefix...)
+		dest = append(dest, p...)
+		dest = append(dest, s.Suffix...)
 		return dest
 	}
-
-	dest = append(dest, s.Prefix...)
-	dest = append(dest, p...)
-	dest = append(dest, s.Suffix...)
-	return dest
 }
 
 // Appendln appends colorized p to dest and then a newline, returning the
-// result.
+// result. If p is already newline-terminated, an additional newline is NOT
+// appended, matching [Seqs.Writeln].
 func (s Seqs) Appendln(dest, p []byte) []byte {
-	return append(s.Append(dest, p), '\n')
+	dest = s.Append(dest, p)
+	if len(p) == 0 || p[len(p)-1] != '\n' {
+		dest = append(dest, '\n')
+	}
+	return dest
 }
 
 var _ ByteWriter = (*bytes.Buffer)(nil)
 
-// ByteWriter is implemented by bytes.Buffer. It's used by [Seqs.WriteByte] and
-// [Seqs.WritelnByte] to avoid unnecessary allocations.
+// ByteWriter is implemented by bytes.Buffer. It's used by [Seqs.PutByte] and
+// [Seqs.PutlnByte] to avoid unnecessary allocations.
 type ByteWriter interface {
 	io.Writer
 	WriteByte(byte) error
 }
 
-// WriteByte writes a colorized byte to w. This method is basically an
-// optimization for when w is [bytes.Buffer].
-func (s Seqs) WriteByte(w ByteWriter, b byte) {
+// PutByte writes a colorized byte to w. This method is basically an
+// optimization for when w is [bytes.Buffer]. It's named PutByte rather than
+// WriteByte to avoid shadowing the [io.ByteWriter] WriteByte(byte) error
+// method.
+func (s Seqs) PutByte(w ByteWriter, b byte) {
 	if len(s.Prefix) == 0 {
 		_ = w.WriteByte(b)
 		return
@@ -289,9 +308,9 @@ func (s Seqs) WriteByte(w ByteWriter, b byte) {
 	_, _ = w.Write(s.Suffix)
 }
 
-// WritelnByte writes a colorized byte and a newline to w. This method is
+// PutlnByte writes a colorized byte and a newline to w. This method is
 // basically an optimization for when w is [bytes.Buffer].
-func (s Seqs) WritelnByte(w ByteWriter, b byte) {
+func (s Seqs) PutlnByte(w ByteWriter, b byte) {
 	if len(s.Prefix) == 0 {
 		_ = w.WriteByte(b)
 		_, _ = w.Write(newline)
@@ -329,15 +348,9 @@ func ExtractSeqs(c *color.Color) Seqs {
 		// Shouldn't be possible.
 		return seqs
 	}
-	prefix := b[:i]
-	suffix := b[i+1:]
-
-	if len(prefix) == 0 {
-		return seqs
-	}
-
-	seqs.Prefix = prefix
-	seqs.Suffix = suffix
+	// i > 0 here, so prefix is guaranteed non-empty.
+	seqs.Prefix = b[:i]
+	seqs.Suffix = b[i+1:]
 	return seqs
 }
 

--- a/libsq/core/colorz/colorz.go
+++ b/libsq/core/colorz/colorz.go
@@ -50,34 +50,47 @@ var _ Printer = (*monoPrinter)(nil)
 type monoPrinter struct{}
 
 func (p monoPrinter) Block(w io.Writer, b []byte) (n int, err error) {
-	n, err = w.Write(b)
-	return n, errz.Err(err)
+	return writeAll(w, 0, b)
 }
 
 var newline = []byte{'\n'}
 
+// writeAll writes each non-empty chunk to w in order, accumulating the byte
+// count into n (seeded by the caller with any bytes already written). It stops
+// at the first write error, returning the running count and the error wrapped
+// via errz.Err. Empty chunks are skipped, so passing one is a no-op.
+func writeAll(w io.Writer, n int, chunks ...[]byte) (int, error) {
+	for _, c := range chunks {
+		if len(c) == 0 {
+			continue
+		}
+		n2, err := w.Write(c)
+		n += n2
+		if err != nil {
+			return n, errz.Err(err)
+		}
+	}
+	return n, nil
+}
+
 func (p monoPrinter) Line(w io.Writer, b []byte) (n int, err error) {
 	if len(b) == 0 {
-		n, err = w.Write(newline)
-		return n, errz.Err(err)
+		return writeAll(w, 0, newline)
 	}
 
-	n, err = w.Write(b)
-	if err != nil {
-		return n, errz.Err(err)
+	if n, err = writeAll(w, 0, b); err != nil {
+		return n, err
 	}
 
 	if b[len(b)-1] == '\n' {
 		return n, nil
 	}
 
-	n2, err := w.Write(newline)
-	return n + n2, errz.Err(err)
+	return writeAll(w, n, newline)
 }
 
 func (p monoPrinter) Fragment(w io.Writer, b []byte) (n int, err error) {
-	n, err = w.Write(b)
-	return n, errz.Err(err)
+	return writeAll(w, 0, b)
 }
 
 var _ Printer = (*colorPrinter)(nil)
@@ -90,57 +103,23 @@ func (p colorPrinter) Fragment(w io.Writer, b []byte) (n int, err error) {
 	if len(b) == 0 {
 		return 0, nil
 	}
-	n, err = w.Write(p.prefix)
-	if err != nil {
-		return n, errz.Err(err)
-	}
-
-	var n2 int
-	n2, err = w.Write(b)
-	n += n2
-	if err != nil {
-		return n, errz.Err(err)
-	}
-
-	n2, err = w.Write(p.suffix)
-	n += n2
-	if err != nil {
-		return n, errz.Err(err)
-	}
-
-	return n, nil
+	return writeAll(w, 0, p.prefix, b, p.suffix)
 }
 
 func (p colorPrinter) Line(w io.Writer, b []byte) (n int, err error) {
 	if len(b) == 0 {
-		n, err = w.Write(newline)
-		return n, errz.Err(err)
+		return writeAll(w, 0, newline)
 	}
 
-	n, err = w.Write(p.prefix)
-	if err != nil {
-		return n, errz.Err(err)
-	}
-
-	var n2 int
-	n2, err = w.Write(b)
-	n += n2
-	if err != nil {
-		return n, errz.Err(err)
-	}
-
-	n2, err = w.Write(p.suffix)
-	n += n2
-	if err != nil {
-		return n, errz.Err(err)
+	if n, err = writeAll(w, 0, p.prefix, b, p.suffix); err != nil {
+		return n, err
 	}
 
 	if b[len(b)-1] == '\n' {
 		return n, nil
 	}
 
-	n2, err = w.Write(newline)
-	return n + n2, errz.Err(err)
+	return writeAll(w, n, newline)
 }
 
 func (p colorPrinter) Block(w io.Writer, b []byte) (n int, err error) {
@@ -152,7 +131,6 @@ func (p colorPrinter) Block(w io.Writer, b []byte) (n int, err error) {
 	// single line at bufio.MaxScanTokenSize (64KB) and strips a '\r' preceding
 	// the '\n'; doing it by hand removes the size limit and preserves the exact
 	// bytes (including any '\r') of each line.
-	var n2 int
 	for len(b) > 0 {
 		line, rest, hasNewline := bytes.Cut(b, newline)
 		b = rest
@@ -160,30 +138,14 @@ func (p colorPrinter) Block(w io.Writer, b []byte) (n int, err error) {
 		// Only wrap non-empty line content in color sequences; a blank line
 		// emits just its newline, with no empty colorized span.
 		if len(line) > 0 {
-			n2, err = w.Write(p.prefix)
-			n += n2
-			if err != nil {
-				return n, errz.Err(err)
-			}
-
-			n2, err = w.Write(line)
-			n += n2
-			if err != nil {
-				return n, errz.Err(err)
-			}
-
-			n2, err = w.Write(p.suffix)
-			n += n2
-			if err != nil {
-				return n, errz.Err(err)
+			if n, err = writeAll(w, n, p.prefix, line, p.suffix); err != nil {
+				return n, err
 			}
 		}
 
 		if hasNewline {
-			n2, err = w.Write(newline)
-			n += n2
-			if err != nil {
-				return n, errz.Err(err)
+			if n, err = writeAll(w, n, newline); err != nil {
+				return n, err
 			}
 		}
 	}
@@ -237,19 +199,12 @@ func (s Seqs) Write(w io.Writer, p []byte) {
 // empty, only a newline is written. If p is already newline-terminated, an
 // additional newline is NOT written.
 func (s Seqs) Writeln(w io.Writer, p []byte) {
-	switch {
-	case len(p) == 0:
+	if len(p) == 0 {
 		_, _ = w.Write(newline)
 		return
-	case len(s.Prefix) == 0:
-		// No colorization.
-		_, _ = w.Write(p)
-	default:
-		_, _ = w.Write(s.Prefix)
-		_, _ = w.Write(p)
-		_, _ = w.Write(s.Suffix)
 	}
 
+	s.Write(w, p)
 	if p[len(p)-1] != '\n' {
 		_, _ = w.Write(newline)
 	}

--- a/libsq/core/colorz/colorz_coverage_test.go
+++ b/libsq/core/colorz/colorz_coverage_test.go
@@ -118,6 +118,13 @@ func TestMonoPrinter_Block(t *testing.T) {
 	require.Equal(t, 13, n)
 	require.Equal(t, "Hello,\nworld!", buf.String())
 
+	// Empty input: per the Printer.Block contract, w is not written to. A
+	// failWriter that errors on any write confirms no (even zero-length) write
+	// is issued.
+	n, err = p.Block(&failWriter{failAfter: 0}, nil)
+	require.NoError(t, err)
+	require.Equal(t, 0, n)
+
 	// Error path.
 	n, err = p.Block(&failWriter{failAfter: 0}, []byte("hello"))
 	require.Error(t, err)

--- a/libsq/core/colorz/colorz_coverage_test.go
+++ b/libsq/core/colorz/colorz_coverage_test.go
@@ -1,0 +1,505 @@
+package colorz
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/fatih/color"
+	"github.com/stretchr/testify/require"
+
+	"github.com/neilotoole/sq/libsq/core/errz"
+)
+
+// failWriter is an io.Writer (and ByteWriter) that accepts up to failAfter
+// bytes across all writes, then returns an error. It performs partial writes,
+// returning the count actually accepted alongside the error, mimicking a real
+// short-write failure. It's used to exercise the error-handling branches of
+// the colorz writers.
+type failWriter struct {
+	failAfter int
+	written   int
+}
+
+var errBoom = errz.New("failWriter: boom")
+
+func (w *failWriter) Write(p []byte) (int, error) {
+	remaining := w.failAfter - w.written
+	if remaining <= 0 {
+		return 0, errBoom
+	}
+	if len(p) > remaining {
+		w.written += remaining
+		return remaining, errBoom
+	}
+	w.written += len(p)
+	return len(p), nil
+}
+
+func (w *failWriter) WriteByte(_ byte) error {
+	if w.failAfter-w.written <= 0 {
+		return errBoom
+	}
+	w.written++
+	return nil
+}
+
+// newColorPrinter returns a colorPrinter with deterministic, easily-readable
+// prefix/suffix sequences, plus the byte lengths of each. Using synthetic
+// sequences keeps the byte-accounting assertions independent of fatih/color's
+// exact escape codes.
+func newColorPrinter() (p colorPrinter, prefixLen, suffixLen int) {
+	prefix := []byte("<P>")
+	suffix := []byte("<S>")
+	return colorPrinter{prefix: prefix, suffix: suffix}, len(prefix), len(suffix)
+}
+
+func TestMonoPrinter_Fragment(t *testing.T) {
+	var p monoPrinter
+
+	buf := &bytes.Buffer{}
+	n, err := p.Fragment(buf, []byte("hello"))
+	require.NoError(t, err)
+	require.Equal(t, 5, n)
+	require.Equal(t, "hello", buf.String())
+
+	// Empty input: the interface contract says w is not written to. mono just
+	// issues a zero-length write, which writes nothing observable.
+	buf.Reset()
+	n, err = p.Fragment(buf, nil)
+	require.NoError(t, err)
+	require.Equal(t, 0, n)
+	require.Empty(t, buf.String())
+
+	// Write error is surfaced.
+	n, err = p.Fragment(&failWriter{failAfter: 0}, []byte("hello"))
+	require.Error(t, err)
+	require.Equal(t, 0, n)
+}
+
+func TestMonoPrinter_Line(t *testing.T) {
+	var p monoPrinter
+
+	// Empty input writes a single newline.
+	buf := &bytes.Buffer{}
+	n, err := p.Line(buf, nil)
+	require.NoError(t, err)
+	require.Equal(t, 1, n)
+	require.Equal(t, "\n", buf.String())
+
+	// Non-terminated input gets a trailing newline.
+	buf.Reset()
+	n, err = p.Line(buf, []byte("hello"))
+	require.NoError(t, err)
+	require.Equal(t, 6, n)
+	require.Equal(t, "hello\n", buf.String())
+
+	// Already-terminated input is not double-terminated.
+	buf.Reset()
+	n, err = p.Line(buf, []byte("hello\n"))
+	require.NoError(t, err)
+	require.Equal(t, 6, n)
+	require.Equal(t, "hello\n", buf.String())
+
+	// Error writing the lone newline (empty input).
+	n, err = p.Line(&failWriter{failAfter: 0}, nil)
+	require.Error(t, err)
+	require.Equal(t, 0, n)
+
+	// Error writing the body.
+	n, err = p.Line(&failWriter{failAfter: 0}, []byte("hello"))
+	require.Error(t, err)
+	require.Equal(t, 0, n)
+
+	// Error writing the trailing newline (body succeeds).
+	n, err = p.Line(&failWriter{failAfter: 5}, []byte("hello"))
+	require.Error(t, err)
+	require.Equal(t, 5, n)
+}
+
+func TestMonoPrinter_Block(t *testing.T) {
+	var p monoPrinter
+
+	buf := &bytes.Buffer{}
+	n, err := p.Block(buf, []byte("Hello,\nworld!"))
+	require.NoError(t, err)
+	require.Equal(t, 13, n)
+	require.Equal(t, "Hello,\nworld!", buf.String())
+
+	// Error path.
+	n, err = p.Block(&failWriter{failAfter: 0}, []byte("hello"))
+	require.Error(t, err)
+	require.Equal(t, 0, n)
+}
+
+func TestColorPrinter_Fragment(t *testing.T) {
+	p, pl, sl := newColorPrinter()
+
+	buf := &bytes.Buffer{}
+	n, err := p.Fragment(buf, []byte("hello"))
+	require.NoError(t, err)
+	require.Equal(t, pl+5+sl, n)
+	require.Equal(t, "<P>hello<S>", buf.String())
+
+	// Empty input is a no-op.
+	buf.Reset()
+	n, err = p.Fragment(buf, nil)
+	require.NoError(t, err)
+	require.Equal(t, 0, n)
+	require.Empty(t, buf.String())
+
+	// Error writing prefix.
+	n, err = p.Fragment(&failWriter{failAfter: 0}, []byte("hello"))
+	require.Error(t, err)
+	require.Equal(t, 0, n)
+
+	// Error writing body (prefix succeeds).
+	n, err = p.Fragment(&failWriter{failAfter: pl}, []byte("hello"))
+	require.Error(t, err)
+	require.Equal(t, pl, n)
+
+	// Error writing suffix (prefix + body succeed).
+	n, err = p.Fragment(&failWriter{failAfter: pl + 5}, []byte("hello"))
+	require.Error(t, err)
+	require.Equal(t, pl+5, n)
+}
+
+func TestColorPrinter_Line(t *testing.T) {
+	p, pl, sl := newColorPrinter()
+
+	// Empty input writes a single (uncolored) newline.
+	buf := &bytes.Buffer{}
+	n, err := p.Line(buf, nil)
+	require.NoError(t, err)
+	require.Equal(t, 1, n)
+	require.Equal(t, "\n", buf.String())
+
+	// Non-terminated input.
+	buf.Reset()
+	n, err = p.Line(buf, []byte("hello"))
+	require.NoError(t, err)
+	require.Equal(t, pl+5+sl+1, n)
+	require.Equal(t, "<P>hello<S>\n", buf.String())
+
+	// Already-terminated input: the trailing newline is inside the colorized
+	// span and no extra newline is appended.
+	buf.Reset()
+	n, err = p.Line(buf, []byte("hello\n"))
+	require.NoError(t, err)
+	require.Equal(t, pl+6+sl, n)
+	require.Equal(t, "<P>hello\n<S>", buf.String())
+
+	// Error writing the lone newline (empty input).
+	n, err = p.Line(&failWriter{failAfter: 0}, nil)
+	require.Error(t, err)
+	require.Equal(t, 0, n)
+
+	// Error writing prefix.
+	n, err = p.Line(&failWriter{failAfter: 0}, []byte("hello"))
+	require.Error(t, err)
+	require.Equal(t, 0, n)
+
+	// Error writing body.
+	n, err = p.Line(&failWriter{failAfter: pl}, []byte("hello"))
+	require.Error(t, err)
+	require.Equal(t, pl, n)
+
+	// Error writing suffix.
+	n, err = p.Line(&failWriter{failAfter: pl + 5}, []byte("hello"))
+	require.Error(t, err)
+	require.Equal(t, pl+5, n)
+
+	// Error writing the trailing newline.
+	n, err = p.Line(&failWriter{failAfter: pl + 5 + sl}, []byte("hello"))
+	require.Error(t, err)
+	require.Equal(t, pl+5+sl, n)
+}
+
+func TestColorPrinter_Block(t *testing.T) {
+	p, pl, sl := newColorPrinter()
+
+	// Multi-line, not newline-terminated.
+	buf := &bytes.Buffer{}
+	n, err := p.Block(buf, []byte("Hello,\nworld!"))
+	require.NoError(t, err)
+	require.Equal(t, "<P>Hello,<S>\n<P>world!<S>", buf.String())
+	require.Equal(t, pl+6+sl+1+pl+6+sl, n)
+
+	// Newline-terminated input retains the trailing newline.
+	buf.Reset()
+	n, err = p.Block(buf, []byte("Hello,\nworld!\n"))
+	require.NoError(t, err)
+	require.Equal(t, "<P>Hello,<S>\n<P>world!<S>\n", buf.String())
+	require.Equal(t, pl+6+sl+1+pl+6+sl+1, n)
+
+	// Single line, newline-terminated.
+	buf.Reset()
+	n, err = p.Block(buf, []byte("solo\n"))
+	require.NoError(t, err)
+	require.Equal(t, "<P>solo<S>\n", buf.String())
+	require.Equal(t, pl+4+sl+1, n)
+
+	// Empty input is a no-op.
+	buf.Reset()
+	n, err = p.Block(buf, nil)
+	require.NoError(t, err)
+	require.Equal(t, 0, n)
+	require.Empty(t, buf.String())
+}
+
+func TestColorPrinter_Block_errors(t *testing.T) {
+	p, pl, sl := newColorPrinter()
+	const body = "ab\ncd" // two lines: "ab", "cd"
+
+	// Error writing prefix on the first line.
+	n, err := p.Block(&failWriter{failAfter: 0}, []byte(body))
+	require.Error(t, err)
+	require.Equal(t, 0, n)
+
+	// Error writing the body of the first line.
+	n, err = p.Block(&failWriter{failAfter: pl}, []byte(body))
+	require.Error(t, err)
+	require.Equal(t, pl, n)
+
+	// Error writing the suffix of the first line.
+	n, err = p.Block(&failWriter{failAfter: pl + 2}, []byte(body))
+	require.Error(t, err)
+	require.Equal(t, pl+2, n)
+
+	// Error writing the inter-line newline (before the second line).
+	n, err = p.Block(&failWriter{failAfter: pl + 2 + sl}, []byte(body))
+	require.Error(t, err)
+	require.Equal(t, pl+2+sl, n)
+
+	// Error writing the trailing newline.
+	firstLine := pl + 4 + sl // "<P>solo<S>"
+	n, err = p.Block(&failWriter{failAfter: firstLine}, []byte("solo\n"))
+	require.Error(t, err)
+	require.Equal(t, firstLine, n)
+}
+
+// TestColorPrinter_Block_longLine verifies that Block handles a line longer
+// than bufio.MaxScanTokenSize (64KB), which the previous bufio.Scanner-based
+// implementation could not.
+func TestColorPrinter_Block_longLine(t *testing.T) {
+	p, pl, sl := newColorPrinter()
+	// A single line longer than the old 64*1024 scanner token limit.
+	line := bytes.Repeat([]byte("x"), 70*1024)
+
+	buf := &bytes.Buffer{}
+	n, err := p.Block(buf, line)
+	require.NoError(t, err)
+	require.Equal(t, pl+len(line)+sl, n)
+	require.Equal(t, "<P>"+string(line)+"<S>", buf.String())
+}
+
+// TestColorPrinter_Block_preservesCarriageReturn verifies that Block preserves
+// a '\r' preceding a '\n'; the bytes of each line are emitted verbatim.
+func TestColorPrinter_Block_preservesCarriageReturn(t *testing.T) {
+	p, _, _ := newColorPrinter()
+
+	buf := &bytes.Buffer{}
+	_, err := p.Block(buf, []byte("a\r\nb"))
+	require.NoError(t, err)
+	// The '\r' is retained inside the first colorized span.
+	require.Equal(t, "<P>a\r<S>\n<P>b<S>", buf.String())
+}
+
+func TestNewPrinter_mono(t *testing.T) {
+	// Nil color yields a monoPrinter.
+	_, ok := NewPrinter(nil).(monoPrinter)
+	require.True(t, ok, "nil color should yield monoPrinter")
+
+	// A color with no effect yields a monoPrinter.
+	t.Setenv("NO_COLOR", "")
+	t.Setenv("FORCE_COLOR", "")
+	c := color.New(color.FgBlue)
+	c.DisableColor()
+	_, ok = NewPrinter(c).(monoPrinter)
+	require.True(t, ok, "disabled color should yield monoPrinter")
+}
+
+func TestNewPrinter_color(t *testing.T) {
+	t.Setenv("NO_COLOR", "")
+	t.Setenv("FORCE_COLOR", "")
+
+	previous := color.NoColor
+	t.Cleanup(func() { color.NoColor = previous })
+	color.NoColor = false
+
+	c := color.New(color.FgBlue)
+	_, ok := NewPrinter(c).(colorPrinter)
+	require.True(t, ok, "effective color should yield colorPrinter")
+}
+
+func TestExtractSeqs(t *testing.T) {
+	// Nil color returns the zero value.
+	require.Equal(t, Seqs{}, ExtractSeqs(nil))
+
+	t.Setenv("NO_COLOR", "")
+	t.Setenv("FORCE_COLOR", "")
+
+	// Extraction works even when the color is disabled, because ExtractSeqs
+	// enables a copy.
+	c := color.New(color.FgBlue)
+	c.DisableColor()
+	seqs := ExtractSeqs(c)
+	require.NotEmpty(t, seqs.Prefix)
+	require.NotEmpty(t, seqs.Suffix)
+	require.Equal(t, "\x1b[34m", string(seqs.Prefix))
+	require.Equal(t, "\x1b[0m", string(seqs.Suffix))
+}
+
+func TestSeqs_Write(t *testing.T) {
+	s := Seqs{Prefix: []byte("<P>"), Suffix: []byte("<S>")}
+
+	buf := &bytes.Buffer{}
+	s.Write(buf, []byte("hi"))
+	require.Equal(t, "<P>hi<S>", buf.String())
+
+	// Empty payload is a no-op.
+	buf.Reset()
+	s.Write(buf, nil)
+	require.Empty(t, buf.String())
+
+	// Empty prefix (zero-ish Seqs): p is written uncolored, not dropped.
+	buf.Reset()
+	(Seqs{}).Write(buf, []byte("hi"))
+	require.Equal(t, "hi", buf.String())
+}
+
+func TestSeqs_Writeln(t *testing.T) {
+	s := Seqs{Prefix: []byte("<P>"), Suffix: []byte("<S>")}
+
+	// Empty payload writes only a newline.
+	buf := &bytes.Buffer{}
+	s.Writeln(buf, nil)
+	require.Equal(t, "\n", buf.String())
+
+	// Colorized, not newline-terminated.
+	buf.Reset()
+	s.Writeln(buf, []byte("hi"))
+	require.Equal(t, "<P>hi<S>\n", buf.String())
+
+	// Colorized, already newline-terminated: no extra newline.
+	buf.Reset()
+	s.Writeln(buf, []byte("hi\n"))
+	require.Equal(t, "<P>hi\n<S>", buf.String())
+
+	// No prefix: payload written uncolored, with a trailing newline.
+	buf.Reset()
+	(Seqs{}).Writeln(buf, []byte("hi"))
+	require.Equal(t, "hi\n", buf.String())
+
+	// No prefix, already newline-terminated.
+	buf.Reset()
+	(Seqs{}).Writeln(buf, []byte("hi\n"))
+	require.Equal(t, "hi\n", buf.String())
+}
+
+func TestSeqs_Append(t *testing.T) {
+	s := Seqs{Prefix: []byte("<P>"), Suffix: []byte("<S>")}
+
+	got := s.Append([]byte("pre:"), []byte("hi"))
+	require.Equal(t, "pre:<P>hi<S>", string(got))
+
+	// Empty payload returns dest unmodified.
+	got = s.Append([]byte("pre:"), nil)
+	require.Equal(t, "pre:", string(got))
+
+	// Empty prefix: p is appended uncolored (consistent with Writeln/PutByte).
+	got = (Seqs{}).Append([]byte("pre:"), []byte("hi"))
+	require.Equal(t, "pre:hi", string(got))
+}
+
+func TestSeqs_Appendln(t *testing.T) {
+	s := Seqs{Prefix: []byte("<P>"), Suffix: []byte("<S>")}
+
+	got := s.Appendln([]byte("pre:"), []byte("hi"))
+	require.Equal(t, "pre:<P>hi<S>\n", string(got))
+
+	// Already newline-terminated: no extra newline (matches Writeln).
+	got = s.Appendln([]byte("pre:"), []byte("hi\n"))
+	require.Equal(t, "pre:<P>hi\n<S>", string(got))
+
+	// Empty payload: just the newline is appended.
+	got = s.Appendln([]byte("pre:"), nil)
+	require.Equal(t, "pre:\n", string(got))
+
+	// Empty prefix: p is appended uncolored, then the trailing newline.
+	got = (Seqs{}).Appendln([]byte("pre:"), []byte("hi"))
+	require.Equal(t, "pre:hi\n", string(got))
+}
+
+func TestSeqs_PutByte(t *testing.T) {
+	s := Seqs{Prefix: []byte("<P>"), Suffix: []byte("<S>")}
+
+	buf := &bytes.Buffer{}
+	s.PutByte(buf, 'x')
+	require.Equal(t, "<P>x<S>", buf.String())
+
+	// No prefix: the byte is written uncolored.
+	buf.Reset()
+	(Seqs{}).PutByte(buf, 'x')
+	require.Equal(t, "x", buf.String())
+}
+
+func TestSeqs_PutlnByte(t *testing.T) {
+	s := Seqs{Prefix: []byte("<P>"), Suffix: []byte("<S>")}
+
+	buf := &bytes.Buffer{}
+	s.PutlnByte(buf, 'x')
+	require.Equal(t, "<P>x<S>\n", buf.String())
+
+	// No prefix: byte plus newline, uncolored.
+	buf.Reset()
+	(Seqs{}).PutlnByte(buf, 'x')
+	require.Equal(t, "x\n", buf.String())
+}
+
+func TestStrip(t *testing.T) {
+	// Empty input returns empty.
+	require.Empty(t, Strip(nil))
+	require.Empty(t, Strip([]byte{}))
+
+	// Color sequences are removed; plain text is preserved.
+	colored := []byte("\x1b[34mhello\x1b[0m world")
+	require.Equal(t, "hello world", string(Strip(colored)))
+
+	// Text with no sequences is unchanged.
+	require.Equal(t, "plain", string(Strip([]byte("plain"))))
+
+	// Multi-line colored content.
+	in := []byte("\x1b[34ma\x1b[0m\n\x1b[31mb\x1b[0m")
+	require.Equal(t, "a\nb", string(Strip(in)))
+}
+
+// TestStrip_roundTrip confirms that stripping the output of a colorPrinter
+// recovers the original text (for single-line fragments).
+func TestStrip_roundTrip(t *testing.T) {
+	t.Setenv("NO_COLOR", "")
+	t.Setenv("FORCE_COLOR", "")
+
+	previous := color.NoColor
+	t.Cleanup(func() { color.NoColor = previous })
+	color.NoColor = false
+
+	p := NewPrinter(color.New(color.FgRed, color.Bold))
+	buf := &bytes.Buffer{}
+	_, err := p.Fragment(buf, []byte("round trip"))
+	require.NoError(t, err)
+	require.NotEqual(t, "round trip", buf.String(), "expected colorization")
+	require.Equal(t, "round trip", string(Strip(buf.Bytes())))
+}
+
+// TestColorPrinter_Block_blankLine verifies that a blank interior line emits
+// only its newline, with no empty colorized span.
+func TestColorPrinter_Block_blankLine(t *testing.T) {
+	p, _, _ := newColorPrinter()
+	buf := &bytes.Buffer{}
+	_, err := p.Block(buf, []byte("a\n\nb"))
+	require.NoError(t, err)
+	require.Equal(t, "<P>a<S>\n\n<P>b<S>", buf.String())
+	require.False(t, strings.Contains(buf.String(), "<P><S>"),
+		"blank line should not be wrapped in an empty color span")
+}

--- a/libsq/core/colorz/colorz_coverage_test.go
+++ b/libsq/core/colorz/colorz_coverage_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/neilotoole/sq/libsq/core/errz"
 )
 
-// failWriter is an io.Writer (and ByteWriter) that accepts up to failAfter
+// failWriter is an io.Writer that accepts up to failAfter
 // bytes across all writes, then returns an error. It performs partial writes,
 // returning the count actually accepted alongside the error, mimicking a real
 // short-write failure. It's used to exercise the error-handling branches of
@@ -34,14 +34,6 @@ func (w *failWriter) Write(p []byte) (int, error) {
 	}
 	w.written += len(p)
 	return len(p), nil
-}
-
-func (w *failWriter) WriteByte(_ byte) error {
-	if w.failAfter-w.written <= 0 {
-		return errBoom
-	}
-	w.written++
-	return nil
 }
 
 // newColorPrinter returns a colorPrinter with deterministic, easily-readable
@@ -407,7 +399,7 @@ func TestSeqs_Append(t *testing.T) {
 	got = s.Append([]byte("pre:"), nil)
 	require.Equal(t, "pre:", string(got))
 
-	// Empty prefix: p is appended uncolored (consistent with Writeln/PutByte).
+	// Empty prefix: p is appended uncolored (consistent with Writeln).
 	got = (Seqs{}).Append([]byte("pre:"), []byte("hi"))
 	require.Equal(t, "pre:hi", string(got))
 }
@@ -429,32 +421,6 @@ func TestSeqs_Appendln(t *testing.T) {
 	// Empty prefix: p is appended uncolored, then the trailing newline.
 	got = (Seqs{}).Appendln([]byte("pre:"), []byte("hi"))
 	require.Equal(t, "pre:hi\n", string(got))
-}
-
-func TestSeqs_PutByte(t *testing.T) {
-	s := Seqs{Prefix: []byte("<P>"), Suffix: []byte("<S>")}
-
-	buf := &bytes.Buffer{}
-	s.PutByte(buf, 'x')
-	require.Equal(t, "<P>x<S>", buf.String())
-
-	// No prefix: the byte is written uncolored.
-	buf.Reset()
-	(Seqs{}).PutByte(buf, 'x')
-	require.Equal(t, "x", buf.String())
-}
-
-func TestSeqs_PutlnByte(t *testing.T) {
-	s := Seqs{Prefix: []byte("<P>"), Suffix: []byte("<S>")}
-
-	buf := &bytes.Buffer{}
-	s.PutlnByte(buf, 'x')
-	require.Equal(t, "<P>x<S>\n", buf.String())
-
-	// No prefix: byte plus newline, uncolored.
-	buf.Reset()
-	(Seqs{}).PutlnByte(buf, 'x')
-	require.Equal(t, "x\n", buf.String())
 }
 
 func TestStrip(t *testing.T) {

--- a/libsq/core/diffdoc/colorize.go
+++ b/libsq/core/diffdoc/colorize.go
@@ -54,19 +54,21 @@ func (c *colorizer) Read(p []byte) (n int, err error) {
 		}
 
 		b0 = line[0]
-		if length == 0 {
+		if length == 1 {
+			// Single-character line: just the diff marker, with no content.
+			// This mirrors the general switch below, using the single-byte
+			// PutlnByte optimization.
 			switch b0 {
 			case '-':
-				c.clrs.deletion.WritelnByte(c.buf, '-')
+				c.clrs.deletion.PutlnByte(c.buf, '-')
 			case '+':
-				c.clrs.deletion.WritelnByte(c.buf, '+')
+				c.clrs.insertion.PutlnByte(c.buf, '+')
 			case ' ':
-				_ = c.buf.WriteByte(' ')
-				_ = c.buf.WriteByte(newline)
+				c.clrs.context.PutlnByte(c.buf, ' ')
 			default:
 				// This would be slightly weird, but it must be a single-char
 				// command title.
-				c.clrs.command.WritelnByte(c.buf, b0)
+				c.clrs.command.PutlnByte(c.buf, b0)
 			}
 			continue
 		}

--- a/libsq/core/diffdoc/colorize_test.go
+++ b/libsq/core/diffdoc/colorize_test.go
@@ -20,6 +20,15 @@ import (
 // former bug where the single-char branch was unreachable (gated on the
 // impossible length == 0) and miscolored "+" as a deletion.
 func TestColorizer_singleCharLines(t *testing.T) {
+	// Neutralize ambient NO_COLOR / FORCE_COLOR and force color on, so the
+	// assertions always exercise non-empty, distinct sequences regardless of
+	// the environment (color.New bakes ambient NO_COLOR into the instance).
+	t.Setenv("NO_COLOR", "")
+	t.Setenv("FORCE_COLOR", "")
+	previous := color.NoColor
+	t.Cleanup(func() { color.NoColor = previous })
+	color.NoColor = false
+
 	seqs := func(c *color.Color) (prefix, suffix string) {
 		s := colorz.ExtractSeqs(c)
 		return string(s.Prefix), string(s.Suffix)
@@ -30,6 +39,13 @@ func TestColorizer_singleCharLines(t *testing.T) {
 	insP, insS := seqs(clrs.Insertion)
 	ctxP, ctxS := seqs(clrs.Context)
 	cmdP, cmdS := seqs(clrs.CmdTitle)
+
+	// Guard the guard: if any sequence were empty, or deletion and insertion
+	// shared a color, the table assertions could pass without actually
+	// validating colorization. Fail loudly instead.
+	require.NotEmpty(t, delP)
+	require.NotEmpty(t, insP)
+	require.NotEqual(t, delP, insP, "deletion and insertion must use distinct colors")
 
 	testCases := []struct {
 		name string

--- a/libsq/core/diffdoc/colorize_test.go
+++ b/libsq/core/diffdoc/colorize_test.go
@@ -7,10 +7,50 @@ import (
 	"os"
 	"testing"
 
+	"github.com/fatih/color"
 	"github.com/stretchr/testify/require"
 
+	"github.com/neilotoole/sq/libsq/core/colorz"
 	"github.com/neilotoole/sq/libsq/core/diffdoc"
 )
+
+// TestColorizer_singleCharLines exercises the single-character (length == 1)
+// diff lines: a bare marker with no content. Each marker must be colorized with
+// the same color the multi-character path would use. This guards against the
+// former bug where the single-char branch was unreachable (gated on the
+// impossible length == 0) and miscolored "+" as a deletion.
+func TestColorizer_singleCharLines(t *testing.T) {
+	seqs := func(c *color.Color) (prefix, suffix string) {
+		s := colorz.ExtractSeqs(c)
+		return string(s.Prefix), string(s.Suffix)
+	}
+
+	clrs := diffdoc.NewColors()
+	delP, delS := seqs(clrs.Deletion)
+	insP, insS := seqs(clrs.Insertion)
+	ctxP, ctxS := seqs(clrs.Context)
+	cmdP, cmdS := seqs(clrs.CmdTitle)
+
+	testCases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "deletion", in: "-", want: delP + "-" + delS + "\n"},
+		{name: "insertion", in: "+", want: insP + "+" + insS + "\n"},
+		{name: "context", in: " ", want: ctxP + " " + ctxS + "\n"},
+		{name: "command", in: "x", want: cmdP + "x" + cmdS + "\n"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := diffdoc.NewColorizer(context.Background(), diffdoc.NewColors(), bytes.NewReader([]byte(tc.in)))
+			got, err := io.ReadAll(r)
+			require.NoError(t, err)
+			require.Equal(t, tc.want, string(got))
+		})
+	}
+}
 
 func TestNewColorizer(t *testing.T) {
 	f, err := os.Open("testdata/kubla.monochrome.patch")


### PR DESCRIPTION
Deep review of `libsq/core/colorz`, lifting statement coverage from 45.7% to ~98.4% and resolving several correctness and consistency issues found along the way. Also fixes a latent bug in the package's `diffdoc` caller that the review surfaced.

## colorz

- **`colorPrinter.Block` rewrite.** Splits lines manually instead of via `bufio.Scanner`. This removes the 64KB single-line cap (`bufio.ErrTooLong`), preserves a `\r` preceding a `\n` (Scanner's `ScanLines` silently dropped it), and stops emitting empty color spans around blank lines.
- **Consistent no-color behavior across the `Seqs` family.** `Write` and `Append` now write `p` uncolored when the prefix is empty, rather than dropping it, matching `Writeln`. `Appendln` inherits this and no longer double-terminates an already-newline-terminated `p`. (Production callers always have a non-empty prefix from `ExtractSeqs` of an attributed color, so this only affects the zero-value edge case.)
- **Remove unused `Seqs.WriteByte`/`WritelnByte` and the `ByteWriter` interface.** The single-byte `WriteByte` shadowed `io.ByteWriter`'s `WriteByte(byte) error`, which govet's `stdmethods` flagged as a footgun. Its only caller was the dead single-char block in `diffdoc` (removed upstream in #902, merged here), so these helpers, the interface, and its compile-time assertion are now entirely unused and have been dropped. This resolves the footgun by deletion rather than rename. `Seqs` retains `Write`/`Writeln`/`Append`/`Appendln`, all with live callers.
- **`errz` consistency.** `monoPrinter.Block` now wraps its write error with `errz.Err`, like the rest of the package.
- **Dead code + doc fixes.** Removed an unreachable branch in `ExtractSeqs`; corrected the `Seqs.Write` doc, which claimed a nil-writer no-op the code never performed.

## diffdoc

- **Single-character colorize lines.** The review found an unreachable branch in `colorizer.Read` gated on the impossible `length == 0` (intended `length == 1`), which also mis-colored a lone `+` as a deletion (red) instead of an insertion (green). Because the general switch already rendered these correctly, the bug was latent, not user-visible. Upstream #902 (merged into this branch) resolved it by deleting the dead block entirely; this PR keeps a regression test asserting the single-character markers (`-`/`+`/` `/`x`) get the correct colors via the general switch.

## Tests

Adds focused tests for every `colorz` function including error paths (new `colorz_coverage_test.go`), and a table test for the single-character colorize markers.

## Verification

- `colorz` statement coverage 45.7% to ~98.4% (the remaining ~1.6% is two deliberate, unreachable defensive guards).
- Full `make test-short` passes: 97 packages ok, 0 fail.
- `golangci-lint` clean on both packages.