### PR TITLE
ci(sakila): dprint-format db-integration/db-scheduled workflows

### DIFF
--- a/.github/workflows/db-integration.yml
+++ b/.github/workflows/db-integration.yml
@@ -4,23 +4,43 @@ on:
   workflow_call:
     inputs:
       selection:
-        description: 'JSON object {engine:[tags]} of engines/tags to test'
+        description: "JSON object {engine:[tags]} of engines/tags to test"
         required: true
         type: string
       scope:
-        description: 'full (go test ./...) or narrow (per-engine packages)'
+        description: "full (go test ./...) or narrow (per-engine packages)"
         required: false
-        default: 'full'
+        default: "full"
         type: string
   workflow_dispatch:
     inputs:
-      postgres:   { description: 'postgres tags (comma-sep; blank=skip)',   type: string, default: 'latest' }
-      mysql:      { description: 'mysql tags (comma-sep; blank=skip)',      type: string, default: 'latest' }
-      sqlserver:  { description: 'sqlserver tags (comma-sep; blank=skip)',  type: string, default: 'latest' }
-      clickhouse: { description: 'clickhouse tags (comma-sep; blank=skip)', type: string, default: 'latest' }
-      oracle:     { description: 'oracle tags (comma-sep; blank=skip)',     type: string, default: 'latest' }
-      rqlite:     { description: 'rqlite tags (comma-sep; blank=skip)',     type: string, default: 'latest' }
-      scope:      { description: 'full or narrow', type: choice, options: [full, narrow], default: full }
+      postgres: {
+        description: "postgres tags (comma-sep; blank=skip)",
+        type: string,
+        default: "latest",
+      }
+      mysql: { description: "mysql tags (comma-sep; blank=skip)", type: string, default: "latest" }
+      sqlserver: {
+        description: "sqlserver tags (comma-sep; blank=skip)",
+        type: string,
+        default: "latest",
+      }
+      clickhouse: {
+        description: "clickhouse tags (comma-sep; blank=skip)",
+        type: string,
+        default: "latest",
+      }
+      oracle: {
+        description: "oracle tags (comma-sep; blank=skip)",
+        type: string,
+        default: "latest",
+      }
+      rqlite: {
+        description: "rqlite tags (comma-sep; blank=skip)",
+        type: string,
+        default: "latest",
+      }
+      scope: { description: "full or narrow", type: choice, options: [full, narrow], default: full }
 
 env:
   BUILD_TAGS: "sqlite_vtable sqlite_stat4 sqlite_fts5 sqlite_introspect sqlite_json sqlite_math_functions"
@@ -35,14 +55,14 @@ jobs:
       - id: build
         shell: bash
         env:
-          INPUT_POSTGRES:   ${{ inputs.postgres   || github.event.inputs.postgres }}
-          INPUT_MYSQL:      ${{ inputs.mysql      || github.event.inputs.mysql }}
-          INPUT_SQLSERVER:  ${{ inputs.sqlserver  || github.event.inputs.sqlserver }}
+          INPUT_POSTGRES: ${{ inputs.postgres   || github.event.inputs.postgres }}
+          INPUT_MYSQL: ${{ inputs.mysql      || github.event.inputs.mysql }}
+          INPUT_SQLSERVER: ${{ inputs.sqlserver  || github.event.inputs.sqlserver }}
           INPUT_CLICKHOUSE: ${{ inputs.clickhouse || github.event.inputs.clickhouse }}
-          INPUT_ORACLE:     ${{ inputs.oracle     || github.event.inputs.oracle }}
-          INPUT_RQLITE:     ${{ inputs.rqlite     || github.event.inputs.rqlite }}
-          INPUT_SELECTION:  ${{ inputs.selection }}
-          INPUT_SCOPE:      ${{ inputs.scope || github.event.inputs.scope || 'full' }}
+          INPUT_ORACLE: ${{ inputs.oracle     || github.event.inputs.oracle }}
+          INPUT_RQLITE: ${{ inputs.rqlite     || github.event.inputs.rqlite }}
+          INPUT_SELECTION: ${{ inputs.selection }}
+          INPUT_SCOPE: ${{ inputs.scope || github.event.inputs.scope || 'full' }}
         run: |
           set -euo pipefail
           if [ -n "$INPUT_SELECTION" ]; then

--- a/.github/workflows/db-scheduled.yml
+++ b/.github/workflows/db-scheduled.yml
@@ -2,9 +2,9 @@ name: DB integration (scheduled)
 
 on:
   schedule:
-    - cron: '0 4 * * *'   # nightly: every engine @ :latest, full scope
-    - cron: '0 5 * * 1'   # weekly (Mon): full version sweep, narrow scope
-  workflow_dispatch: {}    # manual: behaves like the nightly run
+    - cron: "0 4 * * *" # nightly: every engine @ :latest, full scope
+    - cron: "0 5 * * 1" # weekly (Mon): full version sweep, narrow scope
+  workflow_dispatch: {} # manual: behaves like the nightly run
 
 jobs:
   select:


### PR DESCRIPTION
The `Format` (dprint check) job has been failing on master since #966 — the two new workflow files (`db-integration.yml`, `db-scheduled.yml`) weren't dprint-formatted. `actionlint` validates syntax, not dprint style, so it didn't catch it. Ran `dprint fmt`; no functional change (double-quoted cron strings, collapsed key alignment, expanded flow-maps). `dprint check` and `actionlint` both clean locally.