### PR TITLE
test: remove Azure SQL Edge (retired by Microsoft 2025-09-30)

### DIFF
--- a/testh/sakila/sakila.go
+++ b/testh/sakila/sakila.go
@@ -40,13 +40,6 @@ const (
 	MS19           = "@sakila_ms19"
 	MS             = MS19
 
-	// AZ1 is the handle for Azure SQL Edge v1.x.
-	// Note that Azure SQL Edge is basically the same thing as MS SQL Server.
-	// AZ is not well-supported in the sq codebase. It's possible it will be
-	// removed at some point.
-	AZ1 = "@sakila_az1"
-	AZ  = AZ1
-
 	CH25 = "@sakila_ch25"
 	// CH is the handle for the latest ClickHouse.
 	CH = CH25
@@ -73,7 +66,6 @@ func AllHandles() []string {
 		My8,
 		// MS17,
 		MS19,
-		AZ1,
 		CH25,
 		Ora23,
 		RQ,
@@ -95,7 +87,6 @@ func SQLAll() []string {
 		My8,
 		// MS17,
 		MS19,
-		AZ1,
 		CH25,
 		Ora23,
 		RQ,
@@ -115,7 +106,6 @@ func SQLAllExternal() []string {
 		My8,
 		// MS17,
 		MS19,
-		AZ1,
 		CH25,
 		Ora23,
 		RQ,
@@ -149,12 +139,10 @@ func MyAll() []string {
 }
 
 // MSAll returns the handles for all SQL Server versions.
-// This includes both SQLServer and Azure SQL Edge.
 func MSAll() []string {
 	return []string{
 		// MS17,
 		MS19,
-		AZ1,
 	}
 }
 

--- a/testh/testdata/test.sq.yml
+++ b/testh/testdata/test.sq.yml
@@ -40,9 +40,6 @@ collection:
     - handle: '@sakila_ms19'
       driver: sqlserver
       location: ${env:SQ_TEST_SRC__SAKILA_MS19}
-    - handle: '@sakila_az1'
-      driver: sqlserver
-      location: ${env:SQ_TEST_SRC__SAKILA_AZ1}
     - handle: '@sakila_ch25'
       driver: clickhouse
       location: ${env:SQ_TEST_SRC__SAKILA_CH25}


### PR DESCRIPTION
## Summary

[Microsoft retired Azure SQL Edge](https://learn.microsoft.com/en-us/lifecycle/products/azure-sql-edge) on **2025-09-30**. It was a build of the SQL Server engine — functionally the same as the `@sakila_ms*` (sqlserver) fixtures — and the code already flagged it as *"not well-supported … possible it will be removed at some point."* This removes it.

## Changes

- **`testh/sakila/sakila.go`** — remove the `AZ1`/`AZ` handle constants and their comment; remove `AZ1` from `AllHandles()`, `SQLAll()`, `SQLAllExternal()`, and `MSAll()`; drop the Azure mention from the `MSAll` doc comment.
- **`testh/testdata/test.sq.yml`** — remove the `@sakila_az1` source entry (`SQ_TEST_SRC__SAKILA_AZ1`).

Deletion-only (15 lines). No driver code is touched — `AZ` used the `sqlserver` driver. The affected slices are *iterated* in tests, not count-asserted, so removing the handle just drops one iteration.

## Verification

- `gofmt` clean; `go build ./...` and `go vet ./testh/... ./drivers/sqlserver/...` pass.
- No remaining `azure` / `sql-edge` / `SAKILA_AZ` references (the leftover "Azure Key Vault" / "azure/bicep" hits are unrelated comments).

## Related

The `sakiladb/azure-sql-edge` image has been retired in lockstep: its repo README now carries a retirement notice (pointing to `sakiladb/sqlserver`) and the repo is archived; it's removed from the org's image list. The published Docker image remains for reference.