### PR TITLE
ci(sakila): drop EOL mysql 5.6/5.7 from the version sweep

### DIFF
--- a/.github/sakila-db.json
+++ b/.github/sakila-db.json
@@ -11,7 +11,7 @@
     "env": "SQ_TEST_SRC__SAKILA_MY",
     "dsn": "mysql://sakila:p_ssW0rd@localhost:3306/sakila",
     "packages": "./drivers/mysql/... ./libsq/... ./cli/... ./testh/...",
-    "tags": ["latest", "9", "8", "5.7", "5.6"]
+    "tags": ["latest", "9", "8"]
   },
   "sqlserver": {
     "port": 1433,


### PR DESCRIPTION
Both MySQL 5.6 (EOL 2021) and 5.7 (EOL 2023) fail the version matrix on known, documented gaps (#973), which would keep the nightly/weekly sweep red. Trim them to `latest/9/8` so the sweep is green on supported versions.

Re-add is tracked with instructions in #973. Local `sakila-start-local.sh` is unaffected (it uses `tags[0]` = `latest`).