### PR TITLE
fix(join): serialize copy tasks for single-writer joindb (#975)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,11 @@ Breaking changes are annotated with ☢️, and alpha/beta features with 🐥.
 
 ### Fixed
 
+- [#975]: A join across two sources could fail with `database is locked` when
+  the participating tables were copied into the temporary SQLite join database.
+  The copies ran concurrently, but SQLite permits only one writer at a time, so a
+  large table holding the write lock could starve the others past their timeout.
+  The copies into a single-writer join database are now serialized.
 - [#994]: The DuckDB driver now SQL-quotes schema names that contain a double
   quote in `CreateSchema` and `DropSchema`, completing the `%q` → `stringz.DoubleQuote`
   identifier-quoting fix that [#976] applied to the table paths.
@@ -1761,6 +1766,7 @@ make working with lots of sources much easier.
 [#923]: https://github.com/neilotoole/sq/pull/923
 [#926]: https://github.com/neilotoole/sq/pull/926
 [#968]: https://github.com/neilotoole/sq/issues/968
+[#975]: https://github.com/neilotoole/sq/issues/975
 [#976]: https://github.com/neilotoole/sq/pull/976
 [#986]: https://github.com/neilotoole/sq/issues/986
 [#994]: https://github.com/neilotoole/sq/pull/994

--- a/drivers/sqlite3/internal_test.go
+++ b/drivers/sqlite3/internal_test.go
@@ -23,6 +23,14 @@ func TestDriverMetadata(t *testing.T) {
 	require.LessOrEqual(t, md.DefaultPort, 0)
 }
 
+// TestDialect_SingleWriter verifies that the SQLite dialect is marked
+// single-writer (gh975): its rollback journal serializes writers, so
+// concurrent cross-source join copies otherwise contend on the file lock
+// and fail with "database is locked".
+func TestDialect_SingleWriter(t *testing.T) {
+	require.True(t, (&driveri{}).Dialect().SingleWriter)
+}
+
 var (
 	KindFromDBTypeName = kindFromDBTypeName
 	GetTblRowCounts    = getTblRowCounts

--- a/drivers/sqlite3/sqlite3.go
+++ b/drivers/sqlite3/sqlite3.go
@@ -249,6 +249,7 @@ func (d *driveri) Dialect() dialect.Dialect {
 		Placeholders:   placeholders,
 		Enquote:        stringz.DoubleQuote,
 		MaxBatchValues: 500,
+		SingleWriter:   true,
 		Ops:            dialect.DefaultOps(),
 		ExecModeFor:    dialect.DefaultExecModeFor,
 		Joins:          jointype.All(),

--- a/libsq/driver/dialect/dialect.go
+++ b/libsq/driver/dialect/dialect.go
@@ -73,6 +73,16 @@ type Dialect struct {
 	// MaxBatchValues is the maximum number of values in a batch insert.
 	MaxBatchValues int
 
+	// SingleWriter indicates that a database of this dialect permits only one
+	// write transaction at a time, so writers must be serialized. It governs
+	// bulk ingest such as the table copies that populate a cross-source join
+	// DB. The zero value (false) is the common case for client/server
+	// databases (e.g. PostgreSQL) that permit many concurrent writers. SQLite
+	// sets it true: its rollback journal serializes writers, so concurrent
+	// copies otherwise contend on the file lock and fail with "database is
+	// locked" (gh975).
+	SingleWriter bool
+
 	// IntBool is true if BOOLEAN is handled as an INT by the DB driver.
 	IntBool bool `json:"int_bool"`
 

--- a/libsq/pipeline.go
+++ b/libsq/pipeline.go
@@ -52,6 +52,14 @@ type pipeline struct {
 	// is executed against targetGrip. Typically tasks is used to
 	// set up the joindb before it is queried.
 	tasks []tasker
+
+	// tasksSingleWriter, when true, forces executeTasks to run its tasks
+	// one at a time instead of concurrently up to the errgroup limit. It is
+	// set from the join destination's dialect.SingleWriter so that a
+	// single-writer joindb (SQLite) serializes its copy tasks rather than
+	// contending on the write lock and failing with "database is locked"
+	// (gh975).
+	tasksSingleWriter bool
 }
 
 // newPipeline parses query, returning a pipeline prepared for
@@ -155,8 +163,13 @@ func (p *pipeline) executeTasks(ctx context.Context) error {
 	default:
 	}
 
+	limit := tuning.OptErrgroupLimit.Get(options.FromContext(ctx))
+	if p.tasksSingleWriter {
+		limit = 1
+	}
+
 	g, gCtx := errgroup.WithContext(ctx)
-	g.SetLimit(tuning.OptErrgroupLimit.Get(options.FromContext(ctx)))
+	g.SetLimit(limit)
 
 	for _, task := range p.tasks {
 		g.Go(func() error {
@@ -494,6 +507,13 @@ func (p *pipeline) joinCrossSource(ctx context.Context, jc *joinClause) (fromCla
 
 		p.tasks = append(p.tasks, task)
 	}
+
+	// Cap copy-task concurrency to what the joindb tolerates. A
+	// single-writer joindb (SQLite) reports SingleWriter, so its copies
+	// serialize instead of contending on the write lock and failing with
+	// "database is locked" (gh975); a multi-writer joindb leaves the
+	// errgroup limit in force.
+	p.tasksSingleWriter = joinGrip.SQLDriver().Dialect().SingleWriter
 
 	fromClause, err = rndr.Join(p.rc, jc.leftTbl, jc.joins)
 	if err != nil {

--- a/libsq/pipeline_internal_test.go
+++ b/libsq/pipeline_internal_test.go
@@ -1,0 +1,63 @@
+package libsq
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// concProbeTask records the peak number of tasks executing concurrently,
+// so tests can assert executeTasks' effective concurrency limit.
+type concProbeTask struct {
+	active *atomic.Int32
+	peak   *atomic.Int32
+}
+
+func (ct *concProbeTask) executeTask(context.Context) error {
+	n := ct.active.Add(1)
+	defer ct.active.Add(-1)
+	for {
+		p := ct.peak.Load()
+		if n <= p || ct.peak.CompareAndSwap(p, n) {
+			break
+		}
+	}
+	time.Sleep(50 * time.Millisecond)
+	return nil
+}
+
+func newConcProbeTasks(n int) (tasks []tasker, peak *atomic.Int32) {
+	active := &atomic.Int32{}
+	peak = &atomic.Int32{}
+	tasks = make([]tasker, n)
+	for i := range tasks {
+		tasks[i] = &concProbeTask{active: active, peak: peak}
+	}
+	return tasks, peak
+}
+
+// TestPipeline_executeTasks_singleWriterSerializes verifies gh975: when the
+// join destination is single-writer (tasksSingleWriter, as SQLite is),
+// executeTasks runs the copy tasks one at a time, so they never contend on
+// the single write lock and fail with "database is locked".
+func TestPipeline_executeTasks_singleWriterSerializes(t *testing.T) {
+	tasks, peak := newConcProbeTasks(4)
+	p := &pipeline{tasks: tasks, tasksSingleWriter: true}
+	require.NoError(t, p.executeTasks(context.Background()))
+	require.Equal(t, int32(1), peak.Load(),
+		"tasksSingleWriter must serialize join copy tasks")
+}
+
+// TestPipeline_executeTasks_concurrentByDefault verifies that for a
+// multi-writer joindb (tasksSingleWriter false), executeTasks runs tasks
+// concurrently up to the errgroup limit.
+func TestPipeline_executeTasks_concurrentByDefault(t *testing.T) {
+	tasks, peak := newConcProbeTasks(4)
+	p := &pipeline{tasks: tasks, tasksSingleWriter: false}
+	require.NoError(t, p.executeTasks(context.Background()))
+	require.Greater(t, peak.Load(), int32(1),
+		"a multi-writer joindb must allow concurrent task execution")
+}

--- a/libsq/pipeline_internal_test.go
+++ b/libsq/pipeline_internal_test.go
@@ -2,6 +2,7 @@ package libsq
 
 import (
 	"context"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -9,22 +10,38 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// concProbeTask records the peak number of tasks executing concurrently,
-// so tests can assert executeTasks' effective concurrency limit.
+// taskerFunc adapts a plain func to the tasker interface.
+type taskerFunc func(context.Context) error
+
+func (f taskerFunc) executeTask(ctx context.Context) error { return f(ctx) }
+
+// recordPeak increments active, advances peak to the running maximum, and
+// returns the new active count. The caller must decrement active when its
+// task finishes.
+func recordPeak(active, peak *atomic.Int32) int32 {
+	n := active.Add(1)
+	for {
+		p := peak.Load()
+		if n <= p || peak.CompareAndSwap(p, n) {
+			return n
+		}
+	}
+}
+
+// concProbeTask records the peak number of tasks executing concurrently.
+// The sleep widens the window in which overlapping tasks are observable, so
+// that a broken concurrency clamp (tasks running in parallel when they must
+// be serialized) is reliably caught; under a correct serialized run the peak
+// is structurally 1 regardless of the sleep, so this cannot yield a false
+// failure.
 type concProbeTask struct {
 	active *atomic.Int32
 	peak   *atomic.Int32
 }
 
 func (ct *concProbeTask) executeTask(context.Context) error {
-	n := ct.active.Add(1)
+	recordPeak(ct.active, ct.peak)
 	defer ct.active.Add(-1)
-	for {
-		p := ct.peak.Load()
-		if n <= p || ct.peak.CompareAndSwap(p, n) {
-			break
-		}
-	}
 	time.Sleep(50 * time.Millisecond)
 	return nil
 }
@@ -53,9 +70,38 @@ func TestPipeline_executeTasks_singleWriterSerializes(t *testing.T) {
 
 // TestPipeline_executeTasks_concurrentByDefault verifies that for a
 // multi-writer joindb (tasksSingleWriter false), executeTasks runs tasks
-// concurrently up to the errgroup limit.
+// concurrently up to the errgroup limit. Each task blocks until a second
+// task is simultaneously in-flight, so the overlap is observed
+// deterministically rather than depending on sleep timing (which could flake
+// on a loaded runner).
 func TestPipeline_executeTasks_concurrentByDefault(t *testing.T) {
-	tasks, peak := newConcProbeTasks(4)
+	const n = 4
+	var (
+		active, peak atomic.Int32
+		once         sync.Once
+		twoInFlight  = make(chan struct{})
+	)
+
+	tasks := make([]tasker, n)
+	for i := range tasks {
+		tasks[i] = taskerFunc(func(context.Context) error {
+			cur := recordPeak(&active, &peak)
+			defer active.Add(-1)
+			if cur >= 2 {
+				once.Do(func() { close(twoInFlight) })
+			}
+			// Block until two tasks are concurrently in-flight. The timeout is
+			// a safety valve: it fires only if executeTasks failed to run tasks
+			// concurrently, so the assertion below fails cleanly instead of the
+			// test hanging.
+			select {
+			case <-twoInFlight:
+			case <-time.After(3 * time.Second):
+			}
+			return nil
+		})
+	}
+
 	p := &pipeline{tasks: tasks, tasksSingleWriter: false}
 	require.NoError(t, p.executeTasks(context.Background()))
 	require.Greater(t, peak.Load(), int32(1),


### PR DESCRIPTION
## Summary

Fixes #975: a join across two sources could fail with `database is locked`.

A cross-source join copies each participating table into a temporary SQLite join database, then runs the join there. The copies run concurrently via an errgroup, but SQLite (rollback-journal mode) permits only **one writer at a time**. When one table is large, its copy holds the write lock long enough that the concurrent copies exhaust the driver's default 5000ms `busy_timeout` and fail with `database is locked`. The reporter's log shows a 1M-row copy holding the lock ~4.8s while a sibling copy times out.

The concurrency buys nothing for the write side (SQLite serializes writes regardless); it only manufactures the contention.

## Change

- Add `dialect.SingleWriter bool` — true for engines that permit only one write transaction at a time. SQLite sets it; the zero value (false) is the common client/server case.
- The join pipeline reads this from the joindb and clamps copy-task concurrency to 1 when the joindb is single-writer. Multi-writer joindbs keep the errgroup limit, leaving room for a future engine (e.g. Postgres) that supports concurrent writers.

## Tests

- `TestDialect_SingleWriter` pins SQLite as single-writer.
- `TestPipeline_executeTasks_singleWriterSerializes` / `_concurrentByDefault` pin that `executeTasks` serializes when single-writer and runs concurrently otherwise. (The original failure is size/timing-dependent, so the tests pin the mechanism rather than trying to trigger a real lock timeout.)
- Full `libsq` suite (incl. cross-source join tests), `drivers/sqlite3`, and `dialect` packages pass; `go build ./...`, `go vet`, `gofmt` clean.

## Follow-up

This serializes the copies, which gives up parallel *reads* from the remote sources. #995 tracks the larger enhancement: a fan-in writer (N concurrent readers → one serialized writer) that restores read parallelism without lock contention.
