### PR TITLE
Upgrade gofumpt to v0.10 (#928)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@ Breaking changes are annotated with ☢️, and alpha/beta features with 🐥.
   aliasing only changed files (the `-set-alias` whole-module pass cost ~145s; it is now ~1s).
   Formatting, including Go import order, is enforced in CI. This is a contributor-facing
   change with no effect on the `sq` binary.
+- Go formatting upgraded to [gofumpt](https://github.com/mvdan/gofumpt) v0.10 via the dprint
+  plugin v0.0.11 (~67 files; mechanical trailing-comma and redundant-paren changes only, no
+  behavior change). Deferred from [#927] to keep that PR a tooling-only swap.
 
 ### Fixed
 

--- a/cli/buildinfo/buildinfo.go
+++ b/cli/buildinfo/buildinfo.go
@@ -80,7 +80,8 @@ func (bi Info) LogValue() slog.Value {
 	gv := slog.GroupValue(
 		slog.String(lga.Version, bi.Version),
 		slog.String(lga.Commit, bi.Commit),
-		slog.Time(lga.Timestamp, bi.Timestamp))
+		slog.Time(lga.Timestamp, bi.Timestamp),
+	)
 
 	return gv
 }

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -95,7 +95,8 @@ func ExecuteWith(ctx context.Context, ru *run.Run, args []string) (err error) {
 	log := lg.FromContext(ctx)
 	log.Info("EXECUTE", "args", strings.Join(args, " "))
 	log.Info("Build info", "build", buildinfo.Get())
-	log.Info("Config", "config_version", ru.Config.Version,
+	log.Info(
+		"Config", "config_version", ru.Config.Version,
 		lga.Path, ru.ConfigStore.Location(),
 	)
 
@@ -108,7 +109,8 @@ func ExecuteWith(ctx context.Context, ru *run.Run, args []string) (err error) {
 		// Debug setting to log peak memory usage on exit.
 		peakSys, peakAllocs, totalAllocs, gcPause := runtimez.StartMemStatsTracker(ctx)
 		defer func() {
-			log.Info("Memory stats",
+			log.Info(
+				"Memory stats",
 				"sys_peak", datasize.ByteSize(peakSys.Load()).HR(),
 				"heap_peak", datasize.ByteSize(peakAllocs.Load()).HR(),
 				"heap_total", datasize.ByteSize(totalAllocs.Load()).HR(),

--- a/cli/cmd_add.go
+++ b/cli/cmd_add.go
@@ -531,7 +531,8 @@ func checkPathEscape(typedPath string) error {
 		return errz.Errorf(
 			"location contains %q, which sq interprets as an escaped literal '$': "+
 				"a file exists at %s, but the interpreted path %s does not",
-			"$$", typedPath, interpreted)
+			"$$", typedPath, interpreted,
+		)
 	}
 	return nil
 }
@@ -618,7 +619,8 @@ func resolveDriverType(
 					"Either store a full DSN in the secret (e.g. postgres://alice:pw@db/sakila), "+
 					"compose the placeholder into a DSN (e.g. postgres://alice:%s@db/sakila), "+
 					"or pass --%s",
-				location.Redact(loc), location.Redact(loc), flag.AddDriver)
+				location.Redact(loc), location.Redact(loc), flag.AddDriver,
+			)
 		}
 		return typ, nil
 	}
@@ -872,7 +874,8 @@ func filterToAdvertisedParams(ctx context.Context, drvr driver.Driver,
 		// them all rather than persisting unvetted params.
 		lg.FromContext(ctx).Warn(
 			"Detected conn params from non-SQL driver; dropping all",
-			lga.Src, src.Handle)
+			lga.Src, src.Handle,
+		)
 		return url.Values{}
 	}
 	advertised := sqlDrvr.ConnParams()
@@ -881,7 +884,8 @@ func filterToAdvertisedParams(ctx context.Context, drvr driver.Driver,
 		if _, ok := advertised[k]; !ok {
 			lg.FromContext(ctx).Warn(
 				"Detected conn param not advertised by driver; dropping",
-				lga.Src, src.Handle, lga.Key, k)
+				lga.Src, src.Handle, lga.Key, k,
+			)
 			continue
 		}
 		out[k] = vs

--- a/cli/cmd_add_test.go
+++ b/cli/cmd_add_test.go
@@ -1123,7 +1123,8 @@ func TestCmdAdd_Rqlite_ConnParamDetection(t *testing.T) {
 			func(w http.ResponseWriter, r *http.Request) {
 				hits.Add(1)
 				inner.ServeHTTP(w, r)
-			}))
+			},
+		))
 		t.Cleanup(server.Close)
 		host = server.Listener.Addr().String()
 

--- a/cli/cmd_config_export.go
+++ b/cli/cmd_config_export.go
@@ -79,7 +79,8 @@ func execConfigExport(cmd *cobra.Command, _ []string) error {
 		cfg = cloned
 
 		lg.FromContext(ctx).Warn(
-			"sq config export --expand: resolved secrets are written in plaintext")
+			"sq config export --expand: resolved secrets are written in plaintext",
+		)
 	}
 
 	// yamlw renders YAML with the same encoder sq uses for `config ls -y`

--- a/cli/cmd_config_keyring_create.go
+++ b/cli/cmd_config_keyring_create.go
@@ -53,7 +53,8 @@ func execConfigKeyringCreate(cmd *cobra.Command, args []string) error {
 	if _, err := kr.Resolve(cmd.Context(), path); err == nil {
 		return errz.Errorf(
 			"keyring entry already exists at %q: use 'sq config keyring update' to change its value",
-			path)
+			path,
+		)
 	} else if !errors.Is(err, secret.ErrNotFound) {
 		return err
 	}

--- a/cli/cmd_config_keyring_migrate.go
+++ b/cli/cmd_config_keyring_migrate.go
@@ -237,7 +237,8 @@ func applyMigratePlans(ctx context.Context, ru *run.Run, plans []migratePlan) (
 			})
 		}
 		return rows, errz.Errorf(
-			"migration failed and was rolled back; no sources were changed: %s", cause)
+			"migration failed and was rolled back; no sources were changed: %s", cause,
+		)
 	}
 
 	for _, p := range plans {

--- a/cli/cmd_config_keyring_update.go
+++ b/cli/cmd_config_keyring_update.go
@@ -55,7 +55,8 @@ func execConfigKeyringUpdate(cmd *cobra.Command, args []string) error {
 		if errors.Is(err, secret.ErrNotFound) {
 			return errz.Errorf(
 				"no keyring entry at %q: use 'sq config keyring create' to add it",
-				path)
+				path,
+			)
 		}
 		return err
 	}

