### PR TITLE
ci(db): GHCR pulls, full-version matrix, image-digest dedup

### DIFF
--- a/.github/sakila-db.json
+++ b/.github/sakila-db.json
@@ -4,41 +4,41 @@
     "env": "SQ_TEST_SRC__SAKILA_PG",
     "dsn": "postgres://sakila:p_ssW0rd@localhost:5432/sakila",
     "packages": "./drivers/postgres/... ./libsq/... ./cli/... ./testh/...",
-    "tags": ["latest", "17", "12"]
+    "tags": ["18", "17", "16", "15", "14", "13", "12", "11", "10", "9"]
   },
   "mysql": {
     "port": 3306,
     "env": "SQ_TEST_SRC__SAKILA_MY",
     "dsn": "mysql://sakila:p_ssW0rd@localhost:3306/sakila",
     "packages": "./drivers/mysql/... ./libsq/... ./cli/... ./testh/...",
-    "tags": ["latest", "9", "8"]
+    "tags": ["9", "8", "5.7", "5.6"]
   },
   "sqlserver": {
     "port": 1433,
     "env": "SQ_TEST_SRC__SAKILA_MS",
     "dsn": "sqlserver://sakila:p_ssW0rd@localhost:1433?database=sakila",
     "packages": "./drivers/sqlserver/... ./libsq/... ./cli/... ./testh/...",
-    "tags": ["latest", "2019"]
+    "tags": ["2022", "2019"]
   },
   "clickhouse": {
     "port": 9000,
     "env": "SQ_TEST_SRC__SAKILA_CH",
     "dsn": "clickhouse://sakila:p_ssW0rd@localhost:9000?database=sakila",
     "packages": "./drivers/clickhouse/... ./libsq/... ./cli/... ./testh/...",
-    "tags": ["latest"]
+    "tags": ["25"]
   },
   "oracle": {
     "port": 1521,
     "env": "SQ_TEST_SRC__SAKILA_OR",
     "dsn": "oracle://sakila:p_ssW0rd@localhost:1521/SAKILA",
     "packages": "./drivers/oracle/... ./libsq/... ./cli/... ./testh/...",
-    "tags": ["latest"]
+    "tags": ["23"]
   },
   "rqlite": {
     "port": 4001,
     "env": "SQ_TEST_SRC__SAKILA_RQ",
     "dsn": "rqlite://sakila:p_ssW0rd@localhost:4001?disableClusterDiscovery=true",
     "packages": "./drivers/rqlite/... ./libsq/... ./cli/... ./testh/...",
-    "tags": ["latest"]
+    "tags": ["10"]
   }
 }

--- a/.github/workflows/db-integration.yml
+++ b/.github/workflows/db-integration.yml
@@ -35,6 +35,12 @@ on:
 
 env:
   BUILD_TAGS: "sqlite_vtable sqlite_stat4 sqlite_fts5 sqlite_introspect sqlite_json sqlite_math_functions"
+  # Single source of truth for the sakiladb registry. GHCR isn't subject to
+  # Docker Hub's anonymous pull rate limits (easily tripped from shared runner
+  # IPs) and mirrors the same images with identical digests. build-db-matrix.sh
+  # reads it and stamps each matrix entry's `image` ref; the test service and
+  # dedup-db-matrix.sh then both consume that ref, so the registry lives here only.
+  SAKILADB_REGISTRY: ghcr.io/sakiladb
 
 jobs:
   setup:
@@ -74,7 +80,11 @@ jobs:
               | map({key:.key, value:(.value | split(","))}) | from_entries')
           fi
           scope="$INPUT_SCOPE"
-          inc=$(scripts/build-db-matrix.sh "$scope" "$sel")
+          # dedup-db-matrix.sh collapses tags that resolve to the same image
+          # (e.g. a dispatch naming both "latest" and "18" for postgres) so the
+          # image is tested once, not twice. It's best-effort: an unresolvable
+          # digest leaves the entry in place rather than dropping coverage.
+          inc=$(scripts/build-db-matrix.sh "$scope" "$sel" | scripts/dedup-db-matrix.sh)
           matrix="{\"include\":$inc}"
           echo "::notice::scope=$scope selection=$sel"
           echo "::notice::matrix=$matrix"
