### PR TITLE
Tighten isFpath scheme detection: prefix-match schemes instead of substring (#859)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1744,11 +1744,11 @@ make working with lots of sources much easier.
 [#846]: https://github.com/neilotoole/sq/issues/846
 [#851]: https://github.com/neilotoole/sq/issues/851
 [#853]: https://github.com/neilotoole/sq/issues/853
+[#859]: https://github.com/neilotoole/sq/issues/859
 [#863]: https://github.com/neilotoole/sq/pull/863
 [#865]: https://github.com/neilotoole/sq/pull/865
 [#866]: https://github.com/neilotoole/sq/issues/866
 [#868]: https://github.com/neilotoole/sq/issues/868
-[#859]: https://github.com/neilotoole/sq/issues/859
 [#900]: https://github.com/neilotoole/sq/pull/900
 [#902]: https://github.com/neilotoole/sq/pull/902
 [#911]: https://github.com/neilotoole/sq/pull/911

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,9 +43,9 @@ Breaking changes are annotated with ☢️, and alpha/beta features with 🐥.
   conventions.
 - [#926]: On Windows, a bare `${file:/}` source placeholder no longer suggests an invalid
   backslash handle name; the name is now derived using URI path semantics on all platforms.
-- [#859]: `sq add` of a relative file path whose name contains a colon (e.g.
-  `./dump.sqlite3:old.csv`) is now stored as an absolute path, like other file sources,
-  rather than being left relative to the current directory.
+- [#859]: [`sq add`](https://sq.io/docs/cmd/add) of a relative file path whose name contains
+  a colon (e.g. `./dump.sqlite3:old.csv`) is now stored as an absolute path, like other file
+  sources, rather than being left relative to the current directory.
 - Various other bug fixes: [#902], [#911], [#915], [#916], [#918], [#920], [#923].
 
 ## [v0.54.0] - 2026-06-19

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,9 @@ Breaking changes are annotated with ☢️, and alpha/beta features with 🐥.
   conventions.
 - [#926]: On Windows, a bare `${file:/}` source placeholder no longer suggests an invalid
   backslash handle name; the name is now derived using URI path semantics on all platforms.
+- [#859]: `sq add` of a relative file path whose name contains a colon (e.g.
+  `./dump.sqlite3:old.csv`) is now stored as an absolute path, like other file sources,
+  rather than being left relative to the current directory.
 - Various other bug fixes: [#902], [#911], [#915], [#916], [#918], [#920], [#923].
 
 ## [v0.54.0] - 2026-06-19
@@ -1745,6 +1748,7 @@ make working with lots of sources much easier.
 [#865]: https://github.com/neilotoole/sq/pull/865
 [#866]: https://github.com/neilotoole/sq/issues/866
 [#868]: https://github.com/neilotoole/sq/issues/868
+[#859]: https://github.com/neilotoole/sq/issues/859
 [#900]: https://github.com/neilotoole/sq/pull/900
 [#902]: https://github.com/neilotoole/sq/pull/902
 [#911]: https://github.com/neilotoole/sq/pull/911

--- a/libsq/source/location/internal_test.go
+++ b/libsq/source/location/internal_test.go
@@ -383,13 +383,17 @@ func TestIsFpath(t *testing.T) {
 		{loc: "https://acme.com/data.csv", wantOK: false},
 		{loc: "postgres://u:p@host/db", wantOK: false},
 		{loc: "weird://host/x.db", wantOK: false},
-		// Driver schemes are not bare file paths; scheme match is
-		// case-insensitive.
+		// File-DB driver schemes are not bare file paths.
 		{loc: "sqlite3:sakila.db", wantOK: false},
-		{loc: "SQLITE3:sakila.db", wantOK: false},
 		{loc: "sqlite:sakila.db", wantOK: false},
 		{loc: `sqlite3:C:\db`, wantOK: false},
 		{loc: "duckdb:foo.duckdb", wantOK: false},
+		// Scheme matching is case-sensitive, consistent with Parse and
+		// munging: an off-case "SQLITE3:" is not a DSN sq recognizes, so
+		// it stays a path and is absolutized (otherwise isFpath would
+		// disagree with the rest of the pipeline and skip absolutizing a
+		// real file named "SQLITE3:foo.db").
+		{loc: "SQLITE3:sakila.db", wantOK: true},
 		// A known scheme with a malformed single slash is still not a path.
 		{loc: "sqlite3:/path/to/file", wantOK: false},
 		// Well-formed placeholder: resolves at use time, not a path.

--- a/libsq/source/location/internal_test.go
+++ b/libsq/source/location/internal_test.go
@@ -370,7 +370,13 @@ func TestIsFpath(t *testing.T) {
 		// consistent with the no-slash form already being a path.
 		{loc: "weird:notes.db", wantOK: true},
 		{loc: "weird:/notes/x.db", wantOK: true},
-		// Any "scheme://" authority form is a URL, never a path — whether
+		// A leading token matching a *network* DB scheme but lacking a
+		// "://" authority is a colon-bearing filename, not a DSN (network
+		// DSNs are always "scheme://..."), so it stays a path. Only the
+		// file-DB schemes have a bare "scheme:path" DSN form.
+		{loc: "postgres:notes.csv", wantOK: true},
+		{loc: "mysql:data.csv", wantOK: true},
+		// Any "scheme://" authority form is a URL, never a path, whether
 		// the scheme is known or not (the latter avoids mangling a mistyped
 		// URL into a garbage path before it fails downstream).
 		{loc: "http://acme.com/data.csv", wantOK: false},

--- a/libsq/source/location/internal_test.go
+++ b/libsq/source/location/internal_test.go
@@ -357,14 +357,35 @@ func TestIsFpath(t *testing.T) {
 		{loc: "data.csv", wantOK: true},
 		// '$$' escapes to a literal '$': ref-free, still a path.
 		{loc: "q$$exports/data.csv", wantOK: true},
-		// URL-ish: contains ":/", excluded.
+		// A colon is legal in a filename on Unix: the leading token isn't a
+		// known scheme, so these stay paths rather than being read as a
+		// driver DSN (gh #859).
+		{loc: "./dump.sqlite3:old.db", wantOK: true},
+		{loc: "./my-duckdb:thing.db", wantOK: true},
+		// A bare Windows volume "C:" is not a known scheme, so a drive path
+		// is treated as a path, dissolving the gh #797 trap without a
+		// dedicated drive-letter branch.
+		{loc: `C:\db.sqlite`, wantOK: true},
+		// An unknown scheme with no "://" authority is treated as a path,
+		// consistent with the no-slash form already being a path.
+		{loc: "weird:notes.db", wantOK: true},
+		{loc: "weird:/notes/x.db", wantOK: true},
+		// Any "scheme://" authority form is a URL, never a path — whether
+		// the scheme is known or not (the latter avoids mangling a mistyped
+		// URL into a garbage path before it fails downstream).
 		{loc: "http://acme.com/data.csv", wantOK: false},
 		{loc: "https://acme.com/data.csv", wantOK: false},
-		// Driver schemes are not bare file paths.
+		{loc: "postgres://u:p@host/db", wantOK: false},
+		{loc: "weird://host/x.db", wantOK: false},
+		// Driver schemes are not bare file paths; scheme match is
+		// case-insensitive.
 		{loc: "sqlite3:sakila.db", wantOK: false},
+		{loc: "SQLITE3:sakila.db", wantOK: false},
 		{loc: "sqlite:sakila.db", wantOK: false},
 		{loc: `sqlite3:C:\db`, wantOK: false},
 		{loc: "duckdb:foo.duckdb", wantOK: false},
+		// A known scheme with a malformed single slash is still not a path.
+		{loc: "sqlite3:/path/to/file", wantOK: false},
 		// Well-formed placeholder: resolves at use time, not a path.
 		{loc: "${env:DB_PATH}", wantOK: false},
 		// Malformed placeholder syntax: also excluded.

--- a/libsq/source/location/location.go
+++ b/libsq/source/location/location.go
@@ -47,11 +47,15 @@ var fileDBSchemes = map[string]bool{
 	"duckdb":  true,
 }
 
-// isFileDBScheme reports whether scheme (matched case-insensitively, as
-// URL schemes are per RFC 3986) is a file-based DB driver scheme whose
-// bare "scheme:path" form isFpath must treat as a DSN, not a file path.
+// isFileDBScheme reports whether scheme is a file-based DB driver scheme
+// whose bare "scheme:path" form isFpath must treat as a DSN, not a file
+// path. Matching is case-sensitive, consistent with the rest of the
+// location pipeline: IsSQL, Parse, and munging all compare scheme
+// prefixes case-sensitively, so an off-case spelling like "SQLITE3:" is
+// not a DSN sq recognizes and must be left as an ordinary filename (which
+// isFpath then absolutizes).
 func isFileDBScheme(scheme string) bool {
-	return fileDBSchemes[strings.ToLower(scheme)]
+	return fileDBSchemes[scheme]
 }
 
 // Filename returns the final component of the file/URL path.

--- a/libsq/source/location/location.go
+++ b/libsq/source/location/location.go
@@ -524,26 +524,30 @@ func isFpath(loc string) (fpath string, ok bool) {
 		return "", false
 	}
 
-	if strings.Contains(loc, "://") {
-		// Any "scheme://" authority form is a URL (a SQL driver DSN,
-		// http/https, or an unknown/unsupported scheme), never a local
-		// file path. Mirrors the "://" convention used by IsSQL, Short,
-		// and Parse. Excluding unknown schemes here too avoids mangling a
-		// mistyped URL into a garbage path before it fails downstream.
-		return "", false
-	}
+	// Inspect the leading "scheme:" token (the bytes before the first
+	// colon), anchoring the URL/DSN checks on that token rather than
+	// substring-matching anywhere in loc.
+	if scheme, rest, found := strings.Cut(loc, ":"); found {
+		if strings.HasPrefix(rest, "//") {
+			// A "scheme://" authority form is a URL (a SQL driver DSN,
+			// http/https, or an unknown/unsupported scheme), never a local
+			// file path. Excluding unknown schemes here too avoids mangling
+			// a mistyped URL into a garbage path before it fails downstream.
+			return "", false
+		}
 
-	if scheme, _, found := strings.Cut(loc, ":"); found && isFileDBScheme(scheme) {
-		// A leading "scheme:" token naming a file-based DB driver is a
-		// bare DSN, not a path: "sqlite3:f.db", "duckdb:f.db", the legacy
-		// "sqlite:f.db" spelling, and malformed single-slash forms like
-		// "sqlite3:/path". A single-letter Windows volume ("C:\db") is not
-		// such a scheme, so it stays a path, dissolving the gh #797 trap
-		// without a dedicated drive-letter branch. A colon inside a
-		// filename ("./dump.sqlite3:old.db"), or a leading token that only
-		// looks like a network scheme ("postgres:notes.csv"), likewise
-		// stays a path (gh #859).
-		return "", false
+		if isFileDBScheme(scheme) {
+			// A leading "scheme:" token naming a file-based DB driver is a
+			// bare DSN, not a path: "sqlite3:f.db", "duckdb:f.db", the
+			// legacy "sqlite:f.db" spelling, and malformed single-slash
+			// forms like "sqlite3:/path". A single-letter Windows volume
+			// ("C:\db") is not such a scheme, so it stays a path,
+			// dissolving the gh #797 trap without a dedicated drive-letter
+			// branch. A colon inside a filename ("./dump.sqlite3:old.db"),
+			// or a leading token that only looks like a network scheme
+			// ("postgres:notes.csv"), likewise stays a path (gh #859).
+			return "", false
+		}
 	}
 
 	fpath, err := absTemplatePath(loc)

--- a/libsq/source/location/location.go
+++ b/libsq/source/location/location.go
@@ -33,26 +33,25 @@ var dbSchemes = []string{
 	"oracle",
 }
 
-// nonFileSchemes is the set of URL/DSN schemes that isFpath must not
-// treat as a local file path. It is derived from dbSchemes so new SQL
-// drivers are covered automatically; "sqlite" is the legacy spelling of
-// "sqlite3", and "http"/"https" are document URLs.
-var nonFileSchemes = func() map[string]bool {
-	m := make(map[string]bool, len(dbSchemes)+3)
-	for _, s := range dbSchemes {
-		m[s] = true
-	}
-	m["sqlite"] = true
-	m["http"] = true
-	m["https"] = true
-	return m
-}()
+// fileDBSchemes is the set of file-based DB driver schemes whose bare
+// "scheme:path" form (no "://") denotes a DSN rather than a file path:
+// "sqlite3:f.db", "duckdb:f.db", and the legacy "sqlite:f.db" spelling.
+// Network driver schemes (postgres, mysql, etc.) and http/https are
+// deliberately absent: they only ever take the "scheme://..." form, which
+// isFpath already excludes via its "://" check. Listing them here would
+// wrongly exclude a real file whose name begins "postgres:" or "http:"
+// (the gh #859 false-exclusion class).
+var fileDBSchemes = map[string]bool{
+	"sqlite3": true,
+	"sqlite":  true,
+	"duckdb":  true,
+}
 
-// isNonFileScheme reports whether scheme (matched case-insensitively, as
-// URL schemes are per RFC 3986) is a known URL/DSN scheme that isFpath
-// must not treat as a file path.
-func isNonFileScheme(scheme string) bool {
-	return nonFileSchemes[strings.ToLower(scheme)]
+// isFileDBScheme reports whether scheme (matched case-insensitively, as
+// URL schemes are per RFC 3986) is a file-based DB driver scheme whose
+// bare "scheme:path" form isFpath must treat as a DSN, not a file path.
+func isFileDBScheme(scheme string) bool {
+	return fileDBSchemes[strings.ToLower(scheme)]
 }
 
 // Filename returns the final component of the file/URL path.
@@ -522,24 +521,24 @@ func isFpath(loc string) (fpath string, ok bool) {
 	}
 
 	if strings.Contains(loc, "://") {
-		// Any "scheme://" authority form is a URL — a SQL driver DSN,
-		// http/https, or an unknown/unsupported scheme — never a local
+		// Any "scheme://" authority form is a URL (a SQL driver DSN,
+		// http/https, or an unknown/unsupported scheme), never a local
 		// file path. Mirrors the "://" convention used by IsSQL, Short,
 		// and Parse. Excluding unknown schemes here too avoids mangling a
 		// mistyped URL into a garbage path before it fails downstream.
 		return "", false
 	}
 
-	if scheme, _, found := strings.Cut(loc, ":"); found && isNonFileScheme(scheme) {
-		// A leading "scheme:" token naming a known non-file scheme is a
-		// driver DSN, not a path: the bare file-DB forms "sqlite3:f.db",
-		// "duckdb:f.db", the legacy "sqlite:f.db" spelling, and malformed
-		// single-slash forms like "sqlite3:/path". A single-letter Windows
-		// volume ("C:\db") is not a known scheme, so it stays a path,
-		// dissolving the gh #797 trap without a dedicated drive-letter
-		// branch. A colon inside a filename ("./dump.sqlite3:old.db")
-		// likewise has a leading token that isn't a known scheme, so it
-		// too stays a path (gh #859).
+	if scheme, _, found := strings.Cut(loc, ":"); found && isFileDBScheme(scheme) {
+		// A leading "scheme:" token naming a file-based DB driver is a
+		// bare DSN, not a path: "sqlite3:f.db", "duckdb:f.db", the legacy
+		// "sqlite:f.db" spelling, and malformed single-slash forms like
+		// "sqlite3:/path". A single-letter Windows volume ("C:\db") is not
+		// such a scheme, so it stays a path, dissolving the gh #797 trap
+		// without a dedicated drive-letter branch. A colon inside a
+		// filename ("./dump.sqlite3:old.db"), or a leading token that only
+		// looks like a network scheme ("postgres:notes.csv"), likewise
+		// stays a path (gh #859).
 		return "", false
 	}
 

--- a/libsq/source/location/location.go
+++ b/libsq/source/location/location.go
@@ -33,6 +33,28 @@ var dbSchemes = []string{
 	"oracle",
 }
 
+// nonFileSchemes is the set of URL/DSN schemes that isFpath must not
+// treat as a local file path. It is derived from dbSchemes so new SQL
+// drivers are covered automatically; "sqlite" is the legacy spelling of
+// "sqlite3", and "http"/"https" are document URLs.
+var nonFileSchemes = func() map[string]bool {
+	m := make(map[string]bool, len(dbSchemes)+3)
+	for _, s := range dbSchemes {
+		m[s] = true
+	}
+	m["sqlite"] = true
+	m["http"] = true
+	m["https"] = true
+	return m
+}()
+
+// isNonFileScheme reports whether scheme (matched case-insensitively, as
+// URL schemes are per RFC 3986) is a known URL/DSN scheme that isFpath
+// must not treat as a file path.
+func isNonFileScheme(scheme string) bool {
+	return nonFileSchemes[strings.ToLower(scheme)]
+}
+
 // Filename returns the final component of the file/URL path.
 func Filename(loc string) (string, error) {
 	if IsSQL(loc) {
@@ -499,22 +521,25 @@ func isFpath(loc string) (fpath string, ok bool) {
 		return "", false
 	}
 
-	if strings.Contains(loc, ":/") {
-		// Excludes "http:/" etc
+	if strings.Contains(loc, "://") {
+		// Any "scheme://" authority form is a URL — a SQL driver DSN,
+		// http/https, or an unknown/unsupported scheme — never a local
+		// file path. Mirrors the "://" convention used by IsSQL, Short,
+		// and Parse. Excluding unknown schemes here too avoids mangling a
+		// mistyped URL into a garbage path before it fails downstream.
 		return "", false
 	}
 
-	if strings.Contains(loc, "sqlite3:") || strings.Contains(loc, "sqlite:") {
-		// Excludes the sqlite3 driver scheme, e.g. "sqlite3:my_file.db" and
-		// the Windows form "sqlite3:C:\db" (which has no ":/" to catch it
-		// above), plus the legacy "sqlite:" spelling. Without the "sqlite3:"
-		// check a driver-scheme location was wrongly treated as a relative
-		// file path and joined under the cwd (gh #797).
-		return "", false
-	}
-
-	if strings.Contains(loc, "duckdb:") {
-		// Excludes "duckdb:my_file.duckdb" (malformed; missing the double-slash)
+	if scheme, _, found := strings.Cut(loc, ":"); found && isNonFileScheme(scheme) {
+		// A leading "scheme:" token naming a known non-file scheme is a
+		// driver DSN, not a path: the bare file-DB forms "sqlite3:f.db",
+		// "duckdb:f.db", the legacy "sqlite:f.db" spelling, and malformed
+		// single-slash forms like "sqlite3:/path". A single-letter Windows
+		// volume ("C:\db") is not a known scheme, so it stays a path,
+		// dissolving the gh #797 trap without a dedicated drive-letter
+		// branch. A colon inside a filename ("./dump.sqlite3:old.db")
+		// likewise has a leading token that isn't a known scheme, so it
+		// too stays a path (gh #859).
 		return "", false
 	}
 


### PR DESCRIPTION
Closes #859.

## Problem

`isFpath` decided whether a location was a bare file path (that `Abs` should absolutize) using three substring checks:

```go
strings.Contains(loc, ":/")
strings.Contains(loc, "sqlite3:") || strings.Contains(loc, "sqlite:")
strings.Contains(loc, "duckdb:")
```

A scheme is a *prefix*, so substring matching is looser than the intent. Real file paths whose names contain a colon (legal on Linux/macOS) were wrongly excluded: `Abs` left them un-absolutized, so `sq add` of a relative path stored the relative form, which could later resolve against a different working directory. For example:

- `./dump.sqlite3:old.csv` contained `sqlite3:` and was excluded.
- `./my-duckdb:thing.db` contained `duckdb:` and was excluded.

This is the principled follow-up to the substring `sqlite3:` check added in #858 (gh #797).

## Fix

Replace the substring cluster with a single check anchored on the leading `scheme:` token (the bytes before the first colon), via one `strings.Cut`:

1. If the remainder after the colon starts with `//`, it is a `scheme://` authority form: a URL (a SQL driver DSN, http/https, or an unknown/unsupported scheme), never a local file path. Excluding unknown schemes here too avoids mangling a mistyped URL into a garbage path before it fails downstream.
2. If the leading token is a file-based DB driver scheme (`sqlite3`, `duckdb`, or the legacy `sqlite` spelling), the bare `scheme:path` form is a DSN, not a path. Only these file-DB schemes have a bare `scheme:path` DSN form; network schemes (postgres, mysql, etc.) and http/https only ever take the `scheme://` form, already handled by check 1, so they are deliberately not in the set. Listing them would wrongly exclude a real file named e.g. `postgres:notes.csv`.
3. Otherwise it is a file path.

Matching is **case-sensitive**, consistent with the rest of the location pipeline (`IsSQL`, `Parse`, and munging all compare scheme prefixes case-sensitively). An off-case spelling like `SQLITE3:foo.db` is not a DSN sq recognizes, so it stays a path and is absolutized.

The single-letter Windows volume needs **no** special-case: `C` isn't a file-DB scheme, so `C:\db.sqlite` stays a path. This dissolves the gh #797 trap without a dedicated drive-letter branch.

## Scope note

The `weird:/notes/x.db` form (unknown scheme immediately followed by a single slash) is treated as a path by the new rule, but still fails the add downstream: its absolutized form contains `:/`, which `location.Parse` rejects as an invalid scheme, exactly as the current code already does. The realistic bug cases (a colon in a filename, no `:/`) are fully fixed. Loosening `Parse` to support colon-rooted directory paths, and consolidating scheme detection shared across `isFpath`/`Parse`/`Short`/`IsSQL`/`TypeOf`, are separate concerns left as follow-ups.

## Testing

- Expanded the table-driven `TestIsFpath` to cover colon-in-filename paths, Windows drive letters, bare file-DB scheme forms (incl. legacy `sqlite:`), `scheme://` URLs (known and unknown), network-scheme-prefixed filenames (`postgres:notes.csv`), case-sensitive scheme matching (`SQLITE3:` is a path), and malformed single-slash forms.
- The gh #797 regression test (`TestAbs_DriverSchemeNotAbsolutized`) stays green.
- End-to-end: `sq add ./dump.sqlite3:old.csv` from a subdir now stores the absolute path, and the source resolves when queried from an unrelated cwd.