--- a/cli/cmd_config_set_test.go
+++ b/cli/cmd_config_set_test.go
@@ -58,12 +58,14 @@ func TestConfigSetBaseOptOnSourceIsError(t *testing.T) {
 
 	const tpl = "{{.Name}}"
 	tr = testrun.New(ctx, t, tr)
-	require.NoError(t, tr.Exec("config", "set",
+	require.NoError(t, tr.Exec(
+		"config", "set",
 		driver.OptResultColRename.Key(), tpl,
 	), "should work for base config")
 
 	tr = testrun.New(ctx, t, tr)
-	err := tr.Exec("config", "set",
+	err := tr.Exec(
+		"config", "set",
 		"--"+flag.ConfigSrc, handle,
 		driver.OptResultColRename.Key(), tpl,
 	)
@@ -102,7 +104,8 @@ func TestSourceOptOverridesBaseOpt(t *testing.T) {
 
 			const baseTpl = "base_{{.Name}}"
 			tr = testrun.New(ctx, t, tr)
-			require.NoError(t, tr.Exec("config", "set",
+			require.NoError(t, tr.Exec(
+				"config", "set",
 				opt.Key(), baseTpl,
 			))
 
@@ -114,7 +117,8 @@ func TestSourceOptOverridesBaseOpt(t *testing.T) {
 
 			const srcTpl = "src_{{.Name}}"
 			tr = testrun.New(ctx, t, tr)
-			require.NoError(t, tr.Exec("config", "set",
+			require.NoError(t, tr.Exec(
+				"config", "set",
 				"--"+flag.ConfigSrc, handle,
 				opt.Key(), srcTpl,
 			))
@@ -127,7 +131,8 @@ func TestSourceOptOverridesBaseOpt(t *testing.T) {
 
 			// Unset base opt
 			tr = testrun.New(ctx, t, tr)
-			require.NoError(t, tr.Exec("config", "set",
+			require.NoError(t, tr.Exec(
+				"config", "set",
 				opt.Key(), "",
 			))
 
@@ -138,7 +143,8 @@ func TestSourceOptOverridesBaseOpt(t *testing.T) {
 
 			// Unset src opt
 			tr = testrun.New(ctx, t, tr)
-			require.NoError(t, tr.Exec("config", "set",
+			require.NoError(t, tr.Exec(
+				"config", "set",
 				"--"+flag.ConfigSrc, handle,
 				opt.Key(), "",
 			))
@@ -173,13 +179,15 @@ func TestColRenameOptsInteraction(t *testing.T) {
 
 			const ingestTpl = "x_{{.Name}}"
 			tr = testrun.New(ctx, t, tr)
-			require.NoError(t, tr.Exec("config", "set",
+			require.NoError(t, tr.Exec(
+				"config", "set",
 				driver.OptIngestColRename.Key(), ingestTpl,
 			))
 
 			const resultTpl = "{{.Name}}_y"
 			tr = testrun.New(ctx, t, tr)
-			require.NoError(t, tr.Exec("config", "set",
+			require.NoError(t, tr.Exec(
+				"config", "set",
 				driver.OptResultColRename.Key(), resultTpl,
 			))
 

--- a/cli/cmd_inspect.go
+++ b/cli/cmd_inspect.go
@@ -306,7 +306,8 @@ func errBinaryFormatToTerminal(fm format.Format, fileOutputSet, stdoutIsTerminal
 	}
 	return errz.Errorf(
 		"%s is a binary image format and would corrupt the terminal; "+
-			"write it to a file with -o/--output (e.g. -o schema.png)", format.PNGERD)
+			"write it to a file with -o/--output (e.g. -o schema.png)", format.PNGERD,
+	)
 }
 
 // determineInspectTarget determines the source (and, optionally, table)

--- a/cli/cmd_inspect_test.go
+++ b/cli/cmd_inspect_test.go
@@ -373,7 +373,8 @@ func TestCmdInspect_markdown(t *testing.T) { //nolint:tparallel
 	t.Run("overview", func(t *testing.T) {
 		tr2 := testrun.New(th.Context, t, tr)
 		require.NoError(t, tr2.Exec(
-			"inspect", sakila.SL3, "--"+flag.InspectOverview, "--"+format.Markdown.String()))
+			"inspect", sakila.SL3, "--"+flag.InspectOverview, "--"+format.Markdown.String(),
+		))
 		out := tr2.Out.String()
 		require.Contains(t, out, "# "+src.Handle)
 		require.NotContains(t, out, "```mermaid")
@@ -436,7 +437,8 @@ func TestCmdInspect_mermaidERD(t *testing.T) { //nolint:tparallel
 	t.Run("table", func(t *testing.T) {
 		tr2 := testrun.New(th.Context, t, tr)
 		require.NoError(t, tr2.Exec(
-			"inspect", src.Handle+".film_actor", "-f", format.MermaidERD.String()))
+			"inspect", src.Handle+".film_actor", "-f", format.MermaidERD.String(),
+		))
 		out := tr2.Out.String()
 		require.True(t, strings.HasPrefix(out, "erDiagram"))
 		require.Contains(t, out, "film_actor {")
@@ -446,7 +448,8 @@ func TestCmdInspect_mermaidERD(t *testing.T) { //nolint:tparallel
 	t.Run("overview", func(t *testing.T) {
 		tr2 := testrun.New(th.Context, t, tr)
 		err := tr2.Exec(
-			"inspect", sakila.SL3, "--"+flag.InspectOverview, "-f", format.MermaidERD.String())
+			"inspect", sakila.SL3, "--"+flag.InspectOverview, "-f", format.MermaidERD.String(),
+		)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "mermaid-erd")
 	})
@@ -475,7 +478,8 @@ func TestCmdInspect_svgERD(t *testing.T) { //nolint:tparallel
 	t.Run("table", func(t *testing.T) {
 		tr2 := testrun.New(th.Context, t, tr)
 		require.NoError(t, tr2.Exec(
-			"inspect", src.Handle+".film_actor", "-f", format.SVGERD.String()))
+			"inspect", src.Handle+".film_actor", "-f", format.SVGERD.String(),
+		))
 		out := tr2.Out.String()
 		require.Contains(t, out, "<svg")
 		require.Contains(t, out, "film_actor")
@@ -500,7 +504,8 @@ func TestCmdInspect_pngERD(t *testing.T) {
 	})
 
 	require.NoError(t, tr.Exec(
-		"inspect", "--format="+format.PNGERD.String(), "-o", outputFile.Name()))
+		"inspect", "--format="+format.PNGERD.String(), "-o", outputFile.Name(),
+	))
 
 	// Nothing should have been written to stdout.
 	require.Empty(t, tr.Out.String())
@@ -612,7 +617,8 @@ func TestCmdInspect_OutputFlag(t *testing.T) {
 	})
 
 	require.NoError(t, tr.Exec(
-		"inspect", "--"+format.Markdown.String(), "-o", outputFile.Name()))
+		"inspect", "--"+format.Markdown.String(), "-o", outputFile.Name(),
+	))
 
 	// Nothing should have been written to stdout.
 	require.Empty(t, tr.Out.String())

--- a/cli/cmd_ls_test.go
+++ b/cli/cmd_ls_test.go
@@ -147,7 +147,8 @@ func TestRevealFlagConfigPrecedence(t *testing.T) {
 
 			if tc.configReveal != "" {
 				require.NoError(t, tr.Reset().Exec(
-					"config", "set", "secrets.reveal", tc.configReveal))
+					"config", "set", "secrets.reveal", tc.configReveal,
+				))
 			}
 
 			args := append([]string{"ls", "-v"}, tc.args...)

--- a/cli/cmd_slq.go
+++ b/cli/cmd_slq.go
@@ -245,7 +245,8 @@ func execSLQRenderSQL(ctx context.Context, ru *run.Run, mArgs map[string]string)
 	if fm := getFormat(ru.Cmd, ru.Config.Options); !renderSQLSupportsFormat(fm) {
 		lg.FromContext(ctx).Warn(
 			"--render-sql has no writer for the requested format; falling back to text",
-			"format", fm)
+			"format", fm,
+		)
 	}
 
 	slq, err := preprocessUserSLQ(ctx, ru, ru.Args)

--- a/cli/cmd_slq_test.go
+++ b/cli/cmd_slq_test.go
@@ -473,7 +473,8 @@ See: https://github.com/neilotoole/sq/issues/437`,
 
 			// Test combination of --src and --src.schema
 			const qInfoSchemaActor = `.tables | .table_catalog, .table_schema, .table_name, .table_type | where(.table_name == "actor")` //nolint:lll
-			require.NoError(t, tr.Reset().Exec("--csv", "-H",
+			require.NoError(t, tr.Reset().Exec(
+				"--csv", "-H",
 				"--src", tc.handle,
 				"--src.schema", "information_schema",
 				qInfoSchemaActor,
@@ -489,7 +490,8 @@ See: https://github.com/neilotoole/sq/issues/437`,
 			require.Equal(t, tc.defaultSchema, tr.OutString())
 
 			// Test just --src.schema (schema part only)
-			require.NoError(t, tr.Reset().Exec("--csv", "-H",
+			require.NoError(t, tr.Reset().Exec(
+				"--csv", "-H",
 				"--src.schema", "information_schema",
 				qInfoSchemaActor,
 			))
@@ -498,7 +500,8 @@ See: https://github.com/neilotoole/sq/issues/437`,
 
 			if th.SQLDriverFor(src).Dialect().Catalog {
 				// Test --src.schema (catalog and schema parts)
-				require.NoError(t, tr.Reset().Exec("--csv", "-H",
+				require.NoError(t, tr.Reset().Exec(
+					"--csv", "-H",
 					"--src.schema", tc.altCatalog+".information_schema",
 					`.schemata | .catalog_name | unique`,
 				))
@@ -785,13 +788,15 @@ func TestCmdSLQ_NumericSchema(t *testing.T) {
 			tblName := "query_test_tbl"
 			_, err = db.ExecContext(ctx, fmt.Sprintf(
 				`CREATE TABLE %q.%q (id serial PRIMARY KEY, name text, value int)`,
-				schemaName, tblName))
+				schemaName, tblName,
+			))
 			require.NoError(t, err)
 
 			// Insert test data.
 			_, err = db.ExecContext(ctx, fmt.Sprintf(
 				`INSERT INTO %q.%q (name, value) VALUES ('alice', 10), ('bob', 20), ('charlie', 30)`,
-				schemaName, tblName))
+				schemaName, tblName,
+			))
 			require.NoError(t, err)
 
 			// Execute SLQ query with --src.schema pointing to numeric schema.

--- a/cli/config/yamlstore/upgrades/v0.54.0/upgrade.go
+++ b/cli/config/yamlstore/upgrades/v0.54.0/upgrade.go
@@ -78,7 +78,8 @@ func Upgrade(ctx context.Context, before []byte) (after []byte, err error) {
 					if !ok {
 						return nil, errz.Errorf(
 							"corrupt config: invalid 'collection.sources[%d].options' field (want map, got %T)",
-							i, rawSrcOpts)
+							i, rawSrcOpts,
+						)
 					}
 					handle, _ := src["handle"].(string)
 					ctxLabel := fmt.Sprintf("collection.sources[%d] (%s)", i, handle)

--- a/cli/config/yamlstore/yamlstore.go
+++ b/cli/config/yamlstore/yamlstore.go
@@ -263,7 +263,8 @@ func (fs *Store) backupNewerConfig(ctx context.Context) error {
 			"Config version is newer than sq version; wrote verbatim backup of config before save",
 			lga.ConfigVersion, fs.newerCfgVers,
 			lga.BuildVersion, buildinfo.Version,
-			lga.Path, backupFilePath(fs.Path, fs.newerCfgVers))
+			lga.Path, backupFilePath(fs.Path, fs.newerCfgVers),
+		)
 	}
 	fs.newerCfgVers = ""
 	return nil

--- a/cli/logging.go
+++ b/cli/logging.go
@@ -61,7 +61,8 @@ var (
 		},
 		"Log output format (text or json)",
 		fmt.Sprintf(
-			`Log output format. Allowed formats are %q (human-friendly) or %q.`, format.Text, format.JSON),
+			`Log output format. Allowed formats are %q (human-friendly) or %q.`, format.Text, format.JSON,
+		),
 	)
 )
 
@@ -213,7 +214,8 @@ func getLogEnabled(ctx context.Context, osArgs []string, cfg *config.Config) boo
 
 	val, ok = os.LookupEnv(config.EnvarLogEnabled)
 	if ok {
-		bootLog.Debug("Using log 'enabled' specified via envar",
+		bootLog.Debug(
+			"Using log 'enabled' specified via envar",
 			lga.Env, config.EnvarLogEnabled,
 			lga.Val, val,
 		)

--- a/cli/output/erdimgw/metadatawriter.go
+++ b/cli/output/erdimgw/metadatawriter.go
@@ -38,14 +38,16 @@ var _ output.MetadataWriter = (*metadataWriter)(nil)
 // errUnsupported is returned by the metadata operations that have no ERD
 // representation.
 var errUnsupported = errz.New(
-	"the png-erd and svg-erd formats support only source and table schema diagrams")
+	"the png-erd and svg-erd formats support only source and table schema diagrams",
+)
 
 // errNothingToRender is returned when there's no diagram to draw, i.e. no
 // tables with columns and no foreign keys. As with mermaidw, the diagram is
 // the entire output, so an empty render is an error rather than an empty
 // (and invalid) image file.
 var errNothingToRender = errz.New(
-	"the png-erd/svg-erd format has nothing to render: no columns or foreign keys found")
+	"the png-erd/svg-erd format has nothing to render: no columns or foreign keys found",
+)
 
 // metadataWriter implements output.MetadataWriter for the "png-erd" and
 // "svg-erd" formats, rendering the schema ERD to an image via go-graphviz.

--- a/cli/output/markdownw/metadatawriter.go
+++ b/cli/output/markdownw/metadatawriter.go
@@ -136,7 +136,8 @@ func (w *metadataWriter) DriverMetadata(drvrs []driver.Metadata) error {
 	buf := &bytes.Buffer{}
 	buf.WriteString("| Driver | Description | User-defined |\n| --- | --- | :---: |\n")
 	for _, md := range drvrs {
-		writeTableRow(buf,
+		writeTableRow(
+			buf,
 			escapeMarkdown(string(md.Type)),
 			escapeMarkdown(md.Description),
 			yesNo(md.UserDefined),
@@ -339,7 +340,8 @@ func (w *metadataWriter) writeIndexes(buf *bytes.Buffer, tbl *metadata.Table) {
 	writeTableRow(buf, "Index", "Columns", "Unique", "Primary", "Type")
 	writeTableRow(buf, "---", "---", ":---:", ":---:", "---")
 	for _, r := range rows {
-		writeTableRow(buf,
+		writeTableRow(
+			buf,
 			mdCodeCell(r.Name),
 			mdCodeCell(r.Columns),
 			checkMark(r.Unique),

--- a/cli/output/mermaidw/metadatawriter.go
+++ b/cli/output/mermaidw/metadatawriter.go
@@ -24,14 +24,16 @@ var _ output.MetadataWriter = (*metadataWriter)(nil)
 // errUnsupported is returned by the metadata operations that have no Mermaid
 // ERD representation.
 var errUnsupported = errz.New(
-	"the mermaid-erd format supports only source and table schema diagrams")
+	"the mermaid-erd format supports only source and table schema diagrams",
+)
 
 // errNothingToRender is returned when there's no diagram to draw, i.e. no
 // tables with columns and no foreign keys. Unlike markdownw/htmlw, where the
 // ERD is one section of a larger document, here the diagram is the entire
 // output, so an empty render is an error rather than silent empty output.
 var errNothingToRender = errz.New(
-	"the mermaid-erd format has nothing to render: no columns or foreign keys found")
+	"the mermaid-erd format has nothing to render: no columns or foreign keys found",
+)
 
 // metadataWriter implements output.MetadataWriter for the "mermaid-erd"
 // format, emitting bare Mermaid.js erDiagram source.

--- a/cli/run.go
+++ b/cli/run.go
@@ -212,7 +212,8 @@ func preRun(cmd *cobra.Command, ru *run.Run) error {
 	if cmdFlagChanged(ru.Cmd, flag.NoRedact) {
 		lg.FromContext(ctx).Warn(
 			"--no-redact is deprecated; use --reveal instead",
-			lga.Cmd, ru.Cmd.CommandPath())
+			lga.Cmd, ru.Cmd.CommandPath(),
+		)
 	}
 
 	// Build the secret registry before FinishRunInit, which constructs

--- a/cli/source.go
+++ b/cli/source.go
@@ -438,13 +438,15 @@ func newSource(ctx context.Context, dp driver.Provider, typ drivertype.Type, han
 	log := lg.FromContext(ctx)
 
 	if opts == nil {
-		log.Debug("Create new data source",
+		log.Debug(
+			"Create new data source",
 			lga.Handle, handle,
 			lga.Driver, typ,
 			lga.Loc, location.Redact(loc),
 		)
 	} else {
-		log.Debug("Create new data source with opts",
+		log.Debug(
+			"Create new data source with opts",
 			lga.Handle, handle,
 			lga.Driver, typ,
 			lga.Loc, location.Redact(loc),

--- a/dprint.json
+++ b/dprint.json
@@ -59,6 +59,6 @@
     "https://plugins.dprint.dev/g-plane/pretty_yaml-v0.6.0.wasm",
     "https://plugins.dprint.dev/g-plane/malva-v0.16.0.wasm",
     "https://plugins.dprint.dev/biome-0.13.0.wasm",
-    "https://github.com/jakebailey/dprint-plugin-gofumpt/releases/download/v0.0.9/plugin.wasm"
+    "https://github.com/jakebailey/dprint-plugin-gofumpt/releases/download/v0.0.11/plugin.wasm"
   ]
 }

--- a/drivers/clickhouse/batch.go
+++ b/drivers/clickhouse/batch.go
@@ -138,7 +138,8 @@ func (d *driveri) NewBatchInsert(ctx context.Context, msg string, db sqlz.DB,
 					lg.WarnIfFuncError(log, "Abort clickhouse batch", batch.Abort)
 					errCh <- errz.Errorf(
 						"clickhouse batch insert: record should have %d values but found %d",
-						len(destColNames), len(rec))
+						len(destColNames), len(rec),
+					)
 					return
 				}
 

--- a/drivers/clickhouse/clickhouse.go
+++ b/drivers/clickhouse/clickhouse.go
@@ -319,7 +319,8 @@ func (d *driveri) Renderer() *render.Renderer {
 	// so trailing zeros from the fixed scale are trimmed by stringz.FormatDecimal
 	// at render time, as on the other result-cast drivers.
 	r.FunctionOverrides[ast.FuncNameSum] = render.FuncOverrideCastResult(
-		fmt.Sprintf("Nullable(Decimal(%d, %d))", render.AggDecimalPrecision, render.AggDecimalScale))
+		fmt.Sprintf("Nullable(Decimal(%d, %d))", render.AggDecimalPrecision, render.AggDecimalScale),
+	)
 	return r
 }
 
@@ -379,7 +380,8 @@ func (d *driveri) doOpen(ctx context.Context, src *source.Source) (*sql.DB, erro
 	}
 
 	if portAdded {
-		log.Debug("Applied default ClickHouse port at connection time",
+		log.Debug(
+			"Applied default ClickHouse port at connection time",
 			lga.Src, src.Handle,
 			lga.Before, src.Location,
 			lga.After, loc,
@@ -429,7 +431,8 @@ func (d *driveri) ValidateSource(src *source.Source) (*source.Source, error) {
 	}
 
 	if portAdded {
-		d.log.Debug("Applied default ClickHouse port to source location",
+		d.log.Debug(
+			"Applied default ClickHouse port to source location",
 			lga.Src, src.Handle,
 			lga.Before, src.Location,
 			lga.After, loc,
@@ -1013,7 +1016,8 @@ func (d *driveri) PrepareUpdateStmt(ctx context.Context, db sqlz.DB, destTbl str
 // columns (NotNull is false by default), but ClickHouse columns are
 // non-nullable by default. This matches the behavior of buildCreateTableStmt.
 func (d *driveri) AlterTableAddColumn(ctx context.Context, db sqlz.DB, tbl, col string, knd kind.Kind) error {
-	q := fmt.Sprintf("ALTER TABLE %s ADD COLUMN %s Nullable(%s)",
+	q := fmt.Sprintf(
+		"ALTER TABLE %s ADD COLUMN %s Nullable(%s)",
 		stringz.BacktickQuote(tbl),
 		stringz.BacktickQuote(col),
 		dbTypeNameFromKind(knd),
@@ -1026,7 +1030,8 @@ func (d *driveri) AlterTableAddColumn(ctx context.Context, db sqlz.DB, tbl, col 
 // AlterTableRename implements driver.SQLDriver. It renames a table using
 // RENAME TABLE syntax.
 func (d *driveri) AlterTableRename(ctx context.Context, db sqlz.DB, tbl, newName string) error {
-	q := fmt.Sprintf("RENAME TABLE %s TO %s",
+	q := fmt.Sprintf(
+		"RENAME TABLE %s TO %s",
 		stringz.BacktickQuote(tbl),
 		stringz.BacktickQuote(newName),
 	)
@@ -1038,7 +1043,8 @@ func (d *driveri) AlterTableRename(ctx context.Context, db sqlz.DB, tbl, newName
 // AlterTableRenameColumn implements driver.SQLDriver. It renames a column
 // using ALTER TABLE ... RENAME COLUMN syntax.
 func (d *driveri) AlterTableRenameColumn(ctx context.Context, db sqlz.DB, tbl, col, newName string) error {
-	q := fmt.Sprintf("ALTER TABLE %s RENAME COLUMN %s TO %s",
+	q := fmt.Sprintf(
+		"ALTER TABLE %s RENAME COLUMN %s TO %s",
 		stringz.BacktickQuote(tbl),
 		stringz.BacktickQuote(col),
 		stringz.BacktickQuote(newName),
@@ -1086,7 +1092,8 @@ func (d *driveri) AlterTableColumnKinds(ctx context.Context,
 	}
 
 	for i, col := range colNames {
-		q := fmt.Sprintf("ALTER TABLE %s MODIFY COLUMN %s Nullable(%s)",
+		q := fmt.Sprintf(
+			"ALTER TABLE %s MODIFY COLUMN %s Nullable(%s)",
 			stringz.BacktickQuote(tbl),
 			stringz.BacktickQuote(col),
 			dbTypeNameFromKind(kinds[i]),

--- a/drivers/clickhouse/metadata.go
+++ b/drivers/clickhouse/metadata.go
@@ -205,7 +205,8 @@ func getTableMetadata(ctx context.Context, db sqlz.DB, dbName, tblName string) (
 	var totalRows, totalBytes sql.NullInt64
 
 	err := db.QueryRowContext(ctx, queryTable, dbName, tblName).Scan(
-		&tableName, &engine, &totalRows, &totalBytes)
+		&tableName, &engine, &totalRows, &totalBytes,
+	)
 	if err != nil {
 		return nil, errw(err)
 	}

--- a/drivers/csv/ingest.go
+++ b/drivers/csv/ingest.go
@@ -143,7 +143,8 @@ func (d *driveri) ingestCSV(ctx context.Context, src *source.Source, destGrip dr
 		return err
 	}
 
-	log.Info("Ingested rows",
+	log.Info(
+		"Ingested rows",
 		lga.Count, inserted,
 		lga.Elapsed, time.Since(startUTC).Round(time.Millisecond),
 		lga.Target, source.Target(destGrip.Source(), tblDef.Name),

--- a/drivers/duckdb/alter_test.go
+++ b/drivers/duckdb/alter_test.go
@@ -106,7 +106,8 @@ func TestAlterTableColumnKinds(t *testing.T) {
 	drvr := grip.SQLDriver()
 
 	// Change name (VARCHAR→kind.Text) to kind.Bytes and age (INTEGER) to kind.Float.
-	err := drvr.AlterTableColumnKinds(th.Context, db, "tbl",
+	err := drvr.AlterTableColumnKinds(
+		th.Context, db, "tbl",
 		[]string{"name", "age"},
 		[]kind.Kind{kind.Bytes, kind.Float},
 	)
@@ -127,7 +128,8 @@ func TestAlterTableColumnKinds_MismatchedLengths(t *testing.T) {
 	grip := th.Open(src)
 	drvr := grip.SQLDriver()
 
-	err := drvr.AlterTableColumnKinds(th.Context, db, "tbl",
+	err := drvr.AlterTableColumnKinds(
+		th.Context, db, "tbl",
 		[]string{"name"},
 		[]kind.Kind{kind.Text, kind.Int}, // one too many kinds
 	)

--- a/drivers/duckdb/duckdb.go
+++ b/drivers/duckdb/duckdb.go
@@ -127,7 +127,8 @@ func (d *driveri) doOpen(ctx context.Context, src *source.Source, mode driver.Ac
 		if mode == driver.ModeReadOnlyExplicit {
 			if conflict, ok := d.DetectReadOnlyConflict(loc); ok {
 				return nil, errz.Errorf(
-					"duckdb: cannot open %s read-only: its location sets %s", src.Handle, conflict)
+					"duckdb: cannot open %s read-only: its location sets %s", src.Handle, conflict,
+				)
 			}
 		}
 		var changed bool

--- a/drivers/duckdb/metadata_test.go
+++ b/drivers/duckdb/metadata_test.go
@@ -74,7 +74,8 @@ func TestSakilaFixture_ForeignKeyCount(t *testing.T) {
 	require.NoError(t, err)
 
 	var got int
-	require.NoError(t, db.QueryRowContext(context.Background(),
+	require.NoError(t, db.QueryRowContext(
+		context.Background(),
 		`SELECT count(*) FROM duckdb_constraints() WHERE constraint_type = 'FOREIGN KEY'`,
 	).Scan(&got))
 	require.Equal(t, 21, got,

--- a/drivers/json/ingest_jsona.go
+++ b/drivers/json/ingest_jsona.go
@@ -188,7 +188,8 @@ func ingestJSONA(ctx context.Context, job *ingestJob) error {
 		return err
 	}
 
-	log.Debug("Inserted rows",
+	log.Debug(
+		"Inserted rows",
 		lga.Count, inserted,
 		lga.Target, source.Target(job.destGrip.Source(), tblDef.Name),
 	)

--- a/drivers/mysql/mysql.go
+++ b/drivers/mysql/mysql.go
@@ -598,7 +598,8 @@ func (d *driveri) doOpen(ctx context.Context, src *source.Source) (*sql.DB, erro
 	// - https://github.com/go-sql-driver/mysql#readtimeout
 
 	if src.Schema != "" {
-		lg.FromContext(ctx).Debug("Setting default schema for MysQL connection",
+		lg.FromContext(ctx).Debug(
+			"Setting default schema for MysQL connection",
 			lga.Src, src,
 			lga.Schema, src.Schema,
 		)

--- a/drivers/oracle/grip.go
+++ b/drivers/oracle/grip.go
@@ -44,7 +44,8 @@ func (g *grip) Source() *source.Source {
 // TableMetadata implements driver.Grip.
 func (g *grip) TableMetadata(ctx context.Context, tblName string) (*metadata.Table, error) {
 	bar := progress.FromContext(ctx).NewUnitCounter(
-		g.Source().Handle+"."+tblName+": read schema", "item")
+		g.Source().Handle+"."+tblName+": read schema", "item",
+	)
 	defer bar.Stop()
 	ctx = progress.NewBarContext(ctx, bar)
 
@@ -54,7 +55,8 @@ func (g *grip) TableMetadata(ctx context.Context, tblName string) (*metadata.Tab
 // SourceMetadata implements driver.Grip.
 func (g *grip) SourceMetadata(ctx context.Context, noSchema bool) (*metadata.Source, error) {
 	bar := progress.FromContext(ctx).NewUnitCounter(
-		g.Source().Handle+": read schema", "item")
+		g.Source().Handle+": read schema", "item",
+	)
 	defer bar.Stop()
 	ctx = progress.NewBarContext(ctx, bar)
 

--- a/drivers/oracle/metadata.go
+++ b/drivers/oracle/metadata.go
@@ -74,11 +74,13 @@ FROM DUAL`
 	//   3. The BANNER as a last resort.
 	var version string
 	switch {
-	case db.QueryRowContext(ctx,
+	case db.QueryRowContext(
+		ctx,
 		"SELECT version_full FROM product_component_version WHERE ROWNUM = 1",
 	).Scan(&version) == nil && version != "":
 		md.DBVersion = version
-	case db.QueryRowContext(ctx,
+	case db.QueryRowContext(
+		ctx,
 		"SELECT version FROM v$instance WHERE ROWNUM = 1",
 	).Scan(&version) == nil && version != "":
 		md.DBVersion = version
@@ -203,7 +205,8 @@ ORDER BY t.table_name`)
 	for _, tblName := range baseNames {
 		tblMeta, err := getTableMetadata(ctx, db, tblName, false)
 		if err != nil {
-			log.Warn("oracle metadata: skipped base table (continuing)",
+			log.Warn(
+				"oracle metadata: skipped base table (continuing)",
 				lga.Handle, handle,
 				lga.Table, tblName,
 				lga.Err, err,
@@ -216,7 +219,8 @@ ORDER BY t.table_name`)
 	for _, mvName := range mviewNames {
 		tblMeta, err := getMaterializedViewMetadata(ctx, db, mvName)
 		if err != nil {
-			log.Warn("oracle metadata: skipped materialized view (continuing)",
+			log.Warn(
+				"oracle metadata: skipped materialized view (continuing)",
 				lga.Handle, handle,
 				lga.Table, mvName,
 				lga.Err, err,
@@ -229,7 +233,8 @@ ORDER BY t.table_name`)
 	for _, viewName := range viewNames {
 		tblMeta, err := getViewMetadata(ctx, db, viewName)
 		if err != nil {
-			log.Warn("oracle metadata: skipped view (continuing)",
+			log.Warn(
+				"oracle metadata: skipped view (continuing)",
 				lga.Handle, handle,
 				lga.Table, viewName,
 				lga.Err, err,
@@ -347,7 +352,8 @@ WHERE t.table_name = :1`
 	var bytes int64
 
 	err := db.QueryRowContext(ctx, queryTable, strings.ToUpper(tblName)).Scan(
-		&numRows, &comment, &bytes)
+		&numRows, &comment, &bytes,
+	)
 	if err != nil {
 		return nil, errw(err)
 	}

--- a/drivers/oracle/oracle.go
+++ b/drivers/oracle/oracle.go
@@ -188,7 +188,8 @@ func (d *driveri) Renderer() *render.Renderer {
 	// the int64 scan crash. The value is exact up to AggDecimalScale fractional
 	// digits; a sum of values with more decimal places is rounded to that scale.
 	r.FunctionOverrides[ast.FuncNameSum] = render.FuncOverrideCastResult(
-		fmt.Sprintf("NUMBER(%d, %d)", render.AggDecimalPrecision, render.AggDecimalScale))
+		fmt.Sprintf("NUMBER(%d, %d)", render.AggDecimalPrecision, render.AggDecimalScale),
+	)
 	// count(), count_unique(), and rownum() are integer-valued, but Oracle reports
 	// their result column as the same floating-scale NUMBER as division and other
 	// arithmetic, which refineBareNumberKind now classifies as kind.Decimal to

--- a/drivers/oracle/oracle_test.go
+++ b/drivers/oracle/oracle_test.go
@@ -510,7 +510,8 @@ func TestSakilaCrossDatabase(t *testing.T) {
 		// Insert data into Oracle (use uppercase table name)
 		insertSQL := fmt.Sprintf(
 			`INSERT INTO "%s" (ACTOR_ID, FIRST_NAME, LAST_NAME) VALUES (:1, :2, :3)`,
-			strings.ToUpper(testTableName))
+			strings.ToUpper(testTableName),
+		)
 		stmt, err := oracleDB.PrepareContext(ctx, insertSQL)
 		require.NoError(t, err, "Failed to prepare insert statement")
 		defer stmt.Close()

--- a/drivers/postgres/metadata.go
+++ b/drivers/postgres/metadata.go
@@ -121,7 +121,8 @@ func toNullableScanType(log *slog.Logger, colName, dbTypeName string, knd kind.K
 		switch dbTypeName {
 		default:
 			nullableScanType = sqlz.RTypeNullString
-			log.Warn("Unknown Postgres scan type",
+			log.Warn(
+				"Unknown Postgres scan type",
 				lga.Col, colName,
 				lga.ScanType, pgScanType,
 				lga.DBType, dbTypeName,
@@ -254,7 +255,8 @@ current_setting('server_version'), version(), "current_user"()`
 				case isErrRelationNotExist(mdErr):
 					// For example, if the table is dropped while we're collecting
 					// metadata, we log a warning and suppress the error.
-					log.Warn("metadata collection: table not found (continuing regardless)",
+					log.Warn(
+						"metadata collection: table not found (continuing regardless)",
 						lga.Table, tblNames[i],
 						lga.Err, mdErr,
 					)
@@ -773,7 +775,8 @@ func setTblMetaConstraints(log *slog.Logger, tblMeta *metadata.Table, pgConstrai
 			colMeta := tblMeta.Column(pgc.columnName)
 			if colMeta == nil {
 				// Shouldn't happen
-				log.Warn("No column found matching constraint",
+				log.Warn(
+					"No column found matching constraint",
 					lga.Target, tblMeta.Name+"."+pgc.columnName,
 					"constraint", pgc.constraintName,
 				)

--- a/drivers/postgres/tools.go
+++ b/drivers/postgres/tools.go
@@ -125,7 +125,8 @@ func RestoreCatalogCmd(src *source.Source, p *ToolParams) (*execz.Cmd, error) {
 		cmd.Args = append(cmd.Args, p.flag(flagNoACL), p.flag(flagNoOwner)) // -O is --no-owner
 	}
 
-	cmd.Args = append(cmd.Args,
+	cmd.Args = append(
+		cmd.Args,
 		p.flag(flagClean),
 		p.flag(flagIfExists),
 		p.flag(flagCreate),
@@ -183,7 +184,8 @@ func DumpClusterCmd(src *source.Source, p *ToolParams) (*execz.Cmd, error) {
 		cmd.Args = append(cmd.Args, p.flag(flagNoACL), p.flag(flagNoOwner))
 	}
 
-	cmd.Args = append(cmd.Args,
+	cmd.Args = append(
+		cmd.Args,
 		p.flag(flagNoPassword),
 		p.flag(flagDatabase), cfg.ConnConfig.Database,
 		p.flag(flagDBName), cfg.ConnString(),

--- a/drivers/rqlite/detect_test.go
+++ b/drivers/rqlite/detect_test.go
@@ -238,7 +238,8 @@ func TestDetectConnParams_NonRqliteServer(t *testing.T) {
 		func(w http.ResponseWriter, _ *http.Request) {
 			w.Header().Set("Content-Type", "text/html")
 			_, _ = w.Write([]byte("<html>hello</html>"))
-		}))
+		},
+	))
 	t.Cleanup(server.Close)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
@@ -264,7 +265,8 @@ func TestDetectConnParams_NonRqliteJSON(t *testing.T) {
 		func(w http.ResponseWriter, _ *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
 			_, _ = w.Write([]byte(`{"version":"8","status":"ok"}`))
-		}), &hits))
+		},
+	), &hits))
 	t.Cleanup(server.Close)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
@@ -304,7 +306,8 @@ func TestDetectConnParams_RedirectToHTTPS(t *testing.T) {
 			hits.Add(1)
 			target := "https://" + r.Host + r.URL.Path
 			http.Redirect(w, r, target, http.StatusMovedPermanently)
-		}))
+		},
+	))
 	t.Cleanup(front.Close)
 	host := front.Listener.Addr().String()
 
@@ -326,7 +329,8 @@ func TestDetectConnParams_RedirectToHTTPS(t *testing.T) {
 func TestDetectConnParams_HangingEndpointBounded(t *testing.T) {
 	block := make(chan struct{})
 	server := httptest.NewServer(http.HandlerFunc(
-		func(http.ResponseWriter, *http.Request) { <-block }))
+		func(http.ResponseWriter, *http.Request) { <-block },
+	))
 	t.Cleanup(func() { close(block); server.Close() })
 
 	src := detectTestSrc("rqlite://" + server.Listener.Addr().String())
@@ -361,13 +365,15 @@ func TestDetectConnParams_RedirectNotFollowedToBackend(t *testing.T) {
 		func(w http.ResponseWriter, r *http.Request) {
 			backendHits.Add(1)
 			newRqliteMockHandler(&host).ServeHTTP(w, r)
-		}))
+		},
+	))
 	t.Cleanup(backend.Close)
 
 	front := httptest.NewServer(http.HandlerFunc(
 		func(w http.ResponseWriter, r *http.Request) {
 			http.Redirect(w, r, backend.URL+r.URL.Path, http.StatusMovedPermanently)
-		}))
+		},
+	))
 	t.Cleanup(front.Close)
 	host = front.Listener.Addr().String()
 
@@ -410,7 +416,8 @@ func TestDetectConnParams_BasicAuth(t *testing.T) {
 				gotAuth.Store(true)
 			}
 			inner.ServeHTTP(w, r)
-		}))
+		},
+	))
 	t.Cleanup(server.Close)
 	host = server.Listener.Addr().String()
 
@@ -439,7 +446,8 @@ func TestDetectConnParams_BasicAuthPasswordOnly(t *testing.T) {
 				gotAuth.Store(true)
 			}
 			inner.ServeHTTP(w, r)
-		}))
+		},
+	))
 	t.Cleanup(server.Close)
 	host = server.Listener.Addr().String()
 

--- a/drivers/rqlite/metadata.go
+++ b/drivers/rqlite/metadata.go
@@ -86,7 +86,8 @@ func setScanType(ctx context.Context, colType *record.ColumnTypeData) {
 
 	switch knd { //nolint:exhaustive
 	default:
-		lg.FromContext(ctx).Warn("Unknown kind for col",
+		lg.FromContext(ctx).Warn(
+			"Unknown kind for col",
 			lga.Col, colType.Name,
 			lga.DBType, colType.DatabaseTypeName,
 		)
@@ -187,7 +188,8 @@ func kindFromDBTypeName(ctx context.Context, colName, dbTypeName string, scanTyp
 	switch {
 	default:
 		knd = kind.Unknown
-		log.Warn("Unknown SQLite database column type: using alt",
+		log.Warn(
+			"Unknown SQLite database column type: using alt",
 			lga.DBType, dbTypeName,
 			lga.Col, colName,
 			lga.Kind, knd,
@@ -466,7 +468,8 @@ func getTableMetadata(ctx context.Context, db sqlz.DB, tblName string) (*metadat
 	var isVirtualTbl sql.NullFloat64
 	query := fmt.Sprintf(tpl, stringz.DoubleQuote(tblMeta.Name))
 	err := db.QueryRowContext(ctx, query, tblMeta.Name, tblMeta.Name).Scan(
-		&tblMeta.RowCount, &tblMeta.DBTableType, &isVirtualTbl, &schemaName)
+		&tblMeta.RowCount, &tblMeta.DBTableType, &isVirtualTbl, &schemaName,
+	)
 	if err != nil {
 		return nil, errw(err)
 	}

--- a/drivers/rqlite/rqlite.go
+++ b/drivers/rqlite/rqlite.go
@@ -180,7 +180,8 @@ func (d *driveri) doOpen(ctx context.Context, src *source.Source) (*sql.DB, erro
 		return nil, err
 	}
 	if portAdded {
-		lg.FromContext(ctx).Debug("rqlite: applied default port",
+		lg.FromContext(ctx).Debug(
+			"rqlite: applied default port",
 			lga.Src, src.Handle,
 			lga.Default, defaultPort,
 		)
@@ -482,7 +483,8 @@ func dsnFromLocation(loc string) (string, dsnOpts, error) {
 			opts.tls = false
 		default:
 			return "", opts, errz.Errorf(
-				`rqlite: tls must be "true" or "false", got %q`, v)
+				`rqlite: tls must be "true" or "false", got %q`, v,
+			)
 		}
 		q.Del("tls")
 	}
@@ -495,7 +497,8 @@ func dsnFromLocation(loc string) (string, dsnOpts, error) {
 			opts.insecure = false
 		default:
 			return "", opts, errz.Errorf(
-				`rqlite: insecure must be "true" or "false", got %q`, v)
+				`rqlite: insecure must be "true" or "false", got %q`, v,
+			)
 		}
 		q.Del("insecure")
 	}
@@ -503,7 +506,8 @@ func dsnFromLocation(loc string) (string, dsnOpts, error) {
 	if opts.insecure && !opts.tls {
 		return "", opts, errz.New(
 			"rqlite: insecure has no effect without tls=true; " +
-				"either add tls=true or remove insecure")
+				"either add tls=true or remove insecure",
+		)
 	}
 
 	u.Scheme = scheme
@@ -1217,7 +1221,8 @@ func (d *driveri) AlterTableColumnKinds(ctx context.Context, db sqlz.DB,
 		// INSERT covers the case of no row existing. sqlite_sequence has
 		// no unique constraint on name, which rules out INSERT OR
 		// REPLACE.
-		stmts = append(stmts,
+		stmts = append(
+			stmts,
 			gorqlite.ParameterizedStatement{
 				Query:     "UPDATE sqlite_sequence SET seq = max(seq, ?) WHERE name = ?",
 				Arguments: []any{srcSeq.Int64, tbl},
@@ -1256,7 +1261,8 @@ func (d *driveri) AlterTableColumnKinds(ctx context.Context, db sqlz.DB,
 				"rqlite: alter table: failed to restore foreign_keys pragma")
 			lg.FromContext(ctx).Error(
 				"rqlite: alter table: failed to restore foreign_keys pragma",
-				lga.Err, restoreErr)
+				lga.Err, restoreErr,
+			)
 			retErr = errz.Append(retErr, restoreErr)
 		}
 	}()
@@ -1280,7 +1286,8 @@ func readSqliteSequence(ctx context.Context, db sqlz.DB, tbl string) (sql.NullIn
 	// sqlite_sequence only exists once an AUTOINCREMENT table has been
 	// created in the DB; querying it blindly would error.
 	var n int
-	if err := db.QueryRowContext(ctx,
+	if err := db.QueryRowContext(
+		ctx,
 		"SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='sqlite_sequence'",
 	).Scan(&n); err != nil {
 		return seq, errz.Wrap(errw(err),
@@ -1290,7 +1297,8 @@ func readSqliteSequence(ctx context.Context, db sqlz.DB, tbl string) (sql.NullIn
 		return seq, nil
 	}
 
-	if err := db.QueryRowContext(ctx,
+	if err := db.QueryRowContext(
+		ctx,
 		"SELECT seq FROM sqlite_sequence WHERE name=?", tbl,
 	).Scan(&seq); err != nil && !errors.Is(err, sql.ErrNoRows) {
 		return seq, errz.Wrapf(errw(err),

--- a/drivers/rqlite/rqlite_test.go
+++ b/drivers/rqlite/rqlite_test.go
@@ -114,7 +114,8 @@ func TestCreateTable(t *testing.T) {
 		_ = drvr.DropTable(th.Context, db, tablefq.T{Table: tblName}, true)
 	})
 
-	tblDef := schema.NewTable(tblName,
+	tblDef := schema.NewTable(
+		tblName,
 		[]string{"id", "name", "ts"},
 		[]kind.Kind{kind.Int, kind.Text, kind.Datetime},
 	)
@@ -481,7 +482,8 @@ func TestAlterTableColumnKinds_PreservesAutoincrementSeq(t *testing.T) {
 	})
 
 	_, err = db.ExecContext(th.Context, fmt.Sprintf(
-		`CREATE TABLE %q (id INTEGER PRIMARY KEY AUTOINCREMENT, val INTEGER NOT NULL)`, tblName))
+		`CREATE TABLE %q (id INTEGER PRIMARY KEY AUTOINCREMENT, val INTEGER NOT NULL)`, tblName,
+	))
 	require.NoError(t, err)
 
 	for i := 1; i <= 10; i++ {
@@ -732,7 +734,8 @@ func TestBatchInsert(t *testing.T) {
 
 	// 4 columns -> batchSize = MaxBatchValues(500) / 4 = 125.
 	// 1500 records => 12 batches, exercising the goroutine flush path.
-	tblDef := schema.NewTable(tblName,
+	tblDef := schema.NewTable(
+		tblName,
 		[]string{"a", "b", "c", "d"},
 		[]kind.Kind{kind.Int, kind.Text, kind.Text, kind.Datetime},
 	)
@@ -1283,14 +1286,16 @@ func TestCopyTable_LeavesCrossFKsAlone(t *testing.T) {
 	})
 
 	_, err = db.ExecContext(th.Context, fmt.Sprintf(
-		`CREATE TABLE %q (id INTEGER PRIMARY KEY)`, parentName))
+		`CREATE TABLE %q (id INTEGER PRIMARY KEY)`, parentName,
+	))
 	require.NoError(t, err)
 	_, err = db.ExecContext(th.Context, fmt.Sprintf(
 		`CREATE TABLE %q (`+
 			`id INTEGER PRIMARY KEY, `+
 			`parent_id INTEGER REFERENCES %q(id), `+
 			`other_id INTEGER REFERENCES %q(id))`,
-		srcName, srcName, parentName))
+		srcName, srcName, parentName,
+	))
 	require.NoError(t, err)
 
 	_, err = drvr.CopyTable(th.Context, db,
@@ -1341,7 +1346,8 @@ func TestCopyTable_MultipleSelfFKs(t *testing.T) {
 			`id INTEGER PRIMARY KEY, `+
 			`parent_id INTEGER REFERENCES %q(id), `+
 			`buddy_id INTEGER REFERENCES %q(id))`,
-		srcName, srcName, srcName))
+		srcName, srcName, srcName,
+	))
 	require.NoError(t, err)
 
 	_, err = drvr.CopyTable(th.Context, db,
@@ -1385,7 +1391,8 @@ func TestCopyTable_CompositeSelfFK(t *testing.T) {
 			`a INTEGER, b INTEGER, x INTEGER, y INTEGER, `+
 			`PRIMARY KEY (x, y), `+
 			`FOREIGN KEY(a, b) REFERENCES %q(x, y))`,
-		srcName, srcName))
+		srcName, srcName,
+	))
 	require.NoError(t, err)
 
 	_, err = drvr.CopyTable(th.Context, db,
@@ -1428,7 +1435,8 @@ func TestCopyTable_CaseMismatchSelfFK(t *testing.T) {
 
 	_, err = db.ExecContext(th.Context, fmt.Sprintf(
 		`CREATE TABLE %s (id INTEGER PRIMARY KEY, parent_id INTEGER REFERENCES %s(id))`,
-		srcName, upperFKTarget))
+		srcName, upperFKTarget,
+	))
 	require.NoError(t, err)
 
 	_, err = drvr.CopyTable(th.Context, db,
@@ -1476,7 +1484,8 @@ func TestCopyTable_SchemaQualifiedDest(t *testing.T) {
 
 	_, err = db.ExecContext(th.Context, fmt.Sprintf(
 		`CREATE TABLE %q (id INTEGER PRIMARY KEY, parent_id INTEGER REFERENCES %q(id))`,
-		srcName, srcName))
+		srcName, srcName,
+	))
 	require.NoError(t, err)
 
 	_, err = drvr.CopyTable(th.Context, db,
@@ -1521,13 +1530,15 @@ func TestAlterTableColumnKinds_PreservesFKs(t *testing.T) {
 	})
 
 	_, err = db.ExecContext(th.Context, fmt.Sprintf(
-		`CREATE TABLE %q (id INTEGER PRIMARY KEY)`, parentName))
+		`CREATE TABLE %q (id INTEGER PRIMARY KEY)`, parentName,
+	))
 	require.NoError(t, err)
 	_, err = db.ExecContext(th.Context, fmt.Sprintf(
 		`CREATE TABLE %q (`+
 			`id INTEGER PRIMARY KEY, parent_id INTEGER, payload TEXT, `+
 			`FOREIGN KEY (parent_id) REFERENCES %q(id))`,
-		childName, parentName))
+		childName, parentName,
+	))
 	require.NoError(t, err)
 
 	err = drvr.AlterTableColumnKinds(th.Context, db, childName,
@@ -1579,7 +1590,8 @@ func TestColumnTypes_EmptyTable(t *testing.T) {
 			r REAL,
 			b BOOLEAN,
 			blob BLOB
-		)`, tblName))
+		)`, tblName,
+	))
 	require.NoError(t, err)
 
 	// TableColumnTypes runs through a *sql.Conn so the path matches the
@@ -1647,7 +1659,8 @@ func TestCopyTable_PreservesUniqueConstraints(t *testing.T) {
 
 	_, err = db.ExecContext(th.Context, fmt.Sprintf(
 		`CREATE TABLE %q (id INTEGER PRIMARY KEY, email TEXT UNIQUE NOT NULL)`,
-		srcName))
+		srcName,
+	))
 	require.NoError(t, err)
 
 	_, err = drvr.CopyTable(th.Context, db,
@@ -1655,11 +1668,13 @@ func TestCopyTable_PreservesUniqueConstraints(t *testing.T) {
 	require.NoError(t, err)
 
 	_, err = db.ExecContext(th.Context, fmt.Sprintf(
-		`INSERT INTO %q (id, email) VALUES (1, 'a@a.com')`, dstName))
+		`INSERT INTO %q (id, email) VALUES (1, 'a@a.com')`, dstName,
+	))
 	require.NoError(t, err)
 
 	_, err = db.ExecContext(th.Context, fmt.Sprintf(
-		`INSERT INTO %q (id, email) VALUES (2, 'a@a.com')`, dstName))
+		`INSERT INTO %q (id, email) VALUES (2, 'a@a.com')`, dstName,
+	))
 	require.Error(t, err, "duplicate email should violate UNIQUE on copied table")
 }
 
@@ -1688,7 +1703,8 @@ func TestCopyTable_PreservesDefaultExpression(t *testing.T) {
 	})
 
 	_, err = db.ExecContext(th.Context, fmt.Sprintf(
-		`CREATE TABLE %q (id INTEGER PRIMARY KEY, salary REAL DEFAULT 50000)`, srcName))
+		`CREATE TABLE %q (id INTEGER PRIMARY KEY, salary REAL DEFAULT 50000)`, srcName,
+	))
 	require.NoError(t, err)
 
 	_, err = drvr.CopyTable(th.Context, db,
@@ -1696,7 +1712,8 @@ func TestCopyTable_PreservesDefaultExpression(t *testing.T) {
 	require.NoError(t, err)
 
 	_, err = db.ExecContext(th.Context, fmt.Sprintf(
-		`INSERT INTO %q (id) VALUES (1)`, dstName))
+		`INSERT INTO %q (id) VALUES (1)`, dstName,
+	))
 	require.NoError(t, err)
 
 	var got float64
@@ -1732,12 +1749,14 @@ func TestCopyTable_PreservesAutoIncrement(t *testing.T) {
 	})
 
 	_, err = db.ExecContext(th.Context, fmt.Sprintf(
-		`CREATE TABLE %q (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT)`, srcName))
+		`CREATE TABLE %q (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT)`, srcName,
+	))
 	require.NoError(t, err)
 
 	for _, name := range []string{"a", "b", "c"} {
 		_, err = db.ExecContext(th.Context, fmt.Sprintf(
-			`INSERT INTO %q (name) VALUES (?)`, srcName), name)
+			`INSERT INTO %q (name) VALUES (?)`, srcName,
+		), name)
 		require.NoError(t, err)
 	}
 
@@ -1747,7 +1766,8 @@ func TestCopyTable_PreservesAutoIncrement(t *testing.T) {
 	require.Equal(t, int64(3), affected)
 
 	res, err := db.ExecContext(th.Context, fmt.Sprintf(
-		`INSERT INTO %q (name) VALUES ('x')`, dstName))
+		`INSERT INTO %q (name) VALUES ('x')`, dstName,
+	))
 	require.NoError(t, err)
 	id, err := res.LastInsertId()
 	require.NoError(t, err)
@@ -1799,11 +1819,13 @@ func TestCopyTable_PreservesCompositePK(t *testing.T) {
 
 	_, err = db.ExecContext(th.Context, fmt.Sprintf(
 		`INSERT INTO %q (actor_id, film_id, last_update) VALUES (1, 1, CURRENT_TIMESTAMP)`,
-		dstName))
+		dstName,
+	))
 	require.NoError(t, err)
 	_, err = db.ExecContext(th.Context, fmt.Sprintf(
 		`INSERT INTO %q (actor_id, film_id, last_update) VALUES (1, 1, CURRENT_TIMESTAMP)`,
-		dstName))
+		dstName,
+	))
 	require.Error(t, err, "duplicate composite PK should be rejected")
 }
 
@@ -1833,7 +1855,8 @@ func TestCopyTable_PreservesCheckConstraints(t *testing.T) {
 
 	_, err = db.ExecContext(th.Context, fmt.Sprintf(
 		`CREATE TABLE %q (id INTEGER PRIMARY KEY, age INTEGER NOT NULL CHECK (age >= 0))`,
-		srcName))
+		srcName,
+	))
 	require.NoError(t, err)
 
 	_, err = drvr.CopyTable(th.Context, db,
@@ -1842,12 +1865,14 @@ func TestCopyTable_PreservesCheckConstraints(t *testing.T) {
 
 	// Sanity: a valid insert succeeds.
 	_, err = db.ExecContext(th.Context, fmt.Sprintf(
-		`INSERT INTO %q (id, age) VALUES (1, 5)`, dstName))
+		`INSERT INTO %q (id, age) VALUES (1, 5)`, dstName,
+	))
 	require.NoError(t, err)
 
 	// CHECK violation: negative age should be rejected on the destination.
 	_, err = db.ExecContext(th.Context, fmt.Sprintf(
-		`INSERT INTO %q (id, age) VALUES (2, -1)`, dstName))
+		`INSERT INTO %q (id, age) VALUES (2, -1)`, dstName,
+	))
 	require.Error(t, err,
 		"CHECK (age >= 0) should be preserved and reject negative ages")
 }
@@ -1876,7 +1901,8 @@ func TestAlterTableColumnKinds_PreservesUniqueAndDefault(t *testing.T) {
 
 	_, err = db.ExecContext(th.Context, fmt.Sprintf(
 		`CREATE TABLE %q (id INTEGER PRIMARY KEY, email TEXT UNIQUE, salary REAL DEFAULT 50000)`,
-		tblName))
+		tblName,
+	))
 	require.NoError(t, err)
 
 	err = drvr.AlterTableColumnKinds(th.Context, db, tblName,
@@ -1884,10 +1910,12 @@ func TestAlterTableColumnKinds_PreservesUniqueAndDefault(t *testing.T) {
 	require.NoError(t, err)
 
 	_, err = db.ExecContext(th.Context, fmt.Sprintf(
-		`INSERT INTO %q (id, email) VALUES (1, 'a@a.com')`, tblName))
+		`INSERT INTO %q (id, email) VALUES (1, 'a@a.com')`, tblName,
+	))
 	require.NoError(t, err)
 	_, err = db.ExecContext(th.Context, fmt.Sprintf(
-		`INSERT INTO %q (id, email) VALUES (2, 'a@a.com')`, tblName))
+		`INSERT INTO %q (id, email) VALUES (2, 'a@a.com')`, tblName,
+	))
 	require.Error(t, err, "UNIQUE on email should survive the rebuild")
 
 	var salary float64
@@ -1945,10 +1973,12 @@ func TestTableMetadata_ProblematicTableNames(t *testing.T) {
 	for _, tblName := range tblNames {
 		quoted := stringz.DoubleQuote(tblName)
 		_, err = db.ExecContext(th.Context, fmt.Sprintf(
-			"CREATE TABLE %s (id INTEGER PRIMARY KEY, val TEXT)", quoted))
+			"CREATE TABLE %s (id INTEGER PRIMARY KEY, val TEXT)", quoted,
+		))
 		require.NoError(t, err)
 		_, err = db.ExecContext(th.Context, fmt.Sprintf(
-			"INSERT INTO %s (val) VALUES ('a'), ('b')", quoted))
+			"INSERT INTO %s (val) VALUES ('a'), ('b')", quoted,
+		))
 		require.NoError(t, err)
 	}
 
@@ -2004,17 +2034,21 @@ func TestAlterTableColumnKinds_ForeignKeyEnforcement(t *testing.T) {
 
 	_, err = db.ExecContext(th.Context, fmt.Sprintf(
 		"CREATE TABLE %s (id INTEGER PRIMARY KEY, val INTEGER NOT NULL)",
-		stringz.DoubleQuote(parentTbl)))
+		stringz.DoubleQuote(parentTbl),
+	))
 	require.NoError(t, err)
 	_, err = db.ExecContext(th.Context, fmt.Sprintf(
 		"CREATE TABLE %s (id INTEGER PRIMARY KEY, pid INTEGER NOT NULL REFERENCES %s(id))",
-		stringz.DoubleQuote(childTbl), stringz.DoubleQuote(parentTbl)))
+		stringz.DoubleQuote(childTbl), stringz.DoubleQuote(parentTbl),
+	))
 	require.NoError(t, err)
 	_, err = db.ExecContext(th.Context, fmt.Sprintf(
-		"INSERT INTO %s (id, val) VALUES (1, 42)", stringz.DoubleQuote(parentTbl)))
+		"INSERT INTO %s (id, val) VALUES (1, 42)", stringz.DoubleQuote(parentTbl),
+	))
 	require.NoError(t, err)
 	_, err = db.ExecContext(th.Context, fmt.Sprintf(
-		"INSERT INTO %s (id, pid) VALUES (1, 1)", stringz.DoubleQuote(childTbl)))
+		"INSERT INTO %s (id, pid) VALUES (1, 1)", stringz.DoubleQuote(childTbl),
+	))
 	require.NoError(t, err)
 
 	// Enable FK enforcement on the node's write connection. This must go
@@ -2024,7 +2058,8 @@ func TestAlterTableColumnKinds_ForeignKeyEnforcement(t *testing.T) {
 
 	// Sanity check: enforcement is live, so a dangling child insert fails.
 	_, err = db.ExecContext(th.Context, fmt.Sprintf(
-		"INSERT INTO %s (id, pid) VALUES (99, 999)", stringz.DoubleQuote(childTbl)))
+		"INSERT INTO %s (id, pid) VALUES (99, 999)", stringz.DoubleQuote(childTbl),
+	))
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "FOREIGN KEY constraint failed")
 