@@ -90,13 +100,16 @@ jobs:
   test:
     needs: setup
     if: ${{ fromJSON(needs.setup.outputs.matrix).include[0] != null }}
+    # Concise name; without this the matrix auto-appends every include field
+    # (image, port, env, packages) to the job title.
+    name: test ${{ matrix.engine }}:${{ matrix.tag }}
     runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.setup.outputs.matrix) }}
     services:
       db:
-        image: sakiladb/${{ matrix.engine }}:${{ matrix.tag }}
+        image: ${{ matrix.image }}
         ports:
           - ${{ matrix.port }}:${{ matrix.port }}
     steps:

--- a/.github/workflows/db-scheduled.yml
+++ b/.github/workflows/db-scheduled.yml
@@ -28,8 +28,8 @@ jobs:
         run: |
           set -euo pipefail
           # The weekly cron and a manual "sweep" dispatch both run the full
-          # version sweep (every published tag, narrow scope). Everything else —
-          # the nightly cron and the default manual dispatch — runs every engine
+          # version sweep (every published tag, narrow scope). Everything else
+          # (the nightly cron and the default manual dispatch) runs every engine
           # at :latest, full scope. "latest" is derived here (not stored in the
           # config's tags), so it never duplicates the newest numbered tag in
           # the sweep.

--- a/.github/workflows/db-scheduled.yml
+++ b/.github/workflows/db-scheduled.yml
@@ -4,7 +4,13 @@ on:
   schedule:
     - cron: "0 4 * * *" # nightly: every engine @ :latest, full scope
     - cron: "0 5 * * 1" # weekly (Mon): full version sweep, narrow scope
-  workflow_dispatch: {} # manual: behaves like the nightly run
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: "latest (every engine @ latest, full scope) or sweep (every published tag, narrow scope)"
+        type: choice
+        options: [latest, sweep]
+        default: latest
 
 jobs:
   select:
@@ -16,9 +22,18 @@ jobs:
       - uses: actions/checkout@v7
       - id: sel
         shell: bash
+        env:
+          SCHEDULE: ${{ github.event.schedule }}
+          MODE: ${{ github.event.inputs.mode }}
         run: |
           set -euo pipefail
-          if [ "${{ github.event.schedule }}" = '0 5 * * 1' ]; then
+          # The weekly cron and a manual "sweep" dispatch both run the full
+          # version sweep (every published tag, narrow scope). Everything else —
+          # the nightly cron and the default manual dispatch — runs every engine
+          # at :latest, full scope. "latest" is derived here (not stored in the
+          # config's tags), so it never duplicates the newest numbered tag in
+          # the sweep.
+          if [ "$SCHEDULE" = '0 5 * * 1' ] || [ "$MODE" = 'sweep' ]; then
             selection=$(jq -c 'to_entries | map({key:.key, value:.value.tags}) | from_entries' .github/sakila-db.json)
             scope=narrow
           else

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -175,7 +175,9 @@ jobs:
 
       - name: shellcheck
         run: |
-          shellcheck ./install.sh scripts/fmt-go-imports.sh
+          shellcheck ./install.sh scripts/fmt-go-imports.sh scripts/build-db-matrix.sh scripts/dedup-db-matrix.sh scripts/build-db-matrix_test.sh
+          # Hermetic unit test for the shared DB-matrix builder (no network).
+          bash scripts/build-db-matrix_test.sh
 
       - name: Set up Go
         uses: actions/setup-go@v6

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -175,9 +175,11 @@ jobs:
 
       - name: shellcheck
         run: |
