### PR TITLE
fix(mysql): degrade CHECK_CONSTRAINTS inspect on MySQL 5.6 (error 1109)

### DIFF
--- a/drivers/mysql/errors.go
+++ b/drivers/mysql/errors.go
@@ -45,7 +45,19 @@ const (
 	errNumConCount      = uint16(1040)
 	// errNumUnknownColumn is ER_BAD_FIELD_ERROR: "Unknown column 'X' in 'field list'".
 	errNumUnknownColumn = uint16(1054)
+	// errNumUnknownTable is ER_UNKNOWN_TABLE: "Unknown table 'X' in Y". MySQL 5.6
+	// returns this (rather than 1146) for a missing information_schema table,
+	// such as CHECK_CONSTRAINTS.
+	errNumUnknownTable = uint16(1109)
 )
+
+// isMissingInfoSchemaTable reports whether err indicates that a queried
+// information_schema table does not exist on this server version. MySQL 8.0+
+// returns ER_NO_SUCH_TABLE (1146); MySQL 5.6 returns ER_UNKNOWN_TABLE (1109)
+// for a missing information_schema table such as CHECK_CONSTRAINTS.
+func isMissingInfoSchemaTable(err error) bool {
+	return hasErrCode(err, errNumTableNotExist) || hasErrCode(err, errNumUnknownTable)
+}
 
 func isErrTooManyConnections(err error) bool {
 	return hasErrCode(err, errNumConCount)

--- a/drivers/mysql/errors_test.go
+++ b/drivers/mysql/errors_test.go
@@ -1,0 +1,22 @@
+package mysql
+
+import (
+	"testing"
+
+	"github.com/go-sql-driver/mysql"
+	"github.com/stretchr/testify/require"
+)
+
+// TestIsMissingInfoSchemaTable verifies that both the MySQL 8.0+ code
+// (ER_NO_SUCH_TABLE, 1146) and the MySQL 5.6 code (ER_UNKNOWN_TABLE, 1109)
+// are recognized as "information_schema table absent", so the CHECK_CONSTRAINTS
+// inspect path degrades gracefully on older servers instead of erroring.
+func TestIsMissingInfoSchemaTable(t *testing.T) {
+	require.True(t, isMissingInfoSchemaTable(&mysql.MySQLError{Number: errNumTableNotExist}),
+		"1146 (ER_NO_SUCH_TABLE, MySQL 8.0+) should be recognized")
+	require.True(t, isMissingInfoSchemaTable(&mysql.MySQLError{Number: errNumUnknownTable}),
+		"1109 (ER_UNKNOWN_TABLE, MySQL 5.6) should be recognized")
+	require.False(t, isMissingInfoSchemaTable(&mysql.MySQLError{Number: errNumUnknownColumn}),
+		"1054 (unknown column) is a different failure mode")
+	require.False(t, isMissingInfoSchemaTable(nil), "nil is not a missing-table error")
+}

--- a/drivers/mysql/metadata.go
+++ b/drivers/mysql/metadata.go
@@ -1272,7 +1272,8 @@ WHERE tc.CONSTRAINT_TYPE = 'CHECK'
 	if err != nil {
 		// CHECK_CONSTRAINTS is absent in MySQL < 8.0.16 and some MariaDB
 		// variants. Return empty slice rather than failing the inspect.
-		if hasErrCode(err, errNumTableNotExist) {
+		// (MySQL 8.0 reports 1146; MySQL 5.6 reports 1109.)
+		if isMissingInfoSchemaTable(err) {
 			return nil, nil
 		}
 		return nil, errw(err)


### PR DESCRIPTION
Part of the MySQL 5.6 investigation from the #958 version matrix ("A1").

MySQL 5.6 returns `ER_UNKNOWN_TABLE` (1109) — not `ER_NO_SUCH_TABLE` (1146) — for a missing `information_schema.CHECK_CONSTRAINTS` table. The inspect degradation path only recognized 1146, so check-constraint gathering errored on 5.6 instead of returning empty (it was the largest single cause of failures in the mysql:5.6 matrix leg).

Recognize both codes via a new `isMissingInfoSchemaTable` helper. Unit-tested (no DB required). The remaining 5.6 gaps (version-aware `CAST AS DOUBLE`/`RENAME COLUMN` codegen, and test guards for CTE/generated-columns/expression-indexes) are larger and tracked separately, gated on the version-awareness work.