@@ -2057,21 +2092,25 @@ func TestAlterTableColumnKinds_ForeignKeyEnforcement(t *testing.T) {
 	// dangling insert succeeding here proves the restore ran. On a node
 	// actually running -fk, the same restore re-enables enforcement.
 	_, err = db.ExecContext(th.Context, fmt.Sprintf(
-		"INSERT INTO %s (id, pid) VALUES (100, 999)", stringz.DoubleQuote(childTbl)))
+		"INSERT INTO %s (id, pid) VALUES (100, 999)", stringz.DoubleQuote(childTbl),
+	))
 	require.NoError(t, err)
 	_, err = db.ExecContext(th.Context, fmt.Sprintf(
-		"DELETE FROM %s WHERE id = 100", stringz.DoubleQuote(childTbl)))
+		"DELETE FROM %s WHERE id = 100", stringz.DoubleQuote(childTbl),
+	))
 	require.NoError(t, err)
 
 	// Re-enable enforcement: the child's FK must still be wired to the
 	// rebuilt parent (the DROP/RENAME preserved the relationship).
 	require.NoError(t, rqlite.ExecNonTx(th.Context, db, "PRAGMA foreign_keys=on"))
 	_, err = db.ExecContext(th.Context, fmt.Sprintf(
-		"INSERT INTO %s (id, pid) VALUES (101, 999)", stringz.DoubleQuote(childTbl)))
+		"INSERT INTO %s (id, pid) VALUES (101, 999)", stringz.DoubleQuote(childTbl),
+	))
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "FOREIGN KEY constraint failed")
 	_, err = db.ExecContext(th.Context, fmt.Sprintf(
-		"INSERT INTO %s (id, pid) VALUES (2, 1)", stringz.DoubleQuote(childTbl)))
+		"INSERT INTO %s (id, pid) VALUES (2, 1)", stringz.DoubleQuote(childTbl),
+	))
 	require.NoError(t, err)
 }
 
