### PR TITLE
test: restrict cross-source tests to embedded × target (#964)

### DIFF
--- a/cli/cmd_slq_test.go
+++ b/cli/cmd_slq_test.go
@@ -127,18 +127,20 @@ func TestCmdSLQ_Insert_MultipleSchemas(t *testing.T) {
 //   - SLQ query parsing and execution across different database backends
 //   - The CLI's ability to manage multiple source connections simultaneously
 //
-// The test matrix covers all combinations of supported SQL databases as both
-// origin (data source) and destination (insert target).
-// TestCmdSLQ_Insert exercises --insert across the SQLLatest() matrix of
-// origin x dest. The origin==dest cells are self-inserts; the
-// @sakila_duck/@sakila_duck cell is the regression guard for the DuckDB
-// self-insert path (handle+mode cache + QueryContext.WriteHandle, gh #779):
-// without it, the source would open read-only while the destination holds
-// the file read-write, which DuckDB rejects.
+// The test matrix pairs each engine with an embedded source (SQLite/DuckDB) as
+// both origin and destination, plus same-source self-inserts. External x external
+// cross pairs are excluded via sakila.CrossSourceDests because they don't scale
+// (multiple external containers live at once, O(N^2) in the number of engines)
+// and can't run under the per-engine CI model; see gh #964. The origin==dest
+// cells are self-inserts; the @sakila_duck/@sakila_duck cell is the regression
+// guard for the DuckDB self-insert path (handle+mode cache +
+// QueryContext.WriteHandle, gh #779): without it, the source would open
+// read-only while the destination holds the file read-write, which DuckDB
+// rejects.
 func TestCmdSLQ_Insert(t *testing.T) {
 	for _, origin := range sakila.SQLLatest() {
 		t.Run("origin_"+origin, func(t *testing.T) {
-			for _, dest := range sakila.SQLLatest() {
+			for _, dest := range sakila.CrossSourceDests(origin) {
 				t.Run("dest_"+dest, func(t *testing.T) {
 					t.Parallel()
 

--- a/cli/cmd_sql_test.go
+++ b/cli/cmd_sql_test.go
@@ -538,15 +538,18 @@ func TestCmdSQL_ExecTypeEdgeCases(t *testing.T) {
 //   - Schema compatibility between different database engines
 //   - The CLI's ability to manage multiple source connections simultaneously
 //
-// The test matrix covers all combinations of supported SQL databases as both
-// origin (data source) and destination (insert target), ensuring the feature
-// works regardless of which databases are involved.
+// The test matrix pairs each engine with an embedded source (SQLite/DuckDB) as
+// both origin (data source) and destination (insert target), plus same-source
+// self-inserts. External x external cross pairs are excluded via
+// sakila.CrossSourceDests: they don't scale (multiple external containers live
+// at once, O(N^2) in the number of engines) and can't run under the per-engine
+// CI model. See gh #964.
 func TestCmdSQL_Insert(t *testing.T) {
 	for _, origin := range sakila.SQLLatest() {
 		t.Run("origin_"+origin, func(t *testing.T) {
 			tu.SkipShort(t, origin == sakila.XLSX)
 
-			for _, dest := range sakila.SQLLatest() {
+			for _, dest := range sakila.CrossSourceDests(origin) {
 				t.Run("dest_"+dest, func(t *testing.T) {
 					t.Parallel()
 

--- a/cli/cmd_sql_test.go
+++ b/cli/cmd_sql_test.go
@@ -547,8 +547,6 @@ func TestCmdSQL_ExecTypeEdgeCases(t *testing.T) {
 func TestCmdSQL_Insert(t *testing.T) {
 	for _, origin := range sakila.SQLLatest() {
 		t.Run("origin_"+origin, func(t *testing.T) {
-			tu.SkipShort(t, origin == sakila.XLSX)
-
 			for _, dest := range sakila.CrossSourceDests(origin) {
 				t.Run("dest_"+dest, func(t *testing.T) {
 					t.Parallel()

--- a/testh/sakila/sakila.go
+++ b/testh/sakila/sakila.go
@@ -48,13 +48,18 @@ func AllHandles() []string {
 	return []string{SL3, Duck, Pg, My, MS, CH, Ora, RQ, XLSX}
 }
 
-// SQLAll returns all the sakila SQL handles.
+// SQLAll returns every sakila SQL handle: the embedded sources (SQLite,
+// DuckDB) and all external engines, including rqlite. It is the union of
+// [SQLEmbedded] and [SQLAllExternal]. See [SQLLatest] for the same set minus
+// rqlite.
 func SQLAll() []string {
 	return []string{SL3, Duck, Pg, My, MS, CH, Ora, RQ}
 }
 
-// SQLAllExternal is the same as SQLAll, but only includes
-// external (non-embedded) sources. That is, it excludes SL3 and Duck.
+// SQLAllExternal returns the external (non-embedded) SQL handles: every engine
+// that needs a running server, including rqlite. It is [SQLAll] minus the
+// embedded sources, i.e. the complement of [SQLEmbedded]; together the two
+// partition [SQLAll].
 func SQLAllExternal() []string {
 	return []string{Pg, My, MS, CH, Ora, RQ}
 }
@@ -95,9 +100,18 @@ func CrossSourceDests(origin string) []string {
 	return append(SQLEmbedded(), origin)
 }
 
-// SQLLatest returns the canonical per-engine handles. Retained alongside
-// SQLAll for quicker iterative testing; DuckDB is included because it is
-// embedded and exercises read-only/access-mode paths the others don't (gh #779).
+// SQLLatest returns one handle per SQL engine for the standard cross-engine
+// test matrix: the embedded sources (SQLite, DuckDB) plus the external engines,
+// but excluding rqlite. It is therefore [SQLAll] without rqlite — that single
+// handle is the only difference between the two. rqlite is omitted here because
+// its driver supports a narrower feature set than the other engines; coverage
+// of rqlite goes through [SQLAll].
+//
+// The name is historical: it dates from when sources were versioned and this
+// returned the latest version of each engine. Versions are now a CI matrix
+// dimension (gh #958), so there is a single handle per engine. DuckDB is
+// included because, being embedded, it exercises read-only/access-mode paths
+// the others don't (gh #779).
 func SQLLatest() []string {
 	return []string{SL3, Duck, Pg, My, MS, CH, Ora}
 }

--- a/testh/sakila/sakila.go
+++ b/testh/sakila/sakila.go
@@ -57,6 +57,37 @@ func SQLAllExternal() []string {
 	return []string{Pg, My, MS, CH, Ora, RQ}
 }
 
+// Embedded returns the embedded SQL handles: SQLite and DuckDB. These run
+// in-process (no separate server or container) and are always available,
+// unlike the external engines in [SQLAllExternal]. Note that rqlite, though
+// SQLite-backed, is external: it is reached over the network.
+func Embedded() []string {
+	return []string{SL3, Duck}
+}
+
+// IsEmbedded reports whether handle is an embedded SQL source (SQLite or
+// DuckDB), as opposed to an external engine that needs a running server.
+func IsEmbedded(handle string) bool {
+	return handle == SL3 || handle == Duck
+}
+
+// CrossSourceDests returns the destination handles that origin should be
+// paired with in cross-source (origin x dest) tests. Embedded origins
+// (SQLite/DuckDB) pair with every engine; external origins pair only with the
+// embedded sources plus themselves. This yields {embedded} x {target} coverage
+// in both directions, plus same-source self-inserts, while excluding the
+// external x external cross pairs: those need multiple external containers live
+// at once, grow O(N^2) with the number of SQL engines, and can't run under the
+// per-engine CI model. See gh #964.
+func CrossSourceDests(origin string) []string {
+	if IsEmbedded(origin) {
+		return SQLLatest()
+	}
+	// External origin: embedded dests (both directions of {embedded}x{target})
+	// plus origin itself (the single-container same-source insert path).
+	return append(Embedded(), origin)
+}
+
 // SQLLatest returns the canonical per-engine handles. Retained alongside
 // SQLAll for quicker iterative testing; DuckDB is included because it is
 // embedded and exercises read-only/access-mode paths the others don't (gh #779).

--- a/testh/sakila/sakila.go
+++ b/testh/sakila/sakila.go
@@ -2,6 +2,8 @@
 package sakila
 
 import (
+	"slices"
+
 	"github.com/neilotoole/sq/libsq/core/kind"
 )
 
@@ -57,35 +59,40 @@ func SQLAllExternal() []string {
 	return []string{Pg, My, MS, CH, Ora, RQ}
 }
 
-// Embedded returns the embedded SQL handles: SQLite and DuckDB. These run
+// SQLEmbedded returns the embedded SQL handles: SQLite and DuckDB. These run
 // in-process (no separate server or container) and are always available,
-// unlike the external engines in [SQLAllExternal]. Note that rqlite, though
-// SQLite-backed, is external: it is reached over the network.
-func Embedded() []string {
+// unlike the external engines in [SQLAllExternal]. The SQL prefix is
+// deliberate: non-SQL document sources such as CSV and XLSX are also embedded
+// (file-based), but are not SQL drivers and are excluded here. Note that
+// rqlite, though SQLite-backed, is external: it is reached over the network.
+// SQLEmbedded and [SQLAllExternal] partition [SQLAll].
+func SQLEmbedded() []string {
 	return []string{SL3, Duck}
 }
 
-// IsEmbedded reports whether handle is an embedded SQL source (SQLite or
-// DuckDB), as opposed to an external engine that needs a running server.
-func IsEmbedded(handle string) bool {
-	return handle == SL3 || handle == Duck
+// IsSQLEmbedded reports whether handle is an embedded SQL source (SQLite or
+// DuckDB), as opposed to an external engine that needs a running server. It is
+// false for non-SQL embedded sources such as CSV. The embedded set is defined
+// once, by [SQLEmbedded].
+func IsSQLEmbedded(handle string) bool {
+	return slices.Contains(SQLEmbedded(), handle)
 }
 
 // CrossSourceDests returns the destination handles that origin should be
 // paired with in cross-source (origin x dest) tests. Embedded origins
-// (SQLite/DuckDB) pair with every engine; external origins pair only with the
-// embedded sources plus themselves. This yields {embedded} x {target} coverage
-// in both directions, plus same-source self-inserts, while excluding the
-// external x external cross pairs: those need multiple external containers live
-// at once, grow O(N^2) with the number of SQL engines, and can't run under the
-// per-engine CI model. See gh #964.
+// (SQLite/DuckDB) pair with every handle in [SQLLatest]; external origins pair
+// only with the embedded sources plus themselves. This yields
+// {embedded} x {target} coverage in both directions, plus same-source
+// self-inserts, while excluding the external x external cross pairs: those need
+// multiple external containers live at once, grow O(N^2) with the number of SQL
+// engines, and can't run under the per-engine CI model. See gh #964.
 func CrossSourceDests(origin string) []string {
-	if IsEmbedded(origin) {
+	if IsSQLEmbedded(origin) {
 		return SQLLatest()
 	}
 	// External origin: embedded dests (both directions of {embedded}x{target})
 	// plus origin itself (the single-container same-source insert path).
-	return append(Embedded(), origin)
+	return append(SQLEmbedded(), origin)
 }
 
 // SQLLatest returns the canonical per-engine handles. Retained alongside

--- a/testh/sakila/sakila_test.go
+++ b/testh/sakila/sakila_test.go
@@ -12,22 +12,37 @@ import (
 	"github.com/neilotoole/sq/testh/tu"
 )
 
-// TestEmbedded verifies that the embedded SQL handles are exactly SQLite and
-// DuckDB, and that IsEmbedded agrees with both Embedded and SQLAllExternal.
-func TestEmbedded(t *testing.T) {
+// TestSQLEmbedded verifies that the embedded SQL handles are exactly SQLite and
+// DuckDB, and that IsSQLEmbedded agrees with both SQLEmbedded and
+// SQLAllExternal.
+func TestSQLEmbedded(t *testing.T) {
 	t.Parallel()
 
-	require.Equal(t, []string{sakila.SL3, sakila.Duck}, sakila.Embedded())
+	require.Equal(t, []string{sakila.SL3, sakila.Duck}, sakila.SQLEmbedded())
 
-	for _, h := range sakila.Embedded() {
-		assert.True(t, sakila.IsEmbedded(h), "%s should be embedded", h)
+	for _, h := range sakila.SQLEmbedded() {
+		assert.True(t, sakila.IsSQLEmbedded(h), "%s should be embedded", h)
 	}
 	// Every external SQL source (including rqlite, which is SQLite-backed but
 	// reached over the network) must NOT be classified as embedded.
 	for _, h := range sakila.SQLAllExternal() {
-		assert.False(t, sakila.IsEmbedded(h), "%s should not be embedded", h)
+		assert.False(t, sakila.IsSQLEmbedded(h), "%s should not be embedded", h)
 	}
-	assert.False(t, sakila.IsEmbedded(sakila.RQ), "rqlite is external, not embedded")
+	assert.False(t, sakila.IsSQLEmbedded(sakila.RQ), "rqlite is external, not embedded")
+	// A non-SQL embedded source (CSV) is file-based but not a SQL driver, so it
+	// is not an embedded SQL source.
+	assert.False(t, sakila.IsSQLEmbedded(sakila.CSVActor), "CSV is not a SQL source")
+}
+
+// TestSQLPartition guards that SQLEmbedded and SQLAllExternal exactly partition
+// SQLAll. Adding an engine to SQLAll without classifying it in one of the two
+// partition lists is then caught here instead of silently misclassifying it.
+func TestSQLPartition(t *testing.T) {
+	t.Parallel()
+
+	partition := append(append([]string{}, sakila.SQLEmbedded()...), sakila.SQLAllExternal()...)
+	require.ElementsMatch(t, sakila.SQLAll(), partition,
+		"SQLEmbedded() + SQLAllExternal() must partition SQLAll()")
 }
 
 // TestCrossSourceDests asserts the cross-source pairing invariants that keep
@@ -36,18 +51,18 @@ func TestCrossSourceDests(t *testing.T) {
 	t.Parallel()
 
 	// Embedded origins pair with every engine.
-	for _, origin := range sakila.Embedded() {
+	for _, origin := range sakila.SQLEmbedded() {
 		assert.Equal(t, sakila.SQLLatest(), sakila.CrossSourceDests(origin),
 			"embedded origin %s should pair with all of SQLLatest", origin)
 	}
 
 	// External origins pair with exactly the embedded sources plus themselves.
 	for _, origin := range sakila.SQLLatest() {
-		if sakila.IsEmbedded(origin) {
+		if sakila.IsSQLEmbedded(origin) {
 			continue
 		}
 		dests := sakila.CrossSourceDests(origin)
-		assert.ElementsMatch(t, append(sakila.Embedded(), origin), dests,
+		assert.ElementsMatch(t, append(sakila.SQLEmbedded(), origin), dests,
 			"external origin %s should pair with embedded sources + itself", origin)
 	}
 
@@ -56,16 +71,16 @@ func TestCrossSourceDests(t *testing.T) {
 	for _, origin := range sakila.SQLLatest() {
 		for _, dest := range sakila.CrossSourceDests(origin) {
 			// No external x external CROSS pair (the O(N^2) cells #964 drops).
-			if !sakila.IsEmbedded(origin) && !sakila.IsEmbedded(dest) {
+			if !sakila.IsSQLEmbedded(origin) && !sakila.IsSQLEmbedded(dest) {
 				assert.Equal(t, origin, dest,
 					"external pair %s->%s must be a self-insert, not a cross pair", origin, dest)
 			}
 			// Every external engine is exercised against an embedded source in
 			// both directions (origin and dest), preserving per-engine coverage.
-			if !sakila.IsEmbedded(origin) && sakila.IsEmbedded(dest) {
+			if !sakila.IsSQLEmbedded(origin) && sakila.IsSQLEmbedded(dest) {
 				sawExternalAsOrigin = true
 			}
-			if sakila.IsEmbedded(origin) && !sakila.IsEmbedded(dest) {
+			if sakila.IsSQLEmbedded(origin) && !sakila.IsSQLEmbedded(dest) {
 				sawExternalAsDest = true
 			}
 		}
@@ -75,7 +90,7 @@ func TestCrossSourceDests(t *testing.T) {
 
 	// The external self-insert diagonal is retained for every external engine.
 	for _, h := range sakila.SQLLatest() {
-		if sakila.IsEmbedded(h) {
+		if sakila.IsSQLEmbedded(h) {
 			continue
 		}
 		assert.True(t, slices.Contains(sakila.CrossSourceDests(h), h),

--- a/testh/sakila/sakila_test.go
+++ b/testh/sakila/sakila_test.go
@@ -1,14 +1,87 @@
 package sakila_test
 
 import (
+	"slices"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/neilotoole/sq/testh"
 	"github.com/neilotoole/sq/testh/sakila"
 	"github.com/neilotoole/sq/testh/tu"
 )
+
+// TestEmbedded verifies that the embedded SQL handles are exactly SQLite and
+// DuckDB, and that IsEmbedded agrees with both Embedded and SQLAllExternal.
+func TestEmbedded(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, []string{sakila.SL3, sakila.Duck}, sakila.Embedded())
+
+	for _, h := range sakila.Embedded() {
+		assert.True(t, sakila.IsEmbedded(h), "%s should be embedded", h)
+	}
+	// Every external SQL source (including rqlite, which is SQLite-backed but
+	// reached over the network) must NOT be classified as embedded.
+	for _, h := range sakila.SQLAllExternal() {
+		assert.False(t, sakila.IsEmbedded(h), "%s should not be embedded", h)
+	}
+	assert.False(t, sakila.IsEmbedded(sakila.RQ), "rqlite is external, not embedded")
+}
+
+// TestCrossSourceDests asserts the cross-source pairing invariants that keep
+// the test matrix at {embedded}x{target} + self-inserts (see gh #964).
+func TestCrossSourceDests(t *testing.T) {
+	t.Parallel()
+
+	// Embedded origins pair with every engine.
+	for _, origin := range sakila.Embedded() {
+		assert.Equal(t, sakila.SQLLatest(), sakila.CrossSourceDests(origin),
+			"embedded origin %s should pair with all of SQLLatest", origin)
+	}
+
+	// External origins pair with exactly the embedded sources plus themselves.
+	for _, origin := range sakila.SQLLatest() {
+		if sakila.IsEmbedded(origin) {
+			continue
+		}
+		dests := sakila.CrossSourceDests(origin)
+		assert.ElementsMatch(t, append(sakila.Embedded(), origin), dests,
+			"external origin %s should pair with embedded sources + itself", origin)
+	}
+
+	// Whole-matrix invariants over SQLLatest x CrossSourceDests.
+	var sawExternalAsOrigin, sawExternalAsDest bool
+	for _, origin := range sakila.SQLLatest() {
+		for _, dest := range sakila.CrossSourceDests(origin) {
+			// No external x external CROSS pair (the O(N^2) cells #964 drops).
+			if !sakila.IsEmbedded(origin) && !sakila.IsEmbedded(dest) {
+				assert.Equal(t, origin, dest,
+					"external pair %s->%s must be a self-insert, not a cross pair", origin, dest)
+			}
+			// Every external engine is exercised against an embedded source in
+			// both directions (origin and dest), preserving per-engine coverage.
+			if !sakila.IsEmbedded(origin) && sakila.IsEmbedded(dest) {
+				sawExternalAsOrigin = true
+			}
+			if sakila.IsEmbedded(origin) && !sakila.IsEmbedded(dest) {
+				sawExternalAsDest = true
+			}
+		}
+	}
+	assert.True(t, sawExternalAsOrigin, "external engines should appear as origin paired with embedded")
+	assert.True(t, sawExternalAsDest, "external engines should appear as dest paired with embedded")
+
+	// The external self-insert diagonal is retained for every external engine.
+	for _, h := range sakila.SQLLatest() {
+		if sakila.IsEmbedded(h) {
+			continue
+		}
+		assert.True(t, slices.Contains(sakila.CrossSourceDests(h), h),
+			"external self-insert %s->%s should be retained", h, h)
+	}
+}
 
 // TestSakila_SQL is a sanity check for Sakila SQL test sources.
 func TestSakila_SQL(t *testing.T) { //nolint:tparallel


### PR DESCRIPTION
Closes #964. Follow-up to #958 / #966.

## Problem

The `--insert` cross-source matrices (`TestCmdSLQ_Insert`, `TestCmdSQL_Insert`) iterated the full `SQLLatest() × SQLLatest()` product — 7×7 = 49 cells. The 20 **external×external cross** cells (e.g. `@sakila_pg → @sakila_my`) need multiple external DB containers live at once, grow O(N²) with the number of SQL engines, and can't run under #958's per-engine CI legs — so they only ever ran on a full local stack.

## Change

- Add `sakila.SQLEmbedded()` / `sakila.IsSQLEmbedded(handle)` and `sakila.CrossSourceDests(origin)` to `testh/sakila`.
- Drive both matrices' inner loop from `CrossSourceDests(origin)` instead of `SQLLatest()`.

This keeps **{embedded}×{target}** coverage in both directions (every engine paired with SQLite/DuckDB as origin *and* dest) plus **same-source self-inserts**, while dropping only the external×external cross pairs (49 → 29 cells).

### Why keep the external self-insert diagonal

#964's literal wording would drop the whole external×external product, but its *rationale* is about multiple simultaneous containers + O(N²). A self-insert (`@sakila_pg → @sakila_pg`) is **one** container, both insert-test doc comments explicitly value *"same-database query-to-insert (PG→PG)"*, and the per-engine CI legs already run it. So the diagonal is retained deliberately; only the 20 multi-container cross pairs are dropped. The gh#779 `Duck→Duck` regression guard is preserved.

`TestCmdSLQ_Insert_MultipleSchemas` is unchanged — it's already a single-source external self-insert (#484 regression, Postgres/MySQL-only), consistent with the retained diagonal.

## Naming

The helper is `SQLEmbedded` / `IsSQLEmbedded` (not `Embedded`): the `SQL` prefix matches the sibling handle-set helpers (`SQLAll`, `SQLAllExternal`, `SQLLatest`) and disambiguates from non-SQL embedded sources — CSV/JSON/XLSX are file-based ("embedded") but not SQL drivers, and are excluded.

## Review feedback addressed (Copilot + workflow code review)

- **Removed** a dead `tu.SkipShort(origin == sakila.XLSX)` guard in `TestCmdSQL_Insert` (`SQLLatest()` never contains XLSX, so it was always false).
- **Single-sourced** the embedded set: `IsSQLEmbedded` derives from `SQLEmbedded` via `slices.Contains`.
- **Added `TestSQLPartition`** asserting `SQLEmbedded() + SQLAllExternal()` partitions `SQLAll()` — catches a future engine left unclassified.
- **Tightened** the `CrossSourceDests` doc to reference `SQLLatest()` (which omits rqlite) rather than "every engine".
- **Clarified the handle-set godocs** (`SQLAll`/`SQLAllExternal`/`SQLLatest`): the `SQLAll` vs `SQLLatest` distinction is now solely rqlite, and the version-era rationale on `SQLLatest` was stale; rewrote them to state the real relationships and cross-link the family.

## Verification

- New unit tests (`TestSQLEmbedded`, `TestSQLPartition`, `TestCrossSourceDests`) assert the invariants: no external×external cross pair, external self-insert diagonal retained, every external engine paired with embedded in both directions, rqlite and CSV classified non-embedded.
- Ran both insert tests locally: the subtest tree contains **zero** external-origin×external-dest cross pairs; embedded×embedded pairs (incl. `Duck→Duck`) pass; external cells skip when their container isn't up.
- `golangci-lint` clean, `go vet` clean, `dprint` clean. CI green.

## Follow-ups filed

- **#986** — promote "embedded SQL" to a first-class driver property (`driver.Metadata.IsEmbeddedSQL` or a capability method); the `testh/sakila` helper here is the deliberately minimal, test-scoped classification for now.
- **#988** — remove the now-vestigial single-handle `sakila.PgAll/MyAll/MSAll` helpers (24 driver-test call sites); optionally rename `SQLLatest`.