-          shellcheck ./install.sh scripts/fmt-go-imports.sh scripts/build-db-matrix.sh scripts/dedup-db-matrix.sh scripts/build-db-matrix_test.sh
-          # Hermetic unit test for the shared DB-matrix builder (no network).
+          shellcheck ./install.sh scripts/fmt-go-imports.sh scripts/build-db-matrix.sh scripts/dedup-db-matrix.sh scripts/build-db-matrix_test.sh scripts/dedup-db-matrix_test.sh
+          # Hermetic unit tests for the shared DB-matrix scripts (no network;
+          # dedup stubs docker on PATH).
           bash scripts/build-db-matrix_test.sh
+          bash scripts/dedup-db-matrix_test.sh
 
       - name: Set up Go
         uses: actions/setup-go@v6

--- a/Makefile
+++ b/Makefile
@@ -113,7 +113,8 @@ fmt-check: ## Check dprint formatting repo-wide (read-only; does not modify file
 lint: deps ## Run linters: golangci-lint, shellcheck, dprint check, biome.
 	go tool -modfile=tools/golangci-lint/go.mod golangci-lint version
 	go tool -modfile=tools/golangci-lint/go.mod golangci-lint run --output.tab.path stdout
-	@shellcheck ./install.sh .githooks/pre-commit
+	@shellcheck ./install.sh .githooks/pre-commit scripts/build-db-matrix.sh scripts/dedup-db-matrix.sh scripts/build-db-matrix_test.sh
+	@bash scripts/build-db-matrix_test.sh
 	@# Repo-wide formatting gate (markdown, JSON, YAML, TOML, SCSS, Go, JS).
 	@bunx dprint check
 	@# Static analysis for site JS (replaces eslint).

--- a/Makefile
+++ b/Makefile
@@ -113,8 +113,9 @@ fmt-check: ## Check dprint formatting repo-wide (read-only; does not modify file
 lint: deps ## Run linters: golangci-lint, shellcheck, dprint check, biome.
 	go tool -modfile=tools/golangci-lint/go.mod golangci-lint version
 	go tool -modfile=tools/golangci-lint/go.mod golangci-lint run --output.tab.path stdout
-	@shellcheck ./install.sh .githooks/pre-commit scripts/build-db-matrix.sh scripts/dedup-db-matrix.sh scripts/build-db-matrix_test.sh
+	@shellcheck ./install.sh .githooks/pre-commit scripts/build-db-matrix.sh scripts/dedup-db-matrix.sh scripts/build-db-matrix_test.sh scripts/dedup-db-matrix_test.sh
 	@bash scripts/build-db-matrix_test.sh
+	@bash scripts/dedup-db-matrix_test.sh
 	@# Repo-wide formatting gate (markdown, JSON, YAML, TOML, SCSS, Go, JS).
 	@bunx dprint check
 	@# Static analysis for site JS (replaces eslint).

--- a/scripts/build-db-matrix.sh
+++ b/scripts/build-db-matrix.sh
@@ -21,6 +21,7 @@ scope="${1:?usage: build-db-matrix.sh <full|narrow> <selection-json>}"
 selection="${2:?missing selection json}"
 config="$(cd "$(dirname "$0")/.." && pwd)/.github/sakila-db.json"
 registry="${SAKILADB_REGISTRY:-ghcr.io/sakiladb}"
+registry="${registry%/}" # tolerate a trailing slash in the override
 
 # workflow_dispatch constrains scope via type:choice, but the workflow_call
 # input is a free string — reject typos rather than silently treating any

--- a/scripts/build-db-matrix.sh
+++ b/scripts/build-db-matrix.sh
@@ -3,7 +3,13 @@
 #
 # Usage: build-db-matrix.sh <full|narrow> <selection-json>
 #   selection-json: {"postgres":["12","latest"],"mysql":["8"]}
