### PR TITLE
test: remove vestigial sakila.PgAll/MyAll/MSAll helpers (#988)

### DIFF
--- a/drivers/mysql/db_type_test.go
+++ b/drivers/mysql/db_type_test.go
@@ -332,32 +332,25 @@ func createTypeTestTable(th *testh.Helper, src *source.Source, withData bool) (n
 // for various database types, inserts known data, and checks that
 // the returned data matches the inserted data, including verifying
 // that NULL is handled correctly.
-func TestDatabaseTypes(t *testing.T) { //nolint:tparallel
+func TestDatabaseTypes(t *testing.T) {
 	const wantRowCount = 3
 
-	testCases := sakila.MyAll()
-	for _, handle := range testCases {
-		t.Run(handle, func(t *testing.T) {
-			t.Parallel()
+	th := testh.New(t)
+	src := th.Source(sakila.My)
+	t.Logf("using source %s: %s", src.Handle, src.Location)
 
-			th := testh.New(t)
-			src := th.Source(handle)
-			t.Logf("using source %s: %s", src.Handle, src.Location)
+	actualTblName := createTypeTestTable(th, src, true)
+	t.Cleanup(func() { th.DropTable(src, tablefq.From(actualTblName)) })
 
-			actualTblName := createTypeTestTable(th, src, true)
-			t.Cleanup(func() { th.DropTable(src, tablefq.From(actualTblName)) })
+	sink := &testh.RecordSink{}
+	recw := output.NewRecordWriterAdapter(th.Context, sink)
+	err := libsq.QuerySQL(th.Context, th.Open(src), nil, recw, nil, "SELECT * FROM "+actualTblName)
+	require.NoError(t, err)
+	written, err := recw.Wait()
+	require.NoError(t, err)
 
-			sink := &testh.RecordSink{}
-			recw := output.NewRecordWriterAdapter(th.Context, sink)
-			err := libsq.QuerySQL(th.Context, th.Open(src), nil, recw, nil, "SELECT * FROM "+actualTblName)
-			require.NoError(t, err)
-			written, err := recw.Wait()
-			require.NoError(t, err)
-
-			require.Equal(t, int64(wantRowCount), written)
-			require.Equal(t, wantRowCount, len(sink.Recs))
-		})
-	}
+	require.Equal(t, int64(wantRowCount), written)
+	require.Equal(t, wantRowCount, len(sink.Recs))
 }
 
 // TestDatabaseTypeJSON explicitly tests the JSON type

--- a/drivers/mysql/db_type_test.go
+++ b/drivers/mysql/db_type_test.go
@@ -333,6 +333,8 @@ func createTypeTestTable(th *testh.Helper, src *source.Source, withData bool) (n
 // the returned data matches the inserted data, including verifying
 // that NULL is handled correctly.
 func TestDatabaseTypes(t *testing.T) {
+	t.Parallel()
+
 	const wantRowCount = 3
 
 	th := testh.New(t)

--- a/drivers/mysql/metadata_test.go
+++ b/drivers/mysql/metadata_test.go
@@ -74,38 +74,25 @@ func TestKindFromDBTypeName(t *testing.T) {
 func TestDatabase_SourceMetadata_MySQL(t *testing.T) {
 	t.Parallel()
 
-	handles := sakila.MyAll()
-	for _, handle := range handles {
-		t.Run(handle, func(t *testing.T) {
-			t.Parallel()
+	th, _, _, grip, _ := testh.NewWith(t, sakila.My)
+	md, err := grip.SourceMetadata(th.Context, false)
+	require.NoError(t, err)
+	require.Equal(t, "sakila", md.Name)
+	require.Equal(t, sakila.My, md.Handle)
 
-			th, _, _, grip, _ := testh.NewWith(t, handle)
-			md, err := grip.SourceMetadata(th.Context, false)
-			require.NoError(t, err)
-			require.Equal(t, "sakila", md.Name)
-			require.Equal(t, handle, md.Handle)
-
-			tblActor := md.Tables[0]
-			require.Equal(t, sakila.TblActor, tblActor.Name)
-			require.Equal(t, int64(sakila.TblActorCount), tblActor.RowCount)
-			require.Equal(t, len(sakila.TblActorCols()), len(tblActor.Columns))
-		})
-	}
+	tblActor := md.Tables[0]
+	require.Equal(t, sakila.TblActor, tblActor.Name)
+	require.Equal(t, int64(sakila.TblActorCount), tblActor.RowCount)
+	require.Equal(t, len(sakila.TblActorCols()), len(tblActor.Columns))
 }
 
 func TestDatabase_TableMetadata(t *testing.T) {
 	t.Parallel()
 
-	for _, handle := range sakila.MyAll() {
-		t.Run(handle, func(t *testing.T) {
-			t.Parallel()
-
-			th, _, _, grip, _ := testh.NewWith(t, handle)
-			md, err := grip.TableMetadata(th.Context, sakila.TblActor)
-			require.NoError(t, err)
-			require.Equal(t, sakila.TblActor, md.Name)
-		})
-	}
+	th, _, _, grip, _ := testh.NewWith(t, sakila.My)
+	md, err := grip.TableMetadata(th.Context, sakila.TblActor)
+	require.NoError(t, err)
+	require.Equal(t, sakila.TblActor, md.Name)
 }
 
 func TestGetTableRowCounts(t *testing.T) {
@@ -171,36 +158,30 @@ func TestForeignKey_CompositeOrdering_MySQL(t *testing.T) {
 	tu.SkipShort(t, true)
 	t.Parallel()
 
-	for _, handle := range sakila.MyAll() {
-		t.Run(handle, func(t *testing.T) {
-			t.Parallel()
+	th := testh.New(t)
+	src := th.Source(sakila.My)
+	db := th.OpenDB(src)
 
-			th := testh.New(t)
-			src := th.Source(handle)
-			db := th.OpenDB(src)
+	parent := stringz.UniqTableName("fk_comp_parent")
+	child := stringz.UniqTableName("fk_comp_child")
+	_, err := db.ExecContext(th.Context,
+		"CREATE TABLE "+parent+" (a INT, b INT, PRIMARY KEY (b, a)) ENGINE=InnoDB")
+	require.NoError(t, err)
+	t.Cleanup(func() { th.DropTable(src, tablefq.From(parent)) })
+	_, err = db.ExecContext(th.Context,
+		"CREATE TABLE "+child+" (x INT, y INT, FOREIGN KEY (x, y) REFERENCES "+parent+
+			" (b, a)) ENGINE=InnoDB")
+	require.NoError(t, err)
+	t.Cleanup(func() { th.DropTable(src, tablefq.From(child)) })
 
-			parent := stringz.UniqTableName("fk_comp_parent")
-			child := stringz.UniqTableName("fk_comp_child")
-			_, err := db.ExecContext(th.Context,
-				"CREATE TABLE "+parent+" (a INT, b INT, PRIMARY KEY (b, a)) ENGINE=InnoDB")
-			require.NoError(t, err)
-			t.Cleanup(func() { th.DropTable(src, tablefq.From(parent)) })
-			_, err = db.ExecContext(th.Context,
-				"CREATE TABLE "+child+" (x INT, y INT, FOREIGN KEY (x, y) REFERENCES "+parent+
-					" (b, a)) ENGINE=InnoDB")
-			require.NoError(t, err)
-			t.Cleanup(func() { th.DropTable(src, tablefq.From(child)) })
-
-			md, err := th.Open(src).TableMetadata(th.Context, child)
-			require.NoError(t, err)
-			require.NotNil(t, md.FK)
-			require.Len(t, md.FK.Outgoing, 1)
-			fk := md.FK.Outgoing[0]
-			require.Equal(t, parent, fk.RefTable)
-			require.Equal(t, []string{"x", "y"}, fk.Columns)
-			require.Equal(t, []string{"b", "a"}, fk.RefColumns)
-		})
-	}
+	md, err := th.Open(src).TableMetadata(th.Context, child)
+	require.NoError(t, err)
+	require.NotNil(t, md.FK)
+	require.Len(t, md.FK.Outgoing, 1)
+	fk := md.FK.Outgoing[0]
+	require.Equal(t, parent, fk.RefTable)
+	require.Equal(t, []string{"x", "y"}, fk.Columns)
+	require.Equal(t, []string{"b", "a"}, fk.RefColumns)
 }
 
 // TestMySQL_ColumnFlags verifies that AUTO_INCREMENT, GENERATED, GeneratedExpr,
@@ -441,32 +422,26 @@ func TestForeignKey_OnDeleteOnUpdate_MySQL(t *testing.T) {
 	tu.SkipShort(t, true)
 	t.Parallel()
 
-	for _, handle := range sakila.MyAll() {
-		t.Run(handle, func(t *testing.T) {
-			t.Parallel()
+	th := testh.New(t)
+	src := th.Source(sakila.My)
+	db := th.OpenDB(src)
 
-			th := testh.New(t)
-			src := th.Source(handle)
-			db := th.OpenDB(src)
+	parent := stringz.UniqTableName("fk_act_parent")
+	child := stringz.UniqTableName("fk_act_child")
+	_, err := db.ExecContext(th.Context,
+		"CREATE TABLE "+parent+" (id INT PRIMARY KEY) ENGINE=InnoDB")
+	require.NoError(t, err)
+	t.Cleanup(func() { th.DropTable(src, tablefq.From(parent)) })
+	_, err = db.ExecContext(th.Context,
+		"CREATE TABLE "+child+" (parent_id INT, FOREIGN KEY (parent_id) REFERENCES "+parent+
+			" (id) ON DELETE CASCADE ON UPDATE SET NULL) ENGINE=InnoDB")
+	require.NoError(t, err)
+	t.Cleanup(func() { th.DropTable(src, tablefq.From(child)) })
 
-			parent := stringz.UniqTableName("fk_act_parent")
-			child := stringz.UniqTableName("fk_act_child")
-			_, err := db.ExecContext(th.Context,
-				"CREATE TABLE "+parent+" (id INT PRIMARY KEY) ENGINE=InnoDB")
-			require.NoError(t, err)
-			t.Cleanup(func() { th.DropTable(src, tablefq.From(parent)) })
-			_, err = db.ExecContext(th.Context,
-				"CREATE TABLE "+child+" (parent_id INT, FOREIGN KEY (parent_id) REFERENCES "+parent+
-					" (id) ON DELETE CASCADE ON UPDATE SET NULL) ENGINE=InnoDB")
-			require.NoError(t, err)
-			t.Cleanup(func() { th.DropTable(src, tablefq.From(child)) })
-
-			md, err := th.Open(src).TableMetadata(th.Context, child)
-			require.NoError(t, err)
-			require.Len(t, md.FK.Outgoing, 1)
-			fk := md.FK.Outgoing[0]
-			require.Equal(t, "CASCADE", fk.OnDelete)
-			require.Equal(t, "SET NULL", fk.OnUpdate)
-		})
-	}
+	md, err := th.Open(src).TableMetadata(th.Context, child)
+	require.NoError(t, err)
+	require.Len(t, md.FK.Outgoing, 1)
+	fk := md.FK.Outgoing[0]
+	require.Equal(t, "CASCADE", fk.OnDelete)
+	require.Equal(t, "SET NULL", fk.OnUpdate)
 }

--- a/drivers/mysql/metadata_test.go
+++ b/drivers/mysql/metadata_test.go
@@ -151,9 +151,10 @@ func TestIndexes_ExpressionArity_MySQL(t *testing.T) {
 // (x, y) ascending so any loader bug that sorts either side
 // independently — or pairs by name rather than by position — is
 // caught (an alphabetic-on-both-sides fixture would let such a bug
-// slip past). Looped across MyAll() because INFORMATION_SCHEMA
-// column casing has historically differed between MySQL 5.6/5.7 and
-// 8.0 — a real regression vector for this loader.
+// slip past). INFORMATION_SCHEMA column casing has historically
+// differed between MySQL versions (5.6/5.7 vs 8.0), a real regression
+// vector for this loader; the test runs against whichever MySQL version
+// the CI matrix targets (gh #958).
 func TestForeignKey_CompositeOrdering_MySQL(t *testing.T) {
 	tu.SkipShort(t, true)
 	t.Parallel()
@@ -413,11 +414,11 @@ func TestMySQL_ViewDefinition(t *testing.T) {
 // TestForeignKey_OnDeleteOnUpdate_MySQL pins that the loader populates
 // OnDelete / OnUpdate from INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS
 // with the explicit non-default actions ("CASCADE" / "SET NULL").
-// Looped across MyAll() — MySQL only enforces FKs under InnoDB (the
-// DDL pins ENGINE=InnoDB explicitly) and the REFERENTIAL_CONSTRAINTS
-// view's column casing has shifted between 5.6/5.7 and 8.0, so a
-// per-version regression in the loader's column-name unmarshaling
-// would surface here.
+// MySQL only enforces FKs under InnoDB (the DDL pins ENGINE=InnoDB
+// explicitly), and the REFERENTIAL_CONSTRAINTS view's column casing has
+// shifted between MySQL versions (5.6/5.7 vs 8.0), so a per-version
+// regression in the loader's column-name unmarshaling would surface
+// here, against whichever version the CI matrix runs (gh #958).
 func TestForeignKey_OnDeleteOnUpdate_MySQL(t *testing.T) {
 	tu.SkipShort(t, true)
 	t.Parallel()

--- a/drivers/mysql/mysql_test.go
+++ b/drivers/mysql/mysql_test.go
@@ -16,77 +16,59 @@ import (
 func TestSmoke(t *testing.T) {
 	t.Parallel()
 
-	for _, handle := range sakila.MyAll() {
-		t.Run(handle, func(t *testing.T) {
-			t.Parallel()
-
-			th, src, _, _, _ := testh.NewWith(t, handle)
-			sink, err := th.QuerySQL(src, nil, "SELECT * FROM actor")
-			require.NoError(t, err)
-			require.Equal(t, len(sakila.TblActorCols()), len(sink.RecMeta))
-			require.Equal(t, sakila.TblActorCount, len(sink.Recs))
-		})
-	}
+	th, src, _, _, _ := testh.NewWith(t, sakila.My)
+	sink, err := th.QuerySQL(src, nil, "SELECT * FROM actor")
+	require.NoError(t, err)
+	require.Equal(t, len(sakila.TblActorCols()), len(sink.RecMeta))
+	require.Equal(t, sakila.TblActorCount, len(sink.Recs))
 }
 
 func TestDriver_CreateTable_NotNullDefault(t *testing.T) {
 	t.Parallel()
 
-	testCases := sakila.MyAll()
-	for _, handle := range testCases {
-		t.Run(handle, func(t *testing.T) {
-			t.Parallel()
+	th, src, drvr, _, db := testh.NewWith(t, sakila.My)
 
-			th, src, drvr, _, db := testh.NewWith(t, handle)
+	tblName := stringz.UniqTableName(t.Name())
+	colNames, colKinds := fixt.ColNamePerKind(drvr.Dialect().IntBool, false, false)
 
-			tblName := stringz.UniqTableName(t.Name())
-			colNames, colKinds := fixt.ColNamePerKind(drvr.Dialect().IntBool, false, false)
+	tblDef := schema.NewTable(tblName, colNames, colKinds)
+	for _, colDef := range tblDef.Cols {
+		colDef.NotNull = true
+		colDef.HasDefault = true
+	}
 
-			tblDef := schema.NewTable(tblName, colNames, colKinds)
-			for _, colDef := range tblDef.Cols {
-				colDef.NotNull = true
-				colDef.HasDefault = true
-			}
+	err := drvr.CreateTable(th.Context, db, tblDef)
+	require.NoError(t, err)
+	t.Cleanup(func() { th.DropTable(src, tablefq.From(tblName)) })
 
-			err := drvr.CreateTable(th.Context, db, tblDef)
-			require.NoError(t, err)
-			t.Cleanup(func() { th.DropTable(src, tablefq.From(tblName)) })
+	// MySQL doesn't support default values for TEXT or BLOB
+	// See: https://bugs.mysql.com/bug.php?id=21532
+	// So, instead of "INSERT INTO tblName () VALUES ()" we
+	// need to provide explicit values for col_text and col_bytes.
+	insertDefaultStmt := "INSERT INTO " + tblName + " (col_text, col_bytes) VALUES (?, ?)"
+	affected := th.ExecSQL(src, insertDefaultStmt, "", []byte{})
+	require.Equal(t, int64(1), affected)
 
-			// MySQL doesn't support default values for TEXT or BLOB
-			// See: https://bugs.mysql.com/bug.php?id=21532
-			// So, instead of "INSERT INTO tblName () VALUES ()" we
-			// need to provide explicit values for col_text and col_bytes.
-			insertDefaultStmt := "INSERT INTO " + tblName + " (col_text, col_bytes) VALUES (?, ?)"
-			affected := th.ExecSQL(src, insertDefaultStmt, "", []byte{})
-			require.Equal(t, int64(1), affected)
-
-			sink, err := th.QuerySQL(src, nil, "SELECT * FROM "+tblName)
-			require.NoError(t, err)
-			require.Equal(t, 1, len(sink.Recs))
-			require.Equal(t, len(colNames), len(sink.RecMeta))
-			for i := range colNames {
-				require.NotNil(t, sink.Recs[0][i])
-				nullable, ok := sink.RecMeta[i].Nullable()
-				require.True(t, ok)
-				require.False(t, nullable)
-			}
-		})
+	sink, err := th.QuerySQL(src, nil, "SELECT * FROM "+tblName)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(sink.Recs))
+	require.Equal(t, len(colNames), len(sink.RecMeta))
+	for i := range colNames {
+		require.NotNil(t, sink.Recs[0][i])
+		nullable, ok := sink.RecMeta[i].Nullable()
+		require.True(t, ok)
+		require.False(t, nullable)
 	}
 }
 
 // TestBug252_ShowCollation_uint64 tests the
 // bug https://github.com/neilotoole/sq/issues/252.
 func TestBug252_ShowCollation_uint64(t *testing.T) {
-	testCases := sakila.MyAll()
-	for _, handle := range testCases {
-		t.Run(handle, func(t *testing.T) {
-			th, src, _, _, _ := testh.NewWith(t, handle)
+	th, src, _, _, _ := testh.NewWith(t, sakila.My)
 
-			sink, err := th.QuerySQL(src, nil, "SHOW COLLATION")
-			require.NoError(t, err)
-			require.NotNil(t, sink)
-		})
-	}
+	sink, err := th.QuerySQL(src, nil, "SHOW COLLATION")
+	require.NoError(t, err)
+	require.NotNil(t, sink)
 }
 
 // TestNumericSchema tests that numeric and numeric-prefixed database names

--- a/drivers/postgres/db_type_test.go
+++ b/drivers/postgres/db_type_test.go
@@ -439,22 +439,15 @@ func createTypeTestTable(th *testh.Helper, src *source.Source, withData bool) (r
 func TestDatabaseTypes(t *testing.T) {
 	t.Parallel()
 
-	testCases := sakila.PgAll()
-	for _, handle := range testCases {
-		t.Run(handle, func(t *testing.T) {
-			t.Parallel()
-
-			th := testh.New(t)
-			src := th.Source(handle)
-			insertCount, actualTblName := createTypeTestTable(th, src, true)
-			t.Cleanup(func() { th.DropTable(src, tablefq.From(actualTblName)) })
-			sink := &testh.RecordSink{}
-			recw := output.NewRecordWriterAdapter(th.Context, sink)
-			err := libsq.QuerySQL(th.Context, th.Open(src), nil, recw, nil, "SELECT * FROM "+actualTblName)
-			require.NoError(t, err)
-			written, err := recw.Wait()
-			require.NoError(t, err)
-			require.Equal(t, insertCount, written)
-		})
-	}
+	th := testh.New(t)
+	src := th.Source(sakila.Pg)
+	insertCount, actualTblName := createTypeTestTable(th, src, true)
+	t.Cleanup(func() { th.DropTable(src, tablefq.From(actualTblName)) })
+	sink := &testh.RecordSink{}
+	recw := output.NewRecordWriterAdapter(th.Context, sink)
+	err := libsq.QuerySQL(th.Context, th.Open(src), nil, recw, nil, "SELECT * FROM "+actualTblName)
+	require.NoError(t, err)
+	written, err := recw.Wait()
+	require.NoError(t, err)
+	require.Equal(t, insertCount, written)
 }

--- a/drivers/postgres/postgres_test.go
+++ b/drivers/postgres/postgres_test.go
@@ -25,56 +25,44 @@ import (
 func TestSmoke(t *testing.T) {
 	t.Parallel()
 
-	for _, handle := range sakila.PgAll() {
-		t.Run(handle, func(t *testing.T) {
-			t.Parallel()
-
-			th, src, _, _, _ := testh.NewWith(t, handle)
-			sink, err := th.QuerySQL(src, nil, "SELECT * FROM actor")
-			require.NoError(t, err)
-			require.Equal(t, len(sakila.TblActorCols()), len(sink.RecMeta))
-			require.Equal(t, sakila.TblActorCount, len(sink.Recs))
-		})
-	}
+	th, src, _, _, _ := testh.NewWith(t, sakila.Pg)
+	sink, err := th.QuerySQL(src, nil, "SELECT * FROM actor")
+	require.NoError(t, err)
+	require.Equal(t, len(sakila.TblActorCols()), len(sink.RecMeta))
+	require.Equal(t, sakila.TblActorCount, len(sink.Recs))
 }
 
 func TestDriverBehavior(t *testing.T) {
 	// This test was created to help understand the behavior of the driver impl.
 	// It can be deleted eventually.
-	testCases := sakila.PgAll()
+	th := testh.New(t)
+	src := th.Source(sakila.Pg)
+	db := th.OpenDB(src)
 
-	for _, handle := range testCases {
-		t.Run(handle, func(t *testing.T) {
-			th := testh.New(t)
-			src := th.Source(handle)
-			db := th.OpenDB(src)
-
-			query := `SELECT
+	query := `SELECT
        (SELECT actor_id FROM actor limit 1) AS actor_id,
        (SELECT first_name FROM actor LIMIT 1) AS first_name,
        (SELECT last_name FROM actor LIMIT 1) AS last_name
 LIMIT 1`
 
-			rows, err := db.QueryContext(th.Context, query)
-			require.NoError(t, err)
-			require.NoError(t, rows.Err())
-			t.Cleanup(func() { assert.NoError(t, rows.Close()) })
+	rows, err := db.QueryContext(th.Context, query)
+	require.NoError(t, err)
+	require.NoError(t, rows.Err())
+	t.Cleanup(func() { assert.NoError(t, rows.Close()) })
 
-			colTypes, err := rows.ColumnTypes()
-			require.NoError(t, err)
+	colTypes, err := rows.ColumnTypes()
+	require.NoError(t, err)
 
-			for i, colType := range colTypes {
-				nullable, ok := colType.Nullable()
-				t.Logf("%d:	%s	%s	%s	nullable,ok={%v,%v}", i, colType.Name(), colType.DatabaseTypeName(),
-					colType.ScanType().Name(), nullable, ok)
+	for i, colType := range colTypes {
+		nullable, ok := colType.Nullable()
+		t.Logf("%d:	%s	%s	%s	nullable,ok={%v,%v}", i, colType.Name(), colType.DatabaseTypeName(),
+			colType.ScanType().Name(), nullable, ok)
 
-				if !nullable {
-					scanType := colType.ScanType()
-					z := reflect.Zero(scanType)
-					t.Logf("zero: %T %v", z, z)
-				}
-			}
-		})
+		if !nullable {
+			scanType := colType.ScanType()
+			z := reflect.Zero(scanType)
+			t.Logf("zero: %T %v", z, z)
+		}
 	}
 }
 
@@ -86,96 +74,76 @@ func Test_VerifyDriverDoesNotReportNullability(t *testing.T) {
 	// When/if the driver is modified to behave as hoped (if
 	// at all possible) then we can simplify the
 	// postgres driver wrapper.
-	testCases := sakila.PgAll()
-	for _, handle := range testCases {
-		t.Run(handle, func(t *testing.T) {
-			t.Parallel()
+	th := testh.New(t)
+	src := th.Source(sakila.Pg)
+	db := th.OpenDB(src)
 
-			th := testh.New(t)
-			src := th.Source(handle)
-			db := th.OpenDB(src)
+	_, actualTblName := createTypeTestTable(th, src, true)
+	t.Cleanup(func() { th.DropTable(src, tablefq.From(actualTblName)) })
 
-			_, actualTblName := createTypeTestTable(th, src, true)
-			t.Cleanup(func() { th.DropTable(src, tablefq.From(actualTblName)) })
+	rows, err := db.Query("SELECT * FROM " + actualTblName)
+	require.NoError(t, err)
+	require.NoError(t, rows.Err())
+	t.Cleanup(func() { assert.NoError(t, rows.Close()) })
 
-			rows, err := db.Query("SELECT * FROM " + actualTblName)
-			require.NoError(t, err)
-			require.NoError(t, rows.Err())
-			t.Cleanup(func() { assert.NoError(t, rows.Close()) })
+	colTypes, err := rows.ColumnTypes()
+	require.NoError(t, err)
 
-			colTypes, err := rows.ColumnTypes()
-			require.NoError(t, err)
+	for _, colType := range colTypes {
+		colName := colType.Name()
 
-			for _, colType := range colTypes {
-				colName := colType.Name()
+		// The _n suffix indicates a nullable col
+		if !strings.HasSuffix(colName, "_n") {
+			continue
+		}
 
-				// The _n suffix indicates a nullable col
-				if !strings.HasSuffix(colName, "_n") {
-					continue
-				}
+		// The col is indicated as nullable via its name/suffix
+		nullable, hasNullable := colType.Nullable()
+		require.False(t, hasNullable, "ColumnType.hasNullable is unfortunately expected to be false for {%s}",
+			colName)
+		require.False(t, nullable, "ColumnType.nullable is unfortunately expected to be false for {%s}", colName)
+	}
 
-				// The col is indicated as nullable via its name/suffix
-				nullable, hasNullable := colType.Nullable()
-				require.False(t, hasNullable, "ColumnType.hasNullable is unfortunately expected to be false for {%s}",
-					colName)
-				require.False(t, nullable, "ColumnType.nullable is unfortunately expected to be false for {%s}", colName)
-			}
-
-			for rows.Next() {
-				require.NoError(t, rows.Err())
-			}
-		})
+	for rows.Next() {
+		require.NoError(t, rows.Err())
 	}
 }
 
 func TestGetTableColumnNames(t *testing.T) {
-	testCases := sakila.PgAll()
-
-	for _, handle := range testCases {
-		t.Run(handle, func(t *testing.T) {
-			th, _, _, _, db := testh.NewWith(t, handle)
-			colNames, err := postgres.GetTableColumnNames(th.Context, db, sakila.TblActor)
-			require.NoError(t, err)
-			require.Equal(t, sakila.TblActorCols(), colNames)
-		})
-	}
+	th, _, _, _, db := testh.NewWith(t, sakila.Pg)
+	colNames, err := postgres.GetTableColumnNames(th.Context, db, sakila.TblActor)
+	require.NoError(t, err)
+	require.Equal(t, sakila.TblActorCols(), colNames)
 }
 
 func TestDriver_CreateTable_NotNullDefault(t *testing.T) {
 	t.Parallel()
 
-	testCases := sakila.PgAll()
-	for _, handle := range testCases {
-		t.Run(handle, func(t *testing.T) {
-			t.Parallel()
+	th, src, drvr, _, db := testh.NewWith(t, sakila.Pg)
 
-			th, src, drvr, _, db := testh.NewWith(t, handle)
+	tblName := stringz.UniqTableName(t.Name())
+	colNames, colKinds := fixt.ColNamePerKind(drvr.Dialect().IntBool, false, false)
 
-			tblName := stringz.UniqTableName(t.Name())
-			colNames, colKinds := fixt.ColNamePerKind(drvr.Dialect().IntBool, false, false)
+	tblDef := schema.NewTable(tblName, colNames, colKinds)
+	for _, colDef := range tblDef.Cols {
+		colDef.NotNull = true
+		colDef.HasDefault = true
+	}
 
-			tblDef := schema.NewTable(tblName, colNames, colKinds)
-			for _, colDef := range tblDef.Cols {
-				colDef.NotNull = true
-				colDef.HasDefault = true
-			}
+	err := drvr.CreateTable(th.Context, db, tblDef)
+	require.NoError(t, err)
+	t.Cleanup(func() { th.DropTable(src, tablefq.From(tblName)) })
 
-			err := drvr.CreateTable(th.Context, db, tblDef)
-			require.NoError(t, err)
-			t.Cleanup(func() { th.DropTable(src, tablefq.From(tblName)) })
+	th.InsertDefaultRow(src, tblName)
 
-			th.InsertDefaultRow(src, tblName)
-
-			sink, err := th.QuerySQL(src, nil, "SELECT * FROM "+tblName)
-			require.NoError(t, err)
-			require.Equal(t, 1, len(sink.Recs))
-			require.Equal(t, len(colNames), len(sink.RecMeta))
-			for i := range colNames {
-				require.NotNil(t, sink.Recs[0][i])
-				_, ok := sink.RecMeta[i].Nullable()
-				require.False(t, ok, "postgres driver doesn't report nullability")
-			}
-		})
+	sink, err := th.QuerySQL(src, nil, "SELECT * FROM "+tblName)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(sink.Recs))
+	require.Equal(t, len(colNames), len(sink.RecMeta))
+	for i := range colNames {
+		require.NotNil(t, sink.Recs[0][i])
+		_, ok := sink.RecMeta[i].Nullable()
+		require.False(t, ok, "postgres driver doesn't report nullability")
 	}
 }
 
@@ -401,17 +369,13 @@ func TestNumericSchema_CatalogSchema(t *testing.T) {
 }
 
 func BenchmarkDatabase_SourceMetadata(b *testing.B) {
-	for _, handle := range sakila.PgAll() {
-		b.Run(handle, func(b *testing.B) {
-			th := testh.New(b, testh.OptNoLog())
-			grip := th.Open(th.Source(handle))
-			b.ResetTimer()
+	th := testh.New(b, testh.OptNoLog())
+	grip := th.Open(th.Source(sakila.Pg))
+	b.ResetTimer()
 
-			md, err := grip.SourceMetadata(th.Context, false)
-			require.NoError(b, err)
-			require.Equal(b, "sakila", md.Name)
-		})
-	}
+	md, err := grip.SourceMetadata(th.Context, false)
+	require.NoError(b, err)
+	require.Equal(b, "sakila", md.Name)
 }
 
 func TestIsErrRelationDoesNotExist(t *testing.T) {

--- a/drivers/sqlserver/metadata_test.go
+++ b/drivers/sqlserver/metadata_test.go
@@ -19,50 +19,44 @@ func TestInspect_ColumnFlags_SQLServer(t *testing.T) {
 	tu.SkipShort(t, true)
 	t.Parallel()
 
-	for _, handle := range sakila.MSAll() {
-		t.Run(handle, func(t *testing.T) {
-			t.Parallel()
+	th := testh.New(t)
+	src := th.Source(sakila.MS)
+	db := th.OpenDB(src)
 
-			th := testh.New(t)
-			src := th.Source(handle)
-			db := th.OpenDB(src)
+	tblName := stringz.UniqTableName("col_flags")
+	// Computed column expression uses COLLATE DATABASE_DEFAULT to resolve
+	// the collation conflict between Latin1_General_BIN (first_name) and
+	// the server's default collation (last_name and the string literal).
+	_, err := db.ExecContext(th.Context, `CREATE TABLE `+tblName+` (
+		id         INT          IDENTITY(1,1) NOT NULL PRIMARY KEY,
+		first_name NVARCHAR(50) COLLATE Latin1_General_BIN NOT NULL,
+		last_name  NVARCHAR(50) NOT NULL,
+		full_name  AS (first_name COLLATE DATABASE_DEFAULT + N' ' + last_name)
+	)`)
+	require.NoError(t, err)
+	t.Cleanup(func() { th.DropTable(src, tablefq.From(tblName)) })
 
-			tblName := stringz.UniqTableName("col_flags")
-			// Computed column expression uses COLLATE DATABASE_DEFAULT to resolve
-			// the collation conflict between Latin1_General_BIN (first_name) and
-			// the server's default collation (last_name and the string literal).
-			_, err := db.ExecContext(th.Context, `CREATE TABLE `+tblName+` (
-				id         INT          IDENTITY(1,1) NOT NULL PRIMARY KEY,
-				first_name NVARCHAR(50) COLLATE Latin1_General_BIN NOT NULL,
-				last_name  NVARCHAR(50) NOT NULL,
-				full_name  AS (first_name COLLATE DATABASE_DEFAULT + N' ' + last_name)
-			)`)
-			require.NoError(t, err)
-			t.Cleanup(func() { th.DropTable(src, tablefq.From(tblName)) })
+	md, err := th.Open(src).TableMetadata(th.Context, tblName)
+	require.NoError(t, err)
+	require.Len(t, md.Columns, 4)
 
-			md, err := th.Open(src).TableMetadata(th.Context, tblName)
-			require.NoError(t, err)
-			require.Len(t, md.Columns, 4)
+	// id → IDENTITY
+	idCol := md.Columns[0]
+	require.Equal(t, "id", idCol.Name)
+	require.True(t, idCol.Identity, "id column must be Identity=true")
+	require.False(t, idCol.Generated, "id column must not be Generated")
 
-			// id → IDENTITY
-			idCol := md.Columns[0]
-			require.Equal(t, "id", idCol.Name)
-			require.True(t, idCol.Identity, "id column must be Identity=true")
-			require.False(t, idCol.Generated, "id column must not be Generated")
+	// first_name → explicit collation
+	fnCol := md.Columns[1]
+	require.Equal(t, "first_name", fnCol.Name)
+	require.Equal(t, "Latin1_General_BIN", fnCol.Collation,
+		"first_name must carry its explicit Latin1_General_BIN collation")
 
-			// first_name → explicit collation
-			fnCol := md.Columns[1]
-			require.Equal(t, "first_name", fnCol.Name)
-			require.Equal(t, "Latin1_General_BIN", fnCol.Collation,
-				"first_name must carry its explicit Latin1_General_BIN collation")
-
-			// full_name → computed/generated
-			fqCol := md.Columns[3]
-			require.Equal(t, "full_name", fqCol.Name)
-			require.True(t, fqCol.Generated, "full_name must be Generated=true")
-			require.NotEmpty(t, fqCol.GeneratedExpr, "full_name must have a non-empty GeneratedExpr")
-		})
-	}
+	// full_name → computed/generated
+	fqCol := md.Columns[3]
+	require.Equal(t, "full_name", fqCol.Name)
+	require.True(t, fqCol.Generated, "full_name must be Generated=true")
+	require.NotEmpty(t, fqCol.GeneratedExpr, "full_name must have a non-empty GeneratedExpr")
 }
 
 // TestInspect_CheckConstraints_SQLServer verifies that CHECK constraints
@@ -71,35 +65,29 @@ func TestInspect_CheckConstraints_SQLServer(t *testing.T) {
 	tu.SkipShort(t, true)
 	t.Parallel()
 
-	for _, handle := range sakila.MSAll() {
-		t.Run(handle, func(t *testing.T) {
-			t.Parallel()
+	th := testh.New(t)
+	src := th.Source(sakila.MS)
+	db := th.OpenDB(src)
 
-			th := testh.New(t)
-			src := th.Source(handle)
-			db := th.OpenDB(src)
+	tblName := stringz.UniqTableName("chk_test")
+	// SQL Server constraint names are database-scoped (not table-scoped),
+	// so we use a unique name to avoid conflicts across parallel test runs.
+	checkName := stringz.UniqTableName("chk_age")
+	_, err := db.ExecContext(th.Context, `CREATE TABLE `+tblName+` (
+		id  INT NOT NULL PRIMARY KEY,
+		age INT NOT NULL,
+		CONSTRAINT `+checkName+` CHECK (age >= 0)
+	)`)
+	require.NoError(t, err)
+	t.Cleanup(func() { th.DropTable(src, tablefq.From(tblName)) })
 
-			tblName := stringz.UniqTableName("chk_test")
-			// SQL Server constraint names are database-scoped (not table-scoped),
-			// so we use a unique name to avoid conflicts across parallel test runs.
-			checkName := stringz.UniqTableName("chk_age")
-			_, err := db.ExecContext(th.Context, `CREATE TABLE `+tblName+` (
-				id  INT NOT NULL PRIMARY KEY,
-				age INT NOT NULL,
-				CONSTRAINT `+checkName+` CHECK (age >= 0)
-			)`)
-			require.NoError(t, err)
-			t.Cleanup(func() { th.DropTable(src, tablefq.From(tblName)) })
-
-			md, err := th.Open(src).TableMetadata(th.Context, tblName)
-			require.NoError(t, err)
-			require.Len(t, md.CheckConstraints, 1,
-				"expected exactly one check constraint")
-			cc := md.CheckConstraints[0]
-			require.Equal(t, checkName, cc.Name)
-			require.NotEmpty(t, cc.Clause, "check constraint clause must be non-empty")
-		})
-	}
+	md, err := th.Open(src).TableMetadata(th.Context, tblName)
+	require.NoError(t, err)
+	require.Len(t, md.CheckConstraints, 1,
+		"expected exactly one check constraint")
+	cc := md.CheckConstraints[0]
+	require.Equal(t, checkName, cc.Name)
+	require.NotEmpty(t, cc.Clause, "check constraint clause must be non-empty")
 }
 
 // TestInspect_Triggers_SQLServer verifies that DML triggers attached to a
@@ -108,44 +96,38 @@ func TestInspect_Triggers_SQLServer(t *testing.T) {
 	tu.SkipShort(t, true)
 	t.Parallel()
 
-	for _, handle := range sakila.MSAll() {
-		t.Run(handle, func(t *testing.T) {
-			t.Parallel()
+	th := testh.New(t)
+	src := th.Source(sakila.MS)
+	db := th.OpenDB(src)
 
-			th := testh.New(t)
-			src := th.Source(handle)
-			db := th.OpenDB(src)
+	tblName := stringz.UniqTableName("trig_test")
+	trigName := tblName + "_trig"
+	_, err := db.ExecContext(th.Context, `CREATE TABLE `+tblName+` (
+		id  INT NOT NULL PRIMARY KEY,
+		val INT NOT NULL
+	)`)
+	require.NoError(t, err)
+	// Trigger is dropped automatically when its parent table is dropped;
+	// no separate trigger cleanup is needed.
+	t.Cleanup(func() { th.DropTable(src, tablefq.From(tblName)) })
 
-			tblName := stringz.UniqTableName("trig_test")
-			trigName := tblName + "_trig"
-			_, err := db.ExecContext(th.Context, `CREATE TABLE `+tblName+` (
-				id  INT NOT NULL PRIMARY KEY,
-				val INT NOT NULL
-			)`)
-			require.NoError(t, err)
-			// Trigger is dropped automatically when its parent table is dropped;
-			// no separate trigger cleanup is needed.
-			t.Cleanup(func() { th.DropTable(src, tablefq.From(tblName)) })
-
-			_, err = db.ExecContext(th.Context, `CREATE TRIGGER `+trigName+`
+	_, err = db.ExecContext(th.Context, `CREATE TRIGGER `+trigName+`
 ON `+tblName+` AFTER INSERT
 AS BEGIN
     SELECT 1
 END`)
-			require.NoError(t, err)
+	require.NoError(t, err)
 
-			md, err := th.Open(src).TableMetadata(th.Context, tblName)
-			require.NoError(t, err)
-			require.Len(t, md.Triggers, 1)
-			tr := md.Triggers[0]
-			require.Equal(t, trigName, tr.Name)
-			require.Equal(t, "AFTER", tr.Timing)
-			require.Contains(t, tr.Events, "INSERT")
-			require.NotNil(t, tr.Enabled, "SQL Server triggers have an enabled/disabled state")
-			require.True(t, *tr.Enabled, "newly-created trigger must be enabled")
-			require.NotEmpty(t, tr.Definition)
-		})
-	}
+	md, err := th.Open(src).TableMetadata(th.Context, tblName)
+	require.NoError(t, err)
+	require.Len(t, md.Triggers, 1)
+	tr := md.Triggers[0]
+	require.Equal(t, trigName, tr.Name)
+	require.Equal(t, "AFTER", tr.Timing)
+	require.Contains(t, tr.Events, "INSERT")
+	require.NotNil(t, tr.Enabled, "SQL Server triggers have an enabled/disabled state")
+	require.True(t, *tr.Enabled, "newly-created trigger must be enabled")
+	require.NotEmpty(t, tr.Definition)
 }
 
 // TestInspect_ViewInsteadOfTrigger_SQLServer verifies that an INSTEAD OF
@@ -155,47 +137,41 @@ func TestInspect_ViewInsteadOfTrigger_SQLServer(t *testing.T) {
 	tu.SkipShort(t, true)
 	t.Parallel()
 
-	for _, handle := range sakila.MSAll() {
-		t.Run(handle, func(t *testing.T) {
-			t.Parallel()
+	th := testh.New(t)
+	src := th.Source(sakila.MS)
+	db := th.OpenDB(src)
 
-			th := testh.New(t)
-			src := th.Source(handle)
-			db := th.OpenDB(src)
+	baseTbl := stringz.UniqTableName("viot_base")
+	viewName := stringz.UniqTableName("viot_view")
+	trigName := viewName + "_trig"
 
-			baseTbl := stringz.UniqTableName("viot_base")
-			viewName := stringz.UniqTableName("viot_view")
-			trigName := viewName + "_trig"
+	// Register base-table cleanup FIRST (LIFO: view cleaned up first).
+	_, err := db.ExecContext(th.Context,
+		`CREATE TABLE `+baseTbl+` (id INT NOT NULL PRIMARY KEY)`)
+	require.NoError(t, err)
+	t.Cleanup(func() { th.DropTable(src, tablefq.From(baseTbl)) })
 
-			// Register base-table cleanup FIRST (LIFO: view cleaned up first).
-			_, err := db.ExecContext(th.Context,
-				`CREATE TABLE `+baseTbl+` (id INT NOT NULL PRIMARY KEY)`)
-			require.NoError(t, err)
-			t.Cleanup(func() { th.DropTable(src, tablefq.From(baseTbl)) })
+	_, err = db.ExecContext(th.Context,
+		`CREATE VIEW `+viewName+` AS SELECT id FROM `+baseTbl)
+	require.NoError(t, err)
+	// Register view cleanup SECOND (LIFO → runs before base-table cleanup).
+	t.Cleanup(func() {
+		_, _ = db.ExecContext(th.Context, `DROP VIEW `+viewName)
+	})
 
-			_, err = db.ExecContext(th.Context,
-				`CREATE VIEW `+viewName+` AS SELECT id FROM `+baseTbl)
-			require.NoError(t, err)
-			// Register view cleanup SECOND (LIFO → runs before base-table cleanup).
-			t.Cleanup(func() {
-				_, _ = db.ExecContext(th.Context, `DROP VIEW `+viewName)
-			})
+	_, err = db.ExecContext(th.Context, `CREATE TRIGGER `+trigName+
+		` ON `+viewName+` INSTEAD OF INSERT AS BEGIN SET NOCOUNT ON; END`)
+	require.NoError(t, err)
+	// Dropping the view drops its INSTEAD OF triggers automatically.
 
-			_, err = db.ExecContext(th.Context, `CREATE TRIGGER `+trigName+
-				` ON `+viewName+` INSTEAD OF INSERT AS BEGIN SET NOCOUNT ON; END`)
-			require.NoError(t, err)
-			// Dropping the view drops its INSTEAD OF triggers automatically.
-
-			md, err := th.Open(src).TableMetadata(th.Context, viewName)
-			require.NoError(t, err)
-			require.NotEmpty(t, md.Triggers,
-				"INSTEAD OF trigger must appear in per-table view inspect")
-			tr := md.Triggers[0]
-			require.Equal(t, trigName, tr.Name)
-			require.Equal(t, "INSTEAD OF", tr.Timing)
-			require.Contains(t, tr.Events, "INSERT")
-		})
-	}
+	md, err := th.Open(src).TableMetadata(th.Context, viewName)
+	require.NoError(t, err)
+	require.NotEmpty(t, md.Triggers,
+		"INSTEAD OF trigger must appear in per-table view inspect")
+	tr := md.Triggers[0]
+	require.Equal(t, trigName, tr.Name)
+	require.Equal(t, "INSTEAD OF", tr.Timing)
+	require.Contains(t, tr.Events, "INSERT")
 }
 
 // TestInspect_ViewDefinition_SQLServer verifies that view-typed tables carry
@@ -207,40 +183,34 @@ func TestInspect_ViewDefinition_SQLServer(t *testing.T) {
 	tu.SkipShort(t, true)
 	t.Parallel()
 
-	for _, handle := range sakila.MSAll() {
-		t.Run(handle, func(t *testing.T) {
-			t.Parallel()
+	th := testh.New(t)
+	src := th.Source(sakila.MS)
+	db := th.OpenDB(src)
 
-			th := testh.New(t)
-			src := th.Source(handle)
-			db := th.OpenDB(src)
+	baseTbl := stringz.UniqTableName("vd_base")
+	viewName := stringz.UniqTableName("vd_view")
 
-			baseTbl := stringz.UniqTableName("vd_base")
-			viewName := stringz.UniqTableName("vd_view")
+	_, err := db.ExecContext(th.Context,
+		`CREATE TABLE `+baseTbl+` (id INT NOT NULL PRIMARY KEY, val INT NOT NULL)`)
+	require.NoError(t, err)
+	// Register base-table cleanup FIRST so that LIFO ordering drops
+	// the view (registered second) before the base table.
+	t.Cleanup(func() { th.DropTable(src, tablefq.From(baseTbl)) })
 
-			_, err := db.ExecContext(th.Context,
-				`CREATE TABLE `+baseTbl+` (id INT NOT NULL PRIMARY KEY, val INT NOT NULL)`)
-			require.NoError(t, err)
-			// Register base-table cleanup FIRST so that LIFO ordering drops
-			// the view (registered second) before the base table.
-			t.Cleanup(func() { th.DropTable(src, tablefq.From(baseTbl)) })
+	_, err = db.ExecContext(th.Context,
+		`CREATE VIEW `+viewName+` AS SELECT id, val FROM `+baseTbl)
+	require.NoError(t, err)
+	// Register view cleanup SECOND (LIFO → runs before the base table).
+	t.Cleanup(func() {
+		_, _ = db.ExecContext(th.Context, `DROP VIEW `+viewName)
+	})
 
-			_, err = db.ExecContext(th.Context,
-				`CREATE VIEW `+viewName+` AS SELECT id, val FROM `+baseTbl)
-			require.NoError(t, err)
-			// Register view cleanup SECOND (LIFO → runs before the base table).
-			t.Cleanup(func() {
-				_, _ = db.ExecContext(th.Context, `DROP VIEW `+viewName)
-			})
-
-			md, err := th.Open(src).TableMetadata(th.Context, viewName)
-			require.NoError(t, err)
-			require.NotEmpty(t, md.ViewDefinition,
-				"view must have a non-empty ViewDefinition")
-			require.Contains(t, md.ViewDefinition, baseTbl,
-				"ViewDefinition should reference the base table name")
-		})
-	}
+	md, err := th.Open(src).TableMetadata(th.Context, viewName)
+	require.NoError(t, err)
+	require.NotEmpty(t, md.ViewDefinition,
+		"view must have a non-empty ViewDefinition")
+	require.Contains(t, md.ViewDefinition, baseTbl,
+		"ViewDefinition should reference the base table name")
 }
 
 // TestForeignKey_CompositeOrdering_SQLServer verifies that a composite
@@ -255,36 +225,30 @@ func TestForeignKey_CompositeOrdering_SQLServer(t *testing.T) {
 	tu.SkipShort(t, true)
 	t.Parallel()
 
-	for _, handle := range sakila.MSAll() {
-		t.Run(handle, func(t *testing.T) {
-			t.Parallel()
+	th := testh.New(t)
+	src := th.Source(sakila.MS)
+	db := th.OpenDB(src)
 
-			th := testh.New(t)
-			src := th.Source(handle)
-			db := th.OpenDB(src)
+	parent := stringz.UniqTableName("fk_comp_parent")
+	child := stringz.UniqTableName("fk_comp_child")
+	_, err := db.ExecContext(th.Context,
+		"CREATE TABLE "+parent+" (a INT NOT NULL, b INT NOT NULL, PRIMARY KEY (b, a))")
+	require.NoError(t, err)
+	t.Cleanup(func() { th.DropTable(src, tablefq.From(parent)) })
+	_, err = db.ExecContext(th.Context,
+		"CREATE TABLE "+child+" (x INT NOT NULL, y INT NOT NULL, "+
+			"FOREIGN KEY (x, y) REFERENCES "+parent+" (b, a))")
+	require.NoError(t, err)
+	t.Cleanup(func() { th.DropTable(src, tablefq.From(child)) })
 
-			parent := stringz.UniqTableName("fk_comp_parent")
-			child := stringz.UniqTableName("fk_comp_child")
-			_, err := db.ExecContext(th.Context,
-				"CREATE TABLE "+parent+" (a INT NOT NULL, b INT NOT NULL, PRIMARY KEY (b, a))")
-			require.NoError(t, err)
-			t.Cleanup(func() { th.DropTable(src, tablefq.From(parent)) })
-			_, err = db.ExecContext(th.Context,
-				"CREATE TABLE "+child+" (x INT NOT NULL, y INT NOT NULL, "+
-					"FOREIGN KEY (x, y) REFERENCES "+parent+" (b, a))")
-			require.NoError(t, err)
-			t.Cleanup(func() { th.DropTable(src, tablefq.From(child)) })
-
-			md, err := th.Open(src).TableMetadata(th.Context, child)
-			require.NoError(t, err)
-			require.NotNil(t, md.FK)
-			require.Len(t, md.FK.Outgoing, 1)
-			fk := md.FK.Outgoing[0]
-			require.Equal(t, parent, fk.RefTable)
-			require.Equal(t, []string{"x", "y"}, fk.Columns)
-			require.Equal(t, []string{"b", "a"}, fk.RefColumns)
-		})
-	}
+	md, err := th.Open(src).TableMetadata(th.Context, child)
+	require.NoError(t, err)
+	require.NotNil(t, md.FK)
+	require.Len(t, md.FK.Outgoing, 1)
+	fk := md.FK.Outgoing[0]
+	require.Equal(t, parent, fk.RefTable)
+	require.Equal(t, []string{"x", "y"}, fk.Columns)
+	require.Equal(t, []string{"b", "a"}, fk.RefColumns)
 }
 
 // TestForeignKey_OnDeleteOnUpdate_SQLServer pins that the loader
@@ -297,36 +261,30 @@ func TestForeignKey_OnDeleteOnUpdate_SQLServer(t *testing.T) {
 	tu.SkipShort(t, true)
 	t.Parallel()
 
-	for _, handle := range sakila.MSAll() {
-		t.Run(handle, func(t *testing.T) {
-			t.Parallel()
+	th := testh.New(t)
+	src := th.Source(sakila.MS)
+	db := th.OpenDB(src)
 
-			th := testh.New(t)
-			src := th.Source(handle)
-			db := th.OpenDB(src)
+	parent := stringz.UniqTableName("fk_act_parent")
+	child := stringz.UniqTableName("fk_act_child")
+	_, err := db.ExecContext(th.Context,
+		"CREATE TABLE "+parent+" (id INT NOT NULL PRIMARY KEY)")
+	require.NoError(t, err)
+	t.Cleanup(func() { th.DropTable(src, tablefq.From(parent)) })
+	_, err = db.ExecContext(th.Context,
+		"CREATE TABLE "+child+" (parent_id INT, "+
+			"FOREIGN KEY (parent_id) REFERENCES "+parent+
+			" (id) ON DELETE CASCADE ON UPDATE SET NULL)")
+	require.NoError(t, err)
+	t.Cleanup(func() { th.DropTable(src, tablefq.From(child)) })
 
-			parent := stringz.UniqTableName("fk_act_parent")
-			child := stringz.UniqTableName("fk_act_child")
-			_, err := db.ExecContext(th.Context,
-				"CREATE TABLE "+parent+" (id INT NOT NULL PRIMARY KEY)")
-			require.NoError(t, err)
-			t.Cleanup(func() { th.DropTable(src, tablefq.From(parent)) })
-			_, err = db.ExecContext(th.Context,
-				"CREATE TABLE "+child+" (parent_id INT, "+
-					"FOREIGN KEY (parent_id) REFERENCES "+parent+
-					" (id) ON DELETE CASCADE ON UPDATE SET NULL)")
-			require.NoError(t, err)
-			t.Cleanup(func() { th.DropTable(src, tablefq.From(child)) })
-
-			md, err := th.Open(src).TableMetadata(th.Context, child)
-			require.NoError(t, err)
-			require.Len(t, md.FK.Outgoing, 1)
-			fk := md.FK.Outgoing[0]
-			require.Equal(t, "CASCADE", fk.OnDelete)
-			require.Equal(t, "SET NULL", fk.OnUpdate,
-				"loader must normalize SET_NULL → SET NULL to match the other drivers")
-		})
-	}
+	md, err := th.Open(src).TableMetadata(th.Context, child)
+	require.NoError(t, err)
+	require.Len(t, md.FK.Outgoing, 1)
+	fk := md.FK.Outgoing[0]
+	require.Equal(t, "CASCADE", fk.OnDelete)
+	require.Equal(t, "SET NULL", fk.OnUpdate,
+		"loader must normalize SET_NULL → SET NULL to match the other drivers")
 }
 
 // TestForeignKey_SameCatalog_SQLServer pins the loader's current
@@ -342,34 +300,28 @@ func TestForeignKey_SameCatalog_SQLServer(t *testing.T) {
 	tu.SkipShort(t, true)
 	t.Parallel()
 
-	for _, handle := range sakila.MSAll() {
-		t.Run(handle, func(t *testing.T) {
-			t.Parallel()
+	th := testh.New(t)
+	src := th.Source(sakila.MS)
+	db := th.OpenDB(src)
 
-			th := testh.New(t)
-			src := th.Source(handle)
-			db := th.OpenDB(src)
+	parent := stringz.UniqTableName("fk_cat_parent")
+	child := stringz.UniqTableName("fk_cat_child")
+	_, err := db.ExecContext(th.Context,
+		"CREATE TABLE "+parent+" (id INT NOT NULL PRIMARY KEY)")
+	require.NoError(t, err)
+	t.Cleanup(func() { th.DropTable(src, tablefq.From(parent)) })
+	_, err = db.ExecContext(th.Context,
+		"CREATE TABLE "+child+" (parent_id INT, "+
+			"FOREIGN KEY (parent_id) REFERENCES "+parent+" (id))")
+	require.NoError(t, err)
+	t.Cleanup(func() { th.DropTable(src, tablefq.From(child)) })
 
-			parent := stringz.UniqTableName("fk_cat_parent")
-			child := stringz.UniqTableName("fk_cat_child")
-			_, err := db.ExecContext(th.Context,
-				"CREATE TABLE "+parent+" (id INT NOT NULL PRIMARY KEY)")
-			require.NoError(t, err)
-			t.Cleanup(func() { th.DropTable(src, tablefq.From(parent)) })
-			_, err = db.ExecContext(th.Context,
-				"CREATE TABLE "+child+" (parent_id INT, "+
-					"FOREIGN KEY (parent_id) REFERENCES "+parent+" (id))")
-			require.NoError(t, err)
-			t.Cleanup(func() { th.DropTable(src, tablefq.From(child)) })
-
-			md, err := th.Open(src).TableMetadata(th.Context, child)
-			require.NoError(t, err)
-			require.Len(t, md.FK.Outgoing, 1)
-			fk := md.FK.Outgoing[0]
-			require.Empty(t, fk.RefCatalog,
-				"same-DB FK must leave RefCatalog empty; populated only by a cross-catalog loader extension")
-			require.Empty(t, fk.RefSchema,
-				"same-schema FK must have RefSchema cleared by the loader's NULLIF")
-		})
-	}
+	md, err := th.Open(src).TableMetadata(th.Context, child)
+	require.NoError(t, err)
+	require.Len(t, md.FK.Outgoing, 1)
+	fk := md.FK.Outgoing[0]
+	require.Empty(t, fk.RefCatalog,
+		"same-DB FK must leave RefCatalog empty; populated only by a cross-catalog loader extension")
+	require.Empty(t, fk.RefSchema,
+		"same-schema FK must have RefSchema cleared by the loader's NULLIF")
 }

--- a/drivers/sqlserver/sqlserver_test.go
+++ b/drivers/sqlserver/sqlserver_test.go
@@ -20,17 +20,11 @@ import (
 func TestSmoke(t *testing.T) {
 	t.Parallel()
 
-	for _, handle := range sakila.MSAll() {
-		t.Run(handle, func(t *testing.T) {
-			t.Parallel()
-
-			th, src, _, _, _ := testh.NewWith(t, handle)
-			sink, err := th.QuerySQL(src, nil, "SELECT * FROM actor")
-			require.NoError(t, err)
-			require.Equal(t, len(sakila.TblActorCols()), len(sink.RecMeta))
-			require.Equal(t, sakila.TblActorCount, len(sink.Recs))
-		})
-	}
+	th, src, _, _, _ := testh.NewWith(t, sakila.MS)
+	sink, err := th.QuerySQL(src, nil, "SELECT * FROM actor")
+	require.NoError(t, err)
+	require.Equal(t, len(sakila.TblActorCols()), len(sink.RecMeta))
+	require.Equal(t, sakila.TblActorCount, len(sink.Recs))
 }
 
 func TestDriverBehavior(t *testing.T) {

--- a/testh/sakila/sakila.go
+++ b/testh/sakila/sakila.go
@@ -116,16 +116,6 @@ func SQLLatest() []string {
 	return []string{SL3, Duck, Pg, My, MS, CH, Ora}
 }
 
-// PgAll returns the postgres handles. Version coverage is a CI matrix
-// dimension now, so this is a single handle.
-func PgAll() []string { return []string{Pg} }
-
-// MyAll returns the MySQL handles.
-func MyAll() []string { return []string{My} }
-
-// MSAll returns the SQL Server handles.
-func MSAll() []string { return []string{MS} }
-
 // Facts regarding the sakila database.
 const (
 	TblActor          = "actor"


### PR DESCRIPTION
Closes #988. Follow-up to #958 / #964.

## Problem

Since #958 collapsed per-engine version coverage to a CI matrix dimension, `sakila.PgAll()` / `MyAll()` / `MSAll()` each returned a **single-element** slice (`[]string{sakila.Pg}` etc.). The `…All` name implied plurality that no longer exists, and the loops they fed iterated exactly once.

## Change

Remove the three helpers and flatten their **24 call sites** across the postgres, mysql, and sqlserver driver tests. Each site went from:

```go
for _, handle := range sakila.PgAll() {
    t.Run(handle, func(t *testing.T) {
        t.Parallel()
        … body using handle …
    })
}
```

to the flattened body using the engine's handle constant directly:

```go
… body using sakila.Pg …
```

Specifically: drop the single-element range loop and the per-handle `t.Run(handle, …)` subtest wrapper, replace `handle` with `sakila.Pg`/`My`/`MS`, and drop the now-vacuous subtest-level `t.Parallel()` (each enclosing test function keeps its **own** top-level `t.Parallel()`). One `//nolint:tparallel` directive that became unused once its parallel subtest was removed is also dropped.

## Verification

Run against **live** postgres/mysql/sqlserver containers, the per-package top-level pass/fail **sets are identical to the pre-change baseline**:

| package | tests | result |
|---|---|---|
| postgres | 58 | 0 fail — identical to baseline |
| mysql | 54 | 0 fail — identical to baseline |
| sqlserver | 45 | 0 fail — identical to baseline |

`go build ./...`, `go vet`, `golangci-lint`, and `dprint` all clean. Net **−157 lines**.

Note: subtests previously named `TestFoo/@sakila_pg` are now just `TestFoo` (the single per-handle subtest layer is gone) — a test-output naming change only, with no effect on what's exercised.

## Scope note

This is a mechanical, behavior-preserving test refactor. `SQLLatest`'s name is also now a historical artifact (it returns one handle per engine, not a "latest version"); a rename was considered but deferred as a larger, separate change (~17 callers) — tracked in #988's notes.