### PR TITLE
test(sakila): lockstep fixture expectations to 16 tables + 7 views

### DIFF
--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -295,5 +295,5 @@ func TestSQLiteStdin(t *testing.T) {
 	gotMap := tr.BindMap()
 	require.Equal(t, drivertype.SQLite.String(), gotMap["db_driver"])
 	require.Equal(t, source.StdinHandle, gotMap["handle"])
-	require.Len(t, gotMap["tables"], 21)
+	require.Len(t, gotMap["tables"], 23) // 16 tables + 7 views
 }

--- a/drivers/duckdb/internal/portsakila/cmd/portsakila/main.go
+++ b/drivers/duckdb/internal/portsakila/cmd/portsakila/main.go
@@ -242,7 +242,8 @@ func buildSakilaWhitespace(ctx context.Context) error {
 		`CREATE VIEW film_list AS
 SELECT film.film_id AS FID, film.title AS title, film.description AS description, category.name AS category,
        film.rental_rate AS price, film.length AS length, film.rating AS rating,
-       group_concat(actor."first name"||' '||actor."last name", ', ' ORDER BY actor."first name", actor."last name", actor.actor_id) AS actors
+       group_concat(actor."first name"||' '||actor."last name", ', '
+         ORDER BY actor."first name", actor."last name", actor.actor_id) AS actors
 FROM category
   LEFT JOIN film_category ON category.category_id = film_category.category_id
   LEFT JOIN film ON film_category.film_id = film.film_id
@@ -252,7 +253,10 @@ GROUP BY film.film_id, film.title, film.description, category.name, film.rental_
 		`CREATE VIEW nicer_but_slower_film_list AS
 SELECT film.film_id AS FID, film.title AS title, film.description AS description, category.name AS category,
        film.rental_rate AS price, film.length AS length, film.rating AS rating,
-       group_concat(upper(substr(actor."first name",1,1))||lower(substr(actor."first name",2))||' '||upper(substr(actor."last name",1,1))||lower(substr(actor."last name",2)), ', ' ORDER BY actor."first name", actor."last name", actor.actor_id) AS actors
+       group_concat(
+         upper(substr(actor."first name",1,1))||lower(substr(actor."first name",2))||' '||
+         upper(substr(actor."last name",1,1))||lower(substr(actor."last name",2)), ', '
+         ORDER BY actor."first name", actor."last name", actor.actor_id) AS actors
 FROM category
   LEFT JOIN film_category ON category.category_id = film_category.category_id
   LEFT JOIN film ON film_category.film_id = film.film_id

--- a/drivers/rqlite/rqlite_test.go
+++ b/drivers/rqlite/rqlite_test.go
@@ -63,7 +63,7 @@ func TestSourceMetadata(t *testing.T) {
 	// create extra transient tables that may still be live when the
 	// metadata query runs. Assert the lower bound rather than equality.
 	require.GreaterOrEqual(t, md.TableCount, int64(16))
-	require.Equal(t, int64(5), md.ViewCount)
+	require.Equal(t, int64(7), md.ViewCount)
 	// rqlite's HTTP API doesn't expose a database file size, so the
 	// driver leaves Source.Size as nil (gh744). Asserting nil prevents a
 	// regression to the int64 zero value, which would render as "0.0B".
@@ -89,12 +89,11 @@ func TestTableMetadata_Actor(t *testing.T) {
 	for i, col := range tbl.Columns {
 		gotKinds[i] = col.Kind
 	}
-	// actor: actor_id (decimal due to NUMERIC affinity), first_name,
-	// last_name (text), last_update (datetime). sakila.TblActorColKinds
-	// returns kind.Int for actor_id; the SQLite-on-rqlite shape uses
-	// NUMERIC → decimal, so we assert the column kinds explicitly here
-	// rather than reusing the shared helper.
-	require.Equal(t, []kind.Kind{kind.Decimal, kind.Text, kind.Text, kind.Datetime}, gotKinds)
+	// The canonical rqlite fixture (16 tables + 7 views) declares actor_id as
+	// INTEGER, so its column kinds match the shared helper: actor_id (int),
+	// first_name, last_name (text), last_update (datetime). (Older fixtures used
+	// NUMERIC affinity, which mapped actor_id to decimal instead.)
+	require.Equal(t, sakila.TblActorColKinds(), gotKinds)
 	require.True(t, tbl.Columns[0].PrimaryKey, "actor_id should be primary key")
 }
 

--- a/drivers/rqlite/rqlite_test.go
+++ b/drivers/rqlite/rqlite_test.go
@@ -44,7 +44,7 @@ func TestSmoke(t *testing.T) {
 
 // TestSourceMetadata verifies that getSourceMetadata returns the
 // expected shape: rqlite driver, "main" schema, and the right
-// table/view counts (16 tables, 5 views in the bundled Sakila).
+// table/view counts (16 tables, 7 views in the bundled Sakila).
 func TestSourceMetadata(t *testing.T) {
 	tu.SkipShort(t, true)
 	t.Parallel()

--- a/libsq/driver/driver_test.go
+++ b/libsq/driver/driver_test.go
@@ -605,9 +605,9 @@ func TestGrip_SourceMetadata_OracleViewsAndCounts(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, md)
 
-	// The SAKILA Oracle image omits actor_info and nicer_but_slower_film_list
-	// (they rely on MySQL GROUP_CONCAT); see sakiladb/oracle schema notes.
-	require.Equal(t, int64(5), md.ViewCount)
+	// The SAKILA Oracle image now carries all 7 views — actor_info and
+	// nicer_but_slower_film_list are ported via LISTAGG; see sakiladb/oracle schema notes.
+	require.Equal(t, int64(7), md.ViewCount)
 
 	// Oracle stores unquoted identifiers as upper, so look up by uppercase.
 	view := md.Table(strings.ToUpper(sakila.ViewFilmList))
@@ -697,13 +697,13 @@ func TestSQLDriver_ListTableNames_ArgSchemaNotEmpty(t *testing.T) { //nolint:tpa
 		wantViews  int
 	}{
 		{handle: sakila.Pg12, schema: "public", wantTables: 16, wantViews: 7},
-		{handle: sakila.MS19, schema: "dbo", wantTables: 16, wantViews: 5},
-		{handle: sakila.SL3, schema: "main", wantTables: 16, wantViews: 5},
+		{handle: sakila.MS19, schema: "dbo", wantTables: 16, wantViews: 7},
+		{handle: sakila.SL3, schema: "main", wantTables: 16, wantViews: 7},
 		{handle: sakila.My8, schema: "sakila", wantTables: 16, wantViews: 7},
 		// Oracle schemas are users; schema lookup is owner-scoped and case-insensitive.
-		// The SAKILA Oracle image omits the film_text table and the actor_info /
-		// nicer_but_slower_film_list views; see sakiladb/oracle schema notes.
-		{handle: sakila.Ora, schema: "SAKILA", wantTables: 15, wantViews: 5},
+		// The SAKILA Oracle image is now at the full 16 tables + 7 views (film_text
+		// included as a plain table); see sakiladb/oracle schema notes.
+		{handle: sakila.Ora, schema: "SAKILA", wantTables: 16, wantViews: 7},
 	}
 
 	for _, tc := range testCases {

--- a/libsq/driver/driver_test.go
+++ b/libsq/driver/driver_test.go
@@ -605,8 +605,8 @@ func TestGrip_SourceMetadata_OracleViewsAndCounts(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, md)
 
-	// The SAKILA Oracle image now carries all 7 views — actor_info and
-	// nicer_but_slower_film_list are ported via LISTAGG; see sakiladb/oracle schema notes.
+	// The SAKILA Oracle image now carries all 7 views: actor_info and
+	// nicer_but_slower_film_list are ported via LISTAGG. See sakiladb/oracle schema notes.
 	require.Equal(t, int64(7), md.ViewCount)
 
 	// Oracle stores unquoted identifiers as upper, so look up by uppercase.

--- a/sakila-start-local.sh
+++ b/sakila-start-local.sh
@@ -3,6 +3,11 @@
 # This script starts local Postgres, MySQL, SQL Server, ClickHouse,
 # Oracle, and rqlite (via the corresponding sakiladb/* docker images)
 # for repo-wide integration tests.
+#
+# Each `docker run` uses `--pull always` so a republished image (same tag, new
+# digest) is fetched before the container starts. Without it, a locally-cached
+# image can be silently stale — e.g. an old sakiladb/sqlserver:2019 with 5 views
+# instead of the current 7 — which makes the sakila count tests fail confusingly.
 # NOTE: This script has only been tested on MacOS on Apple Silicon.
 
 set +e
@@ -11,12 +16,12 @@ set +e
 
 set -e
 
-docker run -d -p 5432:5432 --name sakiladb-pg sakiladb/postgres:12 &>/dev/null
-docker run -d -p 3306:3306 --name sakiladb-my sakiladb/mysql:8 &>/dev/null
-docker run -d -p 9000:9000 --name sakiladb-ch sakiladb/clickhouse:25 &>/dev/null
-docker run -d -p 1521:1521 --name sakiladb-or sakiladb/oracle:23 &>/dev/null
-docker run -d -p 1433:1433 --name sakiladb-ms --platform=linux/amd64 sakiladb/sqlserver:2019 &>/dev/null
-docker run -d -p 4001:4001 --name sakiladb-rq sakiladb/rqlite:10 &>/dev/null
+docker run -d --pull always -p 5432:5432 --name sakiladb-pg sakiladb/postgres:12 &>/dev/null
+docker run -d --pull always -p 3306:3306 --name sakiladb-my sakiladb/mysql:8 &>/dev/null
+docker run -d --pull always -p 9000:9000 --name sakiladb-ch sakiladb/clickhouse:25 &>/dev/null
+docker run -d --pull always -p 1521:1521 --name sakiladb-or sakiladb/oracle:23 &>/dev/null
+docker run -d --pull always -p 1433:1433 --name sakiladb-ms --platform=linux/amd64 sakiladb/sqlserver:2019 &>/dev/null
+docker run -d --pull always -p 4001:4001 --name sakiladb-rq sakiladb/rqlite:10 &>/dev/null
 
 sleep 5
 

--- a/sakila-start-local.sh
+++ b/sakila-start-local.sh
@@ -6,8 +6,8 @@
 #
 # Each `docker run` uses `--pull always` so a republished image (same tag, new
 # digest) is fetched before the container starts. Without it, a locally-cached
-# image can be silently stale — e.g. an old sakiladb/sqlserver:2019 with 5 views
-# instead of the current 7 — which makes the sakila count tests fail confusingly.
+# image can be silently stale, e.g. an old sakiladb/sqlserver:2019 with 5 views
+# instead of the current 7, which makes the sakila count tests fail confusingly.
 # NOTE: This script has only been tested on MacOS on Apple Silicon.
 
 set +e

--- a/testh/sakila/sakila.go
+++ b/testh/sakila/sakila.go
@@ -159,11 +159,12 @@ const (
 	TblPayment        = "payment"
 	TblPaymentCount   = 16049
 
-	// TblFilmText is present in each sakila dataset, except the Oracle image
-	// (see libsq/driver/driver_test.go and sakiladb/oracle schema notes).
-	TblFilmText   = "film_text"
-	ViewActorInfo = "actor_info"
-	ViewFilmList  = "film_list"
+	// TblFilmText is present in every sakila dataset. (The Oracle image now
+	// includes it too, kept as a plain table — see sakiladb/oracle schema notes.)
+	TblFilmText                = "film_text"
+	ViewActorInfo              = "actor_info"
+	ViewFilmList               = "film_list"
+	ViewNicerButSlowerFilmList = "nicer_but_slower_film_list"
 
 	MillerEmail  = "MARIA.MILLER@sakilacustomer.org"
 	MillerCustID = 7
@@ -237,12 +238,14 @@ func AllTbls() []string {
 	}
 }
 
-// AllTblsViews returns all table AND view names.
+// AllTblsViews returns all table AND view names (16 tables + 7 views),
+// sorted by name.
 func AllTblsViews() []string {
 	return []string{
-		"actor", "address", "category", "city", "country", "customer", "customer_list", "film",
-		"film_actor", "film_category", "film_list", "film_text", "inventory", "language", "payment", "rental",
-		"sales_by_film_category", "sales_by_store", "staff", "staff_list", "store",
+		"actor", "actor_info", "address", "category", "city", "country", "customer", "customer_list", "film",
+		"film_actor", "film_category", "film_list", "film_text", "inventory", "language",
+		"nicer_but_slower_film_list", "payment", "rental", "sales_by_film_category", "sales_by_store",
+		"staff", "staff_list", "store",
 	}
 }
 

--- a/testh/sakila/sakila.go
+++ b/testh/sakila/sakila.go
@@ -160,7 +160,7 @@ const (
 	TblPaymentCount   = 16049
 
 	// TblFilmText is present in every sakila dataset. (The Oracle image now
-	// includes it too, kept as a plain table — see sakiladb/oracle schema notes.)
+	// includes it too, as a plain table. See sakiladb/oracle schema notes.)
 	TblFilmText                = "film_text"
 	ViewActorInfo              = "actor_info"
 	ViewFilmList               = "film_list"


### PR DESCRIPTION
Completes the cross-driver lockstep deferred from #943 (sqlite) and #944 (duckdb): now that every sakiladb image and the sqlite/duckdb fixtures are reconciled to a uniform **16 tables + 7 views**, this updates sq's test expectations to match, turning `master` green again.

## Changes
- **testh/sakila**: `AllTblsViews()` returns all 7 views (23 names, sorted); add the `ViewNicerButSlowerFilmList` constant; `film_text` is now present in every dataset (the Oracle image carries it as a plain table).
- **libsq/driver/driver_test.go**: sqlserver / sqlite / oracle view counts `5 → 7`; oracle table count `15 → 16` (film_text); oracle `SourceMetadata.ViewCount` `5 → 7`.
- **cli/cli_test.go**: `TestSQLiteStdin` object count `21 → 23`.
- **drivers/rqlite**: `SourceMetadata.ViewCount` `5 → 7`; the canonical rqlite fixture declares `actor_id` as `INTEGER`, so its column kinds now match the shared `sakila.TblActorColKinds` (the older fixture's NUMERIC affinity had mapped `actor_id` to decimal).

## Verification
Ran the full `libsq` and `cli` suites locally against refreshed **16+7** containers for every SQL source — sqlite, duckdb, postgres, mysql, sqlserver, oracle, clickhouse, rqlite — all green.

Note: the published sqlserver/oracle/rqlite images had to be re-pulled locally; the previously-running containers were stale (e.g. the local sqlserver image dated from 2022).