### PR TITLE
repo: retire markdownlint in favor of dprint

### DIFF
--- a/.agents/skills/sq-site-dependabot/references/high-risk-packages.md
+++ b/.agents/skills/sq-site-dependabot/references/high-risk-packages.md
@@ -10,17 +10,13 @@ Dependabot PR title and `site/bun.lock` diff against this list.
 - Replacement/alternate PRs may be needed if Dependabot cannot auto-resolve
   (see sq repo history: held PRs, manual migration).
 
-## ESLint ecosystem (T3 when major)
+## JS lint / formatting (moved to root toolchain)
 
-- Flat config (`eslint.config.js`) — major bumps often need rule fixes across
-  `site/scripts/`, `site/bunfig.toml`, and content tooling.
-- Run `make site-test` after merge; expect multi-file lint fixes in a follow-up
-  commit if merging a major without a dedicated migration branch.
-
-## Stylelint (T3 when major)
-
-- Can fail on Doks/Hugo template-adjacent CSS and custom properties.
-- Compare `stylelint.config.*` changelog; run `bun run lint:styles` locally.
+Site JS linting (formerly ESLint) and formatting (formerly Stylelint /
+markdownlint) moved to the repo-root Bun toolchain: **Biome** (JS lint) and
+**dprint** (formatting). Those bumps arrive through the **root `/` bun
+ecosystem**, not this site flow, so they are out of scope here.
+`site/package.json` no longer carries any linter or formatter.
 
 ## `flexsearch` / search index (T4)
 