-# Emits a JSON array of {engine,tag,port,env,packages} on stdout.
+# Emits a JSON array of {engine,tag,image,port,env,packages} on stdout.
+#
+# The `image` field is the fully-qualified pull ref, built once here so both the
+# test job's service container and dedup-db-matrix.sh consume the same string —
+# the registry is defined in exactly one place. Registry defaults to GHCR
+# (ghcr.io/sakiladb), which isn't subject to Docker Hub's anonymous pull rate
+# limits; override with SAKILADB_REGISTRY.
 #
 # Note: the DSN is deliberately NOT included. It contains credentials that
 # GitHub masks as a secret, and a job output containing a masked value is
@@ -14,6 +20,7 @@ set -euo pipefail
 scope="${1:?usage: build-db-matrix.sh <full|narrow> <selection-json>}"
 selection="${2:?missing selection json}"
 config="$(cd "$(dirname "$0")/.." && pwd)/.github/sakila-db.json"
+registry="${SAKILADB_REGISTRY:-ghcr.io/sakiladb}"
 
 # workflow_dispatch constrains scope via type:choice, but the workflow_call
 # input is a free string — reject typos rather than silently treating any
@@ -29,7 +36,8 @@ esac
 jq -cn \
   --argjson sel "$selection" \
   --slurpfile cfg "$config" \