@@ -2164,7 +2203,8 @@ func TestCopyTable_CopiesIndexesAndTriggers(t *testing.T) {
 
 	// The copied trigger's side effect fires on insert into the destination.
 	_, err = db.ExecContext(th.Context, fmt.Sprintf(
-		`INSERT INTO %q (name, email) VALUES ('dave', 'd@x.com')`, dstName))
+		`INSERT INTO %q (name, email) VALUES ('dave', 'd@x.com')`, dstName,
+	))
 	require.NoError(t, err)
 	require.NoError(t, db.QueryRowContext(th.Context,
 		fmt.Sprintf(`SELECT count(*) FROM %q WHERE msg='dave'`, logName)).Scan(&logCount))

--- a/drivers/rqlite/types_test.go
+++ b/drivers/rqlite/types_test.go
@@ -89,7 +89,8 @@ func TestRoundTrip_Bool(t *testing.T) {
 
 	// Rows 1-3: raw SQL literals, the gh775 repro shape.
 	_, err = db.ExecContext(th.Context, fmt.Sprintf(
-		"INSERT INTO %q (id, b) VALUES (1, 1), (2, 0), (3, NULL)", tblName))
+		"INSERT INTO %q (id, b) VALUES (1, 1), (2, 0), (3, NULL)", tblName,
+	))
 	require.NoError(t, err)
 
 	// Rows 4-5: sq's insert path with Go bool args.
