### PR TITLE
site/clickhouse: drop Related link to the driver README

### DIFF
--- a/site/content/en/docs/drivers/clickhouse.md
+++ b/site/content/en/docs/drivers/clickhouse.md
@@ -165,7 +165,6 @@ and the `system.tables` catalog.
 
 <!-- markdownlint-disable-next-line MD013 -->
 
-- [ClickHouse driver README](https://github.com/neilotoole/sq/blob/master/drivers/clickhouse/README.md)
 - [#544](https://github.com/neilotoole/sq/issues/544) — Type roundtrip issues (`kind.Time`, `kind.Bytes`)
 - [#545](https://github.com/neilotoole/sq/issues/545) — Array types flattened to CSV text
   (information loss)


### PR DESCRIPTION
## Summary

Removes the "Related → ClickHouse driver README" link from the sq.io ClickHouse page. The `#544` / `#545` issue links stay.

## Why

The ClickHouse driver README was trimmed (#1019) to purely contributor-facing implementation rationale (batch-API workaround, async-mutation handling, array-flattening architecture). sq.io is user-facing documentation, so a "Related" link there is a promise of useful further reading *for a user*. Pointing a user at driver internals they can't act on is now a category mismatch.

Before the trim the README carried user-facing content (connection strings, type tables), so the link was defensible; the trim changed the file's audience, so the link should follow.

This mirrors the Oracle page (its driver-README link was removed in #1016 when that README was deleted). After this change, **no sq.io page links to a driver README**.

## Notes

- Pure one-line deletion; docs/site only, no code.
- Every remaining line already passes the site markdownlint on master.
- `site/` change: rebuilds the Netlify deploy preview and ships to sq.io with the next release, not immediately.