-  --arg scope "$scope" '
+  --arg scope "$scope" \
+  --arg registry "$registry" '
   ($cfg[0]) as $c
   | [ $sel | to_entries[]
       | .key as $engine
@@ -38,6 +46,7 @@ jq -cn \
       | {
           engine:   $engine,
           tag:      .,
+          image:    "\($registry)/\($engine):\(.)",
           port:     $e.port,
           env:      $e.env,
           packages: (if $scope == "narrow" then $e.packages else "./..." end)

--- a/scripts/build-db-matrix.sh
+++ b/scripts/build-db-matrix.sh
@@ -6,7 +6,7 @@
 # Emits a JSON array of {engine,tag,image,port,env,packages} on stdout.
 #
 # The `image` field is the fully-qualified pull ref, built once here so both the
-# test job's service container and dedup-db-matrix.sh consume the same string —
+# test job's service container and dedup-db-matrix.sh consume the same string;
 # the registry is defined in exactly one place. Registry defaults to GHCR
 # (ghcr.io/sakiladb), which isn't subject to Docker Hub's anonymous pull rate
 # limits; override with SAKILADB_REGISTRY.

--- a/scripts/build-db-matrix_test.sh
+++ b/scripts/build-db-matrix_test.sh
@@ -11,11 +11,19 @@ echo "$out" | jq -e '.[0].port == 5432' >/dev/null
 echo "$out" | jq -e '.[0].env == "SQ_TEST_SRC__SAKILA_PG"' >/dev/null
 echo "$out" | jq -e '.[0].packages | test("drivers/postgres")' >/dev/null
 
+# the image ref defaults to GHCR and is stamped once here for downstream reuse
+echo "$out" | jq -e '.[0].image == "ghcr.io/sakiladb/postgres:12"' >/dev/null
+
 # full scope: packages collapses to ./...
 out=$("$here/build-db-matrix.sh" full '{"mysql":["8","9"]}')
 echo "$out" | jq -e 'length == 2' >/dev/null
 echo "$out" | jq -e 'all(.packages == "./...")' >/dev/null
 echo "$out" | jq -e '[.[].tag] == ["8","9"]' >/dev/null
+echo "$out" | jq -e '[.[].image] == ["ghcr.io/sakiladb/mysql:8","ghcr.io/sakiladb/mysql:9"]' >/dev/null
+
+# SAKILADB_REGISTRY overrides the image registry (single source of truth)
+out=$(SAKILADB_REGISTRY=example.test/ns "$here/build-db-matrix.sh" narrow '{"postgres":["12"]}')
+echo "$out" | jq -e '.[0].image == "example.test/ns/postgres:12"' >/dev/null
 
 # the DSN must NOT travel through the matrix: GitHub masks the credential and
 # drops a job output containing it, which silently empties the matrix.

--- a/scripts/build-db-matrix_test.sh
+++ b/scripts/build-db-matrix_test.sh
@@ -25,6 +25,10 @@ echo "$out" | jq -e '[.[].image] == ["ghcr.io/sakiladb/mysql:8","ghcr.io/sakilad
 out=$(SAKILADB_REGISTRY=example.test/ns "$here/build-db-matrix.sh" narrow '{"postgres":["12"]}')
 echo "$out" | jq -e '.[0].image == "example.test/ns/postgres:12"' >/dev/null
 
+# a trailing slash in the override is tolerated (not doubled into an invalid ref)
+out=$(SAKILADB_REGISTRY=example.test/ns/ "$here/build-db-matrix.sh" narrow '{"postgres":["12"]}')
+echo "$out" | jq -e '.[0].image == "example.test/ns/postgres:12"' >/dev/null
+
 # the DSN must NOT travel through the matrix: GitHub masks the credential and
 # drops a job output containing it, which silently empties the matrix.
 echo "$out" | jq -e 'all(has("dsn") | not)' >/dev/null

--- a/scripts/build-db-matrix_test.sh
+++ b/scripts/build-db-matrix_test.sh
@@ -2,6 +2,11 @@
 set -euo pipefail
 here="$(cd "$(dirname "$0")" && pwd)"
 
+# Keep the default-registry assertions hermetic: a SAKILADB_REGISTRY exported in
+# the caller's shell would otherwise override the default and fail them. Cases
+# that need an override set it inline (prefixed on a single invocation).
+unset SAKILADB_REGISTRY
+
 # narrow scope: postgres@12 picks per-engine packages
 out=$("$here/build-db-matrix.sh" narrow '{"postgres":["12"]}')
 echo "$out" | jq -e 'length == 1' >/dev/null

--- a/scripts/dedup-db-matrix.sh
+++ b/scripts/dedup-db-matrix.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Collapse matrix-include entries that resolve to the same container image, so
+# that e.g. specifying both "latest" and "18" for postgres (which are the same
+# published image) runs it only once instead of twice.
+#
+# Usage: build-db-matrix.sh <scope> <selection> | dedup-db-matrix.sh
+#   stdin:  a JSON array of {engine,tag,image,port,env,packages} (build-db-matrix.sh).
+#   stdout: the same array with duplicates removed.
+#
+# Dedup happens in two passes:
+#   1. Exact (engine,tag) duplicates — pure text, always applied (e.g. "18,18").
+#   2. Same image digest — e.g. postgres:latest == postgres:18. The digest is
+#      resolved by inspecting the entry's `image` ref with `docker buildx
+#      imagetools inspect` (manifest only, no layer pull). This is best-effort:
+#      if resolution fails (offline, unknown tag), the entry is KEPT rather than
+#      dropped, so a registry hiccup can never silently remove test coverage —
+#      the worst case is the original redundant run.
+#
+# The `image` ref (registry included) is chosen once by build-db-matrix.sh; this
+# script never reconstructs it. Because that registry is GHCR by default, digest
+# resolution isn't subject to Docker Hub's anonymous pull rate limits. A tag
+# missing on the registry (e.g. sqlserver:2017 on GHCR) simply fails open.
+#
+# When two tags collapse, the earlier-listed entry wins (input order preserved),
+# so callers control which tag label survives by ordering their tags.
+#
+# Diagnostics go to stderr because stdout carries the JSON result.
+set -euo pipefail
+
+inc="$(cat)"
+
+# Pass 1: drop exact (engine,tag) duplicates, preserving first occurrence.
+inc="$(jq -c '
+  reduce .[] as $x ([];
+    if any(.[]; .engine == $x.engine and .tag == $x.tag) then . else . + [$x] end)
+' <<<"$inc")"
+
+# Pass 2: resolve digests and drop later entries sharing an (engine,digest).
+seen=$'\n'   # newline-delimited "engine<TAB>digest" keys already emitted
+out='[]'
+while read -r entry; do
+  [ -n "$entry" ] || continue
+  engine="$(jq -r '.engine' <<<"$entry")"
+  image="$(jq -r '.image' <<<"$entry")"
+  digest="$(docker buildx imagetools inspect "$image" \
+    --format '{{.Manifest.Digest}}' 2>/dev/null || true)"
+  if [ -n "$digest" ]; then
+    key="${engine}"$'\t'"${digest}"
+    if [[ "$seen" == *$'\n'"$key"$'\n'* ]]; then
+      echo "dedup: ${image} (${digest}) already scheduled; skipping" >&2
+      continue
+    fi
+    seen="${seen}${key}"$'\n'
+  fi
+  out="$(jq -c --argjson e "$entry" '. + [$e]' <<<"$out")"
+done < <(jq -c '.[]' <<<"$inc")
+
+printf '%s\n' "$out"

--- a/scripts/dedup-db-matrix.sh
+++ b/scripts/dedup-db-matrix.sh
@@ -8,12 +8,12 @@
 #   stdout: the same array with duplicates removed.
 #
 # Dedup happens in two passes:
-#   1. Exact (engine,tag) duplicates — pure text, always applied (e.g. "18,18").
-#   2. Same image digest — e.g. postgres:latest == postgres:18. The digest is
+#   1. Exact (engine,tag) duplicates: pure text, always applied (e.g. "18,18").
+#   2. Same image digest, e.g. postgres:latest == postgres:18. The digest is
 #      resolved by inspecting the entry's `image` ref with `docker buildx
 #      imagetools inspect` (manifest only, no layer pull). This is best-effort:
 #      if resolution fails (offline, unknown tag), the entry is KEPT rather than
-#      dropped, so a registry hiccup can never silently remove test coverage —
+#      dropped, so a registry hiccup can never silently remove test coverage;
 #      the worst case is the original redundant run.
 #
 # The `image` ref (registry included) is chosen once by build-db-matrix.sh; this

--- a/scripts/dedup-db-matrix_test.sh
+++ b/scripts/dedup-db-matrix_test.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Hermetic test for dedup-db-matrix.sh. `docker` is stubbed on PATH so the digest
+# pass runs without a registry or network: the stub maps :latest and :18 to one
+# digest and :12 to another, and honours STUB_DOCKER_FAIL to simulate an
+# unresolvable digest (verifying fail-open).
+set -euo pipefail
+here="$(cd "$(dirname "$0")" && pwd)"
+
+stubdir="$(mktemp -d)"
+trap 'rm -rf "$stubdir"' EXIT
+
+cat >"$stubdir/docker" <<'STUB'
+#!/usr/bin/env bash
+# Stub of `docker buildx imagetools inspect <image> --format ...`.
+[ "${STUB_DOCKER_FAIL:-0}" = 1 ] && exit 1
+img=""; want=0
+for a in "$@"; do
+  [ "$want" = 1 ] && { img="$a"; break; }
+  [ "$a" = inspect ] && want=1
+done
+case "$img" in
+  *:latest | *:18) echo "sha256:same" ;;
+  *:12) echo "sha256:twelve" ;;
+  *) echo "sha256:other" ;;
+esac
+STUB
+chmod +x "$stubdir/docker"
+export PATH="$stubdir:$PATH"
+
+dedup() { "$here/dedup-db-matrix.sh"; }
+
+# 1. Exact (engine,tag) duplicates collapse (pass 1, independent of docker).
+out=$(dedup <<'JSON'
+[{"engine":"postgres","tag":"12","image":"r/postgres:12"},
+ {"engine":"postgres","tag":"12","image":"r/postgres:12"}]
+JSON
+)
+echo "$out" | jq -e 'length == 1' >/dev/null
+
+# 2. Same-digest tags collapse; distinct digest kept; first-listed tag wins.
+out=$(dedup <<'JSON'
+[{"engine":"postgres","tag":"latest","image":"r/postgres:latest"},
+ {"engine":"postgres","tag":"18","image":"r/postgres:18"},
+ {"engine":"postgres","tag":"12","image":"r/postgres:12"}]
+JSON
+)
+echo "$out" | jq -e '[.[].tag] == ["latest","12"]' >/dev/null
+
+# 3. Same digest across *different* engines must NOT collapse (keyed by engine).
+out=$(dedup <<'JSON'
+[{"engine":"postgres","tag":"latest","image":"r/postgres:latest"},
+ {"engine":"mysql","tag":"latest","image":"r/mysql:latest"}]
+JSON
+)
+echo "$out" | jq -e 'length == 2' >/dev/null
+
+# 4. Fail-open: unresolvable digest keeps distinct (engine,tag) entries.
+out=$(STUB_DOCKER_FAIL=1 dedup <<'JSON'
+[{"engine":"postgres","tag":"latest","image":"r/postgres:latest"},
+ {"engine":"postgres","tag":"18","image":"r/postgres:18"}]
+JSON
+)
+echo "$out" | jq -e 'length == 2' >/dev/null
+
+echo "dedup-db-matrix_test: PASS"


