### PR TITLE
Revert column-rename template hermetic restriction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,13 +18,6 @@ Breaking changes are annotated with ☢️, and alpha/beta features with 🐥.
 
 ## Unreleased
 
-### Changed
-
-- [#909]: The column-rename templates ([`ingest.column.rename`](https://sq.io/docs/config#ingestcolumnrename)
-  and [`result.column.rename`](https://sq.io/docs/config#resultcolumnrename)) no longer expose
-  the non-deterministic and environment-reading template functions (`env`, `expandenv`, `now`,
-  `randAlphaNum`, `uuidv4`, and similar).
-
 ### Fixed
 
 - [#866], [#868]: Ingesting document sources (CSV, JSON, Excel, etc.) is now much
@@ -1736,7 +1729,6 @@ make working with lots of sources much easier.
 [#868]: https://github.com/neilotoole/sq/issues/868
 [#900]: https://github.com/neilotoole/sq/pull/900
 [#902]: https://github.com/neilotoole/sq/pull/902
-[#909]: https://github.com/neilotoole/sq/pull/909
 [#911]: https://github.com/neilotoole/sq/pull/911
 [#915]: https://github.com/neilotoole/sq/pull/915
 [#916]: https://github.com/neilotoole/sq/pull/916

--- a/libsq/core/templatez/templatez.go
+++ b/libsq/core/templatez/templatez.go
@@ -11,16 +11,10 @@ import (
 )
 
 // NewTemplate returns a new text template, with the sprig
-// functions already loaded.
-//
-// Only sprig's hermetic (repeatable) functions are loaded. The
-// non-hermetic functions (e.g. "env", "now", "randAlphaNum",
-// "uuidv4") are excluded: they read the process environment or
-// global state, which both leaks information into user-supplied
-// templates and makes template output non-deterministic. Excluding
-// them keeps a given template's output a pure function of its input.
+// functions already loaded. The full text/template sprig function
+// set is loaded via sprig.TxtFuncMap.
 func NewTemplate(name, tpl string) (*template.Template, error) {
-	t, err := template.New(name).Funcs(sprig.HermeticTxtFuncMap()).Parse(tpl)
+	t, err := template.New(name).Funcs(sprig.TxtFuncMap()).Parse(tpl)
 	if err != nil {
 		return nil, errz.Err(err)
 	}

--- a/libsq/core/templatez/templatez_test.go
+++ b/libsq/core/templatez/templatez_test.go
@@ -77,7 +77,7 @@ func TestTemplate(t *testing.T) {
 func TestFuncMap(t *testing.T) {
 	t.Setenv("TEMPLATEZ_TEST_SECRET", "revealed")
 
-	// Plain (hermetic) sprig funcs are available.
+	// Plain sprig funcs are available.
 	got, err := templatez.ExecuteTemplate(t.Name(), `{{"abc" | upper}}`, nil)
 	require.NoError(t, err)
 	require.Equal(t, "ABC", got)

--- a/libsq/core/templatez/templatez_test.go
+++ b/libsq/core/templatez/templatez_test.go
@@ -71,26 +71,32 @@ func TestTemplate(t *testing.T) {
 	}
 }
 
-// TestHermeticFuncMap verifies that NewTemplate loads only sprig's
-// hermetic (repeatable) functions. Non-hermetic functions such as
-// "env" and "now" read process environment or global state, and must
-// not be available to user-supplied templates.
-func TestHermeticFuncMap(t *testing.T) {
-	t.Setenv("TEMPLATEZ_TEST_SECRET", "leaked")
+// TestFuncMap verifies that NewTemplate loads the full text/template
+// sprig function set, including the non-hermetic functions such as
+// "env" and "now".
+func TestFuncMap(t *testing.T) {
+	t.Setenv("TEMPLATEZ_TEST_SECRET", "revealed")
 
-	// Hermetic sprig funcs remain available.
+	// Plain (hermetic) sprig funcs are available.
 	got, err := templatez.ExecuteTemplate(t.Name(), `{{"abc" | upper}}`, nil)
 	require.NoError(t, err)
 	require.Equal(t, "ABC", got)
 
-	// Non-hermetic funcs are excluded, so referencing them is a parse error.
+	// The "env" func reads the process environment.
+	got, err = templatez.ExecuteTemplate(t.Name(), `{{env "TEMPLATEZ_TEST_SECRET"}}`, nil)
+	require.NoError(t, err)
+	require.Equal(t, "revealed", got)
+
+	// Other non-hermetic funcs parse and execute without error.
 	for _, tpl := range []string{
-		`{{env "TEMPLATEZ_TEST_SECRET"}}`,
 		`{{now}}`,
 		`{{randAlphaNum 8}}`,
 		`{{uuidv4}}`,
 	} {
-		require.Error(t, templatez.ValidTemplate(t.Name(), tpl),
-			"expected %q to be rejected as a non-hermetic function", tpl)
+		require.NoError(t, templatez.ValidTemplate(t.Name(), tpl),
+			"expected %q to be a valid template", tpl)
+		got, err = templatez.ExecuteTemplate(t.Name(), tpl, nil)
+		require.NoError(t, err)
+		require.NotEmpty(t, got)
 	}
 }


### PR DESCRIPTION
Reverts the behavior change from #909 that restricted the column-rename
templates ([`ingest.column.rename`](https://sq.io/docs/config#ingestcolumnrename)
and [`result.column.rename`](https://sq.io/docs/config#resultcolumnrename))
to sprig's hermetic function map.

## What changed

`NewTemplate` now loads `sprig.TxtFuncMap()` (the full text/template sprig
set) instead of `sprig.HermeticTxtFuncMap()`. This restores `env`,
`expandenv`, `now`, `randAlphaNum`, `uuidv4`, and the other non-hermetic
functions for use in column-rename templates.

`TxtFuncMap()` (not the pre-#909 `sprig.FuncMap()`) is used deliberately:
`FuncMap()` returns the `html/template` variant, which HTML-escapes output
and is the wrong flavor for our `text/template`. Using `TxtFuncMap()` keeps
that correctness fix from #909 while restoring the full function set.

## Retained from #909

- The `errz.Err` wrapping of the `Execute` error (so it carries a stack trace).
- The expanded tests distinguishing parse-time from execute-time failures.

The exclusion test is inverted: it now asserts the non-hermetic functions
are available (e.g. `{{env ...}}` resolves, `{{now}}`/`{{uuidv4}}` execute).

## Note

This reintroduces the trade-offs #909 closed: rename templates can again be
non-deterministic (`{{now}}`, `{{uuidv4}}`) and can read the process
environment (`{{env ...}}`). That is the intended outcome of this revert.

The #909 entry was under `## Unreleased`, so no released behavior is affected
and the CHANGELOG entry is removed rather than annotated as a revert.