### PR TITLE
feat(driver): model embedded SQL as Metadata.IsEmbeddedSQL (#986)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,10 +21,10 @@ Breaking changes are annotated with ☢️, and alpha/beta features with 🐥.
 
 ### Added
 
-- [#986]: `sq driver ls -j` / `-y` now reports an `is_embedded_sql` field for each
-  driver, `true` for the in-process SQL drivers (SQLite, DuckDB) and `false` for
-  the networked engines (including rqlite, which is SQLite-backed but reached over
-  HTTP) and non-SQL drivers.
+- [#986]: [`sq driver ls`](https://sq.io/docs/cmd/driver-ls) with `-j` / `-y` now
+  reports an `is_embedded_sql` field for each driver, `true` for the in-process SQL
+  drivers (SQLite, DuckDB) and `false` for the networked engines (including rqlite,
+  which is SQLite-backed but reached over HTTP) and non-SQL drivers.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,13 @@ Breaking changes are annotated with ☢️, and alpha/beta features with 🐥.
 
 ## [Unreleased]
 
+### Added
+
+- [#986]: `sq driver ls -j` / `-y` now reports an `is_embedded_sql` field for each
+  driver, `true` for the in-process SQL drivers (SQLite, DuckDB) and `false` for
+  the networked engines (including rqlite, which is SQLite-backed but reached over
+  HTTP) and non-SQL drivers.
+
 ### Fixed
 
 - [#968]: Aligned the SQLite and DuckDB Sakila test fixtures with the canonical
@@ -1746,6 +1753,7 @@ make working with lots of sources much easier.
 [#923]: https://github.com/neilotoole/sq/pull/923
 [#926]: https://github.com/neilotoole/sq/pull/926
 [#968]: https://github.com/neilotoole/sq/issues/968
+[#986]: https://github.com/neilotoole/sq/issues/986
 [v0.15.2]: https://github.com/neilotoole/sq/releases/tag/v0.15.2
 [v0.15.3]: https://github.com/neilotoole/sq/compare/v0.15.2...v0.15.3
 [v0.15.4]: https://github.com/neilotoole/sq/compare/v0.15.3...v0.15.4

--- a/drivers/duckdb/duckdb.go
+++ b/drivers/duckdb/duckdb.go
@@ -92,10 +92,11 @@ func (d *driveri) LocationShape() driver.LocationShape {
 // DriverMetadata implements driver.Driver.
 func (d *driveri) DriverMetadata() driver.Metadata {
 	return driver.Metadata{
-		Type:        drivertype.DuckDB,
-		Description: "DuckDB",
-		Doc:         "https://duckdb.org",
-		IsSQL:       true,
+		Type:          drivertype.DuckDB,
+		Description:   "DuckDB",
+		Doc:           "https://duckdb.org",
+		IsSQL:         true,
+		IsEmbeddedSQL: true,
 	}
 }
 

--- a/drivers/duckdb/internal_test.go
+++ b/drivers/duckdb/internal_test.go
@@ -17,6 +17,16 @@ import (
 	"github.com/neilotoole/sq/testh/tu"
 )
 
+// TestDriverMetadata verifies the static driver metadata. DuckDB is an
+// embedded SQL driver.
+func TestDriverMetadata(t *testing.T) {
+	md := (&driveri{}).DriverMetadata()
+	require.Equal(t, drivertype.DuckDB, md.Type)
+	require.True(t, md.IsSQL)
+	require.True(t, md.IsEmbeddedSQL)
+	require.LessOrEqual(t, md.DefaultPort, 0)
+}
+
 func TestMungeLocation(t *testing.T) {
 	cwd, err := os.Getwd()
 	require.NoError(t, err)

--- a/drivers/mysql/mysql_internal_test.go
+++ b/drivers/mysql/mysql_internal_test.go
@@ -73,6 +73,7 @@ func TestDriverMetadata(t *testing.T) {
 	md := d.DriverMetadata()
 	require.Equal(t, drivertype.MySQL, md.Type)
 	require.True(t, md.IsSQL)
+	require.False(t, md.IsEmbeddedSQL)
 	require.Equal(t, 3306, md.DefaultPort)
 }
 

--- a/drivers/oracle/oracle_unit_test.go
+++ b/drivers/oracle/oracle_unit_test.go
@@ -51,6 +51,7 @@ func TestDriveri_DriverMetadata(t *testing.T) {
 	md := (&driveri{}).DriverMetadata()
 	require.Equal(t, drivertype.Oracle, md.Type)
 	require.True(t, md.IsSQL)
+	require.False(t, md.IsEmbeddedSQL)
 	require.Equal(t, 1521, md.DefaultPort)
 	require.NotEmpty(t, md.Description)
 }

--- a/drivers/postgres/unit_test.go
+++ b/drivers/postgres/unit_test.go
@@ -43,6 +43,7 @@ func TestDriver_StaticMetadata(t *testing.T) {
 	md := d.DriverMetadata()
 	require.Equal(t, drivertype.Pg, md.Type)
 	require.True(t, md.IsSQL)
+	require.False(t, md.IsEmbeddedSQL)
 	require.Equal(t, 5432, md.DefaultPort)
 
 	dlct := d.Dialect()

--- a/drivers/rqlite/cover_internal_test.go
+++ b/drivers/rqlite/cover_internal_test.go
@@ -52,6 +52,9 @@ func TestDriverMetadata(t *testing.T) {
 	require.Equal(t, "rqlite", md.Description)
 	require.Equal(t, "https://rqlite.io", md.Doc)
 	require.True(t, md.IsSQL)
+	// rqlite is SQLite-backed but reached over HTTP, so it is external, not
+	// embedded.
+	require.False(t, md.IsEmbeddedSQL)
 	require.Equal(t, defaultPort, md.DefaultPort)
 }
 

--- a/drivers/sqlite3/internal_test.go
+++ b/drivers/sqlite3/internal_test.go
@@ -9,8 +9,19 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/neilotoole/sq/libsq/source/drivertype"
 	"github.com/neilotoole/sq/testh/tu"
 )
+
+// TestDriverMetadata verifies the static driver metadata. SQLite is an
+// embedded SQL driver.
+func TestDriverMetadata(t *testing.T) {
+	md := (&driveri{}).DriverMetadata()
+	require.Equal(t, drivertype.SQLite, md.Type)
+	require.True(t, md.IsSQL)
+	require.True(t, md.IsEmbeddedSQL)
+	require.LessOrEqual(t, md.DefaultPort, 0)
+}
 
 var (
 	KindFromDBTypeName = kindFromDBTypeName

--- a/drivers/sqlite3/sqlite3.go
+++ b/drivers/sqlite3/sqlite3.go
@@ -128,10 +128,11 @@ func (d *driveri) DBProperties(ctx context.Context, db sqlz.DB) (map[string]any,
 // DriverMetadata implements driver.Driver.
 func (d *driveri) DriverMetadata() driver.Metadata {
 	return driver.Metadata{
-		Type:        drivertype.SQLite,
-		Description: "SQLite",
-		Doc:         "https://github.com/mattn/go-sqlite3",
-		IsSQL:       true,
+		Type:          drivertype.SQLite,
+		Description:   "SQLite",
+		Doc:           "https://github.com/mattn/go-sqlite3",
+		IsSQL:         true,
+		IsEmbeddedSQL: true,
 	}
 }
 

--- a/drivers/sqlserver/sqlserver_unit_test.go
+++ b/drivers/sqlserver/sqlserver_unit_test.go
@@ -47,6 +47,7 @@ func TestDriver_DriverMetadata(t *testing.T) {
 	md := newDriver(t).DriverMetadata()
 	require.Equal(t, drivertype.MSSQL, md.Type)
 	require.True(t, md.IsSQL)
+	require.False(t, md.IsEmbeddedSQL)
 	require.Equal(t, 1433, md.DefaultPort)
 	require.NotEmpty(t, md.Description)
 	require.NotEmpty(t, md.Doc)

--- a/libsq/driver/driver.go
+++ b/libsq/driver/driver.go
@@ -314,6 +314,14 @@ type Metadata struct {
 	// DefaultPort is the default port that a driver connects on. A
 	// value <= 0 indicates not applicable.
 	DefaultPort int `json:"default_port" yaml:"default_port"`
+
+	// IsEmbeddedSQL is true if this is an embedded (in-process, no separate
+	// server or network endpoint) SQL driver, such as SQLite or DuckDB. It is
+	// false for external SQL engines that connect over the network, including
+	// rqlite (which is SQLite-backed but reached over HTTP), and for all non-SQL
+	// drivers. An embedded SQL driver is exactly an [IsSQL] driver with no
+	// network endpoint.
+	IsEmbeddedSQL bool `json:"is_embedded_sql" yaml:"is_embedded_sql"`
 }
 
 // OpeningPing is a standardized mechanism to ping db using

--- a/libsq/driver/driver.go
+++ b/libsq/driver/driver.go
@@ -311,10 +311,6 @@ type Metadata struct {
 	// effectively has a single table, such as CSV.
 	Monotable bool `json:"monotable" yaml:"monotable"`
 
-	// DefaultPort is the default port that a driver connects on. A
-	// value <= 0 indicates not applicable.
-	DefaultPort int `json:"default_port" yaml:"default_port"`
-
 	// IsEmbeddedSQL is true if this is an embedded (in-process, no separate
 	// server or network endpoint) SQL driver, such as SQLite or DuckDB. It is
 	// false for external SQL engines that connect over the network, including
@@ -322,6 +318,10 @@ type Metadata struct {
 	// drivers. An embedded SQL driver is exactly an [IsSQL] driver with no
 	// network endpoint.
 	IsEmbeddedSQL bool `json:"is_embedded_sql" yaml:"is_embedded_sql"`
+
+	// DefaultPort is the default port that a driver connects on. A
+	// value <= 0 indicates not applicable.
+	DefaultPort int `json:"default_port" yaml:"default_port"`
 }
 
 // OpeningPing is a standardized mechanism to ping db using

--- a/testh/sakila/sakila.go
+++ b/testh/sakila/sakila.go
@@ -71,6 +71,11 @@ func SQLAllExternal() []string {
 // (file-based), but are not SQL drivers and are excluded here. Note that
 // rqlite, though SQLite-backed, is external: it is reached over the network.
 // SQLEmbedded and [SQLAllExternal] partition [SQLAll].
+//
+// This is a deliberately static, handle-level convenience for the test matrix.
+// The production source of truth for the embedded property is the
+// driver.Metadata.IsEmbeddedSQL field, set by each driver impl; the handles
+// here mirror it for SQLite and DuckDB.
 func SQLEmbedded() []string {
 	return []string{SL3, Duck}
 }


### PR DESCRIPTION
Closes #986.

Promotes the embedded-SQL classification from the test-only sakila handle helper added in #964 to a first-class driver property.

## What

- Add `IsEmbeddedSQL bool` to `driver.Metadata` (`json:"is_embedded_sql" yaml:"is_embedded_sql"`), set `true` only for the in-process SQL drivers (**SQLite, DuckDB**). It is `false` for the networked engines — including **rqlite** (SQLite-backed but reached over HTTP, the documented trap) — and for all non-SQL drivers.
- The field serializes in `sq driver ls -j` / `-y` alongside the other intrinsic metadata fields (`is_sql`, `monotable`, `default_port`).

## Design decisions

**Option A (serialized field), per the issue.** Two findings shaped the human-output decision:

- **No golden-file churn.** The `tablew`/`markdownw`/`htmlw` driver writers are *curated* — they already omit `is_sql`/`monotable`/`default_port` and don't iterate the struct, so they're unaffected. Only `jsonw`/`yamlw` serialize the full struct, and there are no golden tests for `driver ls` machine output.
- **Human output left unchanged.** Following the existing convention, the field surfaces only in the machine formats (`-j`/`-y`), not as a new column in table/markdown/html.

## Tests

- Each driver's metadata unit test now pins its `IsEmbeddedSQL` value: `true` for sqlite3/duckdb (new `TestDriverMetadata` in each), `false` for postgres/mysql/sqlserver/oracle, and an explicit `false` for **rqlite** with a clarifying comment.
- Verified live: `sq driver ls -j` reports exactly 2 `true` (sqlite3, duckdb) and 14 `false`.
- `go build ./...`, `go vet`, `gofmt -l`, and the affected package tests all pass.

The `testh/sakila` handle helper from #964 is documented as an intentional static-handle convenience that mirrors the new production source of truth.

https://claude.ai/code/session_015cQ9j3LiXNm2vRFehwyzyS