@@ -97,7 +98,8 @@ func TestRoundTrip_Bool(t *testing.T) {
 	insertViaSq(t, th, grip, tblName, []string{"id", "b"}, int64(5), false)
 
 	sink, err := th.QuerySQL(src, nil, fmt.Sprintf(
-		"SELECT id, b FROM %q ORDER BY id", tblName))
+		"SELECT id, b FROM %q ORDER BY id", tblName,
+	))
 	require.NoError(t, err)
 	require.Len(t, sink.Recs, 5)
 	require.Equal(t, kind.Bool, sink.RecMeta[1].Kind())
@@ -137,7 +139,8 @@ func TestRoundTrip_Datetime(t *testing.T) {
 	insertViaSq(t, th, grip, tblName, []string{"id", "d", "dt"}, int64(4), wantDate, wantTS)
 
 	sink, err := th.QuerySQL(src, nil, fmt.Sprintf(
-		"SELECT id, d, dt FROM %q ORDER BY id", tblName))
+		"SELECT id, d, dt FROM %q ORDER BY id", tblName,
+	))
 	require.NoError(t, err)
 	require.Len(t, sink.Recs, 4)
 	require.Equal(t, kind.Date, sink.RecMeta[1].Kind())
@@ -177,7 +180,8 @@ func TestRoundTrip_Blob(t *testing.T) {
 
 	// Rows 1-3: raw SQL literals.
 	_, err = db.ExecContext(th.Context, fmt.Sprintf(
-		"INSERT INTO %q (id, bl) VALUES (1, X'DEADBEEF'), (2, X''), (3, NULL)", tblName))
+		"INSERT INTO %q (id, bl) VALUES (1, X'DEADBEEF'), (2, X''), (3, NULL)", tblName,
+	))
 	require.NoError(t, err)
 
 	// Rows 4-5: sq's insert path with []byte args.
