### PR TITLE
fix(files): cache-clear cross-device failure, ingest-cache leaf dir, plus coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,16 @@ Breaking changes are annotated with ☢️, and alpha/beta features with 🐥.
   download had gone stale and the refresh request failed at the transport layer
   (e.g. no network), `sq` crashed instead of falling back to the cached file.
   It now serves the stale download, as the "airplane mode" behavior intends.
+- [`sq cache clear`](https://sq.io/docs/cmd/cache-clear) no longer fails when the
+  cache dir and the system temp dir are on different filesystems. The clear moved
+  the cache dir into the temp dir before deleting it, which failed with a
+  cross-device error on common setups (e.g. a `~/.cache` on disk and a tmpfs
+  `/tmp`). The cache dir is now relocated within its own filesystem.
+- The ingest cache for a document source (CSV, JSON, Excel, etc.) is now written
+  reliably on first use. The checksum that validates the cache could fail to write
+  when the source's cache dir did not yet exist, silently disabling caching so the
+  source was re-ingested on every command. The cache dir is now created before the
+  checksum is written.
 - MySQL: the `maxAllowedPacket` connection parameter is now offered for shell completion
   under its correct name. It was previously misspelled `maxAllowedPackage`, a name the
   underlying driver silently ignores.

--- a/libsq/files/cache.go
+++ b/libsq/files/cache.go
@@ -517,6 +517,12 @@ func clearCacheDirContents(cacheDir string, clearDownloads bool, handle string) 
 	return nil
 }
 
