### PR TITLE
ci(sakila): db matrix polish (skip-on-blank dispatch, scope validation, test guards)

### DIFF
--- a/.github/workflows/db-integration.yml
+++ b/.github/workflows/db-integration.yml
@@ -14,32 +14,23 @@ on:
         type: string
   workflow_dispatch:
     inputs:
-      postgres: {
-        description: "postgres tags (comma-sep; blank=skip)",
-        type: string,
-        default: "latest",
-      }
-      mysql: { description: "mysql tags (comma-sep; blank=skip)", type: string, default: "latest" }
+      # Default "" so a blank engine is skipped (see the select(.value != "")
+      # filter in build-db-matrix.sh). "Run everything at :latest" is the
+      # nightly scheduler's job; a manual dispatch names the engines it wants.
+      postgres: { description: "postgres tags (comma-sep; blank=skip)", type: string, default: "" }
+      mysql: { description: "mysql tags (comma-sep; blank=skip)", type: string, default: "" }
       sqlserver: {
         description: "sqlserver tags (comma-sep; blank=skip)",
         type: string,
-        default: "latest",
+        default: "",
       }
       clickhouse: {
         description: "clickhouse tags (comma-sep; blank=skip)",
         type: string,
-        default: "latest",
+        default: "",
       }
-      oracle: {
-        description: "oracle tags (comma-sep; blank=skip)",
-        type: string,
-        default: "latest",
-      }
-      rqlite: {
-        description: "rqlite tags (comma-sep; blank=skip)",
-        type: string,
-        default: "latest",
-      }
+      oracle: { description: "oracle tags (comma-sep; blank=skip)", type: string, default: "" }
+      rqlite: { description: "rqlite tags (comma-sep; blank=skip)", type: string, default: "" }
       scope: { description: "full or narrow", type: choice, options: [full, narrow], default: full }
 
 env:

--- a/sakila-start-local.sh
+++ b/sakila-start-local.sh
@@ -44,7 +44,8 @@ for engine in "${engines[@]}"; do
   for _ in $(seq 1 60); do
     status=$(docker inspect -f '{{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}}' "$c" 2>/dev/null || echo missing)
     [ "$status" = healthy ] && break
-    [ "$status" = none ] && break   # no healthcheck: don't block
+    [ "$status" = none ] && break    # no healthcheck: don't block
+    [ "$status" = missing ] && break # container gone: stop waiting
     sleep 5
   done
   echo "  $c: $(docker inspect -f '{{if .State.Health}}{{.State.Health.Status}}{{else}}running{{end}}' "$c" 2>/dev/null || echo '?')"

--- a/scripts/build-db-matrix.sh
+++ b/scripts/build-db-matrix.sh
@@ -15,6 +15,17 @@ scope="${1:?usage: build-db-matrix.sh <full|narrow> <selection-json>}"
 selection="${2:?missing selection json}"
 config="$(cd "$(dirname "$0")/.." && pwd)/.github/sakila-db.json"
 
+# workflow_dispatch constrains scope via type:choice, but the workflow_call
+# input is a free string — reject typos rather than silently treating any
+# non-"narrow" value as "full".
+case "$scope" in
+  full | narrow) ;;
+  *)
+    echo "build-db-matrix.sh: scope must be 'full' or 'narrow', got '$scope'" >&2
+    exit 2
+    ;;
+esac
+
 jq -cn \
   --argjson sel "$selection" \
   --slurpfile cfg "$config" \

--- a/scripts/build-db-matrix_test.sh
+++ b/scripts/build-db-matrix_test.sh
@@ -17,4 +17,20 @@ echo "$out" | jq -e 'length == 2' >/dev/null
 echo "$out" | jq -e 'all(.packages == "./...")' >/dev/null
 echo "$out" | jq -e '[.[].tag] == ["8","9"]' >/dev/null
 
+# the DSN must NOT travel through the matrix: GitHub masks the credential and
+# drops a job output containing it, which silently empties the matrix.
+echo "$out" | jq -e 'all(has("dsn") | not)' >/dev/null
+
+# unknown engine is a hard error, not a silently-empty/null row
+if "$here/build-db-matrix.sh" narrow '{"bogus":["1"]}' 2>/dev/null; then
+  echo "build-db-matrix_test: FAIL (expected error for unknown engine)" >&2
+  exit 1
+fi
+
+# invalid scope is rejected
+if "$here/build-db-matrix.sh" sideways '{"postgres":["12"]}' 2>/dev/null; then
+  echo "build-db-matrix_test: FAIL (expected error for invalid scope)" >&2
+  exit 1
+fi
+
 echo "build-db-matrix_test: PASS"


### PR DESCRIPTION
Non-blocking polish for the #958 DB integration matrix, after verifying all legs (incl. postgres:12/17, sqlserver:2019, mysql:9) green.

1. **Dispatch skip-on-blank now works.** Per-engine `workflow_dispatch` defaults were `latest`, which overrode an empty value before the `select(.value != "")` skip filter saw it — so the documented "blank=skip" never worked (a dispatch always ran every engine). Defaults are now `""`. "Run all at :latest" stays the nightly scheduler's job (it uses `workflow_call` + `selection`, unaffected). A bare dispatch with nothing specified selects nothing and trips the existing empty-selection guard.
2. **`build-db-matrix.sh` validates scope** (`full`/`narrow`) — the `workflow_call` scope input is a free string, so a typo no longer silently means full.
3. **Test guards:** `build-db-matrix_test.sh` now asserts the DSN is absent from the matrix (regression guard for the masked-secret output-drop fix, #971) and adds negative tests for unknown-engine and invalid-scope.
4. **`sakila-start-local.sh`** breaks the health-wait on `status=missing` instead of spinning ~5min when a container vanished.

Validated: dprint check, shellcheck, actionlint, and the expanded builder test all clean.