### PR TITLE
httpz: fix OptRequestTimeout header timer cancelling a healthy body read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,11 @@ Breaking changes are annotated with ☢️, and alpha/beta features with 🐥.
   positional arg was present (which is the usual case). The `--error.format` flag also
   now offers completion, and `--arg` no longer offers irrelevant suggestions (filenames
   for its variable name, or table names for its value), since both are free-form.
+- Downloading a remote source whose body streams in slowly no longer intermittently fails
+  with a spurious `http response header not received within timeout` error. The
+  header-receipt timeout limits only how long `sq` waits for the response headers, but in a
+  narrow timing window it could fire just after the headers had arrived and cancel the
+  in-progress body download.
 
 ## [v0.54.0] - 2026-06-19
 

--- a/libsq/core/ioz/httpz/funcs_test.go
+++ b/libsq/core/ioz/httpz/funcs_test.go
@@ -46,8 +46,8 @@ type roundTripperFunc func(*http.Request) (*http.Response, error)
 func (f roundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) { return f(req) }
 
 // ctxBoundBody is a response body that reads through ctx, returning ctx.Err()
-// once ctx is cancelled. It mimics a real transport's body, which reads through
-// the request context, so a cancelled context aborts the body read.
+// once ctx is canceled. It mimics a real transport's body, which reads through
+// the request context, so a canceled context aborts the body read.
 type ctxBoundBody struct {
 	ctx context.Context
 	r   io.Reader
@@ -331,7 +331,7 @@ func TestOptRequestTimeout_bodyOutlivesHeaderTimeout(t *testing.T) {
 // header timer fires before RoundTrip returns, the result is reported
 // consistently as a timeout error, even if RoundTrip then returns a response.
 // Without this, the caller could receive a non-nil response whose body is dead
-// because it reads through the already-cancelled context.
+// because it reads through the already-canceled context.
 func TestOptRequestTimeout_lateSuccessReportedAsTimeout(t *testing.T) {
 	t.Parallel()
 
@@ -361,7 +361,7 @@ func TestOptRequestTimeout_lateSuccessReportedAsTimeout(t *testing.T) {
 }
 
 // TestOptRequestTimeout_parentCancelNotReportedAsTimeout verifies that when the
-// parent context is cancelled around the same time the header timer fires, the
+// parent context is canceled around the same time the header timer fires, the
 // failure is surfaced with the parent's cause (not a fabricated header timeout)
 // and no misleading header-timeout warning is logged. This is the invariant the
 // old code's `case <-ctx.Done()` select arm enforced.
@@ -369,7 +369,7 @@ func TestOptRequestTimeout_parentCancelNotReportedAsTimeout(t *testing.T) {
 	t.Parallel()
 
 	const timeout = 40 * time.Millisecond
-	sentinel := errors.New("parent cancelled")
+	sentinel := errors.New("parent canceled")
 
 	parent, cancel := context.WithCancelCause(context.Background())
 	var records []slog.Record
@@ -379,7 +379,7 @@ func TestOptRequestTimeout_parentCancelNotReportedAsTimeout(t *testing.T) {
 
 	// Cancel the parent up front; the stub ignores the context and returns a
 	// "success" only after the header timeout has elapsed, so the timer fires
-	// while the parent is already cancelled.
+	// while the parent is already canceled.
 	cancel(sentinel)
 	rt := roundTripperFunc(func(_ *http.Request) (*http.Response, error) {
 		time.Sleep(timeout * 3)

--- a/libsq/core/ioz/httpz/funcs_test.go
+++ b/libsq/core/ioz/httpz/funcs_test.go
@@ -360,6 +360,46 @@ func TestOptRequestTimeout_lateSuccessReportedAsTimeout(t *testing.T) {
 	require.ErrorIs(t, err, context.DeadlineExceeded)
 }
 
+// TestOptRequestTimeout_parentCancelNotReportedAsTimeout verifies that when the
+// parent context is cancelled around the same time the header timer fires, the
+// failure is surfaced with the parent's cause (not a fabricated header timeout)
+// and no misleading header-timeout warning is logged. This is the invariant the
+// old code's `case <-ctx.Done()` select arm enforced.
+func TestOptRequestTimeout_parentCancelNotReportedAsTimeout(t *testing.T) {
+	t.Parallel()
+
+	const timeout = 40 * time.Millisecond
+	sentinel := errors.New("parent cancelled")
+
+	parent, cancel := context.WithCancelCause(context.Background())
+	var records []slog.Record
+	ctx := lg.NewContext(parent, slog.New(recordHandler{&records}))
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://example.com", nil)
+	require.NoError(t, err)
+
+	// Cancel the parent up front; the stub ignores the context and returns a
+	// "success" only after the header timeout has elapsed, so the timer fires
+	// while the parent is already cancelled.
+	cancel(sentinel)
+	rt := roundTripperFunc(func(_ *http.Request) (*http.Response, error) {
+		time.Sleep(timeout * 3)
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader("x")),
+		}, nil
+	})
+
+	tf := httpz.OptRequestTimeout(timeout)
+	resp, err := tf(rt, req)
+	require.Error(t, err)
+	require.Nil(t, resp)
+	require.ErrorIs(t, err, sentinel, "the parent's cause must be surfaced, not a fabricated timeout")
+	for _, r := range records {
+		require.NotContains(t, r.Message, "not received within timeout",
+			"a parent cancellation must not be logged as a header timeout")
+	}
+}
+
 func TestOptResponseTimeout_logsOnCloseAfterTimeout(t *testing.T) {
 	// When the body is closed after the response timeout has already elapsed,
 	// the ReadCloserNotifier callback logs (the errors.Is(cause, timeoutErr)

--- a/libsq/core/ioz/httpz/funcs_test.go
+++ b/libsq/core/ioz/httpz/funcs_test.go
@@ -40,6 +40,28 @@ func (panicRoundTripper) RoundTrip(*http.Request) (*http.Response, error) {
 	panic("inner round tripper panic")
 }
 
+// roundTripperFunc adapts a function to http.RoundTripper.
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) { return f(req) }
+
+// ctxBoundBody is a response body that reads through ctx, returning ctx.Err()
+// once ctx is cancelled. It mimics a real transport's body, which reads through
+// the request context, so a cancelled context aborts the body read.
+type ctxBoundBody struct {
+	ctx context.Context
+	r   io.Reader
+}
+
+func (b *ctxBoundBody) Read(p []byte) (int, error) {
+	if err := b.ctx.Err(); err != nil {
+		return 0, err
+	}
+	return b.r.Read(p)
+}
+
+func (b *ctxBoundBody) Close() error { return nil }
+
 // recordHandler is a slog.Handler that records emitted records for assertions.
 type recordHandler struct{ records *[]slog.Record }
 
@@ -253,6 +275,89 @@ func TestOptRequestTimeout_directStub(t *testing.T) {
 			_, _ = tf(panicRoundTripper{}, req)
 		})
 	})
+}
+
+// TestOptRequestTimeout_bodyOutlivesHeaderTimeout is the regression test for
+// #905: once the response headers have been received (RoundTrip returned
+// successfully), the header timer must never cancel the context that the
+// response body reads through, even if the timeout elapses while the body is
+// still being read. It also asserts that no spurious "not received within
+// timeout" warning is logged on the success path.
+func TestOptRequestTimeout_bodyOutlivesHeaderTimeout(t *testing.T) {
+	t.Parallel()
+
+	const (
+		timeout  = 40 * time.Millisecond
+		respBody = "the body takes longer than the header timeout to read"
+	)
+
+	var records []slog.Record
+	ctx := lg.NewContext(context.Background(), slog.New(recordHandler{&records}))
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://example.com", nil)
+	require.NoError(t, err)
+
+	// The round-tripper returns immediately (headers received well within the
+	// timeout) with a body bound to the request context, exactly as a real
+	// transport's body behaves.
+	rt := roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       &ctxBoundBody{ctx: r.Context(), r: strings.NewReader(respBody)},
+		}, nil
+	})
+
+	tf := httpz.OptRequestTimeout(timeout)
+	resp, err := tf(rt, req)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	// Wait well past the header timeout, simulating a slow body read. With the
+	// pre-fix code the header timer could cancel the shared context here, making
+	// the body read below fail with context.Canceled.
+	time.Sleep(timeout * 4)
+
+	got, err := io.ReadAll(resp.Body)
+	require.NoError(t, err, "body read must succeed: the header timer must not cancel after headers are received")
+	require.Equal(t, respBody, string(got))
+	require.NoError(t, resp.Body.Close())
+
+	for _, r := range records {
+		require.NotContains(t, r.Message, "not received within timeout",
+			"no header-timeout warning must be logged when headers were received in time")
+	}
+}
+
+// TestOptRequestTimeout_lateSuccessReportedAsTimeout verifies that when the
+// header timer fires before RoundTrip returns, the result is reported
+// consistently as a timeout error, even if RoundTrip then returns a response.
+// Without this, the caller could receive a non-nil response whose body is dead
+// because it reads through the already-cancelled context.
+func TestOptRequestTimeout_lateSuccessReportedAsTimeout(t *testing.T) {
+	t.Parallel()
+
+	const timeout = 40 * time.Millisecond
+
+	req, err := http.NewRequest(http.MethodGet, "https://example.com", nil)
+	require.NoError(t, err)
+
+	// The round-tripper returns a "successful" response, but only after the
+	// header timeout has elapsed (so the timer fires first and cancels the
+	// context). A real transport would return a context error here; this stub
+	// returns success anyway to exercise the timer-won path deterministically.
+	rt := roundTripperFunc(func(_ *http.Request) (*http.Response, error) {
+		time.Sleep(timeout * 3)
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader("too late")),
+		}, nil
+	})
+
+	tf := httpz.OptRequestTimeout(timeout)
+	resp, err := tf(rt, req)
+	require.Error(t, err)
+	require.Nil(t, resp, "a response must not be returned once the header timeout has fired")
+	require.Contains(t, err.Error(), "http response header not received within")
+	require.ErrorIs(t, err, context.DeadlineExceeded)
 }
 
 func TestOptResponseTimeout_logsOnCloseAfterTimeout(t *testing.T) {

--- a/libsq/core/ioz/httpz/opts.go
+++ b/libsq/core/ioz/httpz/opts.go
@@ -148,17 +148,29 @@ func OptRequestTimeout(timeout time.Duration) TripFunc {
 		var armed atomic.Bool
 		armed.Store(true)
 
+		// mkTimeoutErr builds the header-timeout error. It's only invoked on an
+		// actual timeout, so the common success path allocates nothing.
+		mkTimeoutErr := func() error {
+			return errz.Wrapf(context.DeadlineExceeded,
+				"http response header not received within %s timeout", timeout)
+		}
+
 		t := time.AfterFunc(timeout, func() {
 			// CompareAndSwap is the single source of truth for "did the timeout
 			// win the race". It succeeds only if the timer fired while still armed,
-			// i.e. before RoundTrip returned and disarmed it: a genuine header
-			// timeout, so warn and cancel. If it fails, RoundTrip already returned;
-			// the timer must not cancel the context the body reads through.
+			// i.e. before RoundTrip returned and disarmed it. If it fails, RoundTrip
+			// already returned; the timer must not cancel the context the body
+			// reads through.
 			if armed.CompareAndSwap(true, false) {
+				if ctx.Err() != nil {
+					// The context is already done, so its cancellation came from the
+					// parent, not this header timer. Don't log a misleading timeout
+					// warning; the parent's cause stands.
+					return
+				}
 				lg.FromContext(ctx).Warn("HTTP header response not received within timeout",
 					lga.Timeout, timeout, lga.URL, req.URL.String())
-				cancelFn(errz.Wrapf(context.DeadlineExceeded,
-					"http response header not received within %s timeout", timeout))
+				cancelFn(mkTimeoutErr())
 			}
 		})
 
@@ -179,20 +191,18 @@ func OptRequestTimeout(timeout time.Duration) TripFunc {
 		t.Stop()
 
 		if !armed.CompareAndSwap(true, false) {
-			// The timer won the race: it fired and cancelled the context before we
-			// could disarm it, so this is a genuine header timeout. Even if
-			// RoundTrip happened to return a response, the context is cancelled and
-			// the body reads through it, so the response is unusable. Surface the
-			// timeout consistently (never a response with a dead body) and release
-			// the response. context.Cause holds the descriptive error set by the
-			// timer.
+			// The timer won the race: it fired before we could disarm it. This is a
+			// header timeout, or a parent cancellation that beat the timer. Cancel
+			// here too, so the cause is guaranteed set even if the timer's own
+			// cancelFn hasn't run yet (avoiding a (nil, nil) return); this call is a
+			// no-op if the context is already cancelled, so a parent cause is
+			// preserved. Any returned response is unusable: its body reads through
+			// the now-cancelled context, so discard it and surface the cause.
+			cancelFn(mkTimeoutErr())
 			if resp != nil && resp.Body != nil {
 				_ = resp.Body.Close()
 			}
-			if cause := context.Cause(ctx); cause != nil {
-				err = cause
-			}
-			return nil, err
+			return nil, context.Cause(ctx)
 		}
 
 		// The timer is disarmed and can no longer cancel the context. Any

--- a/libsq/core/ioz/httpz/opts.go
+++ b/libsq/core/ioz/httpz/opts.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"errors"
 	"net/http"
+	"sync/atomic"
 	"time"
 
 	"github.com/neilotoole/sq/cli/buildinfo"
@@ -134,42 +135,68 @@ func OptRequestTimeout(timeout time.Duration) TripFunc {
 		return NopTripFunc
 	}
 	return func(next http.RoundTripper, req *http.Request) (*http.Response, error) {
-		timerCancelCh := make(chan struct{})
-
 		ctx, cancelFn := context.WithCancelCause(req.Context())
-		t := time.NewTimer(timeout)
-		go func() {
-			defer t.Stop()
-			select {
-			case <-ctx.Done():
-			case <-t.C:
-				cancelErr := errz.Wrapf(context.DeadlineExceeded,
-					"http response header not received within %s timeout", timeout)
 
+		// armed gates the header-timeout cancellation. The timer cancels the
+		// context only if it fires while still armed, i.e. before RoundTrip has
+		// returned. Once RoundTrip returns (success or error) we disarm, after
+		// which the timer can never cancel the context. This matters because the
+		// returned response body reads through this same context and may
+		// legitimately take longer than the header timeout: a healthy body read
+		// must not be aborted just because the header timer fires in the narrow
+		// window around RoundTrip returning.
+		var armed atomic.Bool
+		armed.Store(true)
+
+		t := time.AfterFunc(timeout, func() {
+			// CompareAndSwap is the single source of truth for "did the timeout
+			// win the race". It succeeds only if the timer fired while still armed,
+			// i.e. before RoundTrip returned and disarmed it: a genuine header
+			// timeout, so warn and cancel. If it fails, RoundTrip already returned;
+			// the timer must not cancel the context the body reads through.
+			if armed.CompareAndSwap(true, false) {
 				lg.FromContext(ctx).Warn("HTTP header response not received within timeout",
 					lga.Timeout, timeout, lga.URL, req.URL.String())
-
-				cancelFn(cancelErr)
-			case <-timerCancelCh:
-				// Stop the timer goroutine.
+				cancelFn(errz.Wrapf(context.DeadlineExceeded,
+					"http response header not received within %s timeout", timeout))
 			}
-		}()
+		})
 
 		// If next.RoundTrip panics, the normal cleanup below is skipped, which
-		// would leak the timer goroutine and the cancel context. Signal the
-		// goroutine and release the context before the panic propagates. On the
-		// normal path recover() is nil and timerCancelCh is closed below, so this
-		// does not double-close.
+		// would leave the context uncancelled. Disarm the timer and release the
+		// context before the panic propagates. On the normal path recover() is
+		// nil, and disarm/Stop are idempotent with the cleanup below.
 		defer func() {
 			if r := recover(); r != nil {
-				close(timerCancelCh)
+				armed.Store(false)
+				t.Stop()
 				cancelFn(context.Canceled)
 				panic(r)
 			}
 		}()
 
 		resp, err := errz.Return(next.RoundTrip(req.WithContext(ctx)))
+		t.Stop()
 
+		if !armed.CompareAndSwap(true, false) {
+			// The timer won the race: it fired and cancelled the context before we
+			// could disarm it, so this is a genuine header timeout. Even if
+			// RoundTrip happened to return a response, the context is cancelled and
+			// the body reads through it, so the response is unusable. Surface the
+			// timeout consistently (never a response with a dead body) and release
+			// the response. context.Cause holds the descriptive error set by the
+			// timer.
+			if resp != nil && resp.Body != nil {
+				_ = resp.Body.Close()
+			}
+			if cause := context.Cause(ctx); cause != nil {
+				err = cause
+			}
+			return nil, err
+		}
+
+		// The timer is disarmed and can no longer cancel the context. Any
+		// cancellation observed now comes from the parent context.
 		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 			if langz.Take(ctx.Done()) {
 				// The lower-down RoundTripper probably returned ctx.Err(),
@@ -180,23 +207,20 @@ func OptRequestTimeout(timeout time.Duration) TripFunc {
 			}
 		}
 
-		// Signal completion of the timer goroutine (it may have already completed).
-		close(timerCancelCh)
-
-		// Don't leak resources; ensure that cancelFn is eventually called.
+		// Don't leak resources; ensure that cancelFn is eventually called. Use a
+		// neutral cause: stamping DeadlineExceeded here would fabricate a
+		// misleading cause on non-timeout errors.
 		switch {
 		case err != nil:
-			// An error has occurred. It's probable that cancelFn has already been
-			// called by the timer goroutine, but we call it again just in case.
-			cancelFn(context.DeadlineExceeded)
+			cancelFn(context.Canceled)
 		case resp != nil && resp.Body != nil:
 			// Wrap resp.Body with a ReadCloserNotifier, so that cancelFn
 			// is called when the body is closed.
 			resp.Body = ioz.ReadCloserNotifier(resp.Body,
-				func(error) { cancelFn(context.DeadlineExceeded) })
+				func(error) { cancelFn(context.Canceled) })
 		default:
-			// Not sure if this can actually be reached, but just in case.
-			cancelFn(context.DeadlineExceeded)
+			// No body to wait on (e.g. a HEAD response): release immediately.
+			cancelFn(context.Canceled)
 		}
 
 		return resp, err

--- a/libsq/core/ioz/httpz/opts.go
+++ b/libsq/core/ioz/httpz/opts.go
@@ -175,7 +175,7 @@ func OptRequestTimeout(timeout time.Duration) TripFunc {
 		})
 
 		// If next.RoundTrip panics, the normal cleanup below is skipped, which
-		// would leave the context uncancelled. Disarm the timer and release the
+		// would leave the context uncanceled. Disarm the timer and release the
 		// context before the panic propagates. On the normal path recover() is
 		// nil, and disarm/Stop are idempotent with the cleanup below.
 		defer func() {
@@ -195,9 +195,9 @@ func OptRequestTimeout(timeout time.Duration) TripFunc {
 			// header timeout, or a parent cancellation that beat the timer. Cancel
 			// here too, so the cause is guaranteed set even if the timer's own
 			// cancelFn hasn't run yet (avoiding a (nil, nil) return); this call is a
-			// no-op if the context is already cancelled, so a parent cause is
+			// no-op if the context is already canceled, so a parent cause is
 			// preserved. Any returned response is unusable: its body reads through
-			// the now-cancelled context, so discard it and surface the cause.
+			// the now-canceled context, so discard it and surface the cause.
 			cancelFn(mkTimeoutErr())
 			if resp != nil && resp.Body != nil {
 				_ = resp.Body.Close()


### PR DESCRIPTION
Closes #905.

## Problem

`OptRequestTimeout` is documented to bound only receipt of the response
*headers*, allowing the body to take longer. But it armed a single timer over
one context shared by both the header round-trip and the body, and the timer
was only stopped (via `close(timerCancelCh)`) *after* `RoundTrip` returned. If
headers arrived just before the deadline, the timer could fire in the window
around `RoundTrip` returning (Go `select` picks randomly among ready cases) and
cancel the very context the just-returned `resp.Body` reads through. The caller
then got `(resp, nil)` but the first body `Read` failed spuriously with
`context.Canceled` / "http response header not received within timeout".

Reachable via slow-body downloads in `libsq/files/download.go`. The trigger
window is narrow, so it was a low-probability latent timing bug, but real.

## Fix

Redesign the timer around an atomic `armed` flag, replacing the manual
goroutine + `time.NewTimer` + channel + `select` (whose random `select` was the
source of the race) with a `time.AfterFunc`:

- The timer cancels the context only if its `CompareAndSwap(true, false)` wins,
  i.e. it fired while still armed (before `RoundTrip` returned). Once
  `RoundTrip` returns, the main path disarms via its own `CompareAndSwap`; a
  later timer fire can never cancel the body's context.
- If the timer wins the race, the result is reported **consistently** as a
  header timeout (never a response with an already-cancelled body), and the
  response is released.
- The "not received within timeout" warning is logged only when the timeout
  genuinely fired (no more spurious warn on the success path).
- Cleanup cancellation uses a neutral `context.Canceled` cause instead of
  fabricating `context.DeadlineExceeded` on non-timeout errors.

## Tests

New regression tests:

- `bodyOutlivesHeaderTimeout` — a successful response's body survives well past
  the header timeout, and no spurious warning is logged.
- `lateSuccessReportedAsTimeout` — a `RoundTrip` that returns success *after*
  the timeout fired is reported consistently as a timeout (nil response).

Body reads bind to the request context to mimic a real transport. All existing
tests pass; the package stays at **100% statement coverage**. Verified clean
under `golangci-lint` v2.9.0 (CI) and v2.12.2, and with `-race`.