### PR TITLE
ci(sakila): keep DSN out of the db-integration matrix (fixes empty matrix)

### DIFF
--- a/.github/workflows/db-integration.yml
+++ b/.github/workflows/db-integration.yml
@@ -117,7 +117,13 @@ jobs:
 
       - name: Integration tests (${{ matrix.engine }}:${{ matrix.tag }})
         shell: bash
+        env:
+          ENGINE: ${{ matrix.engine }}
+          ENV_NAME: ${{ matrix.env }}
         run: |
           set -euo pipefail
-          export ${{ matrix.env }}='${{ matrix.dsn }}'
+          # Look up the DSN from the manifest at runtime — it carries credentials
+          # that GitHub masks, so it must not travel through the job-output matrix.
+          dsn=$(jq -r --arg e "$ENGINE" '.[$e].dsn' .github/sakila-db.json)
+          export "$ENV_NAME=$dsn"
           go test -tags '${{ env.BUILD_TAGS }}' -timeout 25m -v ${{ matrix.packages }}

--- a/scripts/build-db-matrix.sh
+++ b/scripts/build-db-matrix.sh
@@ -3,7 +3,12 @@
 #
 # Usage: build-db-matrix.sh <full|narrow> <selection-json>
 #   selection-json: {"postgres":["12","latest"],"mysql":["8"]}
-# Emits a JSON array of {engine,tag,port,env,dsn,packages} on stdout.
+# Emits a JSON array of {engine,tag,port,env,packages} on stdout.
+#
+# Note: the DSN is deliberately NOT included. It contains credentials that
+# GitHub masks as a secret, and a job output containing a masked value is
+# dropped (not passed to downstream jobs) — which would silently empty the
+# matrix. The test job looks up the DSN from .github/sakila-db.json at runtime.
 set -euo pipefail
 
 scope="${1:?usage: build-db-matrix.sh <full|narrow> <selection-json>}"
@@ -24,7 +29,6 @@ jq -cn \
           tag:      .,
           port:     $e.port,
           env:      $e.env,
-          dsn:      $e.dsn,
           packages: (if $scope == "narrow" then $e.packages else "./..." end)
         } ]
 '


### PR DESCRIPTION
Follow-up to #966/#970. After fixing the dispatch inputs, the matrix built correctly but the `test` job still skipped: the matrix `dsn` field carries credentials (`sakila:p_ssW0rd@`) that GitHub masks, and **a job output containing a masked secret is not passed to downstream jobs** — so `needs.setup.outputs.matrix` arrived empty.

Fix: drop `dsn` from the matrix (carry only engine/tag/port/env/packages) and have the test job resolve the DSN from `.github/sakila-db.json` at runtime by engine. No credential travels through a job output.