### PR TITLE
docs(clickhouse): note ClickHouse has no dedicated binary type

### DIFF
--- a/drivers/clickhouse/README.md
+++ b/drivers/clickhouse/README.md
@@ -138,10 +138,11 @@ Nullable columns are wrapped with `Nullable(T)` (e.g.,
 non-nullable by default.
 
 ClickHouse has no dedicated binary or `BLOB` type: `String` holds
-arbitrary bytes and stands in for `BLOB`/`VARCHAR`/`CLOB`/`TEXT`. So
-`kind.Bytes` is not faithfully representable; a `kind.Bytes` value
-reads back as `kind.Text`. This is intentional upstream
-([ClickHouse#53482](https://github.com/ClickHouse/ClickHouse/issues/53482)),
+arbitrary bytes and stands in for `BLOB`/`VARCHAR`/`CLOB`/`TEXT`. A column
+cannot be marked binary versus text, so `sq` maps `String` and
+`FixedString` to `kind.Text`, and a `kind.Bytes` value reads back as
+`kind.Text`. This is intentional upstream
+([ClickHouse/ClickHouse#53482](https://github.com/ClickHouse/ClickHouse/issues/53482)),
 not a gap awaiting a fix. See
 [#544](https://github.com/neilotoole/sq/issues/544).
 

--- a/drivers/clickhouse/README.md
+++ b/drivers/clickhouse/README.md
@@ -137,6 +137,14 @@ Nullable columns are wrapped with `Nullable(T)` (e.g.,
 `Nullable(String)`, `Nullable(Int64)`). ClickHouse columns are
 non-nullable by default.
 
+ClickHouse has no dedicated binary or `BLOB` type: `String` holds
+arbitrary bytes and stands in for `BLOB`/`VARCHAR`/`CLOB`/`TEXT`. So
+`kind.Bytes` is not faithfully representable; a `kind.Bytes` value
+reads back as `kind.Text`. This is intentional upstream
+([ClickHouse#53482](https://github.com/ClickHouse/ClickHouse/issues/53482)),
+not a gap awaiting a fix. See
+[#544](https://github.com/neilotoole/sq/issues/544).
+
 ### Metadata
 
 - `CurrentCatalog()` / `CurrentSchema()` via `currentDatabase()`

--- a/site/content/en/docs/drivers/clickhouse.md
+++ b/site/content/en/docs/drivers/clickhouse.md
@@ -127,6 +127,18 @@ comma-separated text values. For example, `["Action", "Drama"]` becomes
 cannot be reconstructed from the text representation.
 See [#545](https://github.com/neilotoole/sq/issues/545).
 
+#### Binary data
+
+ClickHouse has no dedicated binary or `BLOB` type. Its `String` type holds
+arbitrary bytes (including null bytes) and deliberately stands in for `BLOB`,
+`VARCHAR`, `CLOB`, and `TEXT`. Binary data therefore stores fine, but a column
+cannot be marked as binary versus text: `sq` maps `String` and `FixedString` to
+`kind.Text`, and a `kind.Bytes` value written to ClickHouse reads back as
+`kind.Text`. This is intentional upstream (see
+[ClickHouse/ClickHouse#53482](https://github.com/ClickHouse/ClickHouse/issues/53482)),
+not a gap awaiting a fix, so a faithful binary column is not representable on
+ClickHouse.
+
 ### Inspect field provenance
 
 `sq inspect` populates the fields below from ClickHouse built-in functions


### PR DESCRIPTION
Closes #983.

The ClickHouse driver pages document the mechanical type mapping (`String`/`FixedString` -> `kind.Text`; `kind.Bytes` -> `String`) but not *why* or that it's permanent. This adds the narrative.

### Change
- **Site driver page** (`site/content/en/docs/drivers/clickhouse.md`): a new `#### Binary data` subsection under Type mapping (after Array types).
- **Driver README** (`drivers/clickhouse/README.md`): a parallel short note after the Nullable paragraph.

Both state that ClickHouse has no dedicated binary/`BLOB` type: `String` holds arbitrary bytes and stands in for `BLOB`/`VARCHAR`/`CLOB`/`TEXT`, so a column cannot be marked binary vs text and a `kind.Bytes` value reads back as `kind.Text`. This is intentional upstream ([ClickHouse#53482](https://github.com/ClickHouse/ClickHouse/issues/53482)), not a gap awaiting a fix, so a faithful binary column is not representable on ClickHouse.

### Why now
Surfaced while reconciling the Sakila fixtures: `staff.picture` (Sakila's lone `BLOB`) is permanently omitted from `sakiladb/clickhouse` for exactly this reason, a permanent allow-listed exception in the parity guard (#963). Its Oracle counterpart *can* hold a real `BLOB` and was restored there (sakiladb/oracle#7, shipped v23.0.5). Documenting the ClickHouse limitation makes the asymmetry self-explanatory.

Docs-only. `dprint check` passes on both files.