### PR TITLE
sqlserver: fix resource/correctness bugs and push test coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,9 @@ Breaking changes are annotated with ☢️, and alpha/beta features with 🐥.
   header-receipt timeout limits only how long `sq` waits for the response headers, but in a
   narrow timing window it could fire just after the headers had arrived and cancel the
   in-progress body download.
+- [`sq inspect --overview`](https://sq.io/docs/inspect) on SQL Server now reports the
+  `IsExternalGovernanceEnabled` server property. A malformed property name meant the value
+  was always queried as NULL and silently omitted.
 
 ## [v0.54.0] - 2026-06-19
 

--- a/drivers/sqlserver/properties.go
+++ b/drivers/sqlserver/properties.go
@@ -139,7 +139,7 @@ SELECT 'IsClustered', SERVERPROPERTY('IsClustered')
 UNION ALL
 SELECT 'IsExternalAuthenticationOnly', SERVERPROPERTY('IsExternalAuthenticationOnly')
 UNION ALL
-SELECT 'IsExternalGovernanceEnabled', SERVERPROPERTY('IsFullTextIsExternalGovernanceEnabledInstalled')
+SELECT 'IsExternalGovernanceEnabled', SERVERPROPERTY('IsExternalGovernanceEnabled')
 UNION ALL
 SELECT 'IsFullTextInstalled', SERVERPROPERTY('IsFullTextInstalled')
 UNION ALL

--- a/drivers/sqlserver/sqlserver.go
+++ b/drivers/sqlserver/sqlserver.go
@@ -48,7 +48,7 @@ type Provider struct {
 // DriverFor implements driver.Provider.
 func (p *Provider) DriverFor(typ drivertype.Type) (driver.Driver, error) {
 	if typ != drivertype.MSSQL {
-		return nil, errz.Errorf("unsupported driver type {%s}}", typ)
+		return nil, errz.Errorf("unsupported driver type {%s}", typ)
 	}
 
 	return &driveri{log: p.Log}, nil
@@ -464,7 +464,10 @@ func (d *driveri) SchemaExists(ctx context.Context, db sqlz.DB, schma string) (b
 WHERE SCHEMA_NAME = @p1 AND CATALOG_NAME = DB_NAME()`
 
 	var count int
-	return count > 0, errw(db.QueryRowContext(ctx, q, schma).Scan(&count))
+	if err := db.QueryRowContext(ctx, q, schma).Scan(&count); err != nil {
+		return false, errw(err)
+	}
+	return count > 0, nil
 }
 
 // ListSchemaMetadata implements driver.SQLDriver.
@@ -524,7 +527,10 @@ func (d *driveri) CatalogExists(ctx context.Context, db sqlz.DB, catalog string)
 	const q = `SELECT COUNT(name) FROM sys.databases WHERE name = @p1`
 
 	var count int
-	return count > 0, errw(db.QueryRowContext(ctx, q, catalog).Scan(&count))
+	if err := db.QueryRowContext(ctx, q, catalog).Scan(&count); err != nil {
+		return false, errw(err)
+	}
+	return count > 0, nil
 }
 
 // ListCatalogs implements driver.SQLDriver.
@@ -784,6 +790,7 @@ func (d *driveri) getTableColsMeta(ctx context.Context, db sqlz.DB, tblName stri
 	}
 
 	if rows.Err() != nil {
+		sqlz.CloseRows(d.log, rows)
 		return nil, errw(rows.Err())
 	}
 

--- a/drivers/sqlserver/sqlserver_integration_test.go
+++ b/drivers/sqlserver/sqlserver_integration_test.go
@@ -1,0 +1,430 @@
+package sqlserver_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/neilotoole/sq/libsq/core/kind"
+	"github.com/neilotoole/sq/libsq/core/schema"
+	"github.com/neilotoole/sq/libsq/core/stringz"
+	"github.com/neilotoole/sq/libsq/core/tablefq"
+	"github.com/neilotoole/sq/libsq/driver"
+	"github.com/neilotoole/sq/testh"
+	"github.com/neilotoole/sq/testh/sakila"
+	"github.com/neilotoole/sq/testh/tu"
+)
+
+// These tests exercise the SQL Server driver against a live database. They are
+// skipped under -short. They complement the cross-driver conformance suite in
+// libsq/driver, locking down SQL Server-specific behavior in this package.
+
+func TestDriver_Ping_MSSQL(t *testing.T) {
+	tu.SkipShort(t, true)
+	t.Parallel()
+
+	th, src, drvr, _, _ := testh.NewWith(t, sakila.MS)
+	require.NoError(t, drvr.Ping(th.Context, src, driver.ModeReadWrite))
+}
+
+func TestDriver_DBProperties_MSSQL(t *testing.T) {
+	tu.SkipShort(t, true)
+	t.Parallel()
+
+	th, _, drvr, _, db := testh.NewWith(t, sakila.MS)
+	props, err := drvr.DBProperties(th.Context, db)
+	require.NoError(t, err)
+	require.NotEmpty(t, props)
+	// SERVERPROPERTY values and sys.configurations are merged; spot-check a
+	// well-known server property and a well-known configuration option.
+	require.Contains(t, props, "ProductVersion")
+	require.Contains(t, props, "max server memory (MB)")
+}
+
+func TestDriver_TableExists_MSSQL(t *testing.T) {
+	tu.SkipShort(t, true)
+	t.Parallel()
+
+	th, _, drvr, _, db := testh.NewWith(t, sakila.MS)
+
+	exists, err := drvr.TableExists(th.Context, db, sakila.TblActor)
+	require.NoError(t, err)
+	require.True(t, exists)
+
+	exists, err = drvr.TableExists(th.Context, db, stringz.UniqTableName("no_exist"))
+	require.NoError(t, err)
+	require.False(t, exists)
+}
+
+func TestDriver_CurrentSchemaAndCatalog_MSSQL(t *testing.T) {
+	tu.SkipShort(t, true)
+	t.Parallel()
+
+	th, _, drvr, _, db := testh.NewWith(t, sakila.MS)
+
+	schma, err := drvr.CurrentSchema(th.Context, db)
+	require.NoError(t, err)
+	require.Equal(t, "dbo", schma)
+
+	catalog, err := drvr.CurrentCatalog(th.Context, db)
+	require.NoError(t, err)
+	require.Equal(t, "sakila", catalog)
+}
+
+func TestDriver_CatalogExists_MSSQL(t *testing.T) {
+	tu.SkipShort(t, true)
+	t.Parallel()
+
+	th, _, drvr, _, db := testh.NewWith(t, sakila.MS)
+
+	exists, err := drvr.CatalogExists(th.Context, db, "sakila")
+	require.NoError(t, err)
+	require.True(t, exists)
+
+	exists, err = drvr.CatalogExists(th.Context, db, "no_such_catalog_"+stringz.Uniq8())
+	require.NoError(t, err)
+	require.False(t, exists)
+
+	// The empty catalog short-circuits to false without a query.
+	exists, err = drvr.CatalogExists(th.Context, db, "")
+	require.NoError(t, err)
+	require.False(t, exists)
+}
+
+func TestDriver_ListCatalogs_MSSQL(t *testing.T) {
+	tu.SkipShort(t, true)
+	t.Parallel()
+
+	th, _, drvr, _, db := testh.NewWith(t, sakila.MS)
+
+	catalogs, err := drvr.ListCatalogs(th.Context, db)
+	require.NoError(t, err)
+	require.NotEmpty(t, catalogs)
+	// The current catalog is always first.
+	require.Equal(t, "sakila", catalogs[0])
+	require.Contains(t, catalogs, "master")
+}
+
+func TestDriver_ListSchemaMetadata_MSSQL(t *testing.T) {
+	tu.SkipShort(t, true)
+	t.Parallel()
+
+	th, _, drvr, _, db := testh.NewWith(t, sakila.MS)
+
+	schemas, err := drvr.ListSchemaMetadata(th.Context, db)
+	require.NoError(t, err)
+	require.NotEmpty(t, schemas)
+
+	var found bool
+	for _, s := range schemas {
+		require.Equal(t, "sakila", s.Catalog)
+		if s.Name == "dbo" {
+			found = true
+		}
+	}
+	require.True(t, found, "expected to find the dbo schema")
+}
+
+func TestDriver_ListTableNames_MSSQL(t *testing.T) {
+	tu.SkipShort(t, true)
+	t.Parallel()
+
+	th, _, drvr, _, db := testh.NewWith(t, sakila.MS)
+	ctx := th.Context
+
+	tables, err := drvr.ListTableNames(ctx, db, "", true, false)
+	require.NoError(t, err)
+	require.Contains(t, tables, sakila.TblActor)
+
+	views, err := drvr.ListTableNames(ctx, db, "", false, true)
+	require.NoError(t, err)
+	require.NotContains(t, views, sakila.TblActor)
+
+	both, err := drvr.ListTableNames(ctx, db, "", true, true)
+	require.NoError(t, err)
+	require.Contains(t, both, sakila.TblActor)
+	require.GreaterOrEqual(t, len(both), len(tables))
+
+	// Explicit schema arg exercises the @p1 branch.
+	scoped, err := drvr.ListTableNames(ctx, db, "dbo", true, false)
+	require.NoError(t, err)
+	require.Contains(t, scoped, sakila.TblActor)
+
+	// Neither tables nor views returns an empty slice without a query.
+	none, err := drvr.ListTableNames(ctx, db, "", false, false)
+	require.NoError(t, err)
+	require.Empty(t, none)
+}
+
+func TestDriver_TableColumnTypes_MSSQL(t *testing.T) {
+	tu.SkipShort(t, true)
+	t.Parallel()
+
+	th, _, drvr, _, db := testh.NewWith(t, sakila.MS)
+	ctx := th.Context
+
+	// All columns.
+	colTypes, err := drvr.TableColumnTypes(ctx, db, sakila.TblActor, nil)
+	require.NoError(t, err)
+	require.Equal(t, len(sakila.TblActorCols()), len(colTypes))
+
+	// Explicit subset of columns.
+	want := []string{"actor_id", "first_name"}
+	colTypes, err = drvr.TableColumnTypes(ctx, db, sakila.TblActor, want)
+	require.NoError(t, err)
+	require.Equal(t, len(want), len(colTypes))
+	require.Equal(t, "actor_id", colTypes[0].Name())
+}
+
+func TestDriver_AlterTableAddColumn_MSSQL(t *testing.T) {
+	tu.SkipShort(t, true)
+	t.Parallel()
+
+	th, src, drvr, _, db := testh.NewWith(t, sakila.MS)
+
+	tbl := th.CopyTable(true, src, tablefq.From(sakila.TblActor), tablefq.T{}, false)
+
+	require.NoError(t, drvr.AlterTableAddColumn(th.Context, db, tbl, "col_extra", kind.Decimal))
+
+	colTypes, err := drvr.TableColumnTypes(th.Context, db, tbl, []string{"col_extra"})
+	require.NoError(t, err)
+	require.Len(t, colTypes, 1)
+}
+
+func TestDriver_AlterTableRename_MSSQL(t *testing.T) {
+	tu.SkipShort(t, true)
+	t.Parallel()
+
+	th, src, drvr, _, db := testh.NewWith(t, sakila.MS)
+
+	tbl := th.CopyTable(true, src, tablefq.From(sakila.TblActor), tablefq.T{}, false)
+
+	newName := stringz.UniqTableName("actor_renamed")
+	require.NoError(t, drvr.AlterTableRename(th.Context, db, tbl, newName))
+	t.Cleanup(func() { th.DropTable(src, tablefq.From(newName)) })
+
+	exists, err := drvr.TableExists(th.Context, db, newName)
+	require.NoError(t, err)
+	require.True(t, exists)
+}
+
+func TestDriver_AlterTableRenameColumn_MSSQL(t *testing.T) {
+	tu.SkipShort(t, true)
+	t.Parallel()
+
+	th, src, drvr, _, db := testh.NewWith(t, sakila.MS)
+
+	tbl := th.CopyTable(true, src, tablefq.From(sakila.TblActor), tablefq.T{}, false)
+
+	require.NoError(t, drvr.AlterTableRenameColumn(th.Context, db, tbl, "first_name", "given_name"))
+
+	colTypes, err := drvr.TableColumnTypes(th.Context, db, tbl, []string{"given_name"})
+	require.NoError(t, err)
+	require.Len(t, colTypes, 1)
+}
+
+func TestDriver_Truncate_MSSQL(t *testing.T) {
+	tu.SkipShort(t, true)
+	t.Parallel()
+
+	th, src, drvr, _, _ := testh.NewWith(t, sakila.MS)
+
+	// Truncate without reseed.
+	tbl := th.CopyTable(true, src, tablefq.From(sakila.TblActor), tablefq.T{}, true)
+	affected, err := drvr.Truncate(th.Context, src, tbl, false)
+	require.NoError(t, err)
+	require.Equal(t, int64(sakila.TblActorCount), affected)
+
+	// Truncate with reseed on a table that has an identity column.
+	tbl2 := th.CopyTable(true, src, tablefq.From(sakila.TblActor), tablefq.T{}, true)
+	affected, err = drvr.Truncate(th.Context, src, tbl2, true)
+	require.NoError(t, err)
+	require.Equal(t, int64(sakila.TblActorCount), affected)
+}
+
+// TestDriver_Truncate_NoIdentity_MSSQL exercises the branch where reseed is
+// requested but the table has no identity column: the driver logs a warning
+// and returns successfully rather than erroring.
+func TestDriver_Truncate_NoIdentity_MSSQL(t *testing.T) {
+	tu.SkipShort(t, true)
+	t.Parallel()
+
+	th, src, drvr, _, db := testh.NewWith(t, sakila.MS)
+
+	tblName := stringz.UniqTableName("trunc_noident")
+	tblDef := schema.NewTable(
+		tblName,
+		[]string{"name", "val"},
+		[]kind.Kind{kind.Text, kind.Int},
+	)
+	require.NoError(t, drvr.CreateTable(th.Context, db, tblDef))
+	t.Cleanup(func() { th.DropTable(src, tablefq.From(tblName)) })
+
+	th.Insert(src, tblName, []string{"name", "val"}, []any{"a", int64(1)}, []any{"b", int64(2)})
+
+	affected, err := drvr.Truncate(th.Context, src, tblName, true)
+	require.NoError(t, err)
+	require.Equal(t, int64(2), affected)
+}
+
+func TestDriver_PrepareUpdateStmt_MSSQL(t *testing.T) {
+	tu.SkipShort(t, true)
+	t.Parallel()
+
+	th, src, drvr, _, db := testh.NewWith(t, sakila.MS)
+
+	tbl := th.CopyTable(true, src, tablefq.From(sakila.TblActor), tablefq.T{}, true)
+
+	destCols := []string{"first_name", "last_name"}
+	wantVals := []any{"Kubla", "Khan"}
+
+	execer, err := drvr.PrepareUpdateStmt(th.Context, db, tbl, destCols, "actor_id = ?")
+	require.NoError(t, err)
+	require.Equal(t, destCols, execer.DestMeta().Names())
+	require.NoError(t, execer.Munge(wantVals))
+
+	affected, err := execer.Exec(th.Context, append(wantVals, int64(1))...)
+	require.NoError(t, err)
+	require.Equal(t, int64(1), affected)
+}
+
+// TestDriver_PrepareInsertStmt_IdentityInsert_MSSQL exercises the
+// identity-insert recovery path: inserting an explicit value into an identity
+// column first fails with errCodeIdentityInsert, after which the driver sets
+// IDENTITY_INSERT ON and retries successfully.
+func TestDriver_PrepareInsertStmt_IdentityInsert_MSSQL(t *testing.T) {
+	tu.SkipShort(t, true)
+	t.Parallel()
+
+	th, src, drvr, _, db := testh.NewWith(t, sakila.MS)
+
+	// SELECT * INTO preserves the identity property of actor_id.
+	tbl := th.CopyTable(true, src, tablefq.From(sakila.TblActor), tablefq.T{}, true)
+
+	destCols := []string{"actor_id", "first_name", "last_name", "last_update"}
+	const explicitID int64 = 99999
+	vals := []any{explicitID, "Ada", "Lovelace", time.Now()}
+
+	// IDENTITY_INSERT is connection-scoped, so the SET statement issued by the
+	// driver's recovery path and the prepared insert must share one connection.
+	// Use a transaction (a single connection) as the driver does for real
+	// batch inserts; passing the *sql.DB pool would run them on different
+	// connections and the retry would still see IDENTITY_INSERT OFF.
+	tx, err := db.BeginTx(th.Context, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = tx.Rollback() })
+
+	execer, err := drvr.PrepareInsertStmt(th.Context, tx, tbl, destCols, 1)
+	require.NoError(t, err)
+	require.NoError(t, execer.Munge(vals))
+
+	affected, err := execer.Exec(th.Context, vals...)
+	require.NoError(t, err)
+	require.Equal(t, int64(1), affected)
+	require.NoError(t, tx.Commit())
+
+	sink, err := th.QuerySQL(src, nil, "SELECT * FROM "+tbl+" WHERE actor_id = 99999")
+	require.NoError(t, err)
+	require.Equal(t, 1, len(sink.Recs))
+}
+
+// TestDriver_ErrorPaths_ClosedDB_MSSQL drives the DB-error branches of the
+// driver's db-backed methods by issuing them against a closed connection. Every
+// query/exec fails with "database is closed", exercising the errw wrapping that
+// the happy-path tests don't reach.
+func TestDriver_ErrorPaths_ClosedDB_MSSQL(t *testing.T) {
+	tu.SkipShort(t, true)
+	t.Parallel()
+
+	th, src, drvr, _, _ := testh.NewWith(t, sakila.MS)
+	ctx := th.Context
+
+	// Open a dedicated grip so closing it doesn't disturb the shared helper db.
+	grip, err := drvr.Open(ctx, src, driver.ModeReadWrite)
+	require.NoError(t, err)
+	db, err := grip.DB(ctx)
+	require.NoError(t, err)
+	require.NoError(t, grip.Close())
+
+	const bogusTbl = "no_such_table_xyz"
+	fqTbl := tablefq.From(bogusTbl)
+
+	_, err = drvr.DBProperties(ctx, db)
+	assert.Error(t, err)
+	_, err = drvr.TableExists(ctx, db, bogusTbl)
+	assert.Error(t, err)
+	_, err = drvr.CurrentSchema(ctx, db)
+	assert.Error(t, err)
+	_, err = drvr.CurrentCatalog(ctx, db)
+	assert.Error(t, err)
+	// Non-empty names get past the short-circuit and reach the query.
+	_, err = drvr.SchemaExists(ctx, db, "dbo")
+	assert.Error(t, err)
+	_, err = drvr.CatalogExists(ctx, db, "sakila")
+	assert.Error(t, err)
+	_, err = drvr.ListSchemas(ctx, db)
+	assert.Error(t, err)
+	_, err = drvr.ListSchemaMetadata(ctx, db)
+	assert.Error(t, err)
+	_, err = drvr.ListCatalogs(ctx, db)
+	assert.Error(t, err)
+	_, err = drvr.ListTableNames(ctx, db, "", true, true)
+	assert.Error(t, err)
+	_, err = drvr.TableColumnTypes(ctx, db, bogusTbl, nil)
+	assert.Error(t, err)
+	assert.Error(t, drvr.CreateSchema(ctx, db, "sch_"+stringz.Uniq8()))
+	assert.Error(t, drvr.DropSchema(ctx, db, "sch_"+stringz.Uniq8()))
+	assert.Error(t, drvr.AlterTableAddColumn(ctx, db, bogusTbl, "c", kind.Int))
+	assert.Error(t, drvr.AlterTableRename(ctx, db, bogusTbl, "c"))
+	assert.Error(t, drvr.AlterTableRenameColumn(ctx, db, bogusTbl, "c", "d"))
+	_, err = drvr.CopyTable(ctx, db, fqTbl, tablefq.From("dst"), true)
+	assert.Error(t, err)
+	assert.Error(t, drvr.DropTable(ctx, db, fqTbl, false))
+	_, err = drvr.PrepareInsertStmt(ctx, db, bogusTbl, []string{"c"}, 1)
+	assert.Error(t, err)
+	_, err = drvr.PrepareUpdateStmt(ctx, db, bogusTbl, []string{"c"}, "c = ?")
+	assert.Error(t, err)
+
+	tblDef := schema.NewTable("t_"+stringz.Uniq8(), []string{"c"}, []kind.Kind{kind.Int})
+	assert.Error(t, drvr.CreateTable(ctx, db, tblDef))
+
+	// Truncate opens its own connection, so target a non-existent table to
+	// drive its delete-failure branch instead.
+	_, err = drvr.Truncate(ctx, src, bogusTbl, false)
+	assert.Error(t, err)
+}
+
+// TestDriver_Open_BadLocation_MSSQL exercises the error path of Open when the
+// source location can't be connected to.
+func TestDriver_Open_BadLocation_MSSQL(t *testing.T) {
+	tu.SkipShort(t, true)
+	t.Parallel()
+
+	th, src, drvr, _, _ := testh.NewWith(t, sakila.MS)
+
+	bad := src.Clone()
+	bad.Location = "sqlserver://sq:wrongpw@localhost:1433?database=sakila"
+	_, err := drvr.Open(th.Context, bad, driver.ModeReadWrite)
+	assert.Error(t, err)
+}
+
+// TestDriver_Open_WithCatalog_MSSQL covers the doOpen branch that rewrites the
+// connection string when the source specifies a catalog.
+func TestDriver_Open_WithCatalog_MSSQL(t *testing.T) {
+	tu.SkipShort(t, true)
+	t.Parallel()
+
+	th, src, drvr, _, _ := testh.NewWith(t, sakila.MS)
+
+	withCat := src.Clone()
+	withCat.Catalog = "sakila"
+	grip, err := drvr.Open(th.Context, withCat, driver.ModeReadWrite)
+	require.NoError(t, err)
+	t.Cleanup(func() { assert.NoError(t, grip.Close()) })
+
+	catalog, err := drvr.CurrentCatalog(th.Context, th.OpenDB(withCat))
+	require.NoError(t, err)
+	require.Equal(t, "sakila", catalog)
+}

--- a/drivers/sqlserver/sqlserver_integration_test.go
+++ b/drivers/sqlserver/sqlserver_integration_test.go
@@ -407,7 +407,7 @@ func TestDriver_Open_BadLocation_MSSQL(t *testing.T) {
 	bad := src.Clone()
 	bad.Location = "sqlserver://sq:wrongpw@localhost:1433?database=sakila"
 	_, err := drvr.Open(th.Context, bad, driver.ModeReadWrite)
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 // TestDriver_Open_WithCatalog_MSSQL covers the doOpen branch that rewrites the

--- a/drivers/sqlserver/sqlserver_unit_test.go
+++ b/drivers/sqlserver/sqlserver_unit_test.go
@@ -1,0 +1,143 @@
+package sqlserver_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/neilotoole/sq/drivers/sqlserver"
+	"github.com/neilotoole/sq/libsq/ast"
+	"github.com/neilotoole/sq/libsq/core/kind"
+	"github.com/neilotoole/sq/libsq/core/lg/lgt"
+	"github.com/neilotoole/sq/libsq/driver"
+	"github.com/neilotoole/sq/libsq/source"
+	"github.com/neilotoole/sq/libsq/source/drivertype"
+)
+
+// newDriver returns a SQL Server driver instance without opening a database
+// connection. It's for exercising driver methods that don't touch the DB.
+func newDriver(t *testing.T) driver.SQLDriver {
+	t.Helper()
+	p := &sqlserver.Provider{Log: lgt.New(t)}
+	drvr, err := p.DriverFor(drivertype.MSSQL)
+	require.NoError(t, err)
+	sqlDrvr, ok := drvr.(driver.SQLDriver)
+	require.True(t, ok)
+	return sqlDrvr
+}
+
+func TestProvider_DriverFor(t *testing.T) {
+	t.Parallel()
+
+	p := &sqlserver.Provider{Log: lgt.New(t)}
+
+	drvr, err := p.DriverFor(drivertype.MSSQL)
+	require.NoError(t, err)
+	require.NotNil(t, drvr)
+
+	// An unsupported driver type must error.
+	drvr, err = p.DriverFor(drivertype.Pg)
+	require.Error(t, err)
+	require.Nil(t, drvr)
+}
+
+func TestDriver_DriverMetadata(t *testing.T) {
+	t.Parallel()
+
+	md := newDriver(t).DriverMetadata()
+	require.Equal(t, drivertype.MSSQL, md.Type)
+	require.True(t, md.IsSQL)
+	require.Equal(t, 1433, md.DefaultPort)
+	require.NotEmpty(t, md.Description)
+	require.NotEmpty(t, md.Doc)
+}
+
+func TestDriver_Dialect(t *testing.T) {
+	t.Parallel()
+
+	d := newDriver(t).Dialect()
+	require.Equal(t, drivertype.MSSQL, d.Type)
+	require.True(t, d.Catalog)
+	require.Equal(t, 1000, d.MaxBatchValues)
+
+	// Placeholders must use the @pN form.
+	require.Equal(t, "(@p1, @p2)", d.Placeholders(2, 1))
+	// Enquote must double-quote.
+	require.Equal(t, `"col"`, d.Enquote("col"))
+}
+
+func TestDriver_ConnParams(t *testing.T) {
+	t.Parallel()
+
+	params := newDriver(t).ConnParams()
+	require.NotEmpty(t, params)
+	// Spot-check a couple of well-known SQL Server connection parameters.
+	require.Contains(t, params, "database")
+	require.Contains(t, params, "encrypt")
+	require.Equal(t, []string{"disable", "false", "true"}, params["encrypt"])
+}
+
+func TestDriver_LocationShape(t *testing.T) {
+	t.Parallel()
+
+	shape := newDriver(t).LocationShape()
+	require.Equal(t, drivertype.MSSQL, shape.Type)
+	require.Contains(t, shape.Schemes, "sqlserver")
+	require.NotEmpty(t, shape.Segments)
+}
+
+func TestDriver_ErrWrapFunc(t *testing.T) {
+	t.Parallel()
+
+	fn := newDriver(t).ErrWrapFunc()
+	require.NotNil(t, fn)
+	// A nil error must wrap to nil.
+	require.NoError(t, fn(nil))
+}
+
+func TestDriver_Renderer(t *testing.T) {
+	t.Parallel()
+
+	r := newDriver(t).Renderer()
+	require.NotNil(t, r)
+	require.NotNil(t, r.Range)
+	require.NotNil(t, r.Literal)
+
+	// SQL Server-specific function name and override wiring.
+	require.Equal(t, "SCHEMA_NAME", r.FunctionNames[ast.FuncNameSchema])
+	require.Equal(t, "DB_NAME", r.FunctionNames[ast.FuncNameCatalog])
+	require.Contains(t, r.FunctionOverrides, ast.FuncNameAvg)
+	require.Contains(t, r.FunctionOverrides, ast.FuncNameSum)
+	require.Contains(t, r.FunctionOverrides, ast.FuncNameRowNum)
+}
+
+func TestDriver_ValidateSource(t *testing.T) {
+	t.Parallel()
+
+	drvr := newDriver(t)
+
+	src := &source.Source{
+		Handle:   "@ms",
+		Type:     drivertype.MSSQL,
+		Location: "sqlserver://sa:pw@localhost?database=sakila",
+	}
+	got, err := drvr.ValidateSource(src)
+	require.NoError(t, err)
+	require.Same(t, src, got)
+
+	// Wrong driver type must error.
+	bad := &source.Source{Handle: "@pg", Type: drivertype.Pg}
+	got, err = drvr.ValidateSource(bad)
+	require.Error(t, err)
+	require.Nil(t, got)
+}
+
+func TestDriver_AlterTableColumnKinds_NotImplemented(t *testing.T) {
+	t.Parallel()
+
+	// AlterTableColumnKinds is not yet implemented for SQL Server; it must
+	// return an error without touching the (nil) DB.
+	err := newDriver(t).AlterTableColumnKinds(
+		t.Context(), nil, "tbl", []string{"col"}, []kind.Kind{kind.Int})
+	require.Error(t, err)
+}


### PR DESCRIPTION
Deep review of the SQL Server driver (`drivers/sqlserver/sqlserver.go` plus the package it lives in), with bug fixes and a substantial test-coverage push.

Package statement coverage rose **53.7% → 81.5%**; `sqlserver.go` itself now averages **~93%** per function. Verified against the live `sakiladb-ms` container.

## Fixes

- **`getTableColsMeta` leaked `rows` on the `rows.Err()` path.** Every other error branch in the function closed the rows; this one returned without doing so, leaking a connection on a mid-stream row error. The sibling `TableColumnTypes` already handles the same case correctly.
- **`SchemaExists` / `CatalogExists` relied on unspecified Go evaluation order.** Both used `return count > 0, errw(...Scan(&count))`, where the read of `count` in `count > 0` is not ordered by the spec relative to the `Scan` that populates it. It happens to work under gc today, but it's fragile; rewritten to scan-then-compare so the result is correct by construction.
- **`properties.go` queried a malformed `SERVERPROPERTY` name** (`IsFullTextIsExternalGovernanceEnabledInstalled`), a copy-paste mash-up. `SERVERPROPERTY` returns NULL for unknown names, which is silently skipped, so the `IsExternalGovernanceEnabled` property never appeared in `sq inspect --overview`. Fixed to the correct name.
- **`DriverFor` error message** had a stray closing brace.

## Noted, not changed (intentional, flagged for discussion)

- `setIdentityInsert` is never turned back OFF and its OFF branch is dead code; `IDENTITY_INSERT` is session-scoped, so this is a latent footgun on reused connections. Works today because real inserts run in a per-batch transaction.
- `Truncate` mixes `%q` (Go quoting) with the SQL-identifier `tblfmt` used elsewhere, and interpolates the raw name into `DBCC CHECKIDENT`. Fine for normal names; left alone to avoid changing reseed semantics untested.
- `Open` leaks the `*sql.DB` if `OpeningPing` fails, but it's an identical pattern in the postgres and mysql drivers, so it's better fixed across all three at once.

## Tests

- `sqlserver_unit_test.go` — no-DB unit tests via `Provider.DriverFor`, covering the previously-0% pure methods (`ConnParams`, `LocationShape`, `DriverMetadata`, `Dialect`, `Renderer`, `ValidateSource` both paths, `AlterTableColumnKinds`, `ErrWrapFunc`, `DriverFor` error path).
- `sqlserver_integration_test.go` (`SkipShort`) — live-DB tests for `Ping`, `DBProperties`, catalog/schema/table listing and existence checks, `TableColumnTypes`, the three `AlterTable*` ops, `Truncate` (reseed and no-identity-column branches), `PrepareUpdateStmt`, the identity-insert recovery path (`newStmtExecFunc`/`setIdentityInsert`, which has to run in a transaction so the `SET` and retry share one connection), plus a closed-DB sweep that drives the `errw` wrapping branches across the db-backed methods.

`make lint` and `make lint-markdown` are clean.