### PR TITLE
oracle: fix materialized-view inspection; coverage to 91%

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,6 +127,11 @@ Breaking changes are annotated with ☢️, and alpha/beta features with 🐥.
 - [#844]: On [Oracle](https://sq.io/docs/drivers/oracle), a query whose result is a computed
   `NUMBER` with a fractional value no longer fails with a scan error; such numbers are now
   typed as `decimal`.
+- [`sq inspect`](https://sq.io/docs/inspect) on an Oracle source now handles materialized
+  views correctly. A materialized view was previously omitted from the inspection (its metadata
+  query referenced a `NUM_ROWS` column that Oracle exposes only on the backing table, not in
+  `USER_MVIEWS`), and that backing container table was reported as a duplicate base table.
+  Materialized views now appear exactly once, typed as a materialized view.
 - [#594]: On [SQL Server](https://sq.io/docs/drivers/sqlserver), `avg()` over an integer
   column no longer performs integer division and truncates the result.
 - [#741], [#743]: [`sq add`](https://sq.io/docs/cmd/add) shell completion now supports

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -140,11 +140,12 @@ Breaking changes are annotated with ☢️, and alpha/beta features with 🐥.
 - [#844]: On [Oracle](https://sq.io/docs/drivers/oracle), a query whose result is a computed
   `NUMBER` with a fractional value no longer fails with a scan error; such numbers are now
   typed as `decimal`.
-- [`sq inspect`](https://sq.io/docs/inspect) on an Oracle source now handles materialized
-  views correctly. A materialized view was previously omitted from the inspection (its metadata
-  query referenced a `NUM_ROWS` column that Oracle exposes only on the backing table, not in
-  `USER_MVIEWS`), and that backing container table was reported as a duplicate base table.
-  Materialized views now appear exactly once, typed as a materialized view.
+- [`sq inspect`](https://sq.io/docs/inspect) on an Oracle source now handles
+  materialized views correctly. A materialized view was previously omitted from
+  the inspection (its metadata query referenced a `NUM_ROWS` column that Oracle
+  exposes only on the backing table, not in `USER_MVIEWS`), and that backing
+  container table was reported as a duplicate base table. Materialized views now
+  appear exactly once, typed as a materialized view.
 - [#594]: On [SQL Server](https://sq.io/docs/drivers/sqlserver), `avg()` over an integer
   column no longer performs integer division and truncates the result.
 - [#741], [#743]: [`sq add`](https://sq.io/docs/cmd/add) shell completion now supports

--- a/drivers/oracle/metadata.go
+++ b/drivers/oracle/metadata.go
@@ -779,10 +779,11 @@ WHERE m.mview_name = :1`
 		return nil, errw(err)
 	}
 
-	// USER_MVIEWS.NUM_ROWS, like USER_TABLES.NUM_ROWS, is CBO-stats-derived
-	// and is NULL until DBMS_STATS / ANALYZE has run on the materialized
-	// view. See getTableMetadata for the full rationale; the same fallback
-	// applies here.
+	// NUM_ROWS here comes from the MV's container table in USER_TABLES (see
+	// the query above); like any USER_TABLES.NUM_ROWS it is CBO-stats-derived
+	// and NULL until DBMS_STATS / ANALYZE has run on the materialized view.
+	// See getTableMetadata for the full rationale; the same fallback applies
+	// here.
 	rowCount := numRows.Int64
 	if !numRows.Valid {
 		var err error

--- a/drivers/oracle/metadata.go
+++ b/drivers/oracle/metadata.go
@@ -170,12 +170,17 @@ func loadUserSchemaObjectsMetadata(
 	// Oracle backs every materialized view with a container table of the
 	// same name, so that name appears in USER_TABLES as well as USER_MVIEWS.
 	// Exclude MV container tables here so the MV is reported once (via
-	// getMaterializedViewMetadata below) rather than twice.
+	// getMaterializedViewMetadata below) rather than twice. NOT EXISTS (not
+	// NOT IN) avoids the SQL footgun where a NULL in the subquery would
+	// filter out every row, and matches the ListTableNames approach.
 	baseNames, err := queryOracleObjectNames(ctx, db,
-		`SELECT table_name FROM user_tables
-WHERE temporary = 'N'
-  AND table_name NOT IN (SELECT mview_name FROM user_mviews)
-ORDER BY table_name`)
+		`SELECT t.table_name FROM user_tables t
+WHERE t.temporary = 'N'
+  AND NOT EXISTS (
+    SELECT 1 FROM user_mviews m
+    WHERE m.mview_name = t.table_name
+  )
+ORDER BY t.table_name`)
 	if err != nil {
 		return nil, err
 	}

--- a/drivers/oracle/metadata.go
+++ b/drivers/oracle/metadata.go
@@ -167,8 +167,15 @@ FROM DUAL`
 func loadUserSchemaObjectsMetadata(
 	ctx context.Context, log *slog.Logger, handle string, db *sql.DB,
 ) ([]*metadata.Table, error) {
+	// Oracle backs every materialized view with a container table of the
+	// same name, so that name appears in USER_TABLES as well as USER_MVIEWS.
+	// Exclude MV container tables here so the MV is reported once (via
+	// getMaterializedViewMetadata below) rather than twice.
 	baseNames, err := queryOracleObjectNames(ctx, db,
-		`SELECT table_name FROM user_tables WHERE temporary = 'N' ORDER BY table_name`)
+		`SELECT table_name FROM user_tables
+WHERE temporary = 'N'
+  AND table_name NOT IN (SELECT mview_name FROM user_mviews)
+ORDER BY table_name`)
 	if err != nil {
 		return nil, err
 	}
@@ -739,9 +746,15 @@ WHERE v.view_name = :1`
 
 // getMaterializedViewMetadata returns metadata for a materialized view.
 func getMaterializedViewMetadata(ctx context.Context, db *sql.DB, mvName string) (*metadata.Table, error) {
-	const q = `SELECT m.mview_name, tc.comments, m.num_rows,
+	// USER_MVIEWS has no NUM_ROWS column; the CBO row-count statistic for a
+	// materialized view lives on its container table in USER_TABLES (joined
+	// here by name). It's NULL until stats are gathered, in which case the
+	// liveRowCount fallback below applies, mirroring getTableMetadata.
+	const q = `SELECT m.mview_name, tc.comments, t.num_rows,
     NVL(s.bytes, 0) AS bytes
 FROM user_mviews m
+LEFT JOIN user_tables t
+    ON m.mview_name = t.table_name
 LEFT JOIN user_tab_comments tc
     ON m.mview_name = tc.table_name
     AND tc.table_type = 'MATERIALIZED VIEW'

--- a/drivers/oracle/metadata_internal_test.go
+++ b/drivers/oracle/metadata_internal_test.go
@@ -1,0 +1,121 @@
+package oracle
+
+import (
+	"context"
+	"database/sql"
+	"log/slog"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/neilotoole/sq/libsq/source"
+	"github.com/neilotoole/sq/libsq/source/drivertype"
+)
+
+// oracleTestDSN matches the docker-compose default (sakiladb/oracle); override
+// with SQ_TEST_ORACLE_DSN.
+const oracleTestDSN = "oracle://sakila:p_ssW0rd@localhost:1521/SAKILA"
+
+// openOracleForInternalTest opens a connection to the test Oracle instance,
+// skipping the test if it's unreachable. The caller owns Close.
+func openOracleForInternalTest(t *testing.T) *sql.DB {
+	t.Helper()
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	dsn := os.Getenv("SQ_TEST_ORACLE_DSN")
+	if dsn == "" {
+		dsn = oracleTestDSN
+	}
+	db, err := sql.Open("oracle", dsn)
+	if err != nil {
+		t.Skipf("Oracle open failed: %v", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err = db.PingContext(ctx); err != nil {
+		_ = db.Close()
+		t.Skipf("Oracle not reachable: %v", err)
+	}
+	return db
+}
+
+// TestGetSourceMetadata_NoSchema covers the noSchema=true early-return branch
+// of getSourceMetadata, which grip.SourceMetadata(noSchema=false) doesn't hit.
+func TestGetSourceMetadata_NoSchema(t *testing.T) {
+	db := openOracleForInternalTest(t)
+	defer db.Close()
+
+	src := &source.Source{
+		Handle:   "@ora_internal",
+		Type:     drivertype.Oracle,
+		Location: oracleTestDSN,
+	}
+	md, err := getSourceMetadata(context.Background(), src, db, true)
+	require.NoError(t, err)
+	require.NotNil(t, md)
+	require.NotEmpty(t, md.Schema)
+	require.Empty(t, md.Tables, "noSchema=true must skip table enumeration")
+}
+
+// TestMetadataHelpers_ErrorPaths drives the first-query error branch of every
+// unexported metadata helper by handing each a closed *sql.DB. This covers the
+// errw(err) propagation paths deterministically.
+func TestMetadataHelpers_ErrorPaths(t *testing.T) {
+	db := openOracleForInternalTest(t)
+	require.NoError(t, db.Close())
+
+	ctx := context.Background()
+	const tbl = "ACTOR"
+
+	_, err := queryOracleObjectNames(ctx, db, `SELECT table_name FROM user_tables`)
+	require.Error(t, err)
+
+	_, err = liveRowCount(ctx, db, tbl)
+	require.Error(t, err)
+
+	_, err = getColumnsMetadata(ctx, db, tbl)
+	require.Error(t, err)
+
+	_, err = getOraclePKColumnNames(ctx, db, tbl)
+	require.Error(t, err)
+
+	_, err = getOracleForeignKeys(ctx, db, tbl)
+	require.Error(t, err)
+
+	_, err = getOracleForeignKeys(ctx, db, "")
+	require.Error(t, err)
+
+	_, err = getOracleIncomingFKs(ctx, db, tbl)
+	require.Error(t, err)
+
+	_, err = getOracleUniqueConstraints(ctx, db, tbl)
+	require.Error(t, err)
+
+	_, err = getOracleUniqueConstraints(ctx, db, "")
+	require.Error(t, err)
+
+	_, err = getOracleIndexes(ctx, db, tbl)
+	require.Error(t, err)
+
+	_, err = getViewMetadata(ctx, db, tbl)
+	require.Error(t, err)
+
+	_, err = getMaterializedViewMetadata(ctx, db, tbl)
+	require.Error(t, err)
+
+	_, err = getTableMetadata(ctx, db, tbl, true)
+	require.Error(t, err)
+
+	_, err = getObjectMetadata(ctx, db, tbl)
+	require.Error(t, err)
+
+	_, err = loadUserSchemaObjectsMetadata(ctx, slog.New(slog.DiscardHandler), "@h", db)
+	require.Error(t, err)
+
+	src := &source.Source{Handle: "@h", Type: drivertype.Oracle, Location: oracleTestDSN}
+	_, err = getSourceMetadata(ctx, src, db, false)
+	require.Error(t, err)
+}

--- a/drivers/oracle/metadata_internal_test.go
+++ b/drivers/oracle/metadata_internal_test.go
@@ -29,10 +29,11 @@ func openOracleForInternalTest(t *testing.T) *sql.DB {
 	if dsn == "" {
 		dsn = oracleTestDSN
 	}
+	// sql.Open only fails if the "oracle" driver isn't registered or the DSN
+	// is malformed; both are real regressions, so require success here and
+	// skip only when the instance itself is unreachable (PingContext).
 	db, err := sql.Open("oracle", dsn)
-	if err != nil {
-		t.Skipf("Oracle open failed: %v", err)
-	}
+	require.NoError(t, err)
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 	if err = db.PingContext(ctx); err != nil {

--- a/drivers/oracle/oracle.go
+++ b/drivers/oracle/oracle.go
@@ -366,9 +366,17 @@ func (d *driveri) ListTableNames(ctx context.Context, db sqlz.DB, schma string, 
 	owner := strings.ToUpper(schma)
 
 	if tables {
-		const queryTables = `SELECT table_name FROM all_tables
-WHERE owner = :1 AND temporary = 'N'
-ORDER BY table_name`
+		// A materialized view's container table appears in ALL_TABLES under
+		// the same name as the MV in ALL_MVIEWS. Exclude those container
+		// tables so the MV name isn't returned twice (once here, once from
+		// the ALL_MVIEWS query below).
+		const queryTables = `SELECT t.table_name FROM all_tables t
+WHERE t.owner = :1 AND t.temporary = 'N'
+  AND NOT EXISTS (
+    SELECT 1 FROM all_mviews m
+    WHERE m.owner = t.owner AND m.mview_name = t.table_name
+  )
+ORDER BY t.table_name`
 		rows, err := db.QueryContext(ctx, queryTables, owner)
 		if err != nil {
 			return nil, errw(err)

--- a/drivers/oracle/oracle_sqldriver_test.go
+++ b/drivers/oracle/oracle_sqldriver_test.go
@@ -1,0 +1,452 @@
+package oracle_test
+
+import (
+	"database/sql"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/neilotoole/sq/libsq/core/kind"
+	"github.com/neilotoole/sq/libsq/core/schema"
+	"github.com/neilotoole/sq/libsq/core/stringz"
+	"github.com/neilotoole/sq/libsq/core/tablefq"
+	"github.com/neilotoole/sq/libsq/driver"
+	"github.com/neilotoole/sq/libsq/source"
+	"github.com/neilotoole/sq/testh"
+	"github.com/neilotoole/sq/testh/sakila"
+	"github.com/neilotoole/sq/testh/tu"
+)
+
+// sakilaSource bundles the testh fixtures for the Oracle source.
+type sakilaSource struct {
+	src  *source.Source
+	db   *sql.DB
+	drvr driver.SQLDriver
+}
+
+// newOracleTable creates a fresh upper-cased table with (ID NUMBER, NAME
+// VARCHAR2) and registers cleanup. It returns the stored (upper-case) table
+// name.
+func newOracleTable(t *testing.T, th *testh.Helper, s *sakilaSource, prefix string) string {
+	t.Helper()
+	tblName := strings.ToUpper(stringz.UniqTableName(prefix))
+	tblDef := &schema.Table{
+		Name: tblName,
+		Cols: []*schema.Column{
+			{Name: "ID", Kind: kind.Int, NotNull: true},
+			{Name: "NAME", Kind: kind.Text},
+		},
+	}
+	require.NoError(t, s.drvr.CreateTable(th.Context, s.db, tblDef))
+	t.Cleanup(func() { th.DropTable(s.src, tablefq.From(tblName)) })
+	return tblName
+}
+
+// requireOracle returns the standard testh fixtures for the Oracle Sakila
+// source, skipping when it isn't configured.
+func requireOracle(t *testing.T) (*testh.Helper, *sakilaSource) {
+	t.Helper()
+	tu.SkipShort(t, true)
+	th := testh.New(t)
+	if !th.SourceConfigured(sakila.Ora) {
+		t.Skip("Oracle Sakila source not configured")
+	}
+	src := th.Source(sakila.Ora)
+	grip := th.Open(src)
+	db, err := grip.DB(th.Context)
+	require.NoError(t, err)
+	return th, &sakilaSource{src: src, db: db, drvr: grip.SQLDriver()}
+}
+
+// TestDriver_Truncate covers Truncate for both the reset (DROP STORAGE) and
+// non-reset (REUSE STORAGE) paths, asserting the pre-truncate row count is
+// returned.
+func TestDriver_Truncate(t *testing.T) {
+	tu.SkipShort(t, true)
+	t.Parallel()
+	th, s := requireOracle(t)
+
+	for _, reset := range []bool{true, false} {
+		name := "reuse"
+		if reset {
+			name = "reset"
+		}
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			tbl := newOracleTable(t, th, s, "trunc")
+			th.Insert(s.src, tbl, []string{"ID", "NAME"},
+				[]any{1, "a"}, []any{2, "b"}, []any{3, "c"})
+
+			affected, err := s.drvr.Truncate(th.Context, s.src, tbl, reset)
+			require.NoError(t, err)
+			require.Equal(t, int64(3), affected, "Truncate reports pre-truncate count")
+			require.Equal(t, int64(0), th.RowCount(s.src, tbl))
+		})
+	}
+}
+
+// TestDriver_CopyTable covers both the schema-only (copyData=false) and
+// data-copy (copyData=true) paths.
+func TestDriver_CopyTable(t *testing.T) {
+	tu.SkipShort(t, true)
+	t.Parallel()
+	th, s := requireOracle(t)
+
+	src := newOracleTable(t, th, s, "copysrc")
+	th.Insert(s.src, src, []string{"ID", "NAME"}, []any{1, "a"}, []any{2, "b"})
+
+	t.Run("schema_only", func(t *testing.T) {
+		t.Parallel()
+		dst := strings.ToUpper(stringz.UniqTableName("copydst_s"))
+		t.Cleanup(func() { th.DropTable(s.src, tablefq.From(dst)) })
+		affected, err := s.drvr.CopyTable(th.Context, s.db, tablefq.From(src), tablefq.From(dst), false)
+		require.NoError(t, err)
+		require.Equal(t, int64(0), affected)
+		require.Equal(t, int64(0), th.RowCount(s.src, dst), "structure copied, no rows")
+	})
+
+	t.Run("with_data", func(t *testing.T) {
+		t.Parallel()
+		dst := strings.ToUpper(stringz.UniqTableName("copydst_d"))
+		t.Cleanup(func() { th.DropTable(s.src, tablefq.From(dst)) })
+		_, err := s.drvr.CopyTable(th.Context, s.db, tablefq.From(src), tablefq.From(dst), true)
+		require.NoError(t, err)
+		require.Equal(t, int64(2), th.RowCount(s.src, dst), "all rows copied")
+	})
+}
+
+// TestDriver_AlterTable covers AlterTableAddColumn, AlterTableRenameColumn, and
+// AlterTableRename in sequence on a single table.
+func TestDriver_AlterTable(t *testing.T) {
+	tu.SkipShort(t, true)
+	t.Parallel()
+	th, s := requireOracle(t)
+
+	tbl := newOracleTable(t, th, s, "alter")
+
+	require.NoError(t, s.drvr.AlterTableAddColumn(th.Context, s.db, tbl, "EXTRA", kind.Decimal))
+	require.NoError(t, s.drvr.AlterTableRenameColumn(th.Context, s.db, tbl, "EXTRA", "EXTRA2"))
+
+	colTypes, err := s.drvr.TableColumnTypes(th.Context, s.db, tbl, nil)
+	require.NoError(t, err)
+	var names []string
+	for _, ct := range colTypes {
+		names = append(names, ct.Name())
+	}
+	require.Contains(t, names, "EXTRA2")
+	require.NotContains(t, names, "EXTRA")
+
+	newName := strings.ToUpper(stringz.UniqTableName("alter_renamed"))
+	require.NoError(t, s.drvr.AlterTableRename(th.Context, s.db, tbl, newName))
+	t.Cleanup(func() { th.DropTable(s.src, tablefq.From(newName)) })
+
+	exists, err := s.drvr.TableExists(th.Context, s.db, newName)
+	require.NoError(t, err)
+	require.True(t, exists)
+}
+
+// TestDriver_TableColumnTypes covers both the explicit-column path and the
+// empty-column path (which routes through getTableColumnNames).
+func TestDriver_TableColumnTypes(t *testing.T) {
+	tu.SkipShort(t, true)
+	t.Parallel()
+	th, s := requireOracle(t)
+	tbl := newOracleTable(t, th, s, "coltypes")
+
+	all, err := s.drvr.TableColumnTypes(th.Context, s.db, tbl, nil)
+	require.NoError(t, err)
+	require.Len(t, all, 2, "empty colNames returns all columns")
+
+	subset, err := s.drvr.TableColumnTypes(th.Context, s.db, tbl, []string{"NAME"})
+	require.NoError(t, err)
+	require.Len(t, subset, 1)
+	require.Equal(t, "NAME", subset[0].Name())
+}
+
+// TestDriver_PrepareUpdateStmt covers PrepareUpdateStmt with a WHERE clause
+// (exercising oracleSubstWherePlaceholders) and without one.
+func TestDriver_PrepareUpdateStmt(t *testing.T) {
+	tu.SkipShort(t, true)
+	t.Parallel()
+	th, s := requireOracle(t)
+
+	t.Run("with_where", func(t *testing.T) {
+		t.Parallel()
+		tbl := newOracleTable(t, th, s, "upd_w")
+		th.Insert(s.src, tbl, []string{"ID", "NAME"}, []any{1, "a"}, []any{2, "b"})
+
+		execer, err := s.drvr.PrepareUpdateStmt(th.Context, s.db, tbl, []string{"NAME"}, "ID = ?")
+		require.NoError(t, err)
+		t.Cleanup(func() { assert.NoError(t, execer.Close()) })
+
+		vals := []any{"updated"}
+		require.NoError(t, execer.Munge(vals))
+		affected, err := execer.Exec(th.Context, append(vals, 1)...)
+		require.NoError(t, err)
+		require.Equal(t, int64(1), affected)
+	})
+
+	t.Run("no_where", func(t *testing.T) {
+		t.Parallel()
+		tbl := newOracleTable(t, th, s, "upd_n")
+		th.Insert(s.src, tbl, []string{"ID", "NAME"}, []any{1, "a"}, []any{2, "b"})
+
+		execer, err := s.drvr.PrepareUpdateStmt(th.Context, s.db, tbl, []string{"NAME"}, "")
+		require.NoError(t, err)
+		t.Cleanup(func() { assert.NoError(t, execer.Close()) })
+
+		vals := []any{"all"}
+		require.NoError(t, execer.Munge(vals))
+		affected, err := execer.Exec(th.Context, vals...)
+		require.NoError(t, err)
+		require.Equal(t, int64(2), affected, "no WHERE updates every row")
+	})
+}
+
+// TestDriver_Schemas covers ListSchemas, SchemaExists (present and absent), and
+// ListSchemaMetadata.
+func TestDriver_Schemas(t *testing.T) {
+	tu.SkipShort(t, true)
+	t.Parallel()
+	th, s := requireOracle(t)
+
+	schemas, err := s.drvr.ListSchemas(th.Context, s.db)
+	require.NoError(t, err)
+	require.NotEmpty(t, schemas)
+	require.Contains(t, schemas, "SAKILA")
+
+	exists, err := s.drvr.SchemaExists(th.Context, s.db, "sakila")
+	require.NoError(t, err)
+	require.True(t, exists, "SchemaExists is case-insensitive")
+
+	exists, err = s.drvr.SchemaExists(th.Context, s.db, "no_such_schema_xyz")
+	require.NoError(t, err)
+	require.False(t, exists)
+
+	mds, err := s.drvr.ListSchemaMetadata(th.Context, s.db)
+	require.NoError(t, err)
+	require.NotEmpty(t, mds)
+	var found bool
+	for _, md := range mds {
+		if md.Name == "SAKILA" {
+			found = true
+		}
+	}
+	require.True(t, found, "ListSchemaMetadata includes SAKILA")
+}
+
+// TestDriver_DropTable_IfExists covers the ifExists=true path against a
+// nonexistent table (exercising isErrTableNotExist) and the normal drop.
+func TestDriver_DropTable_IfExists(t *testing.T) {
+	tu.SkipShort(t, true)
+	t.Parallel()
+	th, s := requireOracle(t)
+
+	missing := strings.ToUpper(stringz.UniqTableName("nope"))
+	require.NoError(t, s.drvr.DropTable(th.Context, s.db, tablefq.From(missing), true),
+		"dropping a missing table with ifExists=true must be a no-op")
+
+	err := s.drvr.DropTable(th.Context, s.db, tablefq.From(missing), false)
+	require.Error(t, err, "dropping a missing table with ifExists=false must error")
+}
+
+// TestDriver_SourceMetadata_MaterializedView is the regression test for the
+// MV duplicate-listing bug: an Oracle materialized view's container table
+// appears in USER_TABLES under the MV's own name, so the source-metadata
+// loader previously emitted the object twice (once as TABLE, once as
+// MATERIALIZED VIEW). After the fix it must appear exactly once, classified
+// as a materialized view.
+func TestDriver_SourceMetadata_MaterializedView(t *testing.T) {
+	tu.SkipShort(t, true)
+	t.Parallel()
+	th, s := requireOracle(t)
+
+	base := newOracleTable(t, th, s, "mvbase")
+	th.Insert(s.src, base, []string{"ID", "NAME"}, []any{1, "a"}, []any{2, "b"})
+
+	mvName := strings.ToUpper(stringz.UniqTableName("mvdup"))
+	_, err := s.db.ExecContext(th.Context,
+		`CREATE MATERIALIZED VIEW "`+mvName+`" AS SELECT "ID", "NAME" FROM "`+base+`"`)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_, _ = s.db.ExecContext(th.Context, `DROP MATERIALIZED VIEW "`+mvName+`"`)
+	})
+
+	md, err := th.SourceMetadata(s.src)
+	require.NoError(t, err)
+
+	var count int
+	var dbType string
+	for _, tbl := range md.Tables {
+		if tbl.Name == mvName {
+			count++
+			dbType = tbl.DBTableType
+		}
+	}
+	require.Equal(t, 1, count, "materialized view must appear exactly once, not duplicated")
+	require.Equal(t, "MATERIALIZED VIEW", dbType)
+
+	// The single-object path must also resolve it as a materialized view.
+	mvMeta, err := th.Open(s.src).TableMetadata(th.Context, mvName)
+	require.NoError(t, err)
+	require.Equal(t, "MATERIALIZED VIEW", mvMeta.DBTableType)
+	require.Equal(t, int64(2), mvMeta.RowCount)
+}
+
+// TestDriver_ListTableNames_Variants covers the views-only and tables+views
+// paths plus the empty-schema path (which falls back to CurrentSchema).
+func TestDriver_ListTableNames_Variants(t *testing.T) {
+	tu.SkipShort(t, true)
+	t.Parallel()
+	th, s := requireOracle(t)
+
+	// Empty schema → CurrentSchema fallback; views only.
+	views, err := s.drvr.ListTableNames(th.Context, s.db, "", false, true)
+	require.NoError(t, err)
+	require.Contains(t, views, "CUSTOMER_LIST", "Sakila ships the customer_list view")
+
+	tablesOnly, err := s.drvr.ListTableNames(th.Context, s.db, "SAKILA", true, false)
+	require.NoError(t, err)
+	require.Contains(t, tablesOnly, "ACTOR")
+	require.NotContains(t, tablesOnly, "CUSTOMER_LIST", "views excluded when views=false")
+
+	both, err := s.drvr.ListTableNames(th.Context, s.db, "SAKILA", true, true)
+	require.NoError(t, err)
+	require.Contains(t, both, "ACTOR")
+	require.Contains(t, both, "CUSTOMER_LIST")
+	require.True(t, len(both) > len(tablesOnly), "tables+views is a superset of tables")
+}
+
+// TestDriver_QueryAggregates is a package-local regression for the computed-
+// NUMBER kind handling (issues #594, #839, #844): count() must scan as an
+// integer (not a decimal string), sum() stays decimal, and avg() is float.
+// It exercises the renderer function overrides and RecordMeta's kindHints at
+// runtime.
+func TestDriver_QueryAggregates(t *testing.T) {
+	tu.SkipShort(t, true)
+	t.Parallel()
+	th, _ := requireOracle(t)
+
+	t.Run("count", func(t *testing.T) {
+		t.Parallel()
+		sink, err := th.QuerySLQ(sakila.Ora+".actor | count()", nil)
+		require.NoError(t, err)
+		require.Len(t, sink.Recs, 1)
+		// gh844: must surface as an integer, not a decimal string "200".
+		require.EqualValues(t, sakila.TblActorCount, stringz.Val(sink.Recs[0][0]))
+	})
+
+	t.Run("sum_and_avg", func(t *testing.T) {
+		t.Parallel()
+		sink, err := th.QuerySLQ(sakila.Ora+`.payment | sum(.amount)`, nil)
+		require.NoError(t, err)
+		require.Len(t, sink.Recs, 1)
+		require.NotNil(t, sink.Recs[0][0], "sum(.amount) must scan without an int64 crash")
+
+		sink, err = th.QuerySLQ(sakila.Ora+`.payment | avg(.amount)`, nil)
+		require.NoError(t, err)
+		require.Len(t, sink.Recs, 1)
+		require.NotNil(t, sink.Recs[0][0])
+	})
+}
+
+// TestDriver_ErrorPaths exercises the error-return branches of the DB-backed
+// methods by handing them a closed *sql.DB. Every query fails immediately with
+// "sql: database is closed", so this drives the errw(err) propagation paths
+// deterministically without needing fault injection at the wire level.
+func TestDriver_ErrorPaths(t *testing.T) {
+	tu.SkipShort(t, true)
+	t.Parallel()
+	th, s := requireOracle(t)
+
+	closedDB, err := sql.Open("oracle", s.src.Location)
+	require.NoError(t, err)
+	require.NoError(t, closedDB.Close())
+
+	ctx := th.Context
+
+	_, err = s.drvr.CurrentSchema(ctx, closedDB)
+	require.Error(t, err)
+
+	_, err = s.drvr.ListSchemas(ctx, closedDB)
+	require.Error(t, err)
+
+	_, err = s.drvr.SchemaExists(ctx, closedDB, "SAKILA")
+	require.Error(t, err)
+
+	_, err = s.drvr.TableExists(ctx, closedDB, "ACTOR")
+	require.Error(t, err)
+
+	_, err = s.drvr.ListTableNames(ctx, closedDB, "SAKILA", true, true)
+	require.Error(t, err)
+
+	_, err = s.drvr.DBProperties(ctx, closedDB)
+	require.Error(t, err)
+
+	// Explicit column list: the SELECT ... WHERE 1=0 fails.
+	_, err = s.drvr.TableColumnTypes(ctx, closedDB, "ACTOR", []string{"ACTOR_ID"})
+	require.Error(t, err)
+
+	// Empty column list: getTableColumnNames fails first.
+	_, err = s.drvr.TableColumnTypes(ctx, closedDB, "ACTOR", nil)
+	require.Error(t, err)
+
+	_, err = s.drvr.ListSchemaMetadata(ctx, closedDB)
+	require.Error(t, err)
+
+	require.Error(t, s.drvr.CreateTable(ctx, closedDB,
+		&schema.Table{Name: "X", Cols: []*schema.Column{{Name: "ID", Kind: kind.Int}}}))
+
+	// ifExists=true but the error is "database closed", not ORA-00942, so it
+	// must still propagate rather than be swallowed.
+	require.Error(t, s.drvr.DropTable(ctx, closedDB, tablefq.From("ACTOR"), true))
+
+	require.Error(t, s.drvr.AlterTableAddColumn(ctx, closedDB, "ACTOR", "C", kind.Int))
+	require.Error(t, s.drvr.AlterTableRename(ctx, closedDB, "ACTOR", "ACTOR2"))
+	require.Error(t, s.drvr.AlterTableRenameColumn(ctx, closedDB, "ACTOR", "A", "B"))
+
+	_, err = s.drvr.PrepareInsertStmt(ctx, closedDB, "ACTOR", []string{"ACTOR_ID"}, 1)
+	require.Error(t, err)
+
+	_, err = s.drvr.PrepareUpdateStmt(ctx, closedDB, "ACTOR", []string{"FIRST_NAME"}, "ACTOR_ID = ?")
+	require.Error(t, err)
+
+	_, err = s.drvr.CopyTable(ctx, closedDB, tablefq.From("ACTOR"), tablefq.From("ACTOR_COPY"), true)
+	require.Error(t, err)
+}
+
+// TestDriver_ListTableNames_MaterializedView verifies ListTableNames does not
+// return a materialized view's name twice (once from ALL_TABLES, once from
+// ALL_MVIEWS).
+func TestDriver_ListTableNames_MaterializedView(t *testing.T) {
+	tu.SkipShort(t, true)
+	t.Parallel()
+	th, s := requireOracle(t)
+
+	base := newOracleTable(t, th, s, "lmvbase")
+	mvName := strings.ToUpper(stringz.UniqTableName("lmvdup"))
+	_, err := s.db.ExecContext(th.Context,
+		`CREATE MATERIALIZED VIEW "`+mvName+`" AS SELECT "ID", "NAME" FROM "`+base+`"`)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_, _ = s.db.ExecContext(th.Context, `DROP MATERIALIZED VIEW "`+mvName+`"`)
+	})
+
+	names, err := s.drvr.ListTableNames(th.Context, s.db, "SAKILA", true, false)
+	require.NoError(t, err)
+
+	var n int
+	for _, name := range names {
+		if name == mvName {
+			n++
+		}
+	}
+	require.Equal(t, 1, n, "materialized view name must not be listed twice")
+
+	// tables=false && views=false short-circuits to an empty slice.
+	empty, err := s.drvr.ListTableNames(th.Context, s.db, "", false, false)
+	require.NoError(t, err)
+	require.Empty(t, empty)
+}

--- a/drivers/oracle/oracle_sqldriver_test.go
+++ b/drivers/oracle/oracle_sqldriver_test.go
@@ -302,10 +302,16 @@ func TestDriver_ListTableNames_Variants(t *testing.T) {
 	t.Parallel()
 	th, s := requireOracle(t)
 
+	// Membership checks only: sibling parallel tests create and drop temp
+	// tables in this shared schema, so any assertion on total counts would be
+	// racy. The views/tables/both split is verified by the presence and
+	// absence of a known base table (ACTOR) and view (CUSTOMER_LIST).
+
 	// Empty schema → CurrentSchema fallback; views only.
 	views, err := s.drvr.ListTableNames(th.Context, s.db, "", false, true)
 	require.NoError(t, err)
 	require.Contains(t, views, "CUSTOMER_LIST", "Sakila ships the customer_list view")
+	require.NotContains(t, views, "ACTOR", "base tables excluded when tables=false")
 
 	tablesOnly, err := s.drvr.ListTableNames(th.Context, s.db, "SAKILA", true, false)
 	require.NoError(t, err)
@@ -314,9 +320,8 @@ func TestDriver_ListTableNames_Variants(t *testing.T) {
 
 	both, err := s.drvr.ListTableNames(th.Context, s.db, "SAKILA", true, true)
 	require.NoError(t, err)
-	require.Contains(t, both, "ACTOR")
-	require.Contains(t, both, "CUSTOMER_LIST")
-	require.True(t, len(both) > len(tablesOnly), "tables+views is a superset of tables")
+	require.Contains(t, both, "ACTOR", "tables+views includes base tables")
+	require.Contains(t, both, "CUSTOMER_LIST", "tables+views includes views")
 }
 
 // TestDriver_QueryAggregates is a package-local regression for the computed-

--- a/drivers/oracle/oracle_unit_test.go
+++ b/drivers/oracle/oracle_unit_test.go
@@ -1,0 +1,241 @@
+package oracle
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/neilotoole/sq/libsq/ast"
+	"github.com/neilotoole/sq/libsq/core/kind"
+	"github.com/neilotoole/sq/libsq/core/record"
+	"github.com/neilotoole/sq/libsq/core/sqlz"
+	"github.com/neilotoole/sq/libsq/driver"
+	"github.com/neilotoole/sq/libsq/source"
+	"github.com/neilotoole/sq/libsq/source/drivertype"
+)
+
+// TestProvider_DriverFor verifies the provider returns the Oracle driver for
+// the Oracle type and rejects any other type.
+func TestProvider_DriverFor(t *testing.T) {
+	t.Parallel()
+	p := &Provider{Log: slog.Default()}
+
+	drvr, err := p.DriverFor(drivertype.Oracle)
+	require.NoError(t, err)
+	require.NotNil(t, drvr)
+
+	_, err = p.DriverFor(drivertype.Pg)
+	require.Error(t, err, "non-Oracle type must be rejected")
+}
+
+// TestDriveri_ValidateSource covers both the happy path and the type-mismatch
+// rejection.
+func TestDriveri_ValidateSource(t *testing.T) {
+	t.Parallel()
+	d := &driveri{log: slog.Default()}
+
+	src := &source.Source{Handle: "@ora", Type: drivertype.Oracle}
+	got, err := d.ValidateSource(src)
+	require.NoError(t, err)
+	require.Same(t, src, got)
+
+	_, err = d.ValidateSource(&source.Source{Handle: "@bad", Type: drivertype.Pg})
+	require.Error(t, err, "wrong source type must be rejected")
+}
+
+// TestDriveri_DriverMetadata pins the static driver metadata.
+func TestDriveri_DriverMetadata(t *testing.T) {
+	t.Parallel()
+	md := (&driveri{}).DriverMetadata()
+	require.Equal(t, drivertype.Oracle, md.Type)
+	require.True(t, md.IsSQL)
+	require.Equal(t, 1521, md.DefaultPort)
+	require.NotEmpty(t, md.Description)
+}
+
+// TestDriveri_Dialect pins the dialect configuration the renderer and batch
+// machinery rely on.
+func TestDriveri_Dialect(t *testing.T) {
+	t.Parallel()
+	dlct := (&driveri{}).Dialect()
+	require.Equal(t, drivertype.Oracle, dlct.Type)
+	require.False(t, dlct.Catalog, "Oracle uses schemas only")
+	require.True(t, dlct.IntBool, "Oracle emulates BOOLEAN as NUMBER(1,0)")
+	require.Equal(t, 1000, dlct.MaxBatchValues)
+	require.NotNil(t, dlct.Placeholders)
+	require.NotNil(t, dlct.Enquote)
+}
+
+// TestDriveri_ConnParams confirms the advertised go-ora connection parameters.
+func TestDriveri_ConnParams(t *testing.T) {
+	t.Parallel()
+	params := (&driveri{}).ConnParams()
+	require.Contains(t, params, "SSL")
+	require.Contains(t, params, "wallet")
+	require.Contains(t, params, "CONNECTION TIMEOUT")
+}
+
+// TestDriveri_LocationShape confirms the location grammar segments.
+func TestDriveri_LocationShape(t *testing.T) {
+	t.Parallel()
+	shape := (&driveri{}).LocationShape()
+	require.Equal(t, drivertype.Oracle, shape.Type)
+	require.Equal(t, []string{"oracle"}, shape.Schemes)
+	require.NotEmpty(t, shape.Segments)
+}
+
+// TestDriveri_ErrWrapFunc verifies the wrap func is wired and passes nil
+// through unchanged.
+func TestDriveri_ErrWrapFunc(t *testing.T) {
+	t.Parallel()
+	fn := (&driveri{}).ErrWrapFunc()
+	require.NotNil(t, fn)
+	require.NoError(t, fn(nil))
+}
+
+// TestEnquoteOracle verifies identifiers are double-quoted and upper-cased.
+func TestEnquoteOracle(t *testing.T) {
+	t.Parallel()
+	require.Equal(t, `"ACTOR"`, enquoteOracle("actor"))
+	require.Equal(t, `"ACTOR"`, enquoteOracle("Actor"))
+	require.Equal(t, `"FIRST_NAME"`, enquoteOracle("first_name"))
+}
+
+// TestOracleSubstWherePlaceholders verifies "?" markers are rewritten to
+// Oracle :N binds starting at the given offset, leaving other text intact.
+func TestOracleSubstWherePlaceholders(t *testing.T) {
+	t.Parallel()
+	require.Equal(t, `"ID" = :3`, oracleSubstWherePlaceholders(`"ID" = ?`, 3))
+	require.Equal(t,
+		`"A" = :2 AND "B" = :3`,
+		oracleSubstWherePlaceholders(`"A" = ? AND "B" = ?`, 2))
+	require.Equal(t, `"ID" > 0`, oracleSubstWherePlaceholders(`"ID" > 0`, 1),
+		"text without ? is unchanged")
+}
+
+// TestDriveri_Renderer verifies the renderer is assembled with the Oracle
+// row-range, pre-render hook, and the function overrides/result-kind pins that
+// keep computed NUMBER columns scanning correctly (issues #594, #839, #844).
+func TestDriveri_Renderer(t *testing.T) {
+	t.Parallel()
+	r := (&driveri{}).Renderer()
+	require.NotNil(t, r)
+	require.NotNil(t, r.Range)
+	require.NotEmpty(t, r.PreRender)
+
+	require.Contains(t, r.FunctionOverrides, ast.FuncNameSchema)
+	require.Contains(t, r.FunctionOverrides, ast.FuncNameCatalog)
+	require.Contains(t, r.FunctionOverrides, ast.FuncNameAvg)
+	require.Contains(t, r.FunctionOverrides, ast.FuncNameSum)
+
+	require.Equal(t, kind.Int, r.FunctionResultKinds[ast.FuncNameCount])
+	require.Equal(t, kind.Int, r.FunctionResultKinds[ast.FuncNameCountUnique])
+	require.Equal(t, kind.Int, r.FunctionResultKinds[ast.FuncNameRowNum])
+}
+
+// TestDriveri_setScanType maps every kind to its expected scan type, including
+// the Oracle-specific Bool→int64 mapping (NUMBER(1,0)).
+func TestDriveri_setScanType(t *testing.T) {
+	t.Parallel()
+	d := &driveri{}
+	testCases := []struct {
+		knd  kind.Kind
+		want any
+	}{
+		{kind.Null, sqlz.RTypeNullString},
+		{kind.Text, sqlz.RTypeNullString},
+		{kind.Unknown, sqlz.RTypeNullString},
+		{kind.Int, sqlz.RTypeNullInt64},
+		{kind.Float, sqlz.RTypeNullFloat64},
+		{kind.Decimal, sqlz.RTypeNullDecimal},
+		{kind.Bool, sqlz.RTypeNullInt64},
+		{kind.Datetime, sqlz.RTypeNullTime},
+		{kind.Date, sqlz.RTypeNullTime},
+		{kind.Time, sqlz.RTypeNullTime},
+		{kind.Bytes, sqlz.RTypeBytes},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.knd.String(), func(t *testing.T) {
+			t.Parallel()
+			ctd := &record.ColumnTypeData{}
+			d.setScanType(ctd, tc.knd)
+			require.Equal(t, tc.want, ctd.ScanType)
+		})
+	}
+}
+
+// TestDbTypeNameFromKind_Null covers the kind.Null branch not exercised by the
+// internal test's main table.
+func TestDbTypeNameFromKind_Null(t *testing.T) {
+	t.Parallel()
+	require.Equal(t, "VARCHAR2(4000)", dbTypeNameFromKind(kind.Null))
+}
+
+// TestKindFromDBTypeName_RemainingBranches covers the type names not exercised
+// by TestKindFromDBTypeName, plus the unknown-type warning path (non-nil log).
+func TestKindFromDBTypeName_RemainingBranches(t *testing.T) {
+	t.Parallel()
+	testCases := map[string]kind.Kind{
+		"TIMETZ":         kind.Time,
+		"ROWID":          kind.Text,
+		"UROWID":         kind.Text,
+		"VARCHAR":        kind.Text,
+		"LONG":           kind.Text,
+		"LONGVARCHAR":    kind.Text,
+		"OCICLOBLOCATOR": kind.Text,
+		"OCISTRING":      kind.Text,
+		"OCIBLOBLOCATOR": kind.Bytes,
+		"OCIFILELOCATOR": kind.Bytes,
+		"VARRAW":         kind.Bytes,
+		"LONGRAW":        kind.Bytes,
+		"LONGVARRAW":     kind.Bytes,
+		"OCIDATE":        kind.Datetime,
+		"TIMESTAMPTZ":    kind.Datetime,
+		"TIMESTAMPELTZ":  kind.Datetime,
+		"BFLOAT":         kind.Float,
+		"BDOUBLE":        kind.Float,
+		"INTERVALYM":     kind.Text,
+		"INTERVALDS":     kind.Text,
+	}
+	for dbTypeName, want := range testCases {
+		t.Run(dbTypeName, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, want, kindFromDBTypeName(nil, "col", dbTypeName))
+		})
+	}
+
+	// Unknown type with a non-nil logger exercises the log.Warn branch.
+	require.Equal(t, kind.Unknown,
+		kindFromDBTypeName(slog.Default(), "col", "SOME_UNKNOWN_TYPE"))
+}
+
+// TestDriveri_UnsupportedFeatures pins the error-returning stubs for features
+// Oracle doesn't model the sq way (catalogs, CREATE/DROP SCHEMA, and the
+// not-yet-implemented AlterTableColumnKinds). None of these touch the DB, so a
+// nil sqlz.DB is fine.
+func TestDriveri_UnsupportedFeatures(t *testing.T) {
+	t.Parallel()
+	d := &driveri{}
+	ctx := context.Background()
+
+	_, err := d.CurrentCatalog(ctx, nil)
+	require.Error(t, err)
+
+	_, err = d.ListCatalogs(ctx, nil)
+	require.Error(t, err)
+
+	require.Error(t, d.CreateSchema(ctx, nil, "x"))
+	require.Error(t, d.DropSchema(ctx, nil, "x"))
+
+	exists, err := d.CatalogExists(ctx, nil, "x")
+	require.Error(t, err)
+	require.False(t, exists)
+
+	require.Error(t, d.AlterTableColumnKinds(ctx, nil, "t", nil, nil))
+}
+
+// Compile-time assertion mirroring the production var, kept local so the test
+// file documents the contract it exercises.
+var _ driver.SQLDriver = (*driveri)(nil)

--- a/drivers/oracle/oracle_unit_test.go
+++ b/drivers/oracle/oracle_unit_test.go
@@ -206,9 +206,11 @@ func TestKindFromDBTypeName_RemainingBranches(t *testing.T) {
 		})
 	}
 
-	// Unknown type with a non-nil logger exercises the log.Warn branch.
+	// Unknown type with a non-nil logger exercises the log.Warn branch. Use a
+	// discard logger so the warning doesn't print to stderr during the run.
+	discard := slog.New(slog.DiscardHandler)
 	require.Equal(t, kind.Unknown,
-		kindFromDBTypeName(slog.Default(), "col", "SOME_UNKNOWN_TYPE"))
+		kindFromDBTypeName(discard, "col", "SOME_UNKNOWN_TYPE"))
 }
 
 // TestDriveri_UnsupportedFeatures pins the error-returning stubs for features

--- a/drivers/oracle/orshared/wrap_test.go
+++ b/drivers/oracle/orshared/wrap_test.go
@@ -1,0 +1,77 @@
+package orshared
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	goora "github.com/sijms/go-ora/v2/network"
+	"github.com/stretchr/testify/require"
+
+	"github.com/neilotoole/sq/libsq/driver"
+)
+
+// TestWrap covers the error-translation paths: nil passthrough, the two
+// "object does not exist" codes that map to driver.NotExistError, and a
+// generic Oracle/standard error that is annotated but not reclassified.
+func TestWrap(t *testing.T) {
+	t.Parallel()
+
+	require.NoError(t, Wrap(nil), "nil must pass through")
+
+	var notExist *driver.NotExistError
+
+	tableNotFound := Wrap(goora.NewOracleError(ErrCodeTableNotFound))
+	require.Error(t, tableNotFound)
+	require.ErrorAs(t, tableNotFound, &notExist,
+		"ORA-00942 must classify as NotExistError")
+
+	notExist = nil
+	invalidIdent := Wrap(goora.NewOracleError(ErrCodeInvalidIdentifier))
+	require.Error(t, invalidIdent)
+	require.ErrorAs(t, invalidIdent, &notExist,
+		"ORA-00904 must classify as NotExistError")
+
+	// A different Oracle code is annotated but not reclassified.
+	notExist = nil
+	other := Wrap(goora.NewOracleError(1))
+	require.Error(t, other)
+	require.False(t, errors.As(other, &notExist),
+		"unrelated Oracle codes must not become NotExistError")
+
+	// A plain standard error is wrapped without reclassification.
+	notExist = nil
+	std := Wrap(errors.New("boom"))
+	require.Error(t, std)
+	require.False(t, errors.As(std, &notExist))
+}
+
+// TestHasErrCode covers nil, the zero-code guard, a matching code, a
+// non-matching code, and matching through an fmt.Errorf wrap.
+func TestHasErrCode(t *testing.T) {
+	t.Parallel()
+
+	require.False(t, HasErrCode(nil, ErrCodeTableNotFound))
+	require.False(t, HasErrCode(goora.NewOracleError(ErrCodeTableNotFound), 0),
+		"code 0 is the no-Oracle-error sentinel and must never match")
+
+	oraErr := goora.NewOracleError(ErrCodeTableNotFound)
+	require.True(t, HasErrCode(oraErr, ErrCodeTableNotFound))
+	require.False(t, HasErrCode(oraErr, ErrCodeInvalidIdentifier))
+	require.True(t, HasErrCode(fmt.Errorf("exec: %w", oraErr), ErrCodeTableNotFound),
+		"must match through fmt.Errorf wrapping")
+	require.False(t, HasErrCode(errors.New("not an oracle error"), ErrCodeTableNotFound))
+}
+
+// TestIsErrTableNotExist pins ORA-00942 detection, which DropTable relies on
+// to honor ifExists.
+func TestIsErrTableNotExist(t *testing.T) {
+	t.Parallel()
+
+	require.False(t, IsErrTableNotExist(nil))
+	require.True(t, IsErrTableNotExist(goora.NewOracleError(ErrCodeTableNotFound)))
+	require.True(t, IsErrTableNotExist(fmt.Errorf("exec: %w",
+		goora.NewOracleError(ErrCodeTableNotFound))))
+	require.False(t, IsErrTableNotExist(goora.NewOracleError(ErrCodeInvalidIdentifier)),
+		"ORA-00904 is a different error and must not match")
+}


### PR DESCRIPTION
Deep review of the Oracle driver, fixing two materialized-view defects and raising package statement coverage from **47% → 91%**.

## Bugs fixed

Both affect `sq inspect` on Oracle sources that contain a materialized view, and both were caught by the new tests running against a live Oracle instance.

**1. MV metadata query always failed.** `getMaterializedViewMetadata` selected `m.num_rows` from `USER_MVIEWS`, which has no `NUM_ROWS` column. Every MV inspection failed with `ORA-00904`, and the MV was silently dropped from the inspection (logged as a warning). The CBO row count for an MV lives on its backing container table in `USER_TABLES`; the query now joins there. MV inspection had never worked.

**2. MV listed as a duplicate base table.** Oracle backs each MV with a container table of the same name that also appears in `USER_TABLES`/`ALL_TABLES`. So `ListTableNames` returned the MV name twice, and source-level inspect added the MV twice (once as `TABLE`, once as `MATERIALIZED VIEW`). Both base-table queries now exclude MV container tables, so the MV is reported exactly once.

## Coverage (47% → 91%)

Four new test files:
- `oracle_unit_test.go` — DB-free: dialect, conn params, location shape, renderer wiring, `setScanType`, identifier quoting, where-placeholder substitution, unsupported-feature stubs, remaining `kindFromDBTypeName` branches.
- `oracle_sqldriver_test.go` — `testh`-backed integration for the DB-bound `SQLDriver` methods (`Truncate`, `CopyTable`, `AlterTable*`, `Prepare{Insert,Update}Stmt`, `TableColumnTypes`, schema ops, `ListTableNames` variants), the two MV regressions, the #844/#839/#594 `count`/`sum`/`avg` path, and a closed-DB error-propagation sweep.
- `metadata_internal_test.go` — internal: `noSchema` early return plus closed-DB error paths for every unexported metadata helper.
- `orshared/wrap_test.go` — error translation to 100%.

The remaining uncovered statements are defensive `errw` branches needing fault injection, `sql.Open` failures, and DBA-state-dependent stats fallbacks.

## Verification

`go vet`, `golangci-lint` v2.12.2, `markdownlint`, and both full and `-short` test suites pass against the running Oracle container.