### PR TITLE
duckdb: SQL double-quote schema names in CreateSchema/DropSchema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@ Breaking changes are annotated with ☢️, and alpha/beta features with 🐥.
 
 ### Fixed
 
+- [#994]: The DuckDB driver now SQL-quotes schema names that contain a double
+  quote in `CreateSchema` and `DropSchema`, completing the `%q` → `stringz.DoubleQuote`
+  identifier-quoting fix that [#976] applied to the table paths.
 - [#976]: The DuckDB driver now SQL-quotes table and column names that contain a
   double quote (e.g. a `we"ird` table created from a CSV header) in the alter, truncate, and
   row-count paths. These paths used Go's `%q` verb, which emits backslash escaping (`"we\"ird"`)
@@ -1760,6 +1763,7 @@ make working with lots of sources much easier.
 [#968]: https://github.com/neilotoole/sq/issues/968
 [#976]: https://github.com/neilotoole/sq/pull/976
 [#986]: https://github.com/neilotoole/sq/issues/986
+[#994]: https://github.com/neilotoole/sq/pull/994
 [v0.15.2]: https://github.com/neilotoole/sq/releases/tag/v0.15.2
 [v0.15.3]: https://github.com/neilotoole/sq/compare/v0.15.2...v0.15.3
 [v0.15.4]: https://github.com/neilotoole/sq/compare/v0.15.3...v0.15.4

--- a/drivers/duckdb/duckdb.go
+++ b/drivers/duckdb/duckdb.go
@@ -569,14 +569,14 @@ func (d *driveri) CreateTable(ctx context.Context, db sqlz.DB, tblDef *schema.Ta
 
 // CreateSchema implements driver.SQLDriver.
 func (d *driveri) CreateSchema(ctx context.Context, db sqlz.DB, schemaName string) error {
-	stmt := fmt.Sprintf(`CREATE SCHEMA %q`, schemaName)
+	stmt := "CREATE SCHEMA " + stringz.DoubleQuote(schemaName)
 	_, err := db.ExecContext(ctx, stmt)
 	return errz.Wrapf(errw(err), "duckdb: create schema {%s}", schemaName)
 }
 
 // DropSchema implements driver.SQLDriver.
 func (d *driveri) DropSchema(ctx context.Context, db sqlz.DB, schemaName string) error {
-	stmt := fmt.Sprintf(`DROP SCHEMA %q CASCADE`, schemaName)
+	stmt := "DROP SCHEMA " + stringz.DoubleQuote(schemaName) + " CASCADE"
 	_, err := db.ExecContext(ctx, stmt)
 	return errz.Wrapf(errw(err), "duckdb: drop schema {%s}", schemaName)
 }

--- a/drivers/duckdb/impl_test.go
+++ b/drivers/duckdb/impl_test.go
@@ -230,6 +230,32 @@ func TestCreateSchema_DropSchema(t *testing.T) {
 	require.False(t, exists)
 }
 
+// TestCreateSchema_DropSchema_EmbeddedQuoteIdentifier covers a schema name that
+// contains a double quote. CreateSchema and DropSchema previously quoted the
+// schema name with Go's %q verb, which emits C-style backslash escaping
+// ("sc\"hema") that DuckDB rejects; they must use SQL double-quote escaping
+// ("sc""hema") via stringz.DoubleQuote, matching the alter/truncate/count fix
+// in #976.
+func TestCreateSchema_DropSchema_EmbeddedQuoteIdentifier(t *testing.T) {
+	db, th, src := newImplTestDB(t)
+	grip := th.Open(src)
+	drvr := grip.SQLDriver()
+	ctx := th.Context
+
+	const schemaName = `sc"hema`
+	require.NoError(t, drvr.CreateSchema(ctx, db, schemaName))
+
+	exists, err := drvr.SchemaExists(ctx, db, schemaName)
+	require.NoError(t, err)
+	require.True(t, exists)
+
+	require.NoError(t, drvr.DropSchema(ctx, db, schemaName))
+
+	exists, err = drvr.SchemaExists(ctx, db, schemaName)
+	require.NoError(t, err)
+	require.False(t, exists)
+}
+
 // TestCatalogExists verifies that CatalogExists returns true for the current
 // database and false for an unknown catalog.
 func TestCatalogExists(t *testing.T) {


### PR DESCRIPTION
## What

Follow-up to #976. `CreateSchema` and `DropSchema` in `drivers/duckdb/duckdb.go` still quoted the schema name with Go's `%q` verb, which emits C-style backslash escaping (`"sc\"hema"`) that DuckDB rejects. A schema name containing a double quote therefore failed with a DuckDB parser error:

```
Parser Error: syntax error at or near "hema"
LINE 1: CREATE SCHEMA "sc\"hema"
```

These were the only remaining SQL-identifier `%q` sites in the DuckDB driver after #976; a scan of the sibling drivers' schema paths found no equivalent `%q` usage, so this is DuckDB-only.

## Change

- `drivers/duckdb/duckdb.go`: `CreateSchema` and `DropSchema` quote the schema name with `stringz.DoubleQuote` (`"sc""hema"`), matching the alter/truncate/row-count paths fixed in #976, the `CopyTable`/`DropTable` paths, and the driver's dialect `Enquote`.
- New `TestCreateSchema_DropSchema_EmbeddedQuoteIdentifier` exercises both paths against a `sc"hema` schema. `SchemaExists` already binds the name as a parameter, so it was unaffected.

Reverting just the source change (keeping the test) reproduces the parser error above. `go test ./drivers/duckdb/` passes; `go vet` and `gofumpt` are clean.

Closes #993