--- a/.agents/skills/sq-site-dependabot/references/netlify-build-debug.md
+++ b/.agents/skills/sq-site-dependabot/references/netlify-build-debug.md
@@ -50,8 +50,6 @@ Read these fields first:
 
 Example (**PR #621**): `state: error`, `error_message`:
 
-<!-- markdownlint-disable-next-line MD013 -->
-
 `Failed during stage 'Install dependencies': dependency_installation script returned non-zero exit code: 1`
 
 ## 3. Netlify API — build record

--- a/.agents/skills/sq-site-dependabot/references/risk-tiers.md
+++ b/.agents/skills/sq-site-dependabot/references/risk-tiers.md
@@ -23,8 +23,9 @@ Classify every open site PR before ordering merges. Read this file during
 
 ## T2 — Medium (review changelog)
 
-- ESLint / Stylelint **minor** updates or new rules that may fail `site-test`
-- `linkinator`, `dprint`/`biome`, or test-runner bumps
+- Biome or dprint **minor** updates or new rules that may fail the Format gate
+  (`make lint` / `make fmt-check`)
+- `linkinator` or test-runner bumps
 - Netlify plugin version bumps (`@netlify/plugin-lighthouse`, sitemap submit)
 
 **Validation:** Full `make ci`; scan Netlify Lighthouse report on deploy preview
@@ -33,9 +34,9 @@ Lighthouse is ambiguous.
 
 ## T3 — High (hold or dedicated migration PR)
 
-- **Major** ESLint (flat config), Stylelint, or TypeScript-eslint migrations
+- **Major** Biome or dprint migrations (config-schema changes)
 - Hugo/Doks major upgrades, theme swaps, or `bunfig` / build pipeline changes
-- Anything that rewrites `site/config/`, `eslint.config.*`, or CI scripts
+- Anything that rewrites `site/config/`, `dprint.json` / `biome.json`, or CI scripts
 
 **Action:** Do **not** merge via bulk Dependabot flow. Close or leave open;
 open a focused migration PR with human review and expanded test plan.

--- a/.agents/skills/sq-site-dependabot/references/risk-tiers.md
+++ b/.agents/skills/sq-site-dependabot/references/risk-tiers.md
@@ -24,7 +24,7 @@ Classify every open site PR before ordering merges. Read this file during
 ## T2 — Medium (review changelog)
 
 - ESLint / Stylelint **minor** updates or new rules that may fail `site-test`
-- `linkinator`, markdownlint, or test-runner bumps
+- `linkinator`, `dprint`/`biome`, or test-runner bumps
 - Netlify plugin version bumps (`@netlify/plugin-lighthouse`, sitemap submit)
 
 **Validation:** Full `make ci`; scan Netlify Lighthouse report on deploy preview

--- a/.agents/skills/sq-site-dependabot/references/risk-tiers.md
+++ b/.agents/skills/sq-site-dependabot/references/risk-tiers.md
@@ -23,8 +23,6 @@ Classify every open site PR before ordering merges. Read this file during
 
 ## T2 — Medium (review changelog)
 
-- Biome or dprint **minor** updates or new rules that may fail the Format gate
-  (`make lint` / `make fmt-check`)
 - `linkinator` or test-runner bumps
 - Netlify plugin version bumps (`@netlify/plugin-lighthouse`, sitemap submit)
 
@@ -34,9 +32,8 @@ Lighthouse is ambiguous.
 
 ## T3 — High (hold or dedicated migration PR)
 
-- **Major** Biome or dprint migrations (config-schema changes)
 - Hugo/Doks major upgrades, theme swaps, or `bunfig` / build pipeline changes
-- Anything that rewrites `site/config/`, `dprint.json` / `biome.json`, or CI scripts
+- Anything that rewrites `site/config/` or CI scripts
 
 **Action:** Do **not** merge via bulk Dependabot flow. Close or leave open;
 open a focused migration PR with human review and expanded test plan.

--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -1,3 +1,1 @@
-<!-- markdownlint-disable MD041 -->
-
 You know what to do.

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -3,7 +3,7 @@
 # dprint owns formatting for markdown, JSON, YAML, TOML, SCSS/CSS, Go (gofumpt
 # plugin), and site JS; Biome lints site JS (replacing eslint). This single
 # workflow gates all of it, including docs-only and site-only PRs that main.yml
-# skips (it ignores **.md and site/**). Replaces the old markdownlint workflow.
+# skips (it ignores **.md and site/**).
 name: Format
 
 on:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,3 @@
-<!-- CHANGELOG is hand-maintained release notes: long lines (MD013), tab-aligned
-     pasted command/test output in code blocks (MD010), and many issue-reference
-     link definitions (MD053) are intentional and intrinsic to the format. -->
-<!-- markdownlint-configure-file { "MD013": false, "MD010": false, "MD053": false } -->
-
 # CHANGELOG
 
 All notable changes to this project will be documented in this file.

--- a/bun.lock
+++ b/bun.lock
@@ -3,7 +3,7 @@
   "configVersion": 1,
   "workspaces": {
     "": {
-      "name": "sq-markdownlint",
+      "name": "sq-devtools",
       "devDependencies": {
         "@biomejs/biome": "^2.5.1",
         "dprint": "^0.55.0",

--- a/site/CLAUDE.md
+++ b/site/CLAUDE.md
@@ -63,8 +63,7 @@ make fmt      # dprint fmt (plus Go imports)
 make lint     # golangci-lint, shellcheck, dprint check, Biome
 ```
 
-The repo-root [`Format`](../.github/workflows/format.yml) workflow gates this
-and replaced the old ESLint / Stylelint / markdownlint scripts.
+The repo-root [`Format`](../.github/workflows/format.yml) workflow gates this.
 
 ### Content Generation
 

--- a/site/CLAUDE.md
+++ b/site/CLAUDE.md
@@ -46,25 +46,25 @@ bun run preview
 
 ### Linting and Testing
 
+The site's own test/lint suite is **link-checking only** (linkinator):
+
 ```bash
-# Run all linters (scripts, styles, markdown, links)
-make site-test
-# or
-bun test
-# or
-bun run lint
-
-# Individual linters
-bun run lint:scripts       # ESLint on assets/js
-bun run lint:styles        # Stylelint on SCSS files
-bun run lint:markdown      # markdownlint on MD files
-bun run lint:links         # Link checker (starts local server)
-
-# Auto-fix
-bun run lint:scripts-fix
-bun run lint:styles-fix
-bun run lint:markdown-fix
+make site-test        # internal link check (bun run test:ci); matches Site CI
+make site-test-full   # + external link crawl (bun run test:full)
+bun run lint:links:internal   # the internal check directly
 ```
+
+Formatting and JS linting are handled **repo-wide**, not by site scripts.
+Markdown, JSON, YAML, TOML, SCSS/CSS, Go, and site JS are formatted by
+**dprint**, and site JS is linted by **Biome**. Run these from the repo root:
+
+```bash
+make fmt      # dprint fmt (plus Go imports)
+make lint     # golangci-lint, shellcheck, dprint check, Biome
+```
+
+The repo-root [`Format`](../.github/workflows/format.yml) workflow gates this
+and replaced the old ESLint / Stylelint / markdownlint scripts.
 
 ### Content Generation
 

--- a/site/content/en/_index.md
+++ b/site/content/en/_index.md
@@ -6,8 +6,6 @@ draft: false
 images: []
 ---
 
-<!-- markdownlint-disable-next-line MD013 -->
-
 {{< asciicast src="/casts/home-quick.cast" poster="npt:0:25" rows=10 autoPlay=true speed=3 idleTimeLimit=3 >}}
 
 `sq` is a free/libre [open-source](https://github.com/neilotoole/sq) data wrangling swiss-army knife
@@ -24,13 +22,9 @@ sq '@postgres_db | .actor | .first_name, .last_name | .[0:5]'
 {{< tabs name="sq-install" >}}
 {{{< tab name="mac" codelang="shell" >}}brew install sq{{< /tab >}}
 
-<!-- markdownlint-disable-next-line MD013 -->
-
 {{< tab name="linux" codelang="shell" >}}/bin/sh -c "$(curl -fsSL https://sq.io/install.sh)"{{< /tab >}}}
 {{< tab name="win" codelang="shell">}}scoop bucket add sq https://github.com/neilotoole/sq
 scoop install sq{{< /tab >}}}
-
-<!-- markdownlint-disable-next-line MD013 -->
 
 {{% tab name="more" %}}Install options for `apt`, `yum`, `apk`, `pacman`, `yay` on the [install page](/docs/install).{{% /tab %}}}
 {{< /tabs >}}
@@ -92,8 +86,6 @@ extract the table names; pipe the table names
 to `xargs`, invoking `sq` once for each table, outputting a CSV file per table. This snippet
 was tested on macOS.
 
-<!-- markdownlint-disable-next-line MD013 -->
-
 {{< asciicast src="/casts/export-all-tables-to-csv.cast" poster="npt:0:22" idleTimeLimit=0.5 rows=6 speed=2.5 >}}
 
 If you instead wanted to use `sql` mode:
@@ -151,7 +143,5 @@ We can use `sq`'s own [log](/docs/config/#logging) output as an example:
 {"level":"debug","time":"00:07:48.800016","caller":"source/files.go:323:(*Files).Close","msg":"Files.Close invoked: has 1 clean funcs"}
 {"level":"debug","time":"00:07:48.800031","caller":"source/files.go:61:NewFiles.func1","msg":"About to clean fscache from dir: /var/folders/68/qthwmfm93zl4mqdw_7wvsv7w0000gn/T/sq_files_fscache_2273841732"}
 ```
-
-<!-- markdownlint-disable-next-line MD013 -->
 
 {{< asciicast src="/casts/query-jsonl-log-file.cast" poster="npt:0:17" idleTimeLimit=0.5 rows=5 speed=2 >}}

--- a/site/content/en/docs/cmd/add.md
+++ b/site/content/en/docs/cmd/add.md
@@ -133,8 +133,6 @@ The location completion mechanism suggests usernames, hostnames (from history),
 database names, and even values for query params (e.g. `?sslmode=disable`) for
 each supported database. It never suggests passwords.
 
-<!-- markdownlint-disable-next-line MD013 -->
-
 {{< asciicast src="/casts/src-add-location-completion-pg.cast" poster="npt:0:8" idleTimeLimit=0.5 rows=6 speed=1.5 >}}
 
 ## Header row

--- a/site/content/en/docs/config/index.md
+++ b/site/content/en/docs/config/index.md
@@ -285,8 +285,6 @@ an individual source, overriding the base config.
 
 ### `shell-completion.group-filter`
 
-<!-- markdownlint-disable-next-line MD013 -->
-
 {{< readfile file="../cmd/options/shell-completion.group-filter.help.txt" code="true" lang="text" >}}
 
 ### `shell-completion.log`
@@ -337,23 +335,17 @@ an individual source, overriding the base config.
 
 {{< readfile file="../cmd/options/format.excel.datetime.help.txt" code="true" lang="text" >}}
 
-<!-- markdownlint-disable-next-line MD013 -->
-
 See also: [Excel date/time format reference](https://support.microsoft.com/en-gb/office/format-numbers-as-dates-or-times-418bd3fe-0577-47c8-8caa-b4d30c528309#bm2)
 
 ### `format.excel.date`
 
 {{< readfile file="../cmd/options/format.excel.date.help.txt" code="true" lang="text" >}}
 
-<!-- markdownlint-disable-next-line MD013 -->
-
 See also: [Excel date/time format reference](https://support.microsoft.com/en-gb/office/format-numbers-as-dates-or-times-418bd3fe-0577-47c8-8caa-b4d30c528309#bm2)
 
 ### `format.excel.time`
 
 {{< readfile file="../cmd/options/format.excel.time.help.txt" code="true" lang="text" >}}
-
-<!-- markdownlint-disable-next-line MD013 -->
 
 See also: [Excel date/time format reference](https://support.microsoft.com/en-gb/office/format-numbers-as-dates-or-times-418bd3fe-0577-47c8-8caa-b4d30c528309#bm2)
 
@@ -550,8 +542,6 @@ Note that `diff.stop` only applies to table row data diffs, not to metadata diff
 {{< readfile file="../cmd/options/tuning.errgroup-limit.help.txt" code="true" lang="text" >}}
 
 ### `tuning.output-flush-threshold`
-
-<!-- markdownlint-disable-next-line MD013 -->
 
 {{< readfile file="../cmd/options/tuning.output-flush-threshold.help.txt" code="true" lang="text" >}}
 

--- a/site/content/en/docs/drivers/clickhouse.md
+++ b/site/content/en/docs/drivers/clickhouse.md
@@ -163,8 +163,6 @@ and the `system.tables` catalog.
 
 ## Related
 
-<!-- markdownlint-disable-next-line MD013 -->
-
 - [#544](https://github.com/neilotoole/sq/issues/544) — Type roundtrip issues (`kind.Time`, `kind.Bytes`)
 - [#545](https://github.com/neilotoole/sq/issues/545) — Array types flattened to CSV text
   (information loss)

--- a/site/content/en/docs/source/index.md
+++ b/site/content/en/docs/source/index.md
@@ -100,8 +100,6 @@ The location completion mechanism suggests usernames, hostnames (from history),
 database names, and even values for query params (e.g. `?sslmode=disable`) for
 each supported database. It never suggests passwords.
 
-<!-- markdownlint-disable-next-line MD013 -->
-
 {{< asciicast src="/casts/src-add-location-completion-pg.cast" poster="npt:0:8" idleTimeLimit=0.5 rows=6 speed=1.5 >}}
 
 ## List sources


### PR DESCRIPTION
## Summary

markdownlint was replaced by dprint for repo-wide formatting (#927). It is no longer a CI gate, a configured tool, or a declared dependency. This removes every remaining trace of it — **markdownlint is now fully retired repo-wide**, with the sole exception of vendored upstream code.

## Removed

**Directives / comments (dead no-ops under dprint):**
- 13 `<!-- markdownlint-disable-next-line MD013 -->` comments across `site/content` (`_index`, `cmd/add`, `config`, `drivers/clickhouse`, `source`).
- `CHANGELOG.md`: the `markdownlint-configure-file` directive and the comment that only existed to justify it.
- `.github/PULL_REQUEST_TEMPLATE`: the `MD041` disable comment.
- `.agents/skills/.../netlify-build-debug.md`: an `MD013` disable comment.

**Stale references:**
- `site/CLAUDE.md`: documented a lint suite that no longer exists (`lint:scripts`/`lint:styles`/`lint:markdown` via ESLint/Stylelint/markdownlint). Rewritten to the actual setup: site checks are link-only (linkinator via `make site-test`); formatting + JS lint are repo-wide dprint + Biome.
- `.agents/skills/.../risk-tiers.md`: dependabot example listed `markdownlint`; replaced with `dprint`/`biome`.
- `bun.lock`: root workspace name was still `sq-markdownlint`; aligned with `package.json`'s `sq-devtools`.

**Migration notes (the last mentions):**
- `.github/workflows/format.yml` and `site/CLAUDE.md`: dropped the "replaces the old markdownlint" phrasing.

## Left intentionally

- **Vendored `libsq/core/lg/devlog/tint/README.md`** — upstream `lmittmann/tint` (MIT), kept verbatim and explicitly excluded from dprint; its markdownlint comments are upstream's.

## Verification

- `grep -rniE markdownlint` repo-wide returns nothing outside `node_modules` and the vendored `tint` dir.
- `dprint check` (the real formatting gate) passes on every changed file.
- `bun install --frozen-lockfile` passes (lockfile consistent with `package.json`).
- Markdown / YAML / lockfile only; no Go or other code touched.