### PR TITLE
docs(agents): dprint formats workflows/JSON; actionlint won't catch it

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -186,6 +186,15 @@ This covers all markdown in the repo (root docs, `skills/`, and `site/`) under
 the single root [`dprint.json`](./dprint.json). There is no separate markdown
 linter or per-directory config anymore.
 
+### GitHub Actions workflows
+
+`dprint` also formats workflow YAML (`.github/workflows/*.yml`), JSON, and TOML
+via the same `make fmt` / `make fmt-check` as everything else. The
+`Format` CI job runs `dprint check` repo-wide and fails on any unformatted file.
+`actionlint` validates workflow _syntax_, not dprint _style_, so a workflow can
+pass `actionlint` and still fail `Format`. Run `make fmt` on any workflow (or
+JSON) file you touch before committing.
+
 ### `CHANGELOG.md`
 
 See [`CONTRIBUTING.md`](./CONTRIBUTING.md#changelogmd) for the full format.


### PR DESCRIPTION
Adds a short `### GitHub Actions workflows` note to AGENTS.md (under Conventions): `dprint` formats workflow YAML, JSON, and TOML repo-wide; the `Format` CI job runs `dprint check` and fails on any unformatted file; `actionlint` checks syntax, not dprint style, so a workflow can pass actionlint and still fail Format. Run `make fmt` before committing.

Captures the lesson from the #966 follow-ups, where the new workflow files passed actionlint but failed Format (fixed in #978). dprint-clean and em-dash-free per AGENTS.md's own prose rules.