### PR DESCRIPTION
Expands and rationalizes the DB integration test matrix, and pulls test images from GHCR to avoid Docker Hub's anonymous pull rate limits (easily tripped from shared runner IPs).

## Matrix / config
- **Enumerate every published `sakiladb` version** per engine in `sakila-db.json` (concrete tags only). `latest` is *derived* by the scheduler, never stored, so it can't duplicate the newest numbered tag in the sweep.
- **Drop `sqlserver:2017`** — the only tag not mirrored on GHCR — so the config and GHCR are fully aligned.

## Run ergonomics
- `db-scheduled.yml` gains a `workflow_dispatch` **`mode` input (`latest` | `sweep`)**. Both the all-latest run (publish-cycle) and the full version sweep (sanity) are now one-click manual triggers, not cron-only.
  - `latest` (default) / nightly cron: every engine @ `latest`, full scope.
  - `sweep` / Monday cron: every published tag, narrow scope.

## GHCR migration + registry unification
- `build-db-matrix.sh` stamps a fully-qualified **`image`** ref onto each matrix entry, built once from `SAKILADB_REGISTRY` (default `ghcr.io/sakiladb`). The test service **and** the dedup step both consume this ref — the registry is defined in exactly one place.
- `db-integration.yml`'s service container pulls `${{ matrix.image }}` (GHCR).

