### PR TITLE
Make ingest-checksum mismatch test deterministic

### DIFF
--- a/libsq/files/cache_extra_test.go
+++ b/libsq/files/cache_extra_test.go
@@ -366,8 +366,10 @@ func TestFiles_WriteIngestChecksum_File(t *testing.T) {
 	require.Equal(t, drivertype.SQLite, got.Type)
 	require.True(t, strings.HasPrefix(got.Location, "sqlite3://"))
 
-	// Mutate the source file: checksum no longer matches.
-	require.NoError(t, os.WriteFile(src.Location, []byte("a,b,c\n9,9,9\n"), 0o600))
+	// Mutate the source file size: checksum no longer matches. Changing the
+	// size (not just the content) keeps the mismatch deterministic regardless
+	// of mtime resolution.
+	require.NoError(t, os.WriteFile(src.Location, []byte("a,b,c\n9,9,9\nextra\n"), 0o600))
 	_, ok, err = fs.CachedBackingSourceFor(ctx, src)
 	require.NoError(t, err)
 	require.False(t, ok, "checksum mismatch -> not cached")


### PR DESCRIPTION
## Summary

`TestFiles_WriteIngestChecksum_File` exercises the checksum-mismatch path by mutating the source file and asserting it's no longer cached. It rewrote the file with **same-size** content (`a,b,c\n9,9,9\n`, identical length to the original), so the mismatch relied solely on the file's mtime advancing.

`checksum.ForFile` hashes name + mtime + **size** + mode + isDir, never file content. On a filesystem with coarse mtime resolution, a rewrite that lands in the same tick leaves the checksum unchanged, so the assertion (`require.False(t, ok)`) could spuriously fail.

This changes the mutation to alter the file **size** (`...\nextra\n`), guaranteeing the checksum mismatch regardless of mtime resolution. The test still covers the same behavior, just deterministically.

## Notes

Test-only change. No production code touched.