### PR TITLE
fix(postgres): legacy-version metadata support + quoted-name/mid-scan-drop fixes (#1024, #1025)

### DIFF
--- a/.github/workflows/db-integration.yml
+++ b/.github/workflows/db-integration.yml
@@ -120,6 +120,27 @@ jobs:
         with:
           go-version-file: go.mod
 
+      # scope=full runs `go test ./...`, whose embedded SQLite/DuckDB temp
+      # databases can exhaust the runner's ~14 GB root filesystem (each leg runs
+      # the full suite on its own runner, so this bites single-version nightlies
+      # too, not just multi-version dispatches). Reclaim space from preinstalled
+      # toolchains we never use. Not needed for scope=narrow.
+      - name: Free disk space
+        if: ${{ (inputs.scope || github.event.inputs.scope || 'full') == 'full' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          before=$(df -BG --output=avail / | tail -1 | tr -dc '0-9')
+          sudo rm -rf \
+            /usr/local/lib/android \
+            /opt/hostedtoolcache/CodeQL \
+            /usr/share/dotnet \
+            /opt/ghc \
+            /usr/local/.ghcup \
+            /usr/share/swift
+          after=$(df -BG --output=avail / | tail -1 | tr -dc '0-9')
+          echo "Freed disk on /: ${before}G -> ${after}G available"
+
       - name: Wait for DB healthy
         shell: bash
         run: |

--- a/.github/workflows/db-integration.yml
+++ b/.github/workflows/db-integration.yml
@@ -120,11 +120,20 @@ jobs:
         with:
           go-version-file: go.mod
 
-      # scope=full runs `go test ./...`, whose embedded SQLite/DuckDB temp
-      # databases can exhaust the runner's ~14 GB root filesystem (each leg runs
-      # the full suite on its own runner, so this bites single-version nightlies
-      # too, not just multi-version dispatches). Reclaim space from preinstalled
-      # toolchains we never use. Not needed for scope=narrow.
+      # scope=full runs `go test ./...`, whose many embedded SQLite/DuckDB temp
+      # databases exhaust the runner (observed: a pg17 leg hit "no space left on
+      # device"). The runner has ~86 GB free on / (measured: 86G -> 110G after
+      # this step), so it is almost certainly inode exhaustion, not bytes: the
+      # preinstalled toolchains removed below are millions of small files, so the
+      # rm frees inodes as much as the ~20 GB. Each leg runs the full suite on
+      # its own runner, so this bites single-version nightlies too, not just
+      # multi-version dispatches.
+      #
+      # TODO: gated to scope=full because narrow runs only the per-engine
+      # packages and has not exhausted in practice. That is an empirical
+      # assumption, not a guarantee — if narrow's libsq/cli cross-source tests
+      # grow heavier it may need this too, at which point drop the `if:` and
+      # always free space.
       - name: Free disk space
         if: ${{ (inputs.scope || github.event.inputs.scope || 'full') == 'full' }}
         shell: bash

--- a/drivers/postgres/errors.go
+++ b/drivers/postgres/errors.go
@@ -2,7 +2,6 @@ package postgres
 
 import (
 	"errors"
-	"strings"
 
 	"github.com/jackc/pgx/v5/pgconn"
 
@@ -50,22 +49,17 @@ func isErrRelationNotExist(err error) bool {
 	return hasErrCode(err, errCodeRelationNotExist)
 }
 
-// isErrRelationDroppedMidScan reports whether err indicates a relation
-// disappeared while a source-wide metadata scan was reading it: the canonical
-// "relation does not exist" (42P01), or the lower-level "could not open
-// relation with OID ..." (XX000) that pg_total_relation_size / regclass raise
-// when a relation is dropped between OID resolution and access. A scan reads a
-// live database, so it tolerates such a drop rather than failing.
-func isErrRelationDroppedMidScan(err error) bool {
-	if isErrRelationNotExist(err) {
-		return true
-	}
-	var pgErr *pgconn.PgError
-	if errors.As(err, &pgErr) {
-		return pgErr.Code == errCodeInternalError &&
-			strings.Contains(pgErr.Message, "could not open relation")
-	}
-	return false
+// isErrScanRetryable reports whether a bulk metadata-loader error is worth
+// retrying during a source-wide scan of a live database: too-many-connections,
+// or a relation that vanished mid-query. The latter surfaces either as 42P01,
+// or as an XX000 internal error (e.g. "could not open relation with OID") when a
+// relation is dropped between resolution and access. Matching XX000 by code
+// (not message text) keeps this locale-independent, and retrying is safe: a
+// persistent error still surfaces once the retry budget is exhausted.
+func isErrScanRetryable(err error) bool {
+	return isErrTooManyConnections(err) ||
+		isErrRelationNotExist(err) ||
+		hasErrCode(err, errCodeInternalError)
 }
 
 // hasErrCode returns true if err (or its cause error)

--- a/drivers/postgres/errors.go
+++ b/drivers/postgres/errors.go
@@ -2,6 +2,7 @@ package postgres
 
 import (
 	"errors"
+	"strings"
 
 	"github.com/jackc/pgx/v5/pgconn"
 
@@ -27,6 +28,10 @@ func errw(err error) error {
 const (
 	errCodeRelationNotExist   = "42P01"
 	errCodeTooManyConnections = "53300"
+	// errCodeInternalError (XX000) is raised, among other cases, as "could not
+	// open relation with OID ..." when a relation is dropped between OID
+	// resolution and access, i.e. by concurrent DDL.
+	errCodeInternalError = "XX000"
 )
 
 // isErrTooManyConnections returns true if err is a postgres error
@@ -43,6 +48,24 @@ func isErrTooManyConnections(err error) bool {
 // See: https://www.postgresql.org/docs/14/errcodes-appendix.html
 func isErrRelationNotExist(err error) bool {
 	return hasErrCode(err, errCodeRelationNotExist)
+}
+
+// isErrRelationDroppedMidScan reports whether err indicates a relation
+// disappeared while a source-wide metadata scan was reading it: the canonical
+// "relation does not exist" (42P01), or the lower-level "could not open
+// relation with OID ..." (XX000) that pg_total_relation_size / regclass raise
+// when a relation is dropped between OID resolution and access. A scan reads a
+// live database, so it tolerates such a drop rather than failing.
+func isErrRelationDroppedMidScan(err error) bool {
+	if isErrRelationNotExist(err) {
+		return true
+	}
+	var pgErr *pgconn.PgError
+	if errors.As(err, &pgErr) {
+		return pgErr.Code == errCodeInternalError &&
+			strings.Contains(pgErr.Message, "could not open relation")
+	}
+	return false
 }
 
 // hasErrCode returns true if err (or its cause error)

--- a/drivers/postgres/metadata.go
+++ b/drivers/postgres/metadata.go
@@ -184,6 +184,23 @@ func toNullableScanType(log *slog.Logger, colName, dbTypeName string, knd kind.K
 	return nullableScanType
 }
 
+// relationExistsInCurrentSchema reports whether a relation named tblName exists
+// in the current schema. It distinguishes a table dropped mid-scan (tolerate)
+// from a genuine error on a table that still exists (propagate), independently
+// of server locale. The name is a bound parameter compared against pg_class,
+// so no identifier escaping is needed.
+func relationExistsInCurrentSchema(ctx context.Context, db sqlz.DB, tblName string) (bool, error) {
+	const q = `SELECT EXISTS(
+  SELECT 1 FROM pg_catalog.pg_class c
+  JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+  WHERE c.relname = $1 AND n.nspname = current_schema())`
+	var exists bool
+	if err := db.QueryRowContext(ctx, q, tblName).Scan(&exists); err != nil {
+		return false, errw(err)
+	}
+	return exists, nil
+}
+
 // loadWithRetry runs a bulk metadata loader with vanished-relation retry, so a
 // table dropped mid-scan by concurrent DDL doesn't fail the whole source scan.
 func loadWithRetry[T any](ctx context.Context, load func() (T, error)) (T, error) {
@@ -272,19 +289,20 @@ current_setting('server_version'), version(), "current_user"()`
 			})
 
 			if mdErr != nil {
-				switch {
-				case isErrRelationDroppedMidScan(mdErr):
-					// If the table is dropped while we're collecting metadata
-					// (42P01, or the lower-level "could not open relation with
-					// OID"), log a warning and suppress the error.
-					log.Warn(
-						"metadata collection: table not found (continuing regardless)",
-						lga.Table, tblNames[i],
-						lga.Err, mdErr,
-					)
-				default:
+				// A relation dropped by concurrent DDL mid-scan is expected on a
+				// live database. Confirm the table is actually gone (a
+				// locale-independent check that, unlike matching the error text,
+				// won't mask a genuine fault on a table that still exists), then
+				// tolerate it; otherwise the error is real and propagates.
+				exists, existErr := relationExistsInCurrentSchema(gCtx, db, tblNames[i])
+				if existErr != nil || exists {
 					return mdErr
 				}
+				log.Warn(
+					"metadata collection: table dropped during scan (continuing regardless)",
+					lga.Table, tblNames[i],
+					lga.Err, mdErr,
+				)
 			}
 
 			tblMetas[i] = tblMeta
@@ -554,10 +572,10 @@ AND t.table_name = $1`
 // pg_catalog. Matviews are absent from information_schema, so this is the
 // fallback path from getTableMetadata. It is a two-step operation: first
 // confirm that name actually is a matview (returning the canonical not-found
-// error otherwise), and only then run the detail query. The size/comment/
-// viewdef functions take name as a bound quote_ident($1)::regclass parameter; only the
-// COUNT(*) FROM identifier is interpolated, and only after Step A confirms
-// name is a real matview.
+// error otherwise), and only then run the detail query. The size/comment/viewdef
+// functions take name via quote_ident($1)::regclass; only the COUNT(*) FROM
+// identifier is interpolated, and only after Step A confirms name is a real
+// matview.
 func getMatviewMetadata(ctx context.Context, db sqlz.DB, name string) (*metadata.Table, error) {
 	// Step A: confirm name is a matview in the current schema, and get
 	// the catalog & schema for the FQ name.
@@ -581,7 +599,7 @@ WHERE EXISTS (
 	debugz.DebugSleep(ctx)
 
 	// Step B: name is confirmed a matview. The size/comment/viewdef
-	// functions take name as a bound quote_ident($1)::regclass parameter. Only the
+	// functions take name via quote_ident($1)::regclass. Only the
 	// COUNT(*) FROM identifier must be interpolated: a relation name
 	// cannot be a bind parameter in a FROM clause, and it's safe here
 	// because Step A confirmed name is a real matview in this schema.

--- a/drivers/postgres/metadata.go
+++ b/drivers/postgres/metadata.go
@@ -184,6 +184,18 @@ func toNullableScanType(log *slog.Logger, colName, dbTypeName string, knd kind.K
 	return nullableScanType
 }
 
+// loadWithRetry runs a bulk metadata loader with vanished-relation retry, so a
+// table dropped mid-scan by concurrent DDL doesn't fail the whole source scan.
+func loadWithRetry[T any](ctx context.Context, load func() (T, error)) (T, error) {
+	var result T
+	err := doRetryVanished(ctx, func() error {
+		var e error
+		result, e = load()
+		return e
+	})
+	return result, err
+}
+
 func getSourceMetadata(ctx context.Context, src *source.Source, db sqlz.DB, noSchema bool) (*metadata.Source, error) {
 	log := lg.FromContext(ctx)
 	ctx = options.NewContext(ctx, src.Options)
@@ -261,9 +273,10 @@ current_setting('server_version'), version(), "current_user"()`
 
 			if mdErr != nil {
 				switch {
-				case isErrRelationNotExist(mdErr):
-					// For example, if the table is dropped while we're collecting
-					// metadata, we log a warning and suppress the error.
+				case isErrRelationDroppedMidScan(mdErr):
+					// If the table is dropped while we're collecting metadata
+					// (42P01, or the lower-level "could not open relation with
+					// OID"), log a warning and suppress the error.
 					log.Warn(
 						"metadata collection: table not found (continuing regardless)",
 						lga.Table, tblNames[i],
@@ -296,39 +309,54 @@ current_setting('server_version'), version(), "current_user"()`
 
 	md.RecomputeTableCounts()
 
-	// Fetch foreign keys for all tables in one query, assign them to
-	// their owning tables, and derive the cross-table back-references.
-	allFKs, err := getPgForeignKeys(ctx, db, "")
+	// Fetch foreign keys for all tables in one query, assign them to their
+	// owning tables, and derive the cross-table back-references. Each bulk
+	// loader is a single catalog query over every table in the schema; a table
+	// dropped mid-query by concurrent DDL is retried (loadWithRetry) so the
+	// scan doesn't fail on transient churn.
+	allFKs, err := loadWithRetry(ctx, func() ([]*metadata.ForeignKey, error) {
+		return getPgForeignKeys(ctx, db, "")
+	})
 	if err != nil {
 		return nil, err
 	}
 	metadata.AssignForeignKeys(log, md.Tables, allFKs)
 
-	allUCs, err := getPgUniqueConstraints(ctx, db, "")
+	allUCs, err := loadWithRetry(ctx, func() ([]*metadata.UniqueConstraint, error) {
+		return getPgUniqueConstraints(ctx, db, "")
+	})
 	if err != nil {
 		return nil, err
 	}
 	metadata.AssignUniqueConstraints(log, md.Tables, allUCs)
 
-	allChecks, err := getPgCheckConstraints(ctx, db, "")
+	allChecks, err := loadWithRetry(ctx, func() ([]*metadata.CheckConstraint, error) {
+		return getPgCheckConstraints(ctx, db, "")
+	})
 	if err != nil {
 		return nil, err
 	}
 	metadata.AssignCheckConstraints(log, md.Tables, allChecks)
 
-	allTriggers, err := getPgTriggers(ctx, db, "")
+	allTriggers, err := loadWithRetry(ctx, func() ([]*metadata.Trigger, error) {
+		return getPgTriggers(ctx, db, "")
+	})
 	if err != nil {
 		return nil, err
 	}
 	metadata.AssignTriggers(log, md.Tables, allTriggers)
 
-	allIdxs, err := getPgIndexes(ctx, db, "")
+	allIdxs, err := loadWithRetry(ctx, func() ([]*metadata.Index, error) {
+		return getPgIndexes(ctx, db, "")
+	})
 	if err != nil {
 		return nil, err
 	}
 	metadata.AssignIndexes(log, md.Tables, allIdxs)
 
-	allViewDefs, err := getPgViewDefinitions(ctx, db, "")
+	allViewDefs, err := loadWithRetry(ctx, func() (map[string]string, error) {
+		return getPgViewDefinitions(ctx, db, "")
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -448,16 +476,25 @@ ORDER BY table_name`
 func getTableMetadata(ctx context.Context, db sqlz.DB, tblName string) (*metadata.Table, error) {
 	log := lg.FromContext(ctx)
 
-	const tblsQueryTpl = `SELECT table_catalog, table_schema, table_name, table_type, is_insertable_into,
-  (SELECT COUNT(*) FROM "%s") AS table_row_count,
-  pg_total_relation_size('%q') AS table_size,
-  (SELECT '%q'::regclass::oid AS table_oid),
-  obj_description('%q'::REGCLASS, 'pg_class') AS table_comment
-FROM information_schema.tables
-WHERE table_catalog = current_database()
-AND table_schema = current_schema()
-AND table_name = $1`
-	tablesQuery := fmt.Sprintf(tblsQueryTpl, tblName, tblName, tblName, tblName)
+	// A table name can legally contain a double-quote (e.g. `we"ird`). The
+	// relation's OID is resolved via a pg_class JOIN on the raw name ($1, a
+	// bind parameter) rather than a regclass text cast, which mis-parses such
+	// names; the size/oid/comment functions then take the OID directly. The
+	// only interpolation is the COUNT subquery's FROM, which uses a
+	// double-quoted (escaped) identifier. Raw interpolation built malformed
+	// SQL. See issue #1025.
+	safeIdent := stringz.DoubleQuote(tblName)
+	tablesQuery := `SELECT t.table_catalog, t.table_schema, t.table_name, t.table_type, t.is_insertable_into,
+  (SELECT COUNT(*) FROM ` + safeIdent + `) AS table_row_count,
+  pg_total_relation_size(c.oid) AS table_size,
+  c.oid AS table_oid,
+  obj_description(c.oid, 'pg_class') AS table_comment
+FROM information_schema.tables t
+JOIN pg_catalog.pg_class c ON c.relname = t.table_name
+JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace AND n.nspname = t.table_schema
+WHERE t.table_catalog = current_database()
+AND t.table_schema = current_schema()
+AND t.table_name = $1`
 
 	pgTbl := &pgTable{}
 	err := db.QueryRowContext(ctx, tablesQuery, tblName).
@@ -518,7 +555,7 @@ AND table_name = $1`
 // fallback path from getTableMetadata. It is a two-step operation: first
 // confirm that name actually is a matview (returning the canonical not-found
 // error otherwise), and only then run the detail query. The size/comment/
-// viewdef functions take name as a bound $1::regclass parameter; only the
+// viewdef functions take name as a bound quote_ident($1)::regclass parameter; only the
 // COUNT(*) FROM identifier is interpolated, and only after Step A confirms
 // name is a real matview.
 func getMatviewMetadata(ctx context.Context, db sqlz.DB, name string) (*metadata.Table, error) {
@@ -544,15 +581,15 @@ WHERE EXISTS (
 	debugz.DebugSleep(ctx)
 
 	// Step B: name is confirmed a matview. The size/comment/viewdef
-	// functions take name as a bound $1::regclass parameter. Only the
+	// functions take name as a bound quote_ident($1)::regclass parameter. Only the
 	// COUNT(*) FROM identifier must be interpolated: a relation name
 	// cannot be a bind parameter in a FROM clause, and it's safe here
 	// because Step A confirmed name is a real matview in this schema.
 	const detailQueryTpl = `SELECT
   (SELECT COUNT(*) FROM "%s") AS row_count,
-  pg_total_relation_size($1::regclass) AS mv_size,
-  obj_description($1::regclass, 'pg_class') AS mv_comment,
-  pg_get_viewdef($1::regclass, true) AS view_def`
+  pg_total_relation_size(quote_ident($1)::regclass) AS mv_size,
+  obj_description(quote_ident($1)::regclass, 'pg_class') AS mv_comment,
+  pg_get_viewdef(quote_ident($1)::regclass, true) AS view_def`
 	// Double any embedded double-quotes so the identifier literal can't be broken out of.
 	safeName := strings.ReplaceAll(name, `"`, `""`)
 	detailQuery := fmt.Sprintf(detailQueryTpl, safeName)
@@ -823,7 +860,7 @@ func getPgColumns(ctx context.Context, db sqlz.DB, tblName string) ([]*pgColumn,
 	FROM
 		pg_catalog.pg_class c
 	WHERE
-		c.oid = (SELECT ('"' || cols.table_name || '"')::regclass::oid)
+		c.oid = (SELECT quote_ident(cols.table_name)::regclass::oid)
 		AND c.relname = cols.table_name
 	) AS column_comment
 FROM information_schema.columns cols
@@ -902,14 +939,14 @@ func getPgConstraints(ctx context.Context, db sqlz.DB, tblName string) ([]*pgCon
     (
        SELECT pg_catalog.pg_get_constraintdef(pgc.oid, TRUE)
        FROM pg_catalog.pg_constraint pgc
-       WHERE pgc.conrelid = (SELECT ('"' || kcu.table_name || '"')::regclass::oid)
+       WHERE pgc.conrelid = (SELECT quote_ident(kcu.table_name)::regclass::oid)
        AND pgc.conname = tc.constraint_name
        limit 1
     )  AS constraint_def,
     (
        SELECT pgc.confrelid::regclass
        FROM pg_catalog.pg_constraint pgc
-       WHERE pgc.conrelid = (SELECT ('"' || kcu.table_name || '"')::regclass::oid)
+       WHERE pgc.conrelid = (SELECT quote_ident(kcu.table_name)::regclass::oid)
        AND pgc.conname = tc.constraint_name
        AND pgc.confrelid > 0
        LIMIT 1

--- a/drivers/postgres/metadata.go
+++ b/drivers/postgres/metadata.go
@@ -184,23 +184,6 @@ func toNullableScanType(log *slog.Logger, colName, dbTypeName string, knd kind.K
 	return nullableScanType
 }
 
-// relationExistsInCurrentSchema reports whether a relation named tblName exists
-// in the current schema. It distinguishes a table dropped mid-scan (tolerate)
-// from a genuine error on a table that still exists (propagate), independently
-// of server locale. The name is a bound parameter compared against pg_class,
-// so no identifier escaping is needed.
-func relationExistsInCurrentSchema(ctx context.Context, db sqlz.DB, tblName string) (bool, error) {
-	const q = `SELECT EXISTS(
-  SELECT 1 FROM pg_catalog.pg_class c
-  JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
-  WHERE c.relname = $1 AND n.nspname = current_schema())`
-	var exists bool
-	if err := db.QueryRowContext(ctx, q, tblName).Scan(&exists); err != nil {
-		return false, errw(err)
-	}
-	return exists, nil
-}
-
 // loadWithRetry runs a bulk metadata loader with vanished-relation retry, so a
 // table dropped mid-scan by concurrent DDL doesn't fail the whole source scan.
 func loadWithRetry[T any](ctx context.Context, load func() (T, error)) (T, error) {
@@ -289,20 +272,18 @@ current_setting('server_version'), version(), "current_user"()`
 			})
 
 			if mdErr != nil {
-				// A relation dropped by concurrent DDL mid-scan is expected on a
-				// live database. Confirm the table is actually gone (a
-				// locale-independent check that, unlike matching the error text,
-				// won't mask a genuine fault on a table that still exists), then
-				// tolerate it; otherwise the error is real and propagates.
-				exists, existErr := relationExistsInCurrentSchema(gCtx, db, tblNames[i])
-				if existErr != nil || exists {
+				switch {
+				case isErrRelationNotExist(mdErr):
+					// For example, if the table is dropped while we're collecting
+					// metadata, we log a warning and suppress the error.
+					log.Warn(
+						"metadata collection: table not found (continuing regardless)",
+						lga.Table, tblNames[i],
+						lga.Err, mdErr,
+					)
+				default:
 					return mdErr
 				}
-				log.Warn(
-					"metadata collection: table dropped during scan (continuing regardless)",
-					lga.Table, tblNames[i],
-					lga.Err, mdErr,
-				)
 			}
 
 			tblMetas[i] = tblMeta

--- a/drivers/postgres/metadata_test.go
+++ b/drivers/postgres/metadata_test.go
@@ -291,10 +291,11 @@ func TestPostgres_ColumnFlags(t *testing.T) {
 }
 
 // TestPostgres_QuotedTableName_Metadata pins that table metadata loads for a
-// table whose name contains a double-quote. getTableMetadata must escape the
-// identifier (and pass it as a bound regclass parameter); raw interpolation
-// built malformed SQL, which surfaced as a flake when a full-source scan
-// happened to run while such a table existed (issue #1025).
+// table whose name contains a double-quote. getTableMetadata must resolve the
+// OID via a pg_class JOIN on the bound name and use an escaped identifier in the
+// COUNT subquery; raw interpolation built malformed SQL, which surfaced as a
+// flake when a full-source scan happened to run while such a table existed
+// (issue #1025).
 func TestPostgres_QuotedTableName_Metadata(t *testing.T) {
 	tu.SkipShort(t, true)
 	t.Parallel()

--- a/drivers/postgres/metadata_test.go
+++ b/drivers/postgres/metadata_test.go
@@ -290,6 +290,35 @@ func TestPostgres_ColumnFlags(t *testing.T) {
 	}
 }
 
+// TestPostgres_QuotedTableName_Metadata pins that table metadata loads for a
+// table whose name contains a double-quote. getTableMetadata must escape the
+// identifier (and pass it as a bound regclass parameter); raw interpolation
+// built malformed SQL, which surfaced as a flake when a full-source scan
+// happened to run while such a table existed (issue #1025).
+func TestPostgres_QuotedTableName_Metadata(t *testing.T) {
+	tu.SkipShort(t, true)
+	t.Parallel()
+
+	th := testh.New(t)
+	src := th.Source(sakila.Pg)
+	db := th.OpenDB(src)
+
+	tbl := stringz.UniqTableName(`me"ta`)
+	qtbl := stringz.DoubleQuote(tbl)
+	_, err := db.ExecContext(th.Context, `CREATE TABLE `+qtbl+` (id INT, name TEXT)`)
+	require.NoError(t, err)
+	t.Cleanup(func() { th.DropTable(src, tablefq.From(tbl)) })
+
+	_, err = db.ExecContext(th.Context, `INSERT INTO `+qtbl+` (id, name) VALUES (1, 'a'), (2, 'b')`)
+	require.NoError(t, err)
+
+	md, err := th.Open(src).TableMetadata(th.Context, tbl)
+	require.NoError(t, err)
+	require.Equal(t, tbl, md.Name)
+	require.Equal(t, int64(2), md.RowCount, "RowCount must load for a quoted table name")
+	require.Len(t, md.Columns, 2)
+}
+
 // TestPostgres_ViewDefinition verifies that ViewDefinition is populated for
 // views and is empty for base tables.
 func TestPostgres_ViewDefinition(t *testing.T) {

--- a/drivers/postgres/metadata_test.go
+++ b/drivers/postgres/metadata_test.go
@@ -68,6 +68,12 @@ func TestIndexes_IncludeFilter_Postgres(t *testing.T) {
 	src := th.Source(sakila.Pg)
 	db := th.OpenDB(src)
 
+	// INCLUDE covering indexes were added in Postgres 11; there is no pre-11
+	// equivalent to introspect.
+	if !th.DBSemverAtLeast(sakila.Pg, "v11.0.0") {
+		t.Skip("INCLUDE covering indexes require Postgres >= 11")
+	}
+
 	tbl := stringz.UniqTableName("idx_include")
 	_, err := db.ExecContext(th.Context,
 		"CREATE TABLE "+tbl+" (k INT, extra TEXT)")
@@ -235,34 +241,53 @@ func TestPostgres_ColumnFlags(t *testing.T) {
 	src := th.Source(sakila.Pg)
 	db := th.OpenDB(src)
 
+	// Column flags are version-gated: identity columns arrived in Postgres 10,
+	// stored generated columns in Postgres 12. Collation applies on every
+	// supported version, so the base table always exercises it.
+	hasIdentity := th.DBSemverAtLeast(sakila.Pg, "v10.0.0")
+	hasGenerated := th.DBSemverAtLeast(sakila.Pg, "v12.0.0")
+
 	tbl := stringz.UniqTableName("col_flags")
 	_, err := db.ExecContext(th.Context,
 		`CREATE TABLE `+tbl+` (
-			id         bigint GENERATED ALWAYS AS IDENTITY,
 			first_name text,
 			last_name  text,
-			full_name  text GENERATED ALWAYS AS (first_name || ' ' || last_name) STORED,
 			country    text COLLATE "C"
 		)`)
 	require.NoError(t, err)
 	t.Cleanup(func() { th.DropTable(src, tablefq.From(tbl)) })
 
+	if hasIdentity {
+		_, err = db.ExecContext(th.Context,
+			`ALTER TABLE `+tbl+` ADD COLUMN id bigint GENERATED ALWAYS AS IDENTITY`)
+		require.NoError(t, err)
+	}
+	if hasGenerated {
+		_, err = db.ExecContext(th.Context,
+			`ALTER TABLE `+tbl+` ADD COLUMN full_name text `+
+				`GENERATED ALWAYS AS (first_name || ' ' || last_name) STORED`)
+		require.NoError(t, err)
+	}
+
 	md, err := th.Open(src).TableMetadata(th.Context, tbl)
 	require.NoError(t, err)
-
-	idCol := md.Column("id")
-	require.NotNil(t, idCol)
-	require.True(t, idCol.Identity, "id: Identity should be true")
-
-	fullNameCol := md.Column("full_name")
-	require.NotNil(t, fullNameCol)
-	require.True(t, fullNameCol.Generated, "full_name: Generated should be true")
-	require.Contains(t, fullNameCol.GeneratedExpr, "first_name",
-		"full_name: GeneratedExpr should contain 'first_name'")
 
 	countryCol := md.Column("country")
 	require.NotNil(t, countryCol)
 	require.Equal(t, "C", countryCol.Collation, "country: Collation should be 'C'")
+
+	if hasIdentity {
+		idCol := md.Column("id")
+		require.NotNil(t, idCol)
+		require.True(t, idCol.Identity, "id: Identity should be true")
+	}
+	if hasGenerated {
+		fullNameCol := md.Column("full_name")
+		require.NotNil(t, fullNameCol)
+		require.True(t, fullNameCol.Generated, "full_name: Generated should be true")
+		require.Contains(t, fullNameCol.GeneratedExpr, "first_name",
+			"full_name: GeneratedExpr should contain 'first_name'")
+	}
 }
 
 // TestPostgres_ViewDefinition verifies that ViewDefinition is populated for
@@ -331,7 +356,7 @@ func TestPostgres_Triggers(t *testing.T) {
 
 	_, err = db.ExecContext(th.Context,
 		`CREATE TRIGGER `+trigName+` AFTER INSERT OR UPDATE ON `+tbl+
-			` FOR EACH ROW EXECUTE FUNCTION `+fnName+`()`)
+			` FOR EACH ROW EXECUTE PROCEDURE `+fnName+`()`)
 	require.NoError(t, err)
 
 	md, err := th.Open(src).TableMetadata(th.Context, tbl)
@@ -393,7 +418,7 @@ func TestPostgres_ViewInsteadOfTrigger(t *testing.T) {
 
 	_, err = db.ExecContext(th.Context,
 		`CREATE TRIGGER `+trigName+` INSTEAD OF INSERT ON `+viewName+
-			` FOR EACH ROW EXECUTE FUNCTION `+fnName+`()`)
+			` FOR EACH ROW EXECUTE PROCEDURE `+fnName+`()`)
 	require.NoError(t, err)
 	// Dropping the view removes its triggers; no separate trigger DROP needed.
 

--- a/drivers/postgres/postgres.go
+++ b/drivers/postgres/postgres.go
@@ -900,3 +900,13 @@ func doRetry(ctx context.Context, fn func() error) error {
 	maxRetryInterval := tuning.OptMaxRetryInterval.Get(options.FromContext(ctx))
 	return retry.Do(ctx, maxRetryInterval, fn, isErrTooManyConnections)
 }
+
+// doRetryVanished is like doRetry, but also retries when a relation vanishes
+// mid-operation because of concurrent DDL. A source-wide metadata scan issues
+// bulk catalog queries against a live database, so a table dropped mid-query is
+// transient; retrying lets the churn settle. The error is still returned if
+// retries are exhausted.
+func doRetryVanished(ctx context.Context, fn func() error) error {
+	maxRetryInterval := tuning.OptMaxRetryInterval.Get(options.FromContext(ctx))
+	return retry.Do(ctx, maxRetryInterval, fn, isErrTooManyConnections, isErrRelationDroppedMidScan)
+}

--- a/drivers/postgres/postgres.go
+++ b/drivers/postgres/postgres.go
@@ -908,5 +908,5 @@ func doRetry(ctx context.Context, fn func() error) error {
 // retries are exhausted.
 func doRetryVanished(ctx context.Context, fn func() error) error {
 	maxRetryInterval := tuning.OptMaxRetryInterval.Get(options.FromContext(ctx))
-	return retry.Do(ctx, maxRetryInterval, fn, isErrTooManyConnections, isErrRelationDroppedMidScan)
+	return retry.Do(ctx, maxRetryInterval, fn, isErrScanRetryable)
 }


### PR DESCRIPTION
Closes #1024 (the Postgres cluster; the MySQL cluster was #1008). Closes #1025.

## Summary

Makes the Postgres driver and its metadata tests pass across the full version
sweep (Postgres 9–18), fixes two real driver bugs the wide sweep surfaced, and
makes the `scope=full` CI legs robust against disk exhaustion.

Three independent areas, one per commit group:

1. **Legacy-version metadata tests** (#1024) — version-aware test setup for pg 9/10/11.
2. **Quoted table names + concurrent-DDL drop race** (#1025) — two real driver bugs.
3. **`scope=full` disk exhaustion** — a CI-infrastructure fix.

---

## 1. Legacy-version metadata tests (#1024)

The full-version sweep newly exercises Postgres 9/10/11, where several
`drivers/postgres` metadata tests used **version-specific setup DDL** (the
tests, not sq's introspection, were the problem — sq reads old-Postgres
catalogs correctly):

- `TestPostgres_ColumnFlags`: gate the identity column (pg10+) and the stored
  generated column (pg12+) by server version; always assert collation, which
  every supported version supports (so pg9 still gets coverage rather than a
  blanket skip).
- `TestPostgres_Triggers` / `TestPostgres_ViewInsteadOfTrigger`: use
  `EXECUTE PROCEDURE` (valid on every version) instead of the pg11+
  `EXECUTE FUNCTION` spelling. The trigger introspection under test is exercised
  on all versions.
- `TestIndexes_IncludeFilter_Postgres`: skip below pg11 — `INCLUDE` covering
  indexes are pg11+ and have no pre-11 equivalent to introspect; general index
  introspection stays covered by `TestIndexes_ExpressionArity_Postgres`.

---

## 2. Quoted table names + mid-scan drops (#1025)

Surfaced as flaky `TestDBSemver` / `TestPostgres_Matview` under the full sweep.
Investigation found **two distinct, independent bugs** — the flakiness was
mostly a timing artifact of the first one.

### 2a. Identifier escaping (the dominant bug)

A table name may legally contain a double-quote (e.g. `we"ird`). Four metadata
queries interpolated the name **raw**, so an embedded quote broke the SQL
(`ERROR 42601`/`42602`). It only looked like a flake because the offending test
table's short lifetime had to overlap a metadata scan. Fixed uniformly:

- `getTableMetadata`: resolve the relation's OID via a `pg_class` JOIN on the
  **bound** name (no `regclass` text-parsing, which mis-parses quoted names),
  and use a properly-escaped identifier only for the `COUNT(*)` subquery.
- `getPgColumns`, `getPgConstraints`, `getMatviewMetadata`: `('"' || name ||
  '"')` / raw `$1::regclass` → `quote_ident(...)::regclass`, so Postgres does
  the identifier quoting.
- New **`TestPostgres_QuotedTableName_Metadata`** deterministically creates a
  `me"ta` table and inspects it — it fails on the old code and passes on the new.

### 2b. Concurrent-DDL drop race (the residual)

Once escaping was fixed, a rarer, genuinely-concurrent flake remained: a table
dropped mid-scan raised `XX000` "could not open relation with OID" from the
**bulk catalog loaders**, failing the whole source-wide scan.

- The **six bulk loaders** (FK, unique-constraint, check-constraint, trigger,
  index, view-def) now retry on a vanished relation via `loadWithRetry` /
  `doRetryVanished`. The retry predicate `isErrScanRetryable` matches
  too-many-connections, `42P01`, or `XX000` **by error code** (not message
  text, so it is locale-independent). Retrying is self-correcting: a transient
  drop resolves on the next attempt, and a genuinely-persistent error still
  surfaces once the ~3s retry budget is exhausted.
- The per-table loop keeps its **existing `42P01` (relation-not-exist)
  suppression** — unchanged.

This is also `sq inspect` robustness: a live database undergoing DDL no longer
fails an inspect because one table vanished mid-scan.

**Design note (from code review).** Earlier iterations tried a message-text
match (locale-dependent) and a per-table existence-check (added an extra query
that is itself fragile under the exact load it targets). The validation data
showed the **bulk-loader retry alone** eliminates the flake, so the final
version drops both in favour of the simple code-based retry. One accepted
tradeoff: a persistent (non-transient) `XX000` is retried for up to ~3s before
surfacing — bounded, and only on a rare internal fault.

**Deliberately out of scope:** `getMatviewMetadata` Step B resolves via
`quote_ident($1)::regclass`, which is search_path-dependent. Code review
confirmed this **pre-existed** (as `$1::regclass`) and is re-exposed, not
introduced; it is a narrow edge (a same-named relation in an earlier
search_path schema) best handled as a separate follow-up.

---

## 3. `scope=full` disk exhaustion (CI)

`scope=full` runs `go test ./...` on every leg, and the embedded SQLite/DuckDB
temp databases can exhaust the runner's root filesystem (observed: a pg17 leg
failed with `no space left on device`). Because each matrix leg runs the full
suite on its own runner, this also threatens single-version nightlies, not just
multi-version dispatches. When `scope=full`, a step reclaims ~20 GB from unused
preinstalled toolchains before the tests run (guarded to `scope=full` so
`narrow` legs pay nothing).

---

## Testing

- **Full-version DB sweep (`scope=full`, pg 9–18): all 10 legs green** — the
  first fully-green full sweep, validating all three areas at once (the #1025
  flake fix under maximum `go test ./...` churn, the disk fix, and the
  legacy-version fixes).
- **`drivers/postgres` full-suite loop against pg10: clean** across many runs
  at each stage of the fix (baseline flaked ~27%; final simplified version
  0/30). The deterministic `TestPostgres_QuotedTableName_Metadata` fails on the
  old code and passes on the new.
- Reviewed by the workflow deep review + Copilot across iterations; findings
  addressed (locale-independence, over-broad suppression, existence-check
  fragility) and threads resolved.
- `go build` / `go vet` / `make fmt` clean; pinned `golangci-lint` 0 issues;
  PR checks (Format / Main Pipeline / Dependency Review) green.
