### PR TITLE
Fix Windows full-suite failures: file-placeholder name + two non-portable tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ Breaking changes are annotated with ☢️, and alpha/beta features with 🐥.
 - [#865]: Fixed several broken shell-completion things.
 - [#863]: `FORCE_COLOR` handling now follows the [force-color.org](https://force-color.org/)
   conventions.
-- On Windows, a bare `${file:/}` source placeholder no longer suggests an invalid
+- [#926]: On Windows, a bare `${file:/}` source placeholder no longer suggests an invalid
   backslash handle name; the name is now derived using URI path semantics on all platforms.
 - Various other bug fixes: [#902], [#911], [#915], [#916], [#918], [#920], [#923].
 
@@ -1737,6 +1737,7 @@ make working with lots of sources much easier.
 [#918]: https://github.com/neilotoole/sq/pull/918
 [#920]: https://github.com/neilotoole/sq/pull/920
 [#923]: https://github.com/neilotoole/sq/pull/923
+[#926]: https://github.com/neilotoole/sq/pull/926
 
 [v0.15.2]: https://github.com/neilotoole/sq/releases/tag/v0.15.2
 [v0.15.3]: https://github.com/neilotoole/sq/compare/v0.15.2...v0.15.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ Breaking changes are annotated with ☢️, and alpha/beta features with 🐥.
 - [#865]: Fixed several broken shell-completion things.
 - [#863]: `FORCE_COLOR` handling now follows the [force-color.org](https://force-color.org/)
   conventions.
+- On Windows, a bare `${file:/}` source placeholder no longer suggests an invalid
+  backslash handle name; the name is now derived using URI path semantics on all platforms.
 - Various other bug fixes: [#902], [#911], [#915], [#916], [#918], [#920], [#923].
 
 ## [v0.54.0] - 2026-06-19

--- a/libsq/files/cache_extra_test.go
+++ b/libsq/files/cache_extra_test.go
@@ -168,14 +168,18 @@ func TestFiles_CacheClearAll_TempDirUnusable(t *testing.T) {
 	// from depending on TMPDIR too.
 	bogusTmp := filepath.Join(work, "tmpfile")
 	require.NoError(t, os.WriteFile(bogusTmp, nil, 0o600))
+	// os.TempDir reads TMPDIR on Unix but TMP/TEMP on Windows; set all
+	// three so the override takes effect on every platform.
 	t.Setenv("TMPDIR", bogusTmp)
+	t.Setenv("TMP", bogusTmp)
+	t.Setenv("TEMP", bogusTmp)
 
-	// Precondition: the TMPDIR override must actually take effect (os.TempDir
-	// reads TMPDIR on each call, it doesn't cache), otherwise this test would
+	// Precondition: the temp-dir override must actually take effect (os.TempDir
+	// reads the env on each call, it doesn't cache), otherwise this test would
 	// be meaningless and could pass even against the old, temp-dir-dependent
 	// implementation.
 	require.True(t, strings.HasPrefix(files.DefaultTempDir(), bogusTmp),
-		"TMPDIR override must make DefaultTempDir unusable")
+		"temp-dir override must make DefaultTempDir unusable")
 
 	noopLock := func(context.Context) (func(), error) { return func() {}, nil }
 	fs, err := files.New(ctx, nil, noopLock, tmpDir, cacheDir)

--- a/libsq/files/download_test.go
+++ b/libsq/files/download_test.go
@@ -417,11 +417,16 @@ func TestFiles_NewReader_HTTP_BadURL(t *testing.T) {
 
 // TestFiles_AddStdin_Twice covers the duplicate-stdin guard in AddStdin.
 func TestFiles_AddStdin_Twice(t *testing.T) {
+	// stdinDir must be created before fs.Close is registered for cleanup:
+	// t.Cleanup runs LIFO, and fs (via streamcache) holds the first stdin
+	// file open until fs.Close. On Windows an open file can't be removed, so
+	// stdinDir's teardown must run after fs.Close, i.e. be registered first.
+	stdinDir := t.TempDir()
 	ctx, fs := newTestFiles(t)
 	t.Cleanup(func() { assert.NoError(t, fs.Close()) })
 
 	mkStdin := func() *os.File {
-		f, err := os.CreateTemp(t.TempDir(), "stdin-*.csv")
+		f, err := os.CreateTemp(stdinDir, "stdin-*.csv")
 		require.NoError(t, err)
 		_, err = f.WriteString("a,b\n1,2\n")
 		require.NoError(t, err)

--- a/libsq/source/handle.go
+++ b/libsq/source/handle.go
@@ -2,7 +2,7 @@ package source
 
 import (
 	"fmt"
-	"path/filepath"
+	"path"
 	"regexp"
 	"slices"
 	"strconv"
@@ -321,11 +321,14 @@ func suggestNameForScheme(scheme, body string) (string, bool) {
 		return strings.ToLower(body), true
 
 	case "file":
-		base := filepath.Base(body)
+		// body is a URI-style path (always forward-slash), so use
+		// path, not path/filepath: filepath.Base("/") returns "\" on
+		// Windows, which slips past the "/" guard below.
+		base := path.Base(body)
 		if base == "." || base == "/" || base == "" {
 			return "", false
 		}
-		if ext := filepath.Ext(base); ext != "" {
+		if ext := path.Ext(base); ext != "" {
 			base = base[:len(base)-len(ext)]
 		}
 		if base == "" {


### PR DESCRIPTION
The nightly/dispatch full Windows suite (`test-windows-full`) was red on
master. A manual `workflow_dispatch` run surfaced three distinct Windows-only
failures, all in packages unrelated to recent changes. This fixes all three.

## 1. `suggestNameForScheme` — real product bug (`libsq/source/handle.go`)

For a bare `${file:/}` placeholder, the `file` case used `path/filepath`.
`filepath.Base("/")` returns `\` on Windows, which slips past the `base == "/"`
guard, so the function returned `("\\", true)` instead of `("", false)` and
suggested an invalid single-backslash handle name. The placeholder body is a
URI-style path (always forward-slash), so it now uses the slash-based `path`
package, making the result identical on all platforms.

Surfaced by `TestSuggestNameForScheme_edges/file_/`.

## 2. `TestFiles_CacheClearAll_TempDirUnusable` — test-only (`libsq/files/cache_extra_test.go`)

`os.TempDir()` reads `TMPDIR` on Unix but `TMP`/`TEMP` on Windows, so the
test's `t.Setenv("TMPDIR", ...)` override never took effect on Windows and the
precondition `require.True` failed. The test now sets all three env vars. The
production cache-clear path (#923) is platform-independent; only the test's
precondition was non-portable.

## 3. `TestFiles_AddStdin_Twice` — test-only (`libsq/files/download_test.go`)

`t.Cleanup` runs LIFO. `fs` (via streamcache) holds the first stdin file open
until `fs.Close`, but the stdin `t.TempDir()` was registered *after* the
`fs.Close` cleanup, so its teardown ran first. Windows cannot remove an open
file, so cleanup failed the test. `stdinDir` is now created before `fs.Close`
is registered, so the handle is closed before the dir is torn down.

## Verification

`go build ./...`, `go vet`, and `go test ./libsq/source/... ./libsq/files/...`
all pass locally (macOS). The Windows-specific paths are reasoned through in
the per-fix notes above; the merged result should be validated by a fresh
`test-windows-full` dispatch.