### PR TITLE
templatez: wrap exec errors, restrict to hermetic sprig funcs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,14 @@ Breaking changes are annotated with ☢️, and alpha/beta features with 🐥.
 
 ## Unreleased
 
+### Changed
+
+- The column-rename templates ([`ingest.column.rename`](https://sq.io/docs/config#ingestcolumnrename)
+  and [`result.column.rename`](https://sq.io/docs/config#resultcolumnrename)) no longer expose
+  the non-deterministic and environment-reading template functions (`env`, `expandenv`, `now`,
+  `randAlphaNum`, `uuidv4`, and similar). Column names now depend only on the source data, so the
+  same input always produces the same schema, and templates can't read the process environment.
+
 ### Fixed
 
 - [`sq diff --data`](https://sq.io/docs/cmd/diff) output no longer contains NUL

--- a/libsq/core/templatez/templatez.go
+++ b/libsq/core/templatez/templatez.go
@@ -12,8 +12,15 @@ import (
 
 // NewTemplate returns a new text template, with the sprig
 // functions already loaded.
+//
+// Only sprig's hermetic (repeatable) functions are loaded. The
+// non-hermetic functions (e.g. "env", "now", "randAlphaNum",
+// "uuidv4") are excluded: they read the process environment or
+// global state, which both leaks information into user-supplied
+// templates and makes template output non-deterministic. Excluding
+// them keeps a given template's output a pure function of its input.
 func NewTemplate(name, tpl string) (*template.Template, error) {
-	t, err := template.New(name).Funcs(sprig.FuncMap()).Parse(tpl)
+	t, err := template.New(name).Funcs(sprig.HermeticTxtFuncMap()).Parse(tpl)
 	if err != nil {
 		return nil, errz.Err(err)
 	}
@@ -37,7 +44,7 @@ func ExecuteTemplate(name, tpl string, data any) (string, error) {
 
 	buf := &bytes.Buffer{}
 	if err = t.Execute(buf, data); err != nil {
-		return "", err
+		return "", errz.Err(err)
 	}
 
 	return buf.String(), nil

--- a/libsq/core/templatez/templatez_test.go
+++ b/libsq/core/templatez/templatez_test.go
@@ -13,32 +13,84 @@ func TestTemplate(t *testing.T) {
 	data := map[string]string{"Name": "wubble"}
 
 	testCases := []struct {
-		tpl     string
-		data    any
-		want    string
-		wantErr bool
+		tpl  string
+		data any
+		want string
+		// wantParseErr is true if the template is invalid and should
+		// fail at parse time (NewTemplate/ValidTemplate/ExecuteTemplate).
+		wantParseErr bool
+		// wantExecErr is true if the template parses cleanly but fails
+		// when executed against data (ExecuteTemplate only).
+		wantExecErr bool
 	}{
 		// "upper" is a sprig func. Verify that it loads.
-		{"{{.Name | upper}}", data, "WUBBLE", false},
-		{"{{not_a_func .Name}}_", data, "", true},
+		{tpl: "{{.Name | upper}}", data: data, want: "WUBBLE"},
+		// "trim" is a sprig func; verify the sprig func map is wired up.
+		{tpl: "{{.Name | trim}}", data: data, want: "wubble"},
+		// Plain template, no funcs.
+		{tpl: "hello {{.Name}}", data: data, want: "hello wubble"},
+		// Parse error: unknown function.
+		{tpl: "{{not_a_func .Name}}_", data: data, wantParseErr: true},
+		// Parse error: malformed action.
+		{tpl: "{{.Name", data: data, wantParseErr: true},
+		// Execution error: parses fine, but evaluating a field on a
+		// non-struct/non-map value fails at Execute time. This exercises
+		// ExecuteTemplate's t.Execute error branch, which the parse-only
+		// NewTemplate/ValidTemplate can't reach.
+		{tpl: "{{.Missing}}", data: 42, wantExecErr: true},
 	}
 
 	for i, tc := range testCases {
 		t.Run(tu.Name(i, tc.tpl), func(t *testing.T) {
 			got, gotErr := templatez.ExecuteTemplate(t.Name(), tc.tpl, tc.data)
 			t.Logf("\nTPL:   %s\nGOT:   %s\nERR:   %v", tc.tpl, got, gotErr)
-			if tc.wantErr {
-				require.Error(t, gotErr)
-				// Also test ValidTemplate while we're at it.
-				gotErr = templatez.ValidTemplate(t.Name(), tc.tpl)
-				require.Error(t, gotErr)
-				return
-			}
-			require.NoError(t, gotErr)
-			gotErr = templatez.ValidTemplate(t.Name(), tc.tpl)
-			require.NoError(t, gotErr)
 
-			require.Equal(t, tc.want, got)
+			validErr := templatez.ValidTemplate(t.Name(), tc.tpl)
+			_, newErr := templatez.NewTemplate(t.Name(), tc.tpl)
+
+			switch {
+			case tc.wantParseErr:
+				// All three entry points surface the parse error.
+				require.Error(t, gotErr)
+				require.Error(t, validErr)
+				require.Error(t, newErr)
+				require.Empty(t, got)
+			case tc.wantExecErr:
+				// Only ExecuteTemplate sees the error; parsing succeeds.
+				require.Error(t, gotErr)
+				require.NoError(t, validErr)
+				require.NoError(t, newErr)
+				require.Empty(t, got)
+			default:
+				require.NoError(t, gotErr)
+				require.NoError(t, validErr)
+				require.NoError(t, newErr)
+				require.Equal(t, tc.want, got)
+			}
 		})
+	}
+}
+
+// TestHermeticFuncMap verifies that NewTemplate loads only sprig's
+// hermetic (repeatable) functions. Non-hermetic functions such as
+// "env" and "now" read process environment or global state, and must
+// not be available to user-supplied templates.
+func TestHermeticFuncMap(t *testing.T) {
+	t.Setenv("TEMPLATEZ_TEST_SECRET", "leaked")
+
+	// Hermetic sprig funcs remain available.
+	got, err := templatez.ExecuteTemplate(t.Name(), `{{"abc" | upper}}`, nil)
+	require.NoError(t, err)
+	require.Equal(t, "ABC", got)
+
+	// Non-hermetic funcs are excluded, so referencing them is a parse error.
+	for _, tpl := range []string{
+		`{{env "TEMPLATEZ_TEST_SECRET"}}`,
+		`{{now}}`,
+		`{{randAlphaNum 8}}`,
+		`{{uuidv4}}`,
+	} {
+		require.Error(t, templatez.ValidTemplate(t.Name(), tpl),
+			"expected %q to be rejected as a non-hermetic function", tpl)
 	}
 }


### PR DESCRIPTION
Deep review of `libsq/core/templatez`, which backs the
[`ingest.column.rename`](https://sq.io/docs/config#ingestcolumnrename) and
[`result.column.rename`](https://sq.io/docs/config#resultcolumnrename) options.

## Changes

- **Wrap execution errors.** `ExecuteTemplate` returned the raw `text/template`
  error from `t.Execute`. Per the repo convention, errors crossing from stdlib
  must be wrapped at the boundary so they carry a stack trace. Now wrapped with
  `errz.Err`. The parse path already did this.

- **Restrict to hermetic sprig functions.** `NewTemplate` used `sprig.FuncMap`,
  which (a) returns the `html/template` helper, the wrong variant for a
  `text/template`, and (b) includes non-hermetic functions (`env`, `expandenv`,
  `now`, `randAlphaNum`, `uuidv4`, `getHostByName`, ...). Those read the process
  environment or global state, letting user-supplied column-rename templates leak
  environment values and produce non-deterministic schemas. Switched to
  `sprig.HermeticTxtFuncMap`, so a template's output is a pure function of its
  input.

- **Tests to 100% coverage.** Added the execution-error path (previously
  uncovered), split parse-time vs execute-time failure assertions, and added a
  test asserting the non-hermetic functions are excluded while hermetic ones
  still work.

## Compatibility

This is a behavioral change for the two column-rename options: a template using
`now`/`env`/`rand*`/`uuidv4` previously rendered those values and now fails
validation. Such usage was already a misfeature (non-deterministic column names,
environment leakage). Documented under `### Changed` in the CHANGELOG.

## Verification

- `go test -cover ./libsq/core/templatez/` -> 100.0%, all pass
- `go test ./libsq/driver/` -> pass
- `golangci-lint run ./libsq/core/templatez/` -> 0 issues
- `make lint-markdown` -> 0 errors