### PR TITLE
mysql: fix maxAllowedPacket param, harden identifier quoting, expand tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,12 @@ Breaking changes are annotated with ☢️, and alpha/beta features with 🐥.
 
 ### Fixed
 
+- MySQL: the `maxAllowedPacket` connection parameter is now offered for shell completion
+  under its correct name. It was previously misspelled `maxAllowedPackage`, a name the
+  underlying driver silently ignores.
+- MySQL: table and column names containing a backtick are now escaped correctly in
+  generated statements (add/rename column, rename/truncate table, and table-metadata
+  queries), instead of producing malformed SQL.
 - [`sq diff --data`](https://sq.io/docs/cmd/diff) output no longer contains NUL
   padding bytes. The data diff emitted thousands of trailing zero bytes after each
   hunk header, corrupting output redirected to a file or piped to another program.

--- a/cli/complete_location_test.go
+++ b/cli/complete_location_test.go
@@ -659,7 +659,7 @@ func TestCompleteAddLocation_MySQL(t *testing.T) {
 				"mysql://alice@localhost/sakila?connectionAttributes=",
 				"mysql://alice@localhost/sakila?interpolateParams=",
 				"mysql://alice@localhost/sakila?loc=",
-				"mysql://alice@localhost/sakila?maxAllowedPackage=",
+				"mysql://alice@localhost/sakila?maxAllowedPacket=",
 				"mysql://alice@localhost/sakila?multiStatements=",
 				"mysql://alice@localhost/sakila?parseTime=",
 				"mysql://alice@localhost/sakila?readTimeout=",

--- a/drivers/mysql/driver_test.go
+++ b/drivers/mysql/driver_test.go
@@ -238,7 +238,7 @@ func TestDriver_PrepareInsertAndUpdateStmt(t *testing.T) {
 
 		rec := []any{"bob"}
 		require.NoError(t, execer.Munge(rec))
-		affected, err := execer.Exec(ctx, "bob")
+		affected, err := execer.Exec(ctx, rec...)
 		require.NoError(t, err)
 		require.Equal(t, int64(1), affected)
 		return nil

--- a/drivers/mysql/driver_test.go
+++ b/drivers/mysql/driver_test.go
@@ -1,0 +1,424 @@
+package mysql_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/neilotoole/sq/libsq/core/kind"
+	"github.com/neilotoole/sq/libsq/core/schema"
+	"github.com/neilotoole/sq/libsq/core/stringz"
+	"github.com/neilotoole/sq/libsq/core/tablefq"
+	"github.com/neilotoole/sq/libsq/driver"
+	"github.com/neilotoole/sq/libsq/source"
+	"github.com/neilotoole/sq/libsq/source/drivertype"
+	"github.com/neilotoole/sq/testh"
+	"github.com/neilotoole/sq/testh/sakila"
+	"github.com/neilotoole/sq/testh/tu"
+)
+
+func TestDriver_DBProperties(t *testing.T) {
+	tu.SkipShort(t, true)
+	t.Parallel()
+
+	th, _, drvr, _, db := testh.NewWith(t, sakila.My)
+	props, err := drvr.DBProperties(th.Context, db)
+	require.NoError(t, err)
+	require.NotEmpty(t, props)
+}
+
+func TestDriver_SchemaAndCatalog(t *testing.T) {
+	tu.SkipShort(t, true)
+	t.Parallel()
+
+	th, _, drvr, _, db := testh.NewWith(t, sakila.My)
+	ctx := th.Context
+
+	schma, err := drvr.CurrentSchema(ctx, db)
+	require.NoError(t, err)
+	require.Equal(t, "sakila", schma)
+
+	exists, err := drvr.SchemaExists(ctx, db, "sakila")
+	require.NoError(t, err)
+	require.True(t, exists)
+
+	exists, err = drvr.SchemaExists(ctx, db, "")
+	require.NoError(t, err)
+	require.False(t, exists, "empty schema name is never reported as existing")
+
+	exists, err = drvr.SchemaExists(ctx, db, "no_such_schema_"+stringz.Uniq8())
+	require.NoError(t, err)
+	require.False(t, exists)
+
+	schemas, err := drvr.ListSchemas(ctx, db)
+	require.NoError(t, err)
+	require.Contains(t, schemas, "sakila")
+
+	schemaMetas, err := drvr.ListSchemaMetadata(ctx, db)
+	require.NoError(t, err)
+	require.NotEmpty(t, schemaMetas)
+
+	// MySQL doesn't really support catalogs; sq surfaces the fixed "def".
+	cat, err := drvr.CurrentCatalog(ctx, db)
+	require.NoError(t, err)
+	require.Equal(t, "def", cat)
+
+	cats, err := drvr.ListCatalogs(ctx, db)
+	require.NoError(t, err)
+	require.Equal(t, []string{"def"}, cats)
+
+	ok, err := drvr.CatalogExists(ctx, db, "def")
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	ok, err = drvr.CatalogExists(ctx, db, "other")
+	require.NoError(t, err)
+	require.False(t, ok)
+}
+
+func TestDriver_ListTableNames(t *testing.T) {
+	tu.SkipShort(t, true)
+	t.Parallel()
+
+	th, _, drvr, _, db := testh.NewWith(t, sakila.My)
+	ctx := th.Context
+
+	tablesOnly, err := drvr.ListTableNames(ctx, db, "", true, false)
+	require.NoError(t, err)
+	require.Contains(t, tablesOnly, sakila.TblActor)
+
+	viewsOnly, err := drvr.ListTableNames(ctx, db, "", false, true)
+	require.NoError(t, err)
+	require.NotContains(t, viewsOnly, sakila.TblActor, "actor is a base table, not a view")
+
+	both, err := drvr.ListTableNames(ctx, db, "sakila", true, true)
+	require.NoError(t, err)
+	require.Contains(t, both, sakila.TblActor)
+
+	// Neither tables nor views: the contract is an empty slice.
+	neither, err := drvr.ListTableNames(ctx, db, "", false, false)
+	require.NoError(t, err)
+	require.Empty(t, neither)
+}
+
+func TestDriver_TableExistsAndColumnTypes(t *testing.T) {
+	tu.SkipShort(t, true)
+	t.Parallel()
+
+	th, _, drvr, _, db := testh.NewWith(t, sakila.My)
+	ctx := th.Context
+
+	exists, err := drvr.TableExists(ctx, db, sakila.TblActor)
+	require.NoError(t, err)
+	require.True(t, exists)
+
+	exists, err = drvr.TableExists(ctx, db, "no_such_table_"+stringz.Uniq8())
+	require.NoError(t, err)
+	require.False(t, exists)
+
+	colTypes, err := drvr.TableColumnTypes(ctx, db, sakila.TblActor, nil)
+	require.NoError(t, err)
+	require.NotEmpty(t, colTypes)
+
+	// Restrict to a column subset.
+	colTypes, err = drvr.TableColumnTypes(ctx, db, sakila.TblActor, []string{"actor_id", "first_name"})
+	require.NoError(t, err)
+	require.Len(t, colTypes, 2)
+}
+
+func TestDriver_CreateAlterDropTable(t *testing.T) {
+	tu.SkipShort(t, true)
+	t.Parallel()
+
+	th, src, drvr, _, db := testh.NewWith(t, sakila.My)
+	ctx := th.Context
+
+	tblName := stringz.UniqTableName("review_alter")
+	tblDef := schema.NewTable(tblName, []string{"id", "name"}, []kind.Kind{kind.Int, kind.Text})
+	tblDef.PKColName = "id"
+	tblDef.AutoIncrement = true
+
+	require.NoError(t, drvr.CreateTable(ctx, db, tblDef))
+	t.Cleanup(func() { th.DropTable(src, tablefq.From(tblName)) })
+
+	exists, err := drvr.TableExists(ctx, db, tblName)
+	require.NoError(t, err)
+	require.True(t, exists)
+
+	// Add a column.
+	require.NoError(t, drvr.AlterTableAddColumn(ctx, db, tblName, "age", kind.Int))
+
+	// Rename the new column.
+	require.NoError(t, drvr.AlterTableRenameColumn(ctx, db, tblName, "age", "years"))
+
+	colTypes, err := drvr.TableColumnTypes(ctx, db, tblName, nil)
+	require.NoError(t, err)
+	require.Len(t, colTypes, 3)
+
+	// AlterTableColumnKinds is not implemented for MySQL.
+	err = drvr.AlterTableColumnKinds(ctx, db, tblName, []string{"years"}, []kind.Kind{kind.Text})
+	require.Error(t, err)
+
+	// Rename the table.
+	newName := stringz.UniqTableName("review_alter_renamed")
+	require.NoError(t, drvr.AlterTableRename(ctx, db, tblName, newName))
+	t.Cleanup(func() { th.DropTable(src, tablefq.From(newName)) })
+
+	exists, err = drvr.TableExists(ctx, db, newName)
+	require.NoError(t, err)
+	require.True(t, exists)
+
+	// DropTable with ifExists on a missing table is a no-op.
+	require.NoError(t, drvr.DropTable(ctx, db, tablefq.From("no_such_"+stringz.Uniq8()), true))
+}
+
+func TestDriver_CopyTableAndTruncate(t *testing.T) {
+	tu.SkipShort(t, true)
+	t.Parallel()
+
+	th, src, drvr, _, db := testh.NewWith(t, sakila.My)
+	ctx := th.Context
+
+	// Copy with data.
+	dst := tablefq.From(stringz.UniqTableName("review_copy"))
+	affected, err := drvr.CopyTable(ctx, db, tablefq.From(sakila.TblActor), dst, true)
+	require.NoError(t, err)
+	require.Equal(t, int64(sakila.TblActorCount), affected)
+	t.Cleanup(func() { th.DropTable(src, dst) })
+
+	// Truncate returns the count of rows removed.
+	truncated, err := drvr.Truncate(ctx, src, dst.Table, true)
+	require.NoError(t, err)
+	require.Equal(t, int64(sakila.TblActorCount), truncated)
+
+	// Copy without data (schema only).
+	dstEmpty := tablefq.From(stringz.UniqTableName("review_copy_empty"))
+	affected, err = drvr.CopyTable(ctx, db, tablefq.From(sakila.TblActor), dstEmpty, false)
+	require.NoError(t, err)
+	require.Zero(t, affected)
+	t.Cleanup(func() { th.DropTable(src, dstEmpty) })
+}
+
+func TestDriver_PrepareInsertAndUpdateStmt(t *testing.T) {
+	tu.SkipShort(t, true)
+	t.Parallel()
+
+	th, src, drvr, _, db := testh.NewWith(t, sakila.My)
+	ctx := th.Context
+
+	tblName := stringz.UniqTableName("review_prep")
+	tblDef := schema.NewTable(tblName, []string{"id", "name"}, []kind.Kind{kind.Int, kind.Text})
+	require.NoError(t, drvr.CreateTable(ctx, db, tblDef))
+	t.Cleanup(func() { th.DropTable(src, tablefq.From(tblName)) })
+
+	// Insert via prepared statement.
+	insErr := func() error {
+		execer, err := drvr.PrepareInsertStmt(ctx, db, tblName, []string{"id", "name"}, 1)
+		if err != nil {
+			return err
+		}
+		defer func() { require.NoError(t, execer.Close()) }()
+
+		rec := []any{int64(1), "alice"}
+		require.NoError(t, execer.Munge(rec))
+		affected, err := execer.Exec(ctx, rec...)
+		require.NoError(t, err)
+		require.Equal(t, int64(1), affected)
+		return nil
+	}()
+	require.NoError(t, insErr)
+
+	// Update via prepared statement.
+	upErr := func() error {
+		execer, err := drvr.PrepareUpdateStmt(ctx, db, tblName, []string{"name"}, "id = 1")
+		if err != nil {
+			return err
+		}
+		defer func() { require.NoError(t, execer.Close()) }()
+
+		rec := []any{"bob"}
+		require.NoError(t, execer.Munge(rec))
+		affected, err := execer.Exec(ctx, "bob")
+		require.NoError(t, err)
+		require.Equal(t, int64(1), affected)
+		return nil
+	}()
+	require.NoError(t, upErr)
+
+	sink, err := th.QuerySQL(src, nil, "SELECT name FROM "+tblName+" WHERE id = 1")
+	require.NoError(t, err)
+	require.Len(t, sink.Recs, 1)
+}
+
+func TestDriver_NewBatchInsert(t *testing.T) {
+	tu.SkipShort(t, true)
+	t.Parallel()
+
+	th, src, drvr, _, db := testh.NewWith(t, sakila.My)
+	ctx := th.Context
+
+	tblName := stringz.UniqTableName("review_batch")
+	tblDef := schema.NewTable(tblName, []string{"id", "name"}, []kind.Kind{kind.Int, kind.Text})
+	require.NoError(t, drvr.CreateTable(ctx, db, tblDef))
+	t.Cleanup(func() { th.DropTable(src, tablefq.From(tblName)) })
+
+	// Batch insert requires a single dedicated connection, not the pool.
+	conn, err := db.Conn(ctx)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = conn.Close() })
+
+	bi, err := drvr.NewBatchInsert(ctx, "insert", conn, src, tblName, []string{"id", "name"})
+	require.NoError(t, err)
+
+	recs := [][]any{{int64(1), "alice"}, {int64(2), "bob"}}
+	for _, rec := range recs {
+		require.NoError(t, bi.Munge(rec))
+		select {
+		case err = <-bi.ErrCh:
+			close(bi.RecordCh)
+			t.Fatal(err)
+		case bi.RecordCh <- rec:
+		}
+	}
+	close(bi.RecordCh)
+
+	require.NoError(t, <-bi.ErrCh)
+	require.Equal(t, int64(2), bi.Written())
+}
+
+func TestDriver_Ping(t *testing.T) {
+	tu.SkipShort(t, true)
+	t.Parallel()
+
+	th, src, drvr, _, _ := testh.NewWith(t, sakila.My)
+	require.NoError(t, drvr.Ping(th.Context, src, driver.ModeReadWrite))
+}
+
+// TestDriver_OpenWithSchema exercises the doOpen branch that overrides the
+// connection's default schema from src.Schema.
+func TestDriver_OpenWithSchema(t *testing.T) {
+	tu.SkipShort(t, true)
+	t.Parallel()
+
+	th, src, drvr, _, _ := testh.NewWith(t, sakila.My)
+
+	// Clone the source and pin an explicit default schema.
+	withSchema := src.Clone()
+	withSchema.Schema = "sakila"
+
+	grip, err := drvr.Open(th.Context, withSchema, driver.ModeReadWrite)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, grip.Close()) })
+
+	db, err := grip.DB(th.Context)
+	require.NoError(t, err)
+
+	var schma string
+	require.NoError(t, db.QueryRowContext(th.Context, "SELECT DATABASE()").Scan(&schma))
+	require.Equal(t, "sakila", schma)
+}
+
+// TestDriver_ClosedDBErrors closes the DB out from under the driver and
+// asserts every read/metadata method surfaces the error rather than a
+// zero value, exercising the errw error-return branches.
+func TestDriver_ClosedDBErrors(t *testing.T) {
+	tu.SkipShort(t, true)
+	t.Parallel()
+
+	th, _, drvr, _, db := testh.NewWith(t, sakila.My)
+	ctx := th.Context
+	require.NoError(t, db.Close())
+
+	_, err := drvr.CurrentSchema(ctx, db)
+	require.Error(t, err)
+	_, err = drvr.ListSchemas(ctx, db)
+	require.Error(t, err)
+	_, err = drvr.SchemaExists(ctx, db, "sakila")
+	require.Error(t, err)
+	_, err = drvr.ListSchemaMetadata(ctx, db)
+	require.Error(t, err)
+	_, err = drvr.CurrentCatalog(ctx, db)
+	require.Error(t, err)
+	_, err = drvr.ListCatalogs(ctx, db)
+	require.Error(t, err)
+	_, err = drvr.ListTableNames(ctx, db, "", true, true)
+	require.Error(t, err)
+	_, err = drvr.TableExists(ctx, db, sakila.TblActor)
+	require.Error(t, err)
+	_, err = drvr.TableColumnTypes(ctx, db, sakila.TblActor, nil)
+	require.Error(t, err)
+	_, err = drvr.DBProperties(ctx, db)
+	require.Error(t, err)
+
+	// Methods that first resolve dest column metadata fail at that step.
+	_, err = drvr.PrepareInsertStmt(ctx, db, sakila.TblActor, []string{"actor_id"}, 1)
+	require.Error(t, err)
+	_, err = drvr.PrepareUpdateStmt(ctx, db, sakila.TblActor, []string{"actor_id"}, "")
+	require.Error(t, err)
+
+	require.Error(t, drvr.AlterTableAddColumn(ctx, db, sakila.TblActor, "x", kind.Int))
+	require.Error(t, drvr.AlterTableRename(ctx, db, sakila.TblActor, "x"))
+	require.Error(t, drvr.AlterTableRenameColumn(ctx, db, sakila.TblActor, "first_name", "x"))
+	require.Error(t, drvr.DropTable(ctx, db, tablefq.From(sakila.TblActor), false))
+	_, err = drvr.CopyTable(ctx, db, tablefq.From(sakila.TblActor), tablefq.From("x"), true)
+	require.Error(t, err)
+}
+
+// TestDriver_BadSource exercises the doOpen failure path: a source whose
+// location can't be parsed into a DSN must fail Open, Ping and Truncate.
+func TestDriver_BadSource(t *testing.T) {
+	t.Parallel()
+
+	th := testh.New(t)
+	drvr := th.SQLDriverFor(&source.Source{Type: drivertype.MySQL, Location: "mysql://x"})
+
+	badSrc := &source.Source{
+		Handle:   "@bad",
+		Type:     drivertype.MySQL,
+		Location: "mysql://", // too short to yield a DSN
+	}
+
+	_, err := drvr.Open(th.Context, badSrc, driver.ModeReadWrite)
+	require.Error(t, err)
+
+	err = drvr.Ping(th.Context, badSrc, driver.ModeReadWrite)
+	require.Error(t, err)
+
+	_, err = drvr.Truncate(th.Context, badSrc, "actor", true)
+	require.Error(t, err)
+}
+
+// TestDriver_RenderFuncs drives the MySQL-specific function renderers
+// (LIKE BINARY family, ilike fallthrough, rownum, catalog) end-to-end
+// through SLQ so the dialect overrides in Renderer() are exercised.
+func TestDriver_RenderFuncs(t *testing.T) {
+	tu.SkipShort(t, true)
+	t.Parallel()
+
+	h := sakila.My
+
+	testCases := []struct {
+		name string
+		slq  string
+	}{
+		{"contains", h + ` | .actor | where(contains(.first_name, "AN"))`},
+		{"startswith", h + ` | .actor | where(startswith(.first_name, "PEN"))`},
+		{"endswith", h + ` | .actor | where(endswith(.last_name, "MAN"))`},
+		{"like", h + ` | .actor | where(like(.first_name, "PEN%"))`},
+		{"icontains", h + ` | .actor | where(icontains(.first_name, "an"))`},
+		{"rownum", h + ` | .actor | rownum(), .actor_id | order_by(.actor_id)`},
+		{"catalog", h + ` | catalog()`},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			// Each subtest gets its own helper so a sibling's grip
+			// teardown can't close a shared *sql.DB mid-query.
+			th := testh.New(t)
+			sink, err := th.QuerySLQ(tc.slq, nil)
+			require.NoError(t, err)
+			require.NotNil(t, sink)
+		})
+	}
+}

--- a/drivers/mysql/internal_test.go
+++ b/drivers/mysql/internal_test.go
@@ -94,6 +94,16 @@ func TestDSNFromLocation(t *testing.T) {
 			wantDSN:   "sakila:p_ssW0rd@tcp(localhost:3306)/sqtest?allowCleartextPasswords=true&allowOldPasswords=true&parseTime=true",
 			parseTime: true,
 		},
+		{
+			// Wrong scheme: not a mysql:// location.
+			loc:     "postgres://sakila:p_ssW0rd@localhost:5432/sqtest",
+			wantErr: true,
+		},
+		{
+			// Too short: prefix matches but there's nothing after it.
+			loc:     "mysql://",
+			wantErr: true,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/drivers/mysql/metadata.go
+++ b/drivers/mysql/metadata.go
@@ -177,7 +177,7 @@ func getNewRecordFunc(rowMeta record.Meta) driver.NewRecordFunc {
 // implementation of Grip.TableMetadata.
 func getTableMetadata(ctx context.Context, db sqlz.DB, tblName string) (*metadata.Table, error) {
 	query := `SELECT TABLE_SCHEMA, TABLE_NAME, TABLE_TYPE, TABLE_COMMENT, (DATA_LENGTH + INDEX_LENGTH) AS table_size,
-(SELECT COUNT(*) FROM ` + "`" + tblName + "`" + `) AS row_count
+(SELECT COUNT(*) FROM ` + stringz.BacktickQuote(tblName) + `) AS row_count
 FROM information_schema.TABLES
 WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ?`
 

--- a/drivers/mysql/mysql.go
+++ b/drivers/mysql/mysql.go
@@ -663,7 +663,7 @@ func (d *driveri) Truncate(ctx context.Context, src *source.Source, tbl string, 
 
 	affected, err = sqlz.ExecAffected(ctx, tx, "TRUNCATE TABLE "+stringz.BacktickQuote(tbl))
 	if err != nil {
-		return affected, errz.Append(err, errw(tx.Rollback()))
+		return affected, errz.Append(errw(err), errw(tx.Rollback()))
 	}
 
 	if affected != 0 {

--- a/drivers/mysql/mysql.go
+++ b/drivers/mysql/mysql.go
@@ -76,7 +76,7 @@ func (d *driveri) ConnParams() map[string][]string {
 		"connectionAttributes":     nil,
 		"interpolateParams":        {"false", "true"},
 		"loc":                      {"UTC"},
-		"maxAllowedPackage":        {"0", "67108864"},
+		"maxAllowedPacket":         {"0", "67108864"},
 		"multiStatements":          {"false", "true"},
 		"parseTime":                {"false", "true"},
 		"readTimeout":              {"0"},
@@ -212,7 +212,8 @@ func (d *driveri) CreateTable(ctx context.Context, db sqlz.DB, tblDef *schema.Ta
 
 // AlterTableAddColumn implements driver.SQLDriver.
 func (d *driveri) AlterTableAddColumn(ctx context.Context, db sqlz.DB, tbl, col string, knd kind.Kind) error {
-	q := fmt.Sprintf("ALTER TABLE `%s` ADD COLUMN `%s` ", tbl, col) + dbTypeNameFromKind(knd)
+	q := "ALTER TABLE " + stringz.BacktickQuote(tbl) + " ADD COLUMN " +
+		stringz.BacktickQuote(col) + " " + dbTypeNameFromKind(knd)
 
 	_, err := db.ExecContext(ctx, q)
 	if err != nil {
@@ -379,14 +380,15 @@ func (d *driveri) CatalogExists(_ context.Context, _ sqlz.DB, catalog string) (b
 
 // AlterTableRename implements driver.SQLDriver.
 func (d *driveri) AlterTableRename(ctx context.Context, db sqlz.DB, tbl, newName string) error {
-	q := fmt.Sprintf("RENAME TABLE `%s` TO `%s`", tbl, newName)
+	q := "RENAME TABLE " + stringz.BacktickQuote(tbl) + " TO " + stringz.BacktickQuote(newName)
 	_, err := db.ExecContext(ctx, q)
 	return errz.Wrapf(errw(err), "alter table: failed to rename table {%s} to {%s}", tbl, newName)
 }
 
 // AlterTableRenameColumn implements driver.SQLDriver.
 func (d *driveri) AlterTableRenameColumn(ctx context.Context, db sqlz.DB, tbl, col, newName string) error {
-	q := fmt.Sprintf("ALTER TABLE `%s` RENAME COLUMN `%s` TO `%s`", tbl, col, newName)
+	q := "ALTER TABLE " + stringz.BacktickQuote(tbl) + " RENAME COLUMN " +
+		stringz.BacktickQuote(col) + " TO " + stringz.BacktickQuote(newName)
 	_, err := db.ExecContext(ctx, q)
 	return errz.Wrapf(errw(err), "alter table: failed to rename column {%s.%s} to {%s}", tbl, col, newName)
 }
@@ -654,12 +656,12 @@ func (d *driveri) Truncate(ctx context.Context, src *source.Source, tbl string, 
 	// For whatever reason, the "affected" count from TRUNCATE
 	// always returns zero. So, we're going to synthesize it.
 	var beforeCount int64
-	err = tx.QueryRowContext(ctx, fmt.Sprintf("SELECT COUNT(*) FROM `%s`", tbl)).Scan(&beforeCount)
+	err = tx.QueryRowContext(ctx, "SELECT COUNT(*) FROM "+stringz.BacktickQuote(tbl)).Scan(&beforeCount)
 	if err != nil {
-		return 0, errz.Append(err, errw(tx.Rollback()))
+		return 0, errz.Append(errw(err), errw(tx.Rollback()))
 	}
 
-	affected, err = sqlz.ExecAffected(ctx, tx, fmt.Sprintf("TRUNCATE TABLE `%s`", tbl))
+	affected, err = sqlz.ExecAffected(ctx, tx, "TRUNCATE TABLE "+stringz.BacktickQuote(tbl))
 	if err != nil {
 		return affected, errz.Append(err, errw(tx.Rollback()))
 	}

--- a/drivers/mysql/mysql_internal_test.go
+++ b/drivers/mysql/mysql_internal_test.go
@@ -1,0 +1,396 @@
+package mysql
+
+import (
+	"database/sql"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/go-sql-driver/mysql"
+	"github.com/stretchr/testify/require"
+
+	"github.com/neilotoole/sq/libsq/ast/render"
+	"github.com/neilotoole/sq/libsq/core/errz"
+	"github.com/neilotoole/sq/libsq/core/jointype"
+	"github.com/neilotoole/sq/libsq/core/kind"
+	"github.com/neilotoole/sq/libsq/core/record"
+	"github.com/neilotoole/sq/libsq/core/schema"
+	"github.com/neilotoole/sq/libsq/core/sqlz"
+	"github.com/neilotoole/sq/libsq/driver"
+	"github.com/neilotoole/sq/libsq/source"
+	"github.com/neilotoole/sq/libsq/source/drivertype"
+)
+
+func TestDriverFor(t *testing.T) {
+	p := &Provider{}
+
+	drvr, err := p.DriverFor(drivertype.MySQL)
+	require.NoError(t, err)
+	require.NotNil(t, drvr)
+
+	_, err = p.DriverFor(drivertype.Pg)
+	require.Error(t, err, "non-MySQL type should be rejected")
+}
+
+func TestValidateSource(t *testing.T) {
+	d := &driveri{}
+
+	src := &source.Source{Handle: "@my", Type: drivertype.MySQL, Location: "mysql://x"}
+	got, err := d.ValidateSource(src)
+	require.NoError(t, err)
+	require.Equal(t, src, got)
+
+	_, err = d.ValidateSource(&source.Source{Handle: "@bad", Type: drivertype.Pg})
+	require.Error(t, err, "non-MySQL source type should be rejected")
+}
+
+func TestConnParams(t *testing.T) {
+	d := &driveri{}
+	params := d.ConnParams()
+
+	// Regression: the go-sql-driver DSN param is "maxAllowedPacket",
+	// not "maxAllowedPackage". A typo here silently feeds the user a
+	// param name the driver ignores.
+	require.Contains(t, params, "maxAllowedPacket")
+	require.NotContains(t, params, "maxAllowedPackage")
+
+	// Spot-check a few other documented params are present.
+	require.Contains(t, params, "parseTime")
+	require.Contains(t, params, "tls")
+	require.Equal(t, collations, params["collation"])
+}
+
+func TestLocationShape(t *testing.T) {
+	d := &driveri{}
+	shape := d.LocationShape()
+	require.Equal(t, drivertype.MySQL, shape.Type)
+	require.Equal(t, []string{"mysql"}, shape.Schemes)
+	require.NotEmpty(t, shape.Segments)
+}
+
+func TestDriverMetadata(t *testing.T) {
+	d := &driveri{}
+	md := d.DriverMetadata()
+	require.Equal(t, drivertype.MySQL, md.Type)
+	require.True(t, md.IsSQL)
+	require.Equal(t, 3306, md.DefaultPort)
+}
+
+func TestDialect(t *testing.T) {
+	d := &driveri{}
+	dl := d.Dialect()
+	require.Equal(t, drivertype.MySQL, dl.Type)
+	require.True(t, dl.IntBool)
+	require.False(t, dl.Catalog)
+	// MySQL does not support FULL OUTER JOIN.
+	require.NotContains(t, dl.Joins, jointype.FullOuter)
+}
+
+func TestRenderer(t *testing.T) {
+	d := &driveri{}
+	r := d.Renderer()
+	require.NotNil(t, r)
+	// The MySQL renderer installs a number of function overrides; a few
+	// that are load-bearing for portability (issues #594, #839).
+	require.NotNil(t, r.FunctionOverrides)
+	require.NotEmpty(t, r.FunctionNames)
+}
+
+func TestDBTypeNameFromKind(t *testing.T) {
+	testCases := map[kind.Kind]string{ //nolint:exhaustive // Unknown/Null tested via panic below
+		kind.Text:     "TEXT",
+		kind.Int:      "INT",
+		kind.Float:    "DOUBLE",
+		kind.Decimal:  "DECIMAL",
+		kind.Bool:     "TINYINT(1)",
+		kind.Datetime: "DATETIME",
+		kind.Time:     "TIME",
+		kind.Date:     "DATE",
+		kind.Bytes:    "BLOB",
+	}
+
+	for knd, want := range testCases {
+		require.Equal(t, want, dbTypeNameFromKind(knd), "kind %s", knd)
+	}
+
+	// kind.Unknown / kind.Null are not mappable to a column type, and
+	// the function panics rather than emit invalid DDL.
+	require.Panics(t, func() { _ = dbTypeNameFromKind(kind.Unknown) })
+	require.Panics(t, func() { _ = dbTypeNameFromKind(kind.Null) })
+}
+
+func TestCanonicalTableType(t *testing.T) {
+	require.Equal(t, sqlz.TableTypeTable, canonicalTableType("BASE TABLE"))
+	require.Equal(t, sqlz.TableTypeView, canonicalTableType("VIEW"))
+	require.Equal(t, "", canonicalTableType("SYSTEM VIEW"))
+	require.Equal(t, "", canonicalTableType(""))
+}
+
+func TestBuildUpdateStmt(t *testing.T) {
+	got, err := buildUpdateStmt("person", []string{"name", "age"}, "age > 18")
+	require.NoError(t, err)
+	require.Equal(t, "UPDATE `person` SET `name` = ?, `age` = ? WHERE age > 18", got)
+
+	got, err = buildUpdateStmt("person", []string{"name"}, "")
+	require.NoError(t, err)
+	require.Equal(t, "UPDATE `person` SET `name` = ?", got)
+
+	_, err = buildUpdateStmt("person", nil, "")
+	require.Error(t, err, "no columns should be an error")
+}
+
+func TestBuildCreateTableStmt_Minimal(t *testing.T) {
+	tbl := schema.NewTable("t", []string{"a"}, []kind.Kind{kind.Int})
+	got := buildCreateTableStmt(tbl)
+	require.Equal(t, "CREATE TABLE `t` (\n`a` INT\n)", got)
+}
+
+func TestBuildCreateTableStmt_Full(t *testing.T) {
+	tbl := schema.NewTable(
+		"person",
+		[]string{"id", "name", "email", "org_id", "mgr_id"},
+		[]kind.Kind{kind.Int, kind.Text, kind.Text, kind.Int, kind.Int},
+	)
+	tbl.PKColName = "id"
+	tbl.AutoIncrement = true
+
+	// name: NOT NULL + default.
+	tbl.Cols[1].NotNull = true
+	tbl.Cols[1].HasDefault = true
+	// email: unique.
+	tbl.Cols[2].Unique = true
+	// org_id: FK with default (empty) ON DELETE / ON UPDATE -> CASCADE.
+	tbl.Cols[3].ForeignKey = &schema.FKConstraint{RefTable: "org", RefCol: "id"}
+	// mgr_id: FK with explicit actions.
+	tbl.Cols[4].ForeignKey = &schema.FKConstraint{
+		RefTable: "person", RefCol: "id", OnDelete: "SET NULL", OnUpdate: "RESTRICT",
+	}
+
+	got := buildCreateTableStmt(tbl)
+
+	require.Contains(t, got, "CREATE TABLE `person` (")
+	require.Contains(t, got, "`id` INT AUTO_INCREMENT")
+	require.Contains(t, got, "PRIMARY KEY (`id`)")
+	require.Contains(t, got, "UNIQUE KEY `person_id_uindex` (`id`)")
+	require.Contains(t, got, "`name` TEXT  NOT NULL") // text default is empty string
+	require.Contains(t, got, "UNIQUE KEY `person_email_uindex` (`email`)")
+	// FK with defaulted actions.
+	require.Contains(t, got, "REFERENCES `org` (`id`) ON DELETE CASCADE ON UPDATE CASCADE")
+	// FK with explicit actions.
+	require.Contains(t, got, "REFERENCES `person` (`id`) ON DELETE SET NULL ON UPDATE RESTRICT")
+}
+
+func TestExtractTblNameFromNotExistErr(t *testing.T) {
+	t.Run("nil", func(t *testing.T) {
+		_, _, ok := extractTblNameFromNotExistErr(nil)
+		require.False(t, ok)
+	})
+
+	t.Run("non_mysql_err", func(t *testing.T) {
+		_, _, ok := extractTblNameFromNotExistErr(errz.New("boom"))
+		require.False(t, ok)
+	})
+
+	t.Run("wrong_code", func(t *testing.T) {
+		err := &mysql.MySQLError{Number: errNumConCount, Message: "too many"}
+		_, _, ok := extractTblNameFromNotExistErr(err)
+		require.False(t, ok)
+	})
+
+	t.Run("schema_dot_table", func(t *testing.T) {
+		err := &mysql.MySQLError{
+			Number:  errNumTableNotExist,
+			Message: "Table 'sakila.actor' doesn't exist",
+		}
+		schma, tbl, ok := extractTblNameFromNotExistErr(err)
+		require.True(t, ok)
+		require.Equal(t, "sakila", schma)
+		require.Equal(t, "actor", tbl)
+	})
+
+	t.Run("no_separator", func(t *testing.T) {
+		err := &mysql.MySQLError{
+			Number:  errNumTableNotExist,
+			Message: "Table 'actor' doesn't exist",
+		}
+		_, _, ok := extractTblNameFromNotExistErr(err)
+		require.False(t, ok, "a message without a schema.table separator yields no name")
+	})
+
+	t.Run("empty_after_trim", func(t *testing.T) {
+		err := &mysql.MySQLError{
+			Number:  errNumTableNotExist,
+			Message: "Table '' doesn't exist",
+		}
+		_, _, ok := extractTblNameFromNotExistErr(err)
+		require.False(t, ok)
+	})
+}
+
+func TestErrw(t *testing.T) {
+	require.NoError(t, errw(nil))
+
+	generic := errz.New("plain")
+	require.Error(t, errw(generic))
+
+	notExist := &mysql.MySQLError{Number: errNumTableNotExist, Message: "Table 'x.y' doesn't exist"}
+	wrapped := errw(notExist)
+	require.Error(t, wrapped)
+	require.True(t, errz.Has[*driver.NotExistError](wrapped),
+		"table-not-exist must be wrapped as a NotExistError")
+}
+
+func TestIsErrTooManyConnections(t *testing.T) {
+	require.False(t, isErrTooManyConnections(nil))
+	require.False(t, isErrTooManyConnections(errz.New("nope")))
+
+	err := &mysql.MySQLError{Number: errNumConCount, Message: "Too many connections"}
+	require.True(t, isErrTooManyConnections(err))
+	require.True(t, isErrTooManyConnections(errw(err)), "wrapped error should still match")
+}
+
+func TestMungeSetDatetimeFromString(t *testing.T) {
+	rec := []any{nil}
+
+	mungeSetDatetimeFromString("2021-08-30T11:50:00Z", 0, rec)
+	got, ok := rec[0].(time.Time)
+	require.True(t, ok, "a valid RFC3339 string should be parsed to time.Time")
+	require.Equal(t, 2021, got.Year())
+
+	// An unparseable string leaves rec unchanged.
+	rec[0] = "not-a-time"
+	mungeSetDatetimeFromString("not-a-time", 0, rec)
+	require.Equal(t, "not-a-time", rec[0])
+}
+
+func TestMungeSetZeroValue(t *testing.T) {
+	meta := record.Meta{
+		record.NewFieldMeta(
+			&record.ColumnTypeData{Name: "n", Kind: kind.Int, ScanType: reflect.TypeFor[int64]()},
+			"n",
+		),
+	}
+	rec := []any{nil}
+	mungeSetZeroValue(0, rec, meta)
+	require.Equal(t, int64(0), rec[0])
+}
+
+// mkMeta builds a single-column record.Meta for munge tests.
+func mkMeta(name string, knd kind.Kind, nullable bool, scanType reflect.Type) record.Meta {
+	return record.Meta{
+		record.NewFieldMeta(&record.ColumnTypeData{
+			Name:        name,
+			Kind:        knd,
+			ScanType:    scanType,
+			HasNullable: true,
+			Nullable:    nullable,
+		}, name),
+	}
+}
+
+func TestNewInsertMungeFunc(t *testing.T) {
+	t.Run("len_mismatch", func(t *testing.T) {
+		meta := mkMeta("n", kind.Int, false, reflect.TypeFor[int64]())
+		fn := newInsertMungeFunc("t", meta)
+		err := fn(record.Record{1, 2})
+		require.Error(t, err, "record/dest column count mismatch must error")
+	})
+
+	t.Run("nil_non_nullable_gets_zero", func(t *testing.T) {
+		meta := mkMeta("n", kind.Int, false, reflect.TypeFor[int64]())
+		fn := newInsertMungeFunc("t", meta)
+		rec := record.Record{nil}
+		require.NoError(t, fn(rec))
+		require.Equal(t, int64(0), rec[0])
+	})
+
+	t.Run("text_left_untouched", func(t *testing.T) {
+		meta := mkMeta("s", kind.Text, true, reflect.TypeFor[string]())
+		fn := newInsertMungeFunc("t", meta)
+		rec := record.Record{"hello"}
+		require.NoError(t, fn(rec))
+		require.Equal(t, "hello", rec[0])
+	})
+
+	t.Run("empty_string_nullable_becomes_nil", func(t *testing.T) {
+		meta := mkMeta("d", kind.Datetime, true, reflect.TypeFor[sql.NullTime]())
+		fn := newInsertMungeFunc("t", meta)
+		s := ""
+		rec := record.Record{&s}
+		require.NoError(t, fn(rec))
+		require.Nil(t, rec[0])
+	})
+
+	t.Run("datetime_string_parsed", func(t *testing.T) {
+		meta := mkMeta("d", kind.Datetime, true, reflect.TypeFor[sql.NullTime]())
+		fn := newInsertMungeFunc("t", meta)
+		s := "2021-08-30T11:50:00Z"
+		rec := record.Record{&s}
+		require.NoError(t, fn(rec))
+		got, ok := rec[0].(time.Time)
+		require.True(t, ok)
+		require.Equal(t, 2021, got.Year())
+	})
+
+	t.Run("empty_value_string_nullable_becomes_nil", func(t *testing.T) {
+		// A non-pointer empty string into a nullable non-text column.
+		meta := mkMeta("n", kind.Int, true, reflect.TypeFor[int64]())
+		fn := newInsertMungeFunc("t", meta)
+		rec := record.Record{""}
+		require.NoError(t, fn(rec))
+		require.Nil(t, rec[0])
+	})
+
+	t.Run("empty_value_string_non_nullable_gets_zero", func(t *testing.T) {
+		// A non-pointer empty string into a non-nullable non-text column.
+		meta := mkMeta("n", kind.Int, false, reflect.TypeFor[int64]())
+		fn := newInsertMungeFunc("t", meta)
+		rec := record.Record{""}
+		require.NoError(t, fn(rec))
+		require.Equal(t, int64(0), rec[0])
+	})
+
+	t.Run("empty_ptr_string_non_nullable_gets_zero", func(t *testing.T) {
+		meta := mkMeta("n", kind.Int, false, reflect.TypeFor[int64]())
+		fn := newInsertMungeFunc("t", meta)
+		s := ""
+		rec := record.Record{&s}
+		require.NoError(t, fn(rec))
+		require.Equal(t, int64(0), rec[0])
+	})
+}
+
+func TestGetNewRecordFunc(t *testing.T) {
+	t.Run("happy_path", func(t *testing.T) {
+		meta := mkMeta("n", kind.Int, false, reflect.TypeFor[int64]())
+		fn := getNewRecordFunc(meta)
+		v := int64(42)
+		rec, err := fn([]any{&v})
+		require.NoError(t, err)
+		require.Equal(t, int64(42), rec[0])
+	})
+
+	t.Run("unknown_type_errors", func(t *testing.T) {
+		// A value whose type NewRecordFromScanRow does not recognize is
+		// added to the skipped set; getNewRecordFunc cannot munge it and
+		// must return an error rather than emit a bad record.
+		meta := mkMeta("x", kind.Unknown, true, reflect.TypeFor[struct{}]())
+		fn := getNewRecordFunc(meta)
+		type weird struct{ v int }
+		_, err := fn([]any{&weird{v: 1}})
+		require.Error(t, err)
+	})
+}
+
+func TestRenderFuncRowNum(t *testing.T) {
+	rc := &render.Context{Fragments: &render.Fragments{}}
+
+	frag, err := renderFuncRowNum(rc, nil)
+	require.NoError(t, err)
+	require.Contains(t, frag, ":=")
+	require.Contains(t, frag, "@row_number_")
+	require.Len(t, rc.Fragments.PreExecStmts, 1)
+	require.Len(t, rc.Fragments.PostExecStmts, 1)
+	require.Contains(t, rc.Fragments.PreExecStmts[0], "SET @row_number_")
+	require.Contains(t, rc.Fragments.PreExecStmts[0], "= 0;")
+}


### PR DESCRIPTION
Deep review of the MySQL driver (`drivers/mysql`) with a test-coverage push from **56% to ~90%** of statements. All tests pass against the sakila MySQL 8 container; lint and `-race` are clean.

## Fixes

- **`ConnParams`**: corrected the `maxAllowedPackage` typo to `maxAllowedPacket`. The misspelled key offered shell completion for a DSN parameter that go-sql-driver silently ignores (verified against the driver's `dsn.go`).
- **Identifier quoting**: table and column names are now escaped with `stringz.BacktickQuote` (which doubles embedded backticks) in `getTableMetadata`, `AlterTableAddColumn`, `AlterTableRename`, `AlterTableRenameColumn`, and `Truncate`. These previously interpolated names raw, unlike `CreateSchema`/`DropSchema`/`tblfmt`, so an identifier containing a backtick produced malformed SQL.
- **`Truncate`**: `errz`-wrap the row-count error so it carries a stack trace, matching the rest of the package.

## Tests

- `mysql_internal_test.go` (new): white-box unit tests for the pure functions: statement builders, kind mapping (incl. panic path), error helpers (`errw`, `hasErrCode`, `isErrTooManyConnections`, `extractTblNameFromNotExistErr`), munge/record funcs, driver metadata/dialect/renderer, and `renderFuncRowNum`.
- `driver_test.go` (new): integration tests against `@sakila_my8` for the `SQLDriver` DB methods (schema/catalog/table listing, ALTER family, copy/truncate, prepared insert/update, batch insert, ping, open-with-schema), the LIKE BINARY / rownum / catalog renderers via SLQ, and closed-DB / bad-source error paths.
- `internal_test.go`: added invalid-location error cases to `TestDSNFromLocation`.

## Notes for the reviewer

Two findings left in place rather than changed, flagged here for a decision:

- **Possible dead code in `getNewRecordFunc`**: its `*sql.NullTime` and TIME-`RawBytes` branches only run on indices `driver.NewRecordFromScanRow` adds to `skipped`, but that function already handles both types explicitly, so neither is ever skipped. The branches appear unreachable.
- **`buildCreateTableStmt`** panics on a zero-column table (`cols[len(cols)-1]`). Latent only; callers always pass columns.

The remaining ~10% uncovered is almost entirely `errw` wrappers on mid-row-iteration DB failures. Reaching those needs SQL fault injection (`go-sqlmock`), which isn't a direct dependency and isn't used elsewhere in the repo, so I didn't introduce it. Only the MySQL 8 container is available locally, so the `my56`/`my57` legs skip.