@@ -188,7 +192,8 @@ func TestRoundTrip_Blob(t *testing.T) {
 	// The sq-written rows must be stored as genuine blobs, not as the
 	// base64 TEXT that gorqlite's default []byte JSON encoding produces.
 	rows, err := db.QueryContext(th.Context, fmt.Sprintf(
-		"SELECT id, typeof(bl) FROM %q WHERE id IN (1, 4, 5) ORDER BY id", tblName))
+		"SELECT id, typeof(bl) FROM %q WHERE id IN (1, 4, 5) ORDER BY id", tblName,
+	))
 	require.NoError(t, err)
 	defer func() { _ = rows.Close() }()
 	for rows.Next() {
@@ -201,7 +206,8 @@ func TestRoundTrip_Blob(t *testing.T) {
 	require.NoError(t, rows.Close())
 
 	sink, err := th.QuerySQL(src, nil, fmt.Sprintf(
-		"SELECT id, bl FROM %q ORDER BY id", tblName))
+		"SELECT id, bl FROM %q ORDER BY id", tblName,
+	))
 	require.NoError(t, err)
 	require.Len(t, sink.Recs, 5)
 	require.Equal(t, kind.Bytes, sink.RecMeta[1].Kind())

--- a/drivers/rqlite/write.go
+++ b/drivers/rqlite/write.go
@@ -166,7 +166,8 @@ func write(ctx context.Context, db sqlz.DB, withTx bool,
 	if len(results) != len(stmts) {
 		return results, errz.Errorf(
 			"rqlite: write batch: expected %d results but got %d",
-			len(stmts), len(results))
+			len(stmts), len(results),
+		)
 	}
 	return results, nil
 }