## Image de-duplication
- New `dedup-db-matrix.sh` collapses matrix entries that resolve to the **same image**, so a dispatch naming both `latest` and `18` for an engine runs it once. Two passes: exact `(engine,tag)`, then image **digest** via `docker buildx imagetools inspect` (manifest only, no layer pull). Best-effort: an unresolvable digest keeps the entry rather than dropping coverage.
- `db-scheduled.yml` inherits this automatically — it `uses:` `db-integration.yml`, whose `setup` job is the single place the matrix is built and deduped.

## Script hygiene
- `build-db-matrix.sh`, `dedup-db-matrix.sh`, and `build-db-matrix_test.sh` are now shellchecked in both CI (`main.yml`) and `make lint`.
- The previously-orphaned `build-db-matrix_test.sh` now actually runs (CI + `make lint`), extended to cover the `image` field and the `SAKILADB_REGISTRY` override.

## Validation
- shellcheck clean · `build-db-matrix_test.sh` passes · actionlint OK (main / db-integration / db-scheduled) · dprint clean · JSON valid
- Digest dedup verified end-to-end against the live registry (`latest`≡`18`, `latest`≡`23`, etc. collapse; distinct versions untouched)

## Note
GHCR service pulls work anonymously because the `sakiladb/*` packages are public. If ever made private, the `test` job would need `permissions: packages: read` + `docker login ghcr.io`.

## Related

The full-version sweep this PR enables surfaces pre-existing test failures on older Postgres/MySQL engines (versions the matrix never previously covered). These are tracked in #1024 and are **not** a blocker for this PR — the matrix/GHCR/dedup plumbing here runs clean; the failures are in the test suite vs. older engine versions.
