### PR TITLE
fix(diff): seal orphaned hunk on context cancellation (#906)

### DIFF
--- a/cli/diff/tabledata.go
+++ b/cli/diff/tabledata.go
@@ -355,6 +355,11 @@ func (rd *recordDiffer) exec(ctx context.Context, recPairsCh <-chan record.Pair,
 		// numLines of pairs before and after differing pair.
 		hunkPairs []record.Pair
 
+		// pendingHunk holds a hunk that has been created (via doc.NewHunk) but not
+		// yet populated (and thus not yet sealed). It must be sealed before exec
+		// returns on any exit path; see the seal at the end of the function.
+		pendingHunk *diffdoc.Hunk
+
 		rp      record.Pair
 		ok      bool
 		err     error
@@ -399,6 +404,7 @@ LOOP:
 		if hunk, err = doc.NewHunk(row - (len(hunkPairs) - 1)); err != nil {
 			break
 		}
+		pendingHunk = hunk
 
 		// Now we need to get the after-the-difference record pairs. We look for a
 		// sequence of non-differing (matching) record pairs, appending each
@@ -482,7 +488,10 @@ LOOP:
 		}
 
 		// OK, now we've got enough record pairs to populate the hunk.
+		// populateHunk seals the hunk (via RecordHunkWriter.WriteHunk), so it is
+		// no longer pending.
 		rd.populateHunk(ctx, hunkPairs, hunk)
+		pendingHunk = nil
 
 		if len(hunkPairs) >= rd.cfg.HunkMaxSize {
 			// If we've hit the hunk max size, we need to clear the tailbuf, because
@@ -502,6 +511,13 @@ LOOP:
 	if err == nil {
 		// Even if err is nil, it's still possible that the context was canceled.
 		err = errz.Err(context.Cause(ctx))
+	}
+
+	// If we exited with a hunk created but not yet populated (e.g. the context
+	// was canceled in the look-ahead loop), it was never sealed. Seal it now, so
+	// the doc's reader never blocks on an unsealed hunk. See issue #906.
+	if pendingHunk != nil {
+		pendingHunk.Seal(nil, err)
 	}
 
 	return err

--- a/cli/diff/tabledata.go
+++ b/cli/diff/tabledata.go
@@ -357,8 +357,8 @@ func (rd *recordDiffer) exec(ctx context.Context, recPairsCh <-chan record.Pair,
 
 		// pendingHunk holds a hunk that has been created (via doc.NewHunk) but not
 		// yet populated (and thus not yet sealed). It is cleared once populateHunk
-		// seals it; the deferred seal below covers any exit path that leaves a
-		// hunk created but unpopulated.
+		// seals it, and sealed explicitly at the end of the function if some exit
+		// path (e.g. context cancellation) left it unpopulated.
 		pendingHunk *diffdoc.Hunk
 
 		rp      record.Pair
@@ -366,16 +366,6 @@ func (rd *recordDiffer) exec(ctx context.Context, recPairsCh <-chan record.Pair,
 		err     error
 		ctxDone = ctx.Done()
 	)
-
-	// If we exit with a hunk created but not yet populated (e.g. the context was
-	// canceled in the look-ahead loop), it was never sealed. Seal it so the doc's
-	// reader never blocks on an unsealed hunk. A defer makes this hold on every
-	// exit path, including a panic in populateHunk. See issue #906.
-	defer func() {
-		if pendingHunk != nil {
-			pendingHunk.Seal(nil, err)
-		}
-	}()
 
 LOOP:
 	for row := 0; ctx.Err() == nil; row++ {
@@ -522,6 +512,20 @@ LOOP:
 	if err == nil {
 		// Even if err is nil, it's still possible that the context was canceled.
 		err = errz.Err(context.Cause(ctx))
+	}
+
+	// If we exited with a hunk created but not yet populated (e.g. the context
+	// was canceled in the look-ahead loop), it was never sealed. Seal it now so
+	// the doc's reader never blocks on an unsealed hunk. See issue #906.
+	//
+	// This is deliberately a plain statement, not a defer: populateHunk seals the
+	// hunk via RecordHunkWriter.WriteHunk's own defer, even when WriteHunk panics.
+	// A defer here would therefore double-seal (and panic) on the populateHunk
+	// panic path. A plain statement runs only on a normal return, by which point
+	// populateHunk has either sealed the hunk and cleared pendingHunk, or been
+	// skipped entirely.
+	if pendingHunk != nil {
+		pendingHunk.Seal(nil, err)
 	}
 
 	return err

--- a/cli/diff/tabledata.go
+++ b/cli/diff/tabledata.go
@@ -356,8 +356,9 @@ func (rd *recordDiffer) exec(ctx context.Context, recPairsCh <-chan record.Pair,
 		hunkPairs []record.Pair
 
 		// pendingHunk holds a hunk that has been created (via doc.NewHunk) but not
-		// yet populated (and thus not yet sealed). It must be sealed before exec
-		// returns on any exit path; see the seal at the end of the function.
+		// yet populated (and thus not yet sealed). It is cleared once populateHunk
+		// seals it; the deferred seal below covers any exit path that leaves a
+		// hunk created but unpopulated.
 		pendingHunk *diffdoc.Hunk
 
 		rp      record.Pair
@@ -365,6 +366,16 @@ func (rd *recordDiffer) exec(ctx context.Context, recPairsCh <-chan record.Pair,
 		err     error
 		ctxDone = ctx.Done()
 	)
+
+	// If we exit with a hunk created but not yet populated (e.g. the context was
+	// canceled in the look-ahead loop), it was never sealed. Seal it so the doc's
+	// reader never blocks on an unsealed hunk. A defer makes this hold on every
+	// exit path, including a panic in populateHunk. See issue #906.
+	defer func() {
+		if pendingHunk != nil {
+			pendingHunk.Seal(nil, err)
+		}
+	}()
 
 LOOP:
 	for row := 0; ctx.Err() == nil; row++ {
@@ -511,13 +522,6 @@ LOOP:
 	if err == nil {
 		// Even if err is nil, it's still possible that the context was canceled.
 		err = errz.Err(context.Cause(ctx))
-	}
-
-	// If we exited with a hunk created but not yet populated (e.g. the context
-	// was canceled in the look-ahead loop), it was never sealed. Seal it now, so
-	// the doc's reader never blocks on an unsealed hunk. See issue #906.
-	if pendingHunk != nil {
-		pendingHunk.Seal(nil, err)
 	}
 
 	return err

--- a/cli/diff/tabledata_internal_test.go
+++ b/cli/diff/tabledata_internal_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -108,6 +109,74 @@ func runRecordDiffer(t *testing.T, numLines, hunkMaxSize int, equal []bool) (*fa
 	require.NoError(t, err)
 
 	return fake, string(out)
+}
+
+// TestRecordDifferExec_CancelMidLookahead is the regression test for issue
+// #906. When the context is cancelled while exec is in its look-ahead loop, exec
+// has already created a hunk (via doc.NewHunk) but has not yet populated it (the
+// only path that seals it). exec must seal that orphaned hunk before returning,
+// otherwise a reader that traverses the doc's hunks blocks forever on the
+// unsealed hunk.
+func TestRecordDifferExec_CancelMidLookahead(t *testing.T) {
+	fake := &fakeHunkWriter{}
+	rd := &recordDiffer{
+		cfg: &Config{
+			// numLines=1 means the look-ahead needs two contiguous matching pairs
+			// before it stops, so a single matching pair leaves exec blocked in the
+			// look-ahead select, waiting for more.
+			Lines:            1,
+			HunkMaxSize:      100,
+			RecordHunkWriter: fake,
+		},
+		recMetaFn: func() (rm1, rm2 record.Meta) { return nil, nil },
+	}
+
+	doc := diffdoc.NewHunkDoc(
+		diffdoc.Titlef(nil, "test diff"),
+		diffdoc.Headerf(nil, "left", "right"),
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Unbuffered channel: each send completes only once exec receives it, which
+	// makes the sequence below deterministic with no timing assumptions.
+	ch := make(chan record.Pair)
+	execErrCh := make(chan error, 1)
+	go func() {
+		execErrCh <- rd.exec(ctx, ch, doc)
+	}()
+
+	// A differing pair makes exec create a hunk and enter the look-ahead loop.
+	ch <- record.NewPair(0, record.Record{"a0"}, record.Record{"b0"})
+	// A matching pair is consumed inside the look-ahead select; with numLines=1
+	// it is not enough to stop, so exec loops back to the select and waits.
+	ch <- record.NewPair(1, record.Record{"r1"}, record.Record{"r1"})
+	// Now exec is committed to the look-ahead select with an empty channel, so
+	// cancelling makes it take the ctx-done branch (break LOOP) with a hunk
+	// created but not populated.
+	cancel()
+
+	err := <-execErrCh
+	require.Error(t, err, "exec should return the context error")
+
+	// Seal the doc without an error to force the reader to traverse the hunks.
+	// (The production caller seals with the error, which short-circuits Read and
+	// masks an unsealed hunk; sealing nil here exposes it.)
+	doc.Seal(nil)
+
+	done := make(chan struct{})
+	go func() {
+		_, _ = io.ReadAll(doc)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// Reader completed: every hunk exec created was sealed.
+	case <-time.After(10 * time.Second):
+		t.Fatal("io.ReadAll hung: exec left a hunk unsealed (issue #906)")
+	}
 }
 
 func TestRecordDifferExec(t *testing.T) {

--- a/cli/diff/tabledata_internal_test.go
+++ b/cli/diff/tabledata_internal_test.go
@@ -191,6 +191,57 @@ func TestRecordDifferExec_CancelMidLookahead(t *testing.T) {
 	}
 }
 
+// panicHunkWriter mimics recordHunkWriterAdapter.WriteHunk's contract: it always
+// seals the hunk via a defer (even when it panics), then panics. It is used to
+// prove that exec does not double-seal the hunk on a populateHunk panic, which
+// would replace the original panic with a confusing "already sealed" panic.
+type panicHunkWriter struct{}
+
+var _ RecordHunkWriter = panicHunkWriter{}
+
+func (panicHunkWriter) WriteHunk(_ context.Context, hunk *diffdoc.Hunk,
+	_, _ record.Meta, _ []record.Pair,
+) {
+	defer hunk.Seal(nil, nil)
+	panic("boom in WriteHunk")
+}
+
+// TestRecordDifferExec_WriteHunkPanicNoDoubleSeal guards the #906 fix against
+// regressing to a deferred seal. populateHunk (via WriteHunk) seals the hunk in
+// its own defer even on panic, so exec must not also seal it on the panic path,
+// or it double-seals and the original panic is masked.
+func TestRecordDifferExec_WriteHunkPanicNoDoubleSeal(t *testing.T) {
+	rd := &recordDiffer{
+		cfg: &Config{
+			// numLines=0 makes a single matching pair after the difference enough
+			// to close the look-ahead and reach populateHunk.
+			Lines:            0,
+			HunkMaxSize:      100,
+			RecordHunkWriter: panicHunkWriter{},
+		},
+		recMetaFn: func() (rm1, rm2 record.Meta) { return nil, nil },
+	}
+
+	doc := diffdoc.NewHunkDoc(
+		diffdoc.Titlef(nil, "test diff"),
+		diffdoc.Headerf(nil, "left", "right"),
+	)
+
+	ch := make(chan record.Pair, 2)
+	ch <- record.NewPair(0, record.Record{"a0"}, record.Record{"b0"}) // differs: creates a hunk
+	ch <- record.NewPair(1, record.Record{"r1"}, record.Record{"r1"}) // matches: closes look-ahead
+	close(ch)
+
+	defer func() {
+		r := recover()
+		require.NotNil(t, r, "exec should propagate the original WriteHunk panic")
+		require.Equal(t, "boom in WriteHunk", r,
+			"exec must not convert the WriteHunk panic into a double-seal panic")
+	}()
+
+	_ = rd.exec(context.Background(), ch, doc)
+}
+
 func TestRecordDifferExec(t *testing.T) {
 	testCases := []struct {
 		name        string

--- a/cli/diff/tabledata_internal_test.go
+++ b/cli/diff/tabledata_internal_test.go
@@ -112,7 +112,7 @@ func runRecordDiffer(t *testing.T, numLines, hunkMaxSize int, equal []bool) (*fa
 }
 
 // TestRecordDifferExec_CancelMidLookahead is the regression test for issue
-// #906. When the context is cancelled while exec is in its look-ahead loop, exec
+// #906. When the context is canceled while exec is in its look-ahead loop, exec
 // has already created a hunk (via doc.NewHunk) but has not yet populated it (the
 // only path that seals it). exec must seal that orphaned hunk before returning,
 // otherwise a reader that traverses the doc's hunks blocks forever on the
@@ -153,27 +153,39 @@ func TestRecordDifferExec_CancelMidLookahead(t *testing.T) {
 	// it is not enough to stop, so exec loops back to the select and waits.
 	ch <- record.NewPair(1, record.Record{"r1"}, record.Record{"r1"})
 	// Now exec is committed to the look-ahead select with an empty channel, so
-	// cancelling makes it take the ctx-done branch (break LOOP) with a hunk
+	// canceling makes it take the ctx-done branch (break LOOP) with a hunk
 	// created but not populated.
 	cancel()
 
 	err := <-execErrCh
 	require.Error(t, err, "exec should return the context error")
 
+	// The hunk was orphaned mid-look-ahead: it was created but populateHunk (the
+	// only path that calls the writer) never ran. Asserting the writer saw no
+	// hunks confirms we are exercising the orphaned-hunk path, not a normally
+	// populated one, so the test cannot pass for the wrong reason.
+	require.Empty(t, fake.hunks, "populateHunk must not have run on the cancel path")
+
 	// Seal the doc without an error to force the reader to traverse the hunks.
 	// (The production caller seals with the error, which short-circuits Read and
 	// masks an unsealed hunk; sealing nil here exposes it.)
 	doc.Seal(nil)
 
-	done := make(chan struct{})
+	type readResult struct {
+		err error
+	}
+	done := make(chan readResult, 1)
 	go func() {
-		_, _ = io.ReadAll(doc)
-		close(done)
+		_, readErr := io.ReadAll(doc)
+		done <- readResult{err: readErr}
 	}()
 
 	select {
-	case <-done:
-		// Reader completed: every hunk exec created was sealed.
+	case res := <-done:
+		// Reader completed (did not hang): the orphaned hunk was sealed. It was
+		// sealed with the context error, so reading it surfaces that error, which
+		// also proves a hunk really was created and is now readable.
+		require.Error(t, res.err, "the orphaned hunk should be sealed with the context error")
 	case <-time.After(10 * time.Second):
 		t.Fatal("io.ReadAll hung: exec left a hunk unsealed (issue #906)")
 	}


### PR DESCRIPTION
Fixes #906.

## Problem

`recordDiffer.exec` creates a hunk via `doc.NewHunk` and only seals it later via
`populateHunk` → `RecordHunkWriter.WriteHunk`. If the context is canceled while
exec is in its look-ahead loop, it takes the `break LOOP` path
(`cli/diff/tabledata.go:442`) before reaching `populateHunk`, leaving the hunk
created but never sealed.

This is safe today: the caller seals the doc with the error, and `HunkDoc.Read`
short-circuits to an `ErrReader` without traversing the hunk list. But it's a
latent hazard. If the read path ever read hunks on a late error, a read of the
unsealed hunk would block forever on its `sealed` channel. The `Hunk.Seal`
double-seal panic added in #902 makes a robust create/seal lifecycle worth
enforcing on all exit paths.

## Fix

Track the in-flight hunk (`pendingHunk`) and seal it before `exec` returns on any
exit path. On the normal path it's cleared right after `populateHunk` (which
seals it), so the end-of-function seal only fires for a hunk abandoned by
cancellation.

## Test

Added `TestRecordDifferExec_CancelMidLookahead`, which deterministically drives
exec to create a hunk, then cancels the context while it's blocked in the
look-ahead select. It seals the doc without an error (to force the reader through
the hunks, which the production error-seal path would short-circuit) and asserts
`io.ReadAll` completes rather than hanging. The test fails (hangs to timeout)
without the fix and passes with it.

## Verification

- `go test ./cli/diff/... -race` passes (new test + existing `exec` cases).
- `golangci-lint run cli/diff/...`: 0 issues.

No CHANGELOG entry: the bug is latent with no user-visible behavior change today.