--- a/drivers/sqlite3/alter.go
+++ b/drivers/sqlite3/alter.go
@@ -199,7 +199,8 @@ func readSqliteSequence(ctx context.Context, db sqlz.DB, tbl string) (sql.NullIn
 	// sqlite_sequence only exists once an AUTOINCREMENT table has been
 	// created in the DB; querying it blindly would error.
 	var n int
-	if err := db.QueryRowContext(ctx,
+	if err := db.QueryRowContext(
+		ctx,
 		"SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='sqlite_sequence'",
 	).Scan(&n); err != nil {
 		return seq, errz.Wrap(errw(err),
@@ -209,7 +210,8 @@ func readSqliteSequence(ctx context.Context, db sqlz.DB, tbl string) (sql.NullIn
 		return seq, nil
 	}
 
-	if err := db.QueryRowContext(ctx,
+	if err := db.QueryRowContext(
+		ctx,
 		"SELECT seq FROM sqlite_sequence WHERE name=?", tbl,
 	).Scan(&seq); err != nil && !errors.Is(err, sql.ErrNoRows) {
 		return seq, errz.Wrapf(errw(err),

--- a/drivers/sqlite3/metadata.go
+++ b/drivers/sqlite3/metadata.go
@@ -100,7 +100,8 @@ func setScanType(ctx context.Context, colType *record.ColumnTypeData) {
 	switch knd { //nolint:exhaustive
 	default:
 		// Shouldn't happen?
-		lg.FromContext(ctx).Warn("Unknown kind for col",
+		lg.FromContext(ctx).Warn(
+			"Unknown kind for col",
 			lga.Col, colType.Name,
 			lga.DBType, colType.DatabaseTypeName,
 		)
@@ -224,7 +225,8 @@ func kindFromDBTypeName(ctx context.Context, colName, dbTypeName string, scanTyp
 	switch {
 	default:
 		knd = kind.Unknown
-		log.Warn("Unknown SQLite database column type: using alt",
+		log.Warn(
+			"Unknown SQLite database column type: using alt",
 			lga.DBType, dbTypeName,
 			lga.Col, colName,
 			lga.Kind, knd,

--- a/drivers/sqlite3/metadata_test.go
+++ b/drivers/sqlite3/metadata_test.go
@@ -549,10 +549,12 @@ func TestTableMetadata_ProblematicTableNames(t *testing.T) {
 	for _, tblName := range tblNames {
 		quoted := stringz.DoubleQuote(tblName)
 		_, err = db.ExecContext(th.Context, fmt.Sprintf(
-			"CREATE TABLE %s (id INTEGER PRIMARY KEY, val TEXT)", quoted))
+			"CREATE TABLE %s (id INTEGER PRIMARY KEY, val TEXT)", quoted,
+		))
 		require.NoError(t, err)
 		_, err = db.ExecContext(th.Context, fmt.Sprintf(
-			"INSERT INTO %s (val) VALUES ('a'), ('b')", quoted))
+			"INSERT INTO %s (val) VALUES ('a'), ('b')", quoted,
+		))
 		require.NoError(t, err)
 	}
 

--- a/drivers/sqlite3/sqlite3.go
+++ b/drivers/sqlite3/sqlite3.go
@@ -231,7 +231,8 @@ func (d *driveri) Ping(ctx context.Context, src *source.Source, _ driver.AccessM
 
 	if err = db.PingContext(ctx); err != nil {
 		err = errz.Wrapf(err, "ping %s: %s", src.Handle, src.Location)
-		lg.FromContext(ctx).Warn("ping failed",
+		lg.FromContext(ctx).Warn(
+			"ping failed",
 			lga.Src, src,
 			lga.Err, err,
 		)

--- a/drivers/sqlserver/metadata.go
+++ b/drivers/sqlserver/metadata.go
@@ -175,7 +175,8 @@ GROUP BY database_id) AS total_size_bytes`
 				if hasErrCode(gErr, errCodeObjectNotExist) {
 					// This can happen if the table is dropped while
 					// we're collecting metadata. We log a warning and continue.
-					log.Warn("Table metadata: table not found (continuing regardless)",
+					log.Warn(
+						"Table metadata: table not found (continuing regardless)",
 						lga.Table, tblNames[i],
 						lga.Err, gErr,
 					)

--- a/drivers/sqlserver/sqlserver.go
+++ b/drivers/sqlserver/sqlserver.go
@@ -179,7 +179,8 @@ func (d *driveri) Renderer() *render.Renderer {
 	// fractional digits is rounded per row before summing, unlike the result-cast
 	// dialects which round the final sum.
 	r.FunctionOverrides[ast.FuncNameSum] = render.FuncOverrideCastOperand(
-		fmt.Sprintf("DECIMAL(%d, %d)", render.AggDecimalPrecision, render.AggDecimalScale))
+		fmt.Sprintf("DECIMAL(%d, %d)", render.AggDecimalPrecision, render.AggDecimalScale),
+	)
 	r.FunctionOverrides[ast.FuncNameRowNum] = renderFuncRowNum
 	r.FunctionOverrides[ast.FuncNameContains] = renderFuncContainsCollate
 	r.FunctionOverrides[ast.FuncNameStartsWith] = renderFuncStartsWithCollate
@@ -233,7 +234,8 @@ func (d *driveri) doOpen(ctx context.Context, src *source.Source) (*sql.DB, erro
 		cfg.Database = src.Catalog
 		loc = cfg.URL().String()
 
-		log.Debug("Using catalog as database in connection string",
+		log.Debug(
+			"Using catalog as database in connection string",
 			lga.Src, src,
 			lga.Catalog, src.Catalog,
 			lga.Conn, location.Redact(loc),

--- a/drivers/sqlserver/sqlserver_unit_test.go
+++ b/drivers/sqlserver/sqlserver_unit_test.go
@@ -138,6 +138,7 @@ func TestDriver_AlterTableColumnKinds_NotImplemented(t *testing.T) {
 	// AlterTableColumnKinds is not yet implemented for SQL Server; it must
 	// return an error without touching the (nil) DB.
 	err := newDriver(t).AlterTableColumnKinds(
-		t.Context(), nil, "tbl", []string{"col"}, []kind.Kind{kind.Int})
+		t.Context(), nil, "tbl", []string{"col"}, []kind.Kind{kind.Int},
+	)
 	require.Error(t, err)
 }

--- a/drivers/xlsx/ingest.go
+++ b/drivers/xlsx/ingest.go
@@ -150,7 +150,8 @@ func ingestXLSX(ctx context.Context, src *source.Source, destGrip driver.Grip, x
 		bar.Incr(1)
 	}
 
-	log.Debug("Sheets ingested",
+	log.Debug(
+		"Sheets ingested",
 		lga.Count, ingestCount,
 		"skipped", skipped,
 		lga.From, src,
@@ -497,7 +498,8 @@ func rowToRecord(ctx context.Context, destColKinds []kind.Kind, ingestMungeFns [
 				// This shouldn't happen, but if it does, fall back
 				// to the string value.
 				vals[coli] = str
-				log.Warn("Cell munge func failed",
+				log.Warn(
+					"Cell munge func failed",
 					laSheet, sheetName,
 					"cell", fmt.Sprintf("%d:%d", rowi, coli),
 					lga.Val, vals[coli],

--- a/drivers/xlsx/xlsx_test.go
+++ b/drivers/xlsx/xlsx_test.go
@@ -296,7 +296,8 @@ func TestIngestDuplicateColumns(t *testing.T) {
 	ctx := context.Background()
 	tr := testrun.New(ctx, t, nil).Hush()
 
-	err := tr.Exec("add",
+	err := tr.Exec(
+		"add",
 		"--handle", "@actor_dup",
 		"--ingest.header=true",
 		filepath.Join("testdata", "actor_duplicate_cols.xlsx"),

--- a/libsq/ast/parser.go
+++ b/libsq/ast/parser.go
@@ -219,7 +219,8 @@ func (v *parseTreeVisitor) using(node Node, fn func() any) any {
 
 // Visit implements antlr.ParseTreeVisitor.
 func (v *parseTreeVisitor) Visit(ctx antlr.ParseTree) any {
-	v.log.Debug("Visit",
+	v.log.Debug(
+		"Visit",
 		lga.Type, stringz.Type(ctx),
 		lga.Text, ctx.GetText(),
 	)

--- a/libsq/ast/render/function_like.go
+++ b/libsq/ast/render/function_like.go
@@ -115,7 +115,8 @@ func parseLikeColArg(rc *Context, fn *ast.FuncNode) (colSQL string, rhsChild ast
 	if len(children) != 2 {
 		return "", nil, errz.Errorf(
 			"%s() requires exactly 2 arguments (column, pattern), got %d",
-			fn.FuncName(), len(children))
+			fn.FuncName(), len(children),
+		)
 	}
 	colNode := unwrapExpr(children[0])
 	colSQL, err = renderSelectorNode(rc.Dialect, colNode)
@@ -145,7 +146,8 @@ func ParseLikeArgs(rc *Context, fn *ast.FuncNode) (colSQL, literal string, err e
 	if !ok {
 		return "", "", errz.Errorf(
 			"%s() second argument must be a string literal, got %T: %s",
-			fn.FuncName(), rhsNode, rhsNode.Text())
+			fn.FuncName(), rhsNode, rhsNode.Text(),
+		)
 	}
 	val, wasQuoted, err := unquoteLiteral(litNode.Text())
 	if err != nil {
@@ -154,7 +156,8 @@ func ParseLikeArgs(rc *Context, fn *ast.FuncNode) (colSQL, literal string, err e
 	if !wasQuoted {
 		return "", "", errz.Errorf(
 			"%s() second argument must be a quoted string literal",
-			fn.FuncName())
+			fn.FuncName(),
+		)
 	}
 	return colSQL, val, nil
 }
@@ -184,7 +187,8 @@ func ParseLikePatternArgs(rc *Context, fn *ast.FuncNode) (colSQL, rhsSQL string,
 		if !wasQuoted {
 			return "", "", errz.Errorf(
 				"%s() second argument must be a quoted string literal or column selector",
-				fn.FuncName())
+				fn.FuncName(),
+			)
 		}
 		return colSQL, stringz.SingleQuote(val), nil
 	}

--- a/libsq/core/diffdoc/diffdoc.go
+++ b/libsq/core/diffdoc/diffdoc.go
@@ -23,7 +23,7 @@ import (
 	"github.com/neilotoole/sq/libsq/core/langz"
 )
 
-var _ io.ReadCloser = (Doc)(nil)
+var _ io.ReadCloser = Doc(nil)
 
 // Doc is a diff document that implements [io.ReadCloser]. It is used to stream
 // diff output.

--- a/libsq/core/errz/stack.go
+++ b/libsq/core/errz/stack.go
@@ -26,7 +26,7 @@ var _ Opt = (*Skip)(nil)
 type Skip int
 
 func (s Skip) apply(e *errz) {
-	*(e.stack) = (*e.stack)[int(s):]
+	*e.stack = (*e.stack)[int(s):]
 }
 
 const unknown = "unknown"

--- a/libsq/core/execz/execz_test.go
+++ b/libsq/core/execz/execz_test.go
@@ -336,7 +336,8 @@ func helperCmd(t *testing.T, ctrl helperControl) *execz.Cmd {
 	return &execz.Cmd{
 		Name: testExe(t),
 		Args: []string{"-test.run=^TestHelperProcess$", "--"},
-		Env: append(base,
+		Env: append(
+			base,
 			"GO_EXECZ_WANT_HELPER_PROCESS=1",
 			"HELPER_STDOUT="+ctrl.stdout,
 			"HELPER_STDERR="+ctrl.stderr,

--- a/libsq/core/ioz/lockfile/lockfile.go
+++ b/libsq/core/ioz/lockfile/lockfile.go
@@ -52,7 +52,8 @@ func (l Lockfile) Lock(ctx context.Context, timeout time.Duration) error {
 
 	start, attempts := time.Now(), 0
 
-	err := retry.Do(ctx, timeout,
+	err := retry.Do(
+		ctx, timeout,
 		func() error {
 			err := lockfile.Lockfile(l).TryLock()
 			attempts++
@@ -68,7 +69,8 @@ func (l Lockfile) Lock(ctx context.Context, timeout time.Duration) error {
 
 	elapsed := time.Since(start)
 	if err != nil {
-		log.Error("Failed to acquire pid lock",
+		log.Error(
+			"Failed to acquire pid lock",
 			lga.Attempts, attempts,
 			lga.Elapsed, elapsed,
 			lga.Err, err,

--- a/libsq/core/ioz/scannerz/scannerz.go
+++ b/libsq/core/ioz/scannerz/scannerz.go
@@ -34,7 +34,8 @@ func NewScanner(ctx context.Context, r io.Reader) *bufio.Scanner {
 	limit := OptScanBufLimit.Get(options.FromContext(ctx)).Bytes()
 	initial := min(
 		// 4096 is the default initial bufio.Scanner buffer size.
-		uint64(4096), limit)
+		uint64(4096), limit,
+	)
 
 	sc.Buffer(make([]byte, int(initial)), int(limit)) //nolint:gosec // ignore overflow concern
 	return sc

--- a/libsq/core/progress/virtualbar.go
+++ b/libsq/core/progress/virtualbar.go
@@ -259,7 +259,8 @@ func (vb *virtualBar) startConcrete() {
 	// Recover on any interaction with mpb.
 	defer func() { _ = recover() }()
 
-	vb.bimpl = vb.p.life.pc.New(vb.cfg.total,
+	vb.bimpl = vb.p.life.pc.New(
+		vb.cfg.total,
 		vb.cfg.style,
 		mpb.BarWidth(barWidth),
 		mpb.PrependDecorators(vb.cfg.msgWidget),

--- a/libsq/core/sqlz/reflect.go
+++ b/libsq/core/sqlz/reflect.go
@@ -29,5 +29,5 @@ var (
 	RTypeNullTime    = reflect.TypeFor[sql.NullTime]()
 	RTypeBytes       = reflect.TypeFor[[]byte]()
 	RTypeNil         = reflect.TypeOf(nil)
-	RTypeAny         = reflect.TypeOf((any)(nil))
+	RTypeAny         = reflect.TypeOf(any(nil))
 )

--- a/libsq/driver/grips.go
+++ b/libsq/driver/grips.go
@@ -403,7 +403,8 @@ func (gs *Grips) openIngestGripNoCache(ctx context.Context, src *source.Source,
 	elapsed := time.Since(start)
 
 	if err != nil {
-		log.Error("Ingest failed",
+		log.Error(
+			"Ingest failed",
 			lga.Src, src, lga.Dest, impl.Source(),
 			lga.Elapsed, elapsed, lga.Err, err,
 		)
@@ -437,7 +438,8 @@ func (gs *Grips) openIngestGripCache(ctx context.Context, src *source.Source,
 		return nil, err
 	}
 	if foundCached {
-		log.Info("Ingest cache HIT: found cached ingest DB",
+		log.Info(
+			"Ingest cache HIT: found cached ingest DB",
 			lga.Src, src, "cached", impl.Source(),
 		)
 		return impl, nil

--- a/libsq/files/download.go
+++ b/libsq/files/download.go
@@ -169,7 +169,8 @@ func (fs *Files) downloaderFor(ctx context.Context, src *source.Source) (*downlo
 
 func (fs *Files) httpClientFor(ctx context.Context, src *source.Source) *http.Client {
 	o := options.Merge(options.FromContext(ctx), src.Options)
-	return httpz.NewClient(httpz.DefaultUserAgent,
+	return httpz.NewClient(
+		httpz.DefaultUserAgent,
 		httpz.OptRequestTimeout(OptHTTPRequestTimeout.Get(o)),
 		httpz.OptResponseTimeout(OptHTTPResponseTimeout.Get(o)),
 		httpz.OptInsecureSkipVerify(OptHTTPSInsecureSkipVerify.Get(o)),

--- a/libsq/libsq_test.go
+++ b/libsq/libsq_test.go
@@ -99,7 +99,8 @@ func TestQuerySQL_Smoke(t *testing.T) {
 			require.Equal(t, sakila.TblActorCount, len(sink.Recs))
 			require.Equal(t, len(tc.fieldTypes), len(sink.Recs[0]))
 			for i := range sink.Recs[0] {
-				require.Equal(t,
+				require.Equal(
+					t,
 					tc.fieldTypes[i].String(),
 					reflect.TypeOf(sink.Recs[0][i]).String(),
 					"expected field[%d] {%s} to have type %s but got %s",

--- a/libsq/query_test.go
+++ b/libsq/query_test.go
@@ -46,7 +46,8 @@ func oracleSQL(s string) string {
 
 func TestOracleSQL(t *testing.T) {
 	t.Parallel()
-	assert.Equal(t,
+	assert.Equal(
+		t,
 		`SELECT "ACTOR_ID" FROM "ACTOR" WHERE "FIRST_NAME" = 'x'`,
 		oracleSQL(`SELECT "actor_id" FROM "actor" WHERE "first_name" = 'x'`),
 	)

--- a/testh/testh.go
+++ b/testh/testh.go
@@ -617,7 +617,8 @@ func (h *Helper) CopyTable(
 		h.Cleanup.Add(func() { h.DropTable(src, toTable) })
 	}
 
-	h.Log().Debug("Copied table",
+	h.Log().Debug(
+		"Copied table",
 		lga.From, fromTable,
 		lga.To, toTable,
 		"copy_data", copyData,

--- a/testh/tu/tu.go
+++ b/testh/tu/tu.go
@@ -423,7 +423,8 @@ func TempDir(tb testing.TB, subs ...string) string {
 			dirCount.Add(1),
 			time.Now().UnixMicro(),
 			randString(),
-		))
+		),
+	)
 
 	for _, sub := range subs {
 		fp = filepath.Join(fp, sub)


### PR DESCRIPTION
## Summary

Stacks on #927. Bumps the dprint gofumpt plugin from v0.0.9 (embedded gofumpt v0.9.x) to v0.0.11 (stable gofumpt v0.10.0 with the commented-code crash patch), then applies the resulting mechanical reformat across 67 Go files. Closes #928.

The changes are formatting-only: trailing commas on multi-line function calls and a few redundant-paren simplifications (e.g. `*(e.stack)` → `*e.stack`). No logic or behavior changes.

**golangci-lint note:** Go formatting is owned entirely by dprint since #927; golangci-lint v2.12.2 still transitively pins gofumpt v0.9.2 but does not run it. No golangci-lint release bundles gofumpt v0.10 yet.

## Commits

1. Bump dprint gofumpt plugin to v0.0.11
2. Apply gofumpt v0.10 formatting (67 files)
3. Document gofumpt v0.10 upgrade in CHANGELOG

## Detailed changes

This pull request makes mechanical formatting changes across the codebase to enforce consistent use of trailing commas and parentheses, as required by the upgrade to `gofumpt` v0.10 via the `dprint` plugin. There are no behavior changes. All updates are deferred from a previous tooling-only PR and affect roughly 67 files.

Formatting and code consistency:

* Upgraded Go formatting to use `gofumpt` v0.10 with `dprint` plugin v0.0.11, resulting in mechanical changes (trailing commas, redundant parentheses) throughout the codebase. No functional changes were made. (`CHANGELOG.md`)
* Updated all multi-line function calls and composite literals to include trailing commas where appropriate, improving diffs and code consistency (e.g., `cli/cmd_add.go`, `cli/cli.go`, `cli/cmd_config_set_test.go`, `cli/cmd_inspect_test.go`, `cli/cmd_slq_test.go`, and others). [[1]](diffhunk://#diff-0132151fae66a5c6f03a4ba35202a0e8da41221d6794c832c4d03e3ec49ed25eL83-R84) [[2]](diffhunk://#diff-ef44b92f1ba3916c39c98fc4a25b67da847cb2a07a5d1253e1978365338888a6L98-R99) [[3]](diffhunk://#diff-22d8f484547a3100ea1ca1bdb4e9279ba16b0e96777469391b695c6075c49695L534-R535) [[4]](diffhunk://#diff-3b43dbcf133fbf5390f9537c7fb546440847a9cc4a89d733f31c4714d00f5534L61-R68) [[5]](diffhunk://#diff-a89051bd3eccb0bfcc56bcae172ecd52b2f1ebfa92c9d68a067e2551de67062fL376-R377) [[6]](diffhunk://#diff-052b0f8afe16fa2a3d0893afa60e5000962502330c1f79e0eef352fd36ae9b43L476-R477) etc.)
* Added or adjusted parentheses in function calls and error wrapping for improved readability and to match formatting requirements. [[1]](diffhunk://#diff-3704ef10e3fca1abd856760977d5f5586ab242102ca8e7909d530de028ec5c44L309-R310) [[2]](diffhunk://#diff-9ccea5e2dd8cf9cdbd9bafc47e9402f3eab736a814f0f77b6a0057554c0e7ef7L58-R59) [[3]](diffhunk://#diff-cd9c18d4a68afbe3d5e7661151d84e964995335e3311b89f03fb1fb3f3259f6aL240-R241) [[4]](diffhunk://#diff-c5e639a8849e30fb9aee155246e27cfd5e8abd48967d85db7e80b0e6ac6ef45cL266-R267) [[5]](diffhunk://#diff-6ed126cfc22bcd613053b5384fc90f93747f73f476df401c3a01ebc899800f64L81-R82)

Test code updates:

* Applied the same formatting changes to test files, ensuring consistency in test assertions and function calls. [[1]](diffhunk://#diff-3b43dbcf133fbf5390f9537c7fb546440847a9cc4a89d733f31c4714d00f5534L105-R108) [[2]](diffhunk://#diff-3b43dbcf133fbf5390f9537c7fb546440847a9cc4a89d733f31c4714d00f5534L117-R121) [[3]](diffhunk://#diff-3b43dbcf133fbf5390f9537c7fb546440847a9cc4a89d733f31c4714d00f5534L130-R135) [[4]](diffhunk://#diff-3b43dbcf133fbf5390f9537c7fb546440847a9cc4a89d733f31c4714d00f5534L141-R147) [[5]](diffhunk://#diff-3b43dbcf133fbf5390f9537c7fb546440847a9cc4a89d733f31c4714d00f5534L176-R190) [[6]](diffhunk://#diff-a89051bd3eccb0bfcc56bcae172ecd52b2f1ebfa92c9d68a067e2551de67062fL439-R441) [[7]](diffhunk://#diff-a89051bd3eccb0bfcc56bcae172ecd52b2f1ebfa92c9d68a067e2551de67062fL449-R452) [[8]](diffhunk://#diff-a89051bd3eccb0bfcc56bcae172ecd52b2f1ebfa92c9d68a067e2551de67062fL478-R482) [[9]](diffhunk://#diff-a89051bd3eccb0bfcc56bcae172ecd52b2f1ebfa92c9d68a067e2551de67062fL503-R508) [[10]](diffhunk://#diff-a89051bd3eccb0bfcc56bcae172ecd52b2f1ebfa92c9d68a067e2551de67062fL615-R621) [[11]](diffhunk://#diff-ada15e9ce8111f4d661546acdcf01a85930425ccba50a8ef4d88d9dd410f79f0L150-R151) [[12]](diffhunk://#diff-052b0f8afe16fa2a3d0893afa60e5000962502330c1f79e0eef352fd36ae9b43L492-R494) [[13]](diffhunk://#diff-052b0f8afe16fa2a3d0893afa60e5000962502330c1f79e0eef352fd36ae9b43L501-R504) [[14]](diffhunk://#diff-052b0f8afe16fa2a3d0893afa60e5000962502330c1f79e0eef352fd36ae9b43L788-R799)

No behavior changes were introduced; all modifications are to align the codebase with the new formatting standards.

## Test plan

- [x] `make fmt-check`
- [x] `make lint`
- [x] `make test-short`

After #927 merges, retarget this PR to `master`.


Made with [Cursor](https://cursor.com)