+// relocateDirPrefix is the name prefix for the temporary dir that
+// doCacheClearAll moves the cache dir to before deleting it. It is
+// sq-specific because the dir is created in the shared user-cache root, and
+// the self-healing cleanup must only remove dirs that sq itself created.
+const relocateDirPrefix = "sq_dead_cache_"
+
 func (fs *Files) doCacheClearAll(ctx context.Context) error {
 	log := lg.FromContext(ctx).With(lga.Dir, fs.cacheDir)
 	log.Debug("Clearing cache dir")
@@ -541,15 +547,17 @@ func (fs *Files) doCacheClearAll(ctx context.Context) error {
 	// Best-effort: remove leftover relocated cache dirs from previous clears
 	// whose deletion failed (e.g. a file was still open). They are siblings of
 	// the cache dir, so doCacheSweep doesn't reach them; cleaning them here
-	// makes repeated clears self-healing rather than accumulating cruft.
-	strays, _ := filepath.Glob(filepath.Join(parent, "dead_cache_*"))
+	// makes repeated clears self-healing rather than accumulating cruft. The
+	// name is sq-specific (relocateDirPrefix) because parent is the shared
+	// user-cache root: we must only remove dirs that sq itself created.
+	strays, _ := filepath.Glob(filepath.Join(parent, relocateDirPrefix+"*"))
 	for _, stray := range strays {
 		if err := os.RemoveAll(stray); err != nil {
 			log.Warn("Could not remove stray relocated cache dir", lga.Path, stray, lga.Err, err)
 		}
 	}
 
-	relocateDir := filepath.Join(parent, "dead_cache_"+stringz.Uniq8())
+	relocateDir := filepath.Join(parent, relocateDirPrefix+stringz.Uniq8())
 	if err := os.Rename(fs.cacheDir, relocateDir); err != nil {
 		return errz.Wrap(err, "cache clear: relocate")
 	}

--- a/libsq/files/cache.go
+++ b/libsq/files/cache.go
@@ -547,13 +547,22 @@ func (fs *Files) doCacheClearAll(ctx context.Context) error {
 	// Best-effort: remove leftover relocated cache dirs from previous clears
 	// whose deletion failed (e.g. a file was still open). They are siblings of
 	// the cache dir, so doCacheSweep doesn't reach them; cleaning them here
-	// makes repeated clears self-healing rather than accumulating cruft. The
-	// name is sq-specific (relocateDirPrefix) because parent is the shared
-	// user-cache root: we must only remove dirs that sq itself created.
-	strays, _ := filepath.Glob(filepath.Join(parent, relocateDirPrefix+"*"))
-	for _, stray := range strays {
-		if err := os.RemoveAll(stray); err != nil {
-			log.Warn("Could not remove stray relocated cache dir", lga.Path, stray, lga.Err, err)
+	// makes repeated clears self-healing rather than accumulating cruft.
+	//
+	// We match by name prefix via os.ReadDir rather than filepath.Glob:
+	// filepath.Glob would misinterpret glob metacharacters in the parent path
+	// (e.g. '[' in a home dir name) and could match non-directories. The prefix
+	// is sq-specific (relocateDirPrefix) because parent is the shared user-cache
+	// root: we must only remove dirs that sq itself created.
+	if entries, rdErr := os.ReadDir(parent); rdErr == nil {
+		for _, entry := range entries {
+			if !entry.IsDir() || !strings.HasPrefix(entry.Name(), relocateDirPrefix) {
+				continue
+			}
+			stray := filepath.Join(parent, entry.Name())
+			if err := os.RemoveAll(stray); err != nil {
+				log.Warn("Could not remove stray relocated cache dir", lga.Path, stray, lga.Err, err)
+			}
 		}
 	}
 

--- a/libsq/files/cache.go
+++ b/libsq/files/cache.go
@@ -518,16 +518,19 @@ func (fs *Files) doCacheClearAll(ctx context.Context) error {
 		return nil
 	}
 
-	// Instead of directly deleting the existing cache dir, we first
-	// move it to /tmp, and then try to delete it. This should probably
-	// help with the situation where another sq instance has an open pid
-	// lock in the cache dir.
-
-	tmpDir := DefaultTempDir()
-	if err := ioz.RequireDir(tmpDir); err != nil {
+	// Instead of directly deleting the existing cache dir, we first move it
+	// aside, then delete it. This should help with the situation where
+	// another sq instance has an open pid lock in the cache dir.
+	//
+	// The relocation target is a sibling of the cache dir (same parent, hence
+	// same filesystem) rather than the global temp dir: os.Rename can't move
+	// across filesystems (EXDEV), and the cache dir and os.TempDir are
+	// routinely on different mounts (e.g. ~/.cache vs a tmpfs /tmp).
+	parent := filepath.Dir(fs.cacheDir)
+	if err := ioz.RequireDir(parent); err != nil {
 		return errz.Wrap(err, "cache clear")
 	}
-	relocateDir := filepath.Join(tmpDir, "dead_cache_"+stringz.Uniq8())
+	relocateDir := filepath.Join(parent, "dead_cache_"+stringz.Uniq8())
 	if err := os.Rename(fs.cacheDir, relocateDir); err != nil {
 		return errz.Wrap(err, "cache clear: relocate")
 	}

--- a/libsq/files/cache.go
+++ b/libsq/files/cache.go
@@ -537,6 +537,18 @@ func (fs *Files) doCacheClearAll(ctx context.Context) error {
 	if err := ioz.RequireDir(parent); err != nil {
 		return errz.Wrap(err, "cache clear")
 	}
+
+	// Best-effort: remove leftover relocated cache dirs from previous clears
+	// whose deletion failed (e.g. a file was still open). They are siblings of
+	// the cache dir, so doCacheSweep doesn't reach them; cleaning them here
+	// makes repeated clears self-healing rather than accumulating cruft.
+	strays, _ := filepath.Glob(filepath.Join(parent, "dead_cache_*"))
+	for _, stray := range strays {
+		if err := os.RemoveAll(stray); err != nil {
+			log.Warn("Could not remove stray relocated cache dir", lga.Path, stray, lga.Err, err)
+		}
+	}
+
 	relocateDir := filepath.Join(parent, "dead_cache_"+stringz.Uniq8())
 	if err := os.Rename(fs.cacheDir, relocateDir); err != nil {
 		return errz.Wrap(err, "cache clear: relocate")

--- a/libsq/files/cache.go
+++ b/libsq/files/cache.go
@@ -124,9 +124,16 @@ func (fs *Files) WriteIngestChecksum(ctx context.Context, src, backingSrc *sourc
 		return err
 	}
 
-	var checksumsPath string
-	if _, _, checksumsPath, err = fs.CachePaths(src); err != nil {
+	var srcCacheDir, checksumsPath string
+	if srcCacheDir, _, checksumsPath, err = fs.CachePaths(src); err != nil {
 		return err
+	}
+
+	// checksum.WriteFile doesn't create parent dirs, so ensure the cache leaf
+	// dir exists; otherwise the write fails when this is the first thing to
+	// touch the leaf.
+	if err = ioz.RequireDir(srcCacheDir); err != nil {
+		return errz.Wrap(err, "write ingest checksum")
 	}
 
 	if err = checksum.WriteFile(checksumsPath, sum, ingestFilePath); err != nil {

--- a/libsq/files/cache_extra_test.go
+++ b/libsq/files/cache_extra_test.go
@@ -142,6 +142,47 @@ func TestFiles_CacheClearAll(t *testing.T) {
 	require.True(t, ioz.DirExists(fs.CacheDir()), "cache dir should be recreated")
 }
 
+// TestFiles_CacheClearAll_TempDirUnusable verifies that CacheClearAll does not
+// depend on the global temp dir (DefaultTempDir) being usable. The clear
+// relocates the cache dir before deleting it; that relocation must happen
+// within the cache dir's own filesystem, not via os.TempDir, otherwise it
+// fails with EXDEV when the cache and temp dirs are on different filesystems.
+//
+// The cross-filesystem condition is simulated by pointing TMPDIR at a regular
+// file, which makes DefaultTempDir() impossible to create: the old
+// implementation relocated there and failed.
+func TestFiles_CacheClearAll_TempDirUnusable(t *testing.T) {
+	ctx := lg.NewContext(context.Background(), lgt.New(t))
+
+	// Real, writable workspace, created before TMPDIR is clobbered.
+	work := t.TempDir()
+	cacheDir := filepath.Join(work, "cache")
+	tmpDir := filepath.Join(work, "ftmp")
+	require.NoError(t, os.MkdirAll(cacheDir, 0o700))
+	require.NoError(t, os.MkdirAll(tmpDir, 0o700))
+	// Populate the cache dir so the relocate-then-delete path runs.
+	require.NoError(t, os.WriteFile(filepath.Join(cacheDir, "stale"), []byte("x"), 0o600))
+
+	// Point TMPDIR at a regular file so DefaultTempDir() (os.TempDir()/sq)
+	// cannot be created. A no-op config lock keeps the cache sweep on Close
+	// from depending on TMPDIR too.
+	bogusTmp := filepath.Join(work, "tmpfile")
+	require.NoError(t, os.WriteFile(bogusTmp, nil, 0o600))
+	t.Setenv("TMPDIR", bogusTmp)
+
+	noopLock := func(context.Context) (func(), error) { return func() {}, nil }
+	fs, err := files.New(ctx, nil, noopLock, tmpDir, cacheDir)
+	require.NoError(t, err)
+	t.Cleanup(func() { assert.NoError(t, fs.Close()) })
+
+	require.NoError(t, fs.CacheClearAll(ctx),
+		"CacheClearAll must not depend on the global temp dir")
+	require.True(t, ioz.DirExists(cacheDir), "cache dir recreated")
+	entries, err := os.ReadDir(cacheDir)
+	require.NoError(t, err)
+	require.Empty(t, entries, "cache dir emptied")
+}
+
 // TestFiles_CacheClearSource verifies both clearDownloads modes.
 func TestFiles_CacheClearSource(t *testing.T) {
 	for _, clearDownloads := range []bool{true, false} {

--- a/libsq/files/cache_extra_test.go
+++ b/libsq/files/cache_extra_test.go
@@ -183,6 +183,28 @@ func TestFiles_CacheClearAll_TempDirUnusable(t *testing.T) {
 	require.Empty(t, entries, "cache dir emptied")
 }
 
+// TestFiles_CacheClearAll_RemovesStrayDeadCache verifies that CacheClearAll
+// cleans up leftover relocated cache dirs (dead_cache_*) from a previous clear
+// whose deletion failed. They are siblings of the cache dir, so the cache
+// sweep doesn't reach them; the next clear must remove them (self-healing).
+func TestFiles_CacheClearAll_RemovesStrayDeadCache(t *testing.T) {
+	ctx, fs := newTestFiles(t)
+	t.Cleanup(func() { assert.NoError(t, fs.Close()) })
+
+	require.NoError(t, ioz.RequireDir(fs.CacheDir()))
+
+	// Simulate a leftover from a prior failed clear: a non-empty dead_cache_*
+	// dir sitting next to the cache dir.
+	parent := filepath.Dir(fs.CacheDir())
+	stray := filepath.Join(parent, "dead_cache_stale")
+	require.NoError(t, os.MkdirAll(filepath.Join(stray, "sub"), 0o700))
+	require.True(t, ioz.DirExists(stray))
+
+	require.NoError(t, fs.CacheClearAll(ctx))
+	require.False(t, ioz.DirExists(stray),
+		"stray dead_cache dir should be cleaned up by the next clear")
+}
+
 // TestFiles_CacheClearSource verifies both clearDownloads modes.
 func TestFiles_CacheClearSource(t *testing.T) {
 	for _, clearDownloads := range []bool{true, false} {

--- a/libsq/files/cache_extra_test.go
+++ b/libsq/files/cache_extra_test.go
@@ -238,6 +238,28 @@ func TestFiles_CacheLockAcquire(t *testing.T) {
 	require.Error(t, err)
 }
 
+// TestFiles_WriteIngestChecksum_CreatesLeafDir verifies that
+// WriteIngestChecksum creates the cache leaf dir when it doesn't already
+// exist, rather than failing because checksum.WriteFile can't open a file in
+// a missing directory.
+func TestFiles_WriteIngestChecksum_CreatesLeafDir(t *testing.T) {
+	ctx, fs := newTestFiles(t)
+	t.Cleanup(func() { assert.NoError(t, fs.Close()) })
+
+	dir := tu.TempDir(t, "src")
+	src := mustCSVSrc(t, dir, "a,b,c\n1,2,3\n")
+	backingSrc := &source.Source{Handle: src.Handle + "_cached", Type: drivertype.SQLite}
+
+	// Deliberately do NOT create the cache leaf dir first.
+	leafDir, _, checksumsPath, err := fs.CachePaths(src)
+	require.NoError(t, err)
+	require.False(t, ioz.DirExists(leafDir), "precondition: leaf dir absent")
+
+	require.NoError(t, fs.WriteIngestChecksum(ctx, src, backingSrc),
+		"WriteIngestChecksum must create the cache leaf dir if absent")
+	require.True(t, ioz.FileAccessible(checksumsPath), "checksums file written")
+}
+
 // TestFiles_WriteIngestChecksum_File covers WriteIngestChecksum and
 // CachedBackingSourceFor for a local file source.
 func TestFiles_WriteIngestChecksum_File(t *testing.T) {
@@ -252,12 +274,6 @@ func TestFiles_WriteIngestChecksum_File(t *testing.T) {
 	_, ok, err := fs.CachedBackingSourceFor(ctx, src)
 	require.NoError(t, err)
 	require.False(t, ok)
-
-	// The real ingest flow creates the cache leaf dir (via the cache lock)
-	// before writing the checksum; replicate that here.
-	leafDir, _, _, err := fs.CachePaths(src)
-	require.NoError(t, err)
-	require.NoError(t, os.MkdirAll(leafDir, 0o700))
 
 	require.NoError(t, fs.WriteIngestChecksum(ctx, src, backingSrc))
 

--- a/libsq/files/cache_extra_test.go
+++ b/libsq/files/cache_extra_test.go
@@ -170,6 +170,13 @@ func TestFiles_CacheClearAll_TempDirUnusable(t *testing.T) {
 	require.NoError(t, os.WriteFile(bogusTmp, nil, 0o600))
 	t.Setenv("TMPDIR", bogusTmp)
 
+	// Precondition: the TMPDIR override must actually take effect (os.TempDir
+	// reads TMPDIR on each call, it doesn't cache), otherwise this test would
+	// be meaningless and could pass even against the old, temp-dir-dependent
+	// implementation.
+	require.True(t, strings.HasPrefix(files.DefaultTempDir(), bogusTmp),
+		"TMPDIR override must make DefaultTempDir unusable")
+
 	noopLock := func(context.Context) (func(), error) { return func() {}, nil }
 	fs, err := files.New(ctx, nil, noopLock, tmpDir, cacheDir)
 	require.NoError(t, err)

--- a/libsq/files/cache_extra_test.go
+++ b/libsq/files/cache_extra_test.go
@@ -191,25 +191,32 @@ func TestFiles_CacheClearAll_TempDirUnusable(t *testing.T) {
 }
 
 // TestFiles_CacheClearAll_RemovesStrayDeadCache verifies that CacheClearAll
-// cleans up leftover relocated cache dirs (dead_cache_*) from a previous clear
-// whose deletion failed. They are siblings of the cache dir, so the cache
-// sweep doesn't reach them; the next clear must remove them (self-healing).
+// cleans up sq's leftover relocated cache dirs from a previous clear whose
+// deletion failed. They are siblings of the cache dir, so the cache sweep
+// doesn't reach them; the next clear must remove them (self-healing). It must
+// also leave foreign dirs in the shared cache root untouched, since that root
+// is not owned by sq.
 func TestFiles_CacheClearAll_RemovesStrayDeadCache(t *testing.T) {
 	ctx, fs := newTestFiles(t)
 	t.Cleanup(func() { assert.NoError(t, fs.Close()) })
 
 	require.NoError(t, ioz.RequireDir(fs.CacheDir()))
-
-	// Simulate a leftover from a prior failed clear: a non-empty dead_cache_*
-	// dir sitting next to the cache dir.
 	parent := filepath.Dir(fs.CacheDir())
-	stray := filepath.Join(parent, "dead_cache_stale")
+
+	// An sq-owned leftover from a prior failed clear: must be removed.
+	stray := filepath.Join(parent, "sq_dead_cache_stale")
 	require.NoError(t, os.MkdirAll(filepath.Join(stray, "sub"), 0o700))
-	require.True(t, ioz.DirExists(stray))
+
+	// A foreign dir in the shared cache root that merely resembles the old
+	// naming: must NOT be removed.
+	foreign := filepath.Join(parent, "dead_cache_not_ours")
+	require.NoError(t, os.MkdirAll(foreign, 0o700))
 
 	require.NoError(t, fs.CacheClearAll(ctx))
 	require.False(t, ioz.DirExists(stray),
-		"stray dead_cache dir should be cleaned up by the next clear")
+		"sq's stray relocated cache dir should be cleaned up by the next clear")
+	require.True(t, ioz.DirExists(foreign),
+		"a foreign dir in the shared cache root must be left untouched")
 }
 
 // TestFiles_CacheClearSource verifies both clearDownloads modes.

--- a/libsq/files/cache_extra_test.go
+++ b/libsq/files/cache_extra_test.go
@@ -511,3 +511,16 @@ func TestFiles_CacheClearSource_InvalidHandle(t *testing.T) {
 	err := fs.CacheClearSource(ctx, bad, true)
 	require.Error(t, err)
 }
+
+// TestFiles_CachedBackingSourceFor_RemoteBadURL covers the error path of
+// cachedBackingSourceForRemoteFile: starting the download fails because the
+// URL is malformed (rejected by downloader.New).
+func TestFiles_CachedBackingSourceFor_RemoteBadURL(t *testing.T) {
+	ctx, fs := newTestFiles(t)
+	t.Cleanup(func() { assert.NoError(t, fs.Close()) })
+
+	src := &source.Source{Handle: "@remote", Type: drivertype.CSV, Location: "http://%zz"}
+	_, ok, err := fs.CachedBackingSourceFor(ctx, src)
+	require.Error(t, err)
+	require.False(t, ok)
+}

--- a/libsq/files/cache_extra_test.go
+++ b/libsq/files/cache_extra_test.go
@@ -219,6 +219,35 @@ func TestFiles_CacheClearAll_RemovesStrayDeadCache(t *testing.T) {
 		"a foreign dir in the shared cache root must be left untouched")
 }
 
+// TestFiles_CacheClearAll_StrayCleanupGlobMetacharParent verifies that the
+// stray cleanup works even when the cache dir's parent path contains glob
+// metacharacters: the cleanup must match by name prefix, not via filepath.Glob
+// (which would misinterpret a metacharacter like '[' and silently skip).
+func TestFiles_CacheClearAll_StrayCleanupGlobMetacharParent(t *testing.T) {
+	ctx := lg.NewContext(context.Background(), lgt.New(t))
+
+	base := t.TempDir()
+	// Parent dir name contains a glob metacharacter.
+	parent := filepath.Join(base, "weird[name]")
+	cacheDir := filepath.Join(parent, "cache")
+	tmpDir := filepath.Join(base, "tmp")
+	require.NoError(t, os.MkdirAll(cacheDir, 0o700))
+	require.NoError(t, os.MkdirAll(tmpDir, 0o700))
+
+	// An sq stray sitting next to the cache dir.
+	stray := filepath.Join(parent, "sq_dead_cache_stale")
+	require.NoError(t, os.MkdirAll(filepath.Join(stray, "sub"), 0o700))
+
+	noopLock := func(context.Context) (func(), error) { return func() {}, nil }
+	fs, err := files.New(ctx, nil, noopLock, tmpDir, cacheDir)
+	require.NoError(t, err)
+	t.Cleanup(func() { assert.NoError(t, fs.Close()) })
+
+	require.NoError(t, fs.CacheClearAll(ctx))
+	require.False(t, ioz.DirExists(stray),
+		"stray must be cleaned even when the parent path contains glob metacharacters")
+}
+
 // TestFiles_CacheClearSource verifies both clearDownloads modes.
 func TestFiles_CacheClearSource(t *testing.T) {
 	for _, clearDownloads := range []bool{true, false} {

--- a/libsq/files/download.go
+++ b/libsq/files/download.go
@@ -53,19 +53,25 @@ Contrast with http.request.timeout.`,
 	OptDownloadCache           = downloader.OptCache
 )
 
-// maybeStartDownload starts a download for src if one is not already in progress
-// or completed. If there's a download in progress, dlStream returns non-nil.
-// If the file is already downloaded to disk (and is valid/fresh), dlFile
-// returns non-empty and contains the absolute path to the downloaded file.
-// Otherwise, a new download is started (on a spawned goroutine), and the
-// stream returned from the downloader is added to Files.streams. On successful
-// download and cache update completion, the stream is removed from Files.streams
-// and the path to the cached file is added to Files.downloadedFiles.
+// maybeStartDownload returns the remote file for src, either as the path to an
+// already-cached file (dlFile) or as a stream of an in-progress download
+// (dlStream). Exactly one of dlFile, dlStream, err is non-nil.
 //
-// If arg checkFresh is false, and there's already a cached download on disk,
-// then the cached file is returned immediately, and no download is started.
+// Resolution order:
+//   - If src's download path is already recorded in Files.downloadedFiles, it
+//     is returned.
+//   - If a download stream for src is already registered in Files.streams, it
+//     is returned. Note that a stream stays registered for the lifetime of this
+//     Files instance: it is not removed when the download completes. So a
+//     completed download is re-served from its stream here, and (because the
+//     stream lingers) cachedBackingSourceForFile conservatively treats src as
+//     still downloading.
+//   - Otherwise a downloader is consulted. If checkFresh is false and the file
+//     is already cached on disk, that path is returned (but is not added to
+//     downloadedFiles). Otherwise the downloader either returns an
+//     already-cached file path (which is added to downloadedFiles) or starts a
+//     new download, whose stream is added to Files.streams and returned.
 //
-// It is guaranteed that one (and only one) of the returned values will be non-nil.
 // REVISIT: look into use of checkFresh?
 func (fs *Files) maybeStartDownload(ctx context.Context, src *source.Source, checkFresh bool) (dlFile string,
 	dlStream *streamcache.Stream, err error,

--- a/libsq/files/download.go
+++ b/libsq/files/download.go
@@ -55,7 +55,8 @@ Contrast with http.request.timeout.`,
 
 // maybeStartDownload returns the remote file for src, either as the path to an
 // already-cached file (dlFile) or as a stream of an in-progress download
-// (dlStream). Exactly one of dlFile, dlStream, err is non-nil.
+// (dlStream). Exactly one of the three results is set: dlFile is non-empty, or
+// dlStream is non-nil, or err is non-nil.
 //
 // Resolution order:
 //   - If src's download path is already recorded in Files.downloadedFiles, it

--- a/libsq/files/download_test.go
+++ b/libsq/files/download_test.go
@@ -379,3 +379,82 @@ func TestFiles_NewReader_HTTP_StreamReuseSeal(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, body, string(got2))
 }
+
+// TestFiles_Filesize_StdinNotCached covers the Filesize stdin branch when
+// AddStdin was never invoked: that's a programming error and returns an error.
+func TestFiles_Filesize_StdinNotCached(t *testing.T) {
+	ctx, fs := newTestFiles(t)
+	t.Cleanup(func() { assert.NoError(t, fs.Close()) })
+
+	src := &source.Source{Handle: source.StdinHandle, Location: source.StdinHandle}
+	_, err := fs.Filesize(ctx, src)
+	require.Error(t, err, "stdin not added -> error")
+}
+
+// TestFiles_Filesize_HTTP_NotDownloaded covers the Filesize HTTP path that falls
+// through to the downloader when the file is neither in downloadedFiles nor an
+// active stream. With no prior download the downloader has no cache, so Filesize
+// returns an error rather than a size (no network is touched).
+func TestFiles_Filesize_HTTP_NotDownloaded(t *testing.T) {
+	ctx, fs := newTestFiles(t)
+	t.Cleanup(func() { assert.NoError(t, fs.Close()) })
+
+	src := &source.Source{Handle: "@remote", Type: drivertype.CSV, Location: "http://example.com/data.csv"}
+	_, err := fs.Filesize(ctx, src)
+	require.Error(t, err, "no download yet -> no cache file -> error")
+}
+
+// TestFiles_NewReader_HTTP_BadURL covers downloaderFor's error path: a malformed
+// download URL is rejected by downloader.New.
+func TestFiles_NewReader_HTTP_BadURL(t *testing.T) {
+	ctx, fs := newTestFiles(t)
+	t.Cleanup(func() { assert.NoError(t, fs.Close()) })
+
+	src := &source.Source{Handle: "@remote", Type: drivertype.CSV, Location: "http://%zz"}
+	_, err := fs.NewReader(ctx, src, false)
+	require.Error(t, err)
+}
+
+// TestFiles_AddStdin_Twice covers the duplicate-stdin guard in AddStdin.
+func TestFiles_AddStdin_Twice(t *testing.T) {
+	ctx, fs := newTestFiles(t)
+	t.Cleanup(func() { assert.NoError(t, fs.Close()) })
+
+	mkStdin := func() *os.File {
+		f, err := os.CreateTemp(t.TempDir(), "stdin-*.csv")
+		require.NoError(t, err)
+		_, err = f.WriteString("a,b\n1,2\n")
+		require.NoError(t, err)
+		require.NoError(t, f.Close())
+		fh, err := os.Open(f.Name())
+		require.NoError(t, err)
+		return fh
+	}
+
+	require.NoError(t, fs.AddStdin(ctx, mkStdin()))
+	require.Error(t, fs.AddStdin(ctx, mkStdin()), "second AddStdin must error")
+}
+
+// TestFiles_Ping_HTTP_TransportError covers the Ping HTTP branch where the HTTP
+// client's Do fails (here, connection refused on a loopback port nothing
+// listens on).
+func TestFiles_Ping_HTTP_TransportError(t *testing.T) {
+	ctx, fs := newTestFiles(t)
+	t.Cleanup(func() { assert.NoError(t, fs.Close()) })
+
+	src := &source.Source{Handle: "@remote", Type: drivertype.CSV, Location: "http://127.0.0.1:1/x.csv"}
+	require.Error(t, fs.Ping(ctx, src))
+}
+
+// TestFiles_Ping_HTTP_BadRequestURL covers the Ping HTTP branch where
+// http.NewRequestWithContext rejects the URL (here, an invalid control
+// character), before any request is sent.
+func TestFiles_Ping_HTTP_BadRequestURL(t *testing.T) {
+	ctx, fs := newTestFiles(t)
+	t.Cleanup(func() { assert.NoError(t, fs.Close()) })
+
+	// Classified as an HTTP location, but http.NewRequestWithContext can't
+	// parse it.
+	src := &source.Source{Handle: "@remote", Type: drivertype.CSV, Location: "http://\x7f/x.csv"}
+	require.Error(t, fs.Ping(ctx, src))
+}

--- a/libsq/files/download_test.go
+++ b/libsq/files/download_test.go
@@ -432,7 +432,12 @@ func TestFiles_AddStdin_Twice(t *testing.T) {
 	}
 
 	require.NoError(t, fs.AddStdin(ctx, mkStdin()))
-	require.Error(t, fs.AddStdin(ctx, mkStdin()), "second AddStdin must error")
+
+	// The duplicate guard returns early without taking ownership of the file,
+	// so the test must close this handle itself.
+	dup := mkStdin()
+	t.Cleanup(func() { _ = dup.Close() })
+	require.Error(t, fs.AddStdin(ctx, dup), "second AddStdin must error")
 }
 
 // TestFiles_Ping_HTTP_TransportError covers the Ping HTTP branch where the HTTP


### PR DESCRIPTION
## Summary

Follow-up to #915 (downloader review). This addresses the latent issues found in the **top-level `libsq/files`** package during that review, with regression tests, and closes the reachable coverage gaps.

### Fixes

**1. `sq cache clear` fails across filesystems (`cache.go`)** — bug
`doCacheClearAll` relocated the cache dir into the global temp dir (`os.TempDir()/sq`) via `os.Rename` before deleting it. `os.Rename` can't cross filesystems, and the cache dir and temp dir are routinely on different mounts (e.g. `~/.cache` on disk vs a tmpfs `/tmp`), so the clear failed with `EXDEV`. It now relocates to a sibling of the cache dir (same filesystem). Regression test forces the condition by pointing `TMPDIR` at a regular file.

**2. Ingest cache silently not written (`cache.go`)** — bug
`WriteIngestChecksum` wrote the checksums file via `checksum.WriteFile`, which uses `O_CREATE` but doesn't `MkdirAll`. If the source's cache leaf dir didn't exist yet, the write failed and ingest caching silently did not take effect — so the source was re-ingested on every command. It worked only because the ingest flow happened to create the leaf earlier under the cache lock (an implicit ordering dependency). Now ensures the leaf dir exists first. Regression test calls it with no pre-existing leaf.

**3. `maybeStartDownload` doc correction (`download.go`)** — docs
The comment claimed completed download streams are removed from `Files.streams` and added to `Files.downloadedFiles`. Neither happens; a completed stream lingers for the instance lifetime, which also makes `cachedBackingSourceForFile` treat the source as still downloading. The comment now describes the actual behavior.

### Coverage

`libsq/files`: **87.0% → 89.5%** via meaningful characterization tests (`Filesize` uncached-stdin / never-downloaded-remote, `AddStdin` duplicate guard → 100%, `Ping` transport + bad-request-URL → 100%, `downloaderFor` / `cachedBackingSourceForRemoteFile` error paths). The remaining gap is dominated by disk-fault-injection arms and branches unreachable by contract.

All changes are test-first (RED→GREEN for the two fixes); `make lint`, `go test -race`, and markdown lint are clean.