### PR TITLE
fix(drivers): escape identifiers in write-path builders and SQL Server scan (#1027)

### DIFF
--- a/.github/workflows/db-integration.yml
+++ b/.github/workflows/db-integration.yml
@@ -120,22 +120,18 @@ jobs:
         with:
           go-version-file: go.mod
 
-      # scope=full runs `go test ./...`, whose many embedded SQLite/DuckDB temp
-      # databases exhaust the runner (observed: a pg17 leg hit "no space left on
-      # device"). The runner has ~86 GB free on / (measured: 86G -> 110G after
-      # this step), so it is almost certainly inode exhaustion, not bytes: the
-      # preinstalled toolchains removed below are millions of small files, so the
-      # rm frees inodes as much as the ~20 GB. Each leg runs the full suite on
-      # its own runner, so this bites single-version nightlies too, not just
-      # multi-version dispatches.
-      #
-      # TODO: gated to scope=full because narrow runs only the per-engine
-      # packages and has not exhausted in practice. That is an empirical
-      # assumption, not a guarantee — if narrow's libsq/cli cross-source tests
-      # grow heavier it may need this too, at which point drop the `if:` and
-      # always free space.
+      # The DB test legs exhaust the runner's root filesystem. scope=full runs
+      # `go test ./...` (many embedded SQLite/DuckDB temp databases; observed: a
+      # pg17 leg hit "no space left on device"), and scope=narrow compiles
+      # ./libsq/... and ./cli/..., whose large test binaries have hit ENOSPC
+      # during compile/link (observed: mysql and sqlserver narrow legs). The
+      # runner has ~86 GB free on / but the preinstalled toolchains removed
+      # below are millions of small files, so the rm reclaims inodes as much as
+      # the ~20 GB. This runs for every scope: each leg builds on its own
+      # runner, so it bites single-version nightlies and narrow dispatches too,
+      # not just full runs. (It was previously gated to scope=full on the
+      # assumption narrow never exhausted; narrow now does, so the gate is gone.)
       - name: Free disk space
-        if: ${{ (inputs.scope || github.event.inputs.scope || 'full') == 'full' }}
         shell: bash
         run: |
           set -euo pipefail

--- a/drivers/duckdb/create.go
+++ b/drivers/duckdb/create.go
@@ -6,6 +6,7 @@ import (
 	"github.com/neilotoole/sq/libsq/core/errz"
 	"github.com/neilotoole/sq/libsq/core/kind"
 	"github.com/neilotoole/sq/libsq/core/schema"
+	"github.com/neilotoole/sq/libsq/core/stringz"
 )
 
 // createTblKindDefaults maps kind.Kind to the DEFAULT clause used when
@@ -38,14 +39,14 @@ var createTblKindDefaults = map[kind.Kind]string{ //nolint:exhaustive // kind.Nu
 // `sq inspect` (see drivers/duckdb/metadata.go).
 func buildCreateTableStmt(tblDef *schema.Table) string {
 	sb := strings.Builder{}
-	sb.WriteString(`CREATE TABLE "`)
-	sb.WriteString(tblDef.Name)
-	sb.WriteString("\" (\n")
+	sb.WriteString(`CREATE TABLE `)
+	sb.WriteString(stringz.DoubleQuote(tblDef.Name))
+	sb.WriteString(" (\n")
 
 	for i, col := range tblDef.Cols {
-		sb.WriteString(`  "`)
-		sb.WriteString(col.Name)
-		sb.WriteString(`" `)
+		sb.WriteString(`  `)
+		sb.WriteString(stringz.DoubleQuote(col.Name))
+		sb.WriteRune(' ')
 		sb.WriteString(dbTypeNameFromKind(col.Kind))
 
 		if col.Name == tblDef.PKColName {
@@ -83,17 +84,16 @@ func buildUpdateStmt(tbl string, cols []string, where string) (string, error) {
 	}
 
 	sb := strings.Builder{}
-	sb.WriteString(`UPDATE "`)
-	sb.WriteString(tbl)
-	sb.WriteString(`" SET `)
+	sb.WriteString(`UPDATE `)
+	sb.WriteString(stringz.DoubleQuote(tbl))
+	sb.WriteString(` SET `)
 
 	for i, col := range cols {
 		if i > 0 {
 			sb.WriteString(", ")
 		}
-		sb.WriteRune('"')
-		sb.WriteString(col)
-		sb.WriteString(`" = $`)
+		sb.WriteString(stringz.DoubleQuote(col))
+		sb.WriteString(` = $`)
 		// Use 1-based positional placeholders.
 		writeInt(&sb, i+1)
 	}

--- a/drivers/mysql/render.go
+++ b/drivers/mysql/render.go
@@ -57,15 +57,13 @@ var createTblKindDefaults = map[kind.Kind]string{ //nolint:exhaustive
 	kind.Unknown:  ``,
 }
 
-//nolint:funlen
 func buildCreateTableStmt(tblDef *schema.Table) string {
 	buf := &bytes.Buffer{}
 
 	cols := make([]string, len(tblDef.Cols))
 	for i, col := range tblDef.Cols {
-		buf.WriteRune('`')
-		buf.WriteString(col.Name)
-		buf.WriteString("` ")
+		buf.WriteString(stringz.BacktickQuote(col.Name))
+		buf.WriteRune(' ')
 		buf.WriteString(dbTypeNameFromKind(col.Kind))
 
 		if col.HasDefault {
@@ -86,16 +84,14 @@ func buildCreateTableStmt(tblDef *schema.Table) string {
 
 	pk := ""
 	if tblDef.PKColName != "" {
-		buf.WriteString("PRIMARY KEY (`")
-		buf.WriteString(tblDef.PKColName)
-		buf.WriteString("`),\n")
-		buf.WriteString("UNIQUE KEY `")
-		buf.WriteString(tblDef.Name)
-		buf.WriteRune('_')
-		buf.WriteString(tblDef.PKColName)
-		buf.WriteString("_uindex` (`")
-		buf.WriteString(tblDef.PKColName)
-		buf.WriteString("`)")
+		buf.WriteString("PRIMARY KEY (")
+		buf.WriteString(stringz.BacktickQuote(tblDef.PKColName))
+		buf.WriteString("),\n")
+		buf.WriteString("UNIQUE KEY ")
+		buf.WriteString(stringz.BacktickQuote(tblDef.Name + "_" + tblDef.PKColName + "_uindex"))
+		buf.WriteString(" (")
+		buf.WriteString(stringz.BacktickQuote(tblDef.PKColName))
+		buf.WriteString(")")
 		pk = buf.String()
 	}
 
@@ -111,13 +107,11 @@ func buildCreateTableStmt(tblDef *schema.Table) string {
 			if buf.Len() > 0 {
 				buf.WriteString(",\n")
 			}
-			buf.WriteString("UNIQUE KEY `")
-			buf.WriteString(tblDef.Name)
-			buf.WriteRune('_')
-			buf.WriteString(col.Name)
-			buf.WriteString("_uindex` (`")
-			buf.WriteString(col.Name)
-			buf.WriteString("`)")
+			buf.WriteString("UNIQUE KEY ")
+			buf.WriteString(stringz.BacktickQuote(tblDef.Name + "_" + col.Name + "_uindex"))
+			buf.WriteString(" (")
+			buf.WriteString(stringz.BacktickQuote(col.Name))
+			buf.WriteString(")")
 		}
 	}
 	uniq = buf.String()
@@ -132,31 +126,21 @@ func buildCreateTableStmt(tblDef *schema.Table) string {
 		if buf.Len() > 0 {
 			buf.WriteString(",\n")
 		}
-		buf.WriteString("KEY `")
-		buf.WriteString(tblDef.Name)
-		buf.WriteRune('_')
-		buf.WriteString(col.Name)
-		buf.WriteRune('_')
-		buf.WriteString(col.ForeignKey.RefTable)
-		buf.WriteRune('_')
-		buf.WriteString(col.ForeignKey.RefCol)
-		buf.WriteString("_key` (`")
-		buf.WriteString(col.Name)
-		buf.WriteString("`),\nCONSTRAINT `")
-		buf.WriteString(tblDef.Name)
-		buf.WriteRune('_')
-		buf.WriteString(col.Name)
-		buf.WriteRune('_')
-		buf.WriteString(col.ForeignKey.RefTable)
-		buf.WriteRune('_')
-		buf.WriteString(col.ForeignKey.RefCol)
-		buf.WriteString("_fk` FOREIGN KEY (`")
-		buf.WriteString(col.Name)
-		buf.WriteString("`) REFERENCES `")
-		buf.WriteString(col.ForeignKey.RefTable)
-		buf.WriteString("` (`")
-		buf.WriteString(col.ForeignKey.RefCol)
-		buf.WriteString("`) ON DELETE ")
+		fkBase := tblDef.Name + "_" + col.Name + "_" +
+			col.ForeignKey.RefTable + "_" + col.ForeignKey.RefCol
+		buf.WriteString("KEY ")
+		buf.WriteString(stringz.BacktickQuote(fkBase + "_key"))
+		buf.WriteString(" (")
+		buf.WriteString(stringz.BacktickQuote(col.Name))
+		buf.WriteString("),\nCONSTRAINT ")
+		buf.WriteString(stringz.BacktickQuote(fkBase + "_fk"))
+		buf.WriteString(" FOREIGN KEY (")
+		buf.WriteString(stringz.BacktickQuote(col.Name))
+		buf.WriteString(") REFERENCES ")
+		buf.WriteString(stringz.BacktickQuote(col.ForeignKey.RefTable))
+		buf.WriteString(" (")
+		buf.WriteString(stringz.BacktickQuote(col.ForeignKey.RefCol))
+		buf.WriteString(") ON DELETE ")
 		if col.ForeignKey.OnDelete == "" {
 			buf.WriteString("CASCADE")
 		} else {
@@ -172,9 +156,9 @@ func buildCreateTableStmt(tblDef *schema.Table) string {
 	fk = buf.String()
 
 	buf.Reset()
-	buf.WriteString("CREATE TABLE `")
-	buf.WriteString(tblDef.Name)
-	buf.WriteString("` (\n")
+	buf.WriteString("CREATE TABLE ")
+	buf.WriteString(stringz.BacktickQuote(tblDef.Name))
+	buf.WriteString(" (\n")
 
 	for x := 0; x < len(cols)-1; x++ {
 		buf.WriteString(cols[x])
@@ -204,11 +188,16 @@ func buildUpdateStmt(tbl string, cols []string, where string) (string, error) {
 	}
 
 	buf := strings.Builder{}
-	buf.WriteString("UPDATE `")
-	buf.WriteString(tbl)
-	buf.WriteString("` SET `")
-	buf.WriteString(strings.Join(cols, "` = ?, `"))
-	buf.WriteString("` = ?")
+	buf.WriteString("UPDATE ")
+	buf.WriteString(stringz.BacktickQuote(tbl))
+	buf.WriteString(" SET ")
+	for i, col := range cols {
+		if i > 0 {
+			buf.WriteString(", ")
+		}
+		buf.WriteString(stringz.BacktickQuote(col))
+		buf.WriteString(" = ?")
+	}
 	if where != "" {
 		buf.WriteString(" WHERE ")
 		buf.WriteString(where)

--- a/drivers/oracle/render.go
+++ b/drivers/oracle/render.go
@@ -269,14 +269,14 @@ func preRenderOracle(_ *render.Context, f *render.Fragments) error {
 // buildCreateTableStmt builds a CREATE TABLE statement for Oracle.
 func buildCreateTableStmt(tblDef *schema.Table) string {
 	sb := strings.Builder{}
-	sb.WriteString(`CREATE TABLE "`)
-	sb.WriteString(strings.ToUpper(tblDef.Name))
-	sb.WriteString(`" (`)
+	sb.WriteString(`CREATE TABLE `)
+	sb.WriteString(enquoteOracle(tblDef.Name))
+	sb.WriteString(` (`)
 
 	for i, colDef := range tblDef.Cols {
-		sb.WriteString("\n  \"")
-		sb.WriteString(strings.ToUpper(colDef.Name))
-		sb.WriteString("\" ")
+		sb.WriteString("\n  ")
+		sb.WriteString(enquoteOracle(colDef.Name))
+		sb.WriteRune(' ')
 		sb.WriteString(dbTypeNameFromKind(colDef.Kind))
 
 		if colDef.NotNull {

--- a/drivers/rqlite/builders.go
+++ b/drivers/rqlite/builders.go
@@ -14,6 +14,7 @@ import (
 	"github.com/neilotoole/sq/libsq/core/errz"
 	"github.com/neilotoole/sq/libsq/core/kind"
 	"github.com/neilotoole/sq/libsq/core/schema"
+	"github.com/neilotoole/sq/libsq/core/stringz"
 )
 
 // createTblKindDefaults maps Kind to the DEFAULT clause emitted in a
@@ -39,9 +40,8 @@ func buildCreateTableStmt(tblDef *schema.Table) string {
 	cols := make([]string, len(tblDef.Cols))
 	for i, col := range tblDef.Cols {
 		buf = &bytes.Buffer{}
-		buf.WriteRune('"')
-		buf.WriteString(col.Name)
-		buf.WriteString(`" `)
+		buf.WriteString(stringz.DoubleQuote(col.Name))
+		buf.WriteRune(' ')
 		buf.WriteString(DBTypeForKind(col.Kind))
 
 		if col.Name == tblDef.PKColName {
@@ -78,21 +78,17 @@ func buildCreateTableStmt(tblDef *schema.Table) string {
 			buf.WriteString(",\n")
 		}
 
-		buf.WriteString(`CONSTRAINT "`)
-		buf.WriteString(tblDef.Name)
-		buf.WriteRune('_')
-		buf.WriteString(col.Name)
-		buf.WriteRune('_')
-		buf.WriteString(col.ForeignKey.RefTable)
-		buf.WriteRune('_')
-		buf.WriteString(col.ForeignKey.RefCol)
-		buf.WriteString(`_fk" FOREIGN KEY ("`)
-		buf.WriteString(col.Name)
-		buf.WriteString(`") REFERENCES "`)
-		buf.WriteString(col.ForeignKey.RefTable)
-		buf.WriteString(`" ("`)
-		buf.WriteString(col.ForeignKey.RefCol)
-		buf.WriteString(`") ON DELETE `)
+		fkName := tblDef.Name + "_" + col.Name + "_" +
+			col.ForeignKey.RefTable + "_" + col.ForeignKey.RefCol + "_fk"
+		buf.WriteString(`CONSTRAINT `)
+		buf.WriteString(stringz.DoubleQuote(fkName))
+		buf.WriteString(` FOREIGN KEY (`)
+		buf.WriteString(stringz.DoubleQuote(col.Name))
+		buf.WriteString(`) REFERENCES `)
+		buf.WriteString(stringz.DoubleQuote(col.ForeignKey.RefTable))
+		buf.WriteString(` (`)
+		buf.WriteString(stringz.DoubleQuote(col.ForeignKey.RefCol))
+		buf.WriteString(`) ON DELETE `)
 		if col.ForeignKey.OnDelete == "" {
 			buf.WriteString("CASCADE")
 		} else {
@@ -108,9 +104,9 @@ func buildCreateTableStmt(tblDef *schema.Table) string {
 	fk = buf.String()
 
 	buf = &bytes.Buffer{}
-	buf.WriteString(`CREATE TABLE "`)
-	buf.WriteString(tblDef.Name)
-	buf.WriteString("\" (\n")
+	buf.WriteString(`CREATE TABLE `)
+	buf.WriteString(stringz.DoubleQuote(tblDef.Name))
+	buf.WriteString(" (\n")
 
 	for x := 0; x < len(cols)-1; x++ {
 		buf.WriteString(cols[x])
@@ -134,11 +130,16 @@ func buildUpdateStmt(tbl string, cols []string, where string) (string, error) {
 	}
 
 	buf := strings.Builder{}
-	buf.WriteString(`UPDATE "`)
-	buf.WriteString(tbl)
-	buf.WriteString(`" SET "`)
-	buf.WriteString(strings.Join(cols, `" = ?, "`))
-	buf.WriteString(`" = ?`)
+	buf.WriteString(`UPDATE `)
+	buf.WriteString(stringz.DoubleQuote(tbl))
+	buf.WriteString(` SET `)
+	for i, col := range cols {
+		if i > 0 {
+			buf.WriteString(`, `)
+		}
+		buf.WriteString(stringz.DoubleQuote(col))
+		buf.WriteString(` = ?`)
+	}
 	if where != "" {
 		buf.WriteString(" WHERE ")
 		buf.WriteString(where)

--- a/drivers/sqlite3/render.go
+++ b/drivers/sqlite3/render.go
@@ -29,15 +29,18 @@ var createTblKindDefaults = map[kind.Kind]string{ //nolint:exhaustive // ignore 
 	kind.Unknown:  `DEFAULT ''`,
 }
 
+// buildCreateTableStmt builds a CREATE TABLE statement from tblDef. Identifiers
+// are quoted via stringz.DoubleQuote (sqlite3's dialect Enquote func), which
+// doubles any embedded quote char, so a name like `we"ird` cannot break out of
+// its quoting.
 func buildCreateTableStmt(tblDef *schema.Table) string {
 	var buf *bytes.Buffer
 
 	cols := make([]string, len(tblDef.Cols))
 	for i, col := range tblDef.Cols {
 		buf = &bytes.Buffer{}
-		buf.WriteRune('"')
-		buf.WriteString(col.Name)
-		buf.WriteString(`" `)
+		buf.WriteString(stringz.DoubleQuote(col.Name))
+		buf.WriteRune(' ')
 		buf.WriteString(DBTypeForKind(col.Kind))
 
 		if col.Name == tblDef.PKColName {
@@ -74,21 +77,17 @@ func buildCreateTableStmt(tblDef *schema.Table) string {
 			buf.WriteString(",\n")
 		}
 
-		buf.WriteString(`CONSTRAINT "`)
-		buf.WriteString(tblDef.Name)
-		buf.WriteRune('_')
-		buf.WriteString(col.Name)
-		buf.WriteRune('_')
-		buf.WriteString(col.ForeignKey.RefTable)
-		buf.WriteRune('_')
-		buf.WriteString(col.ForeignKey.RefCol)
-		buf.WriteString(`_fk" FOREIGN KEY ("`)
-		buf.WriteString(col.Name)
-		buf.WriteString(`") REFERENCES "`)
-		buf.WriteString(col.ForeignKey.RefTable)
-		buf.WriteString(`" ("`)
-		buf.WriteString(col.ForeignKey.RefCol)
-		buf.WriteString(`") ON DELETE `)
+		fkName := tblDef.Name + "_" + col.Name + "_" +
+			col.ForeignKey.RefTable + "_" + col.ForeignKey.RefCol + "_fk"
+		buf.WriteString(`CONSTRAINT `)
+		buf.WriteString(stringz.DoubleQuote(fkName))
+		buf.WriteString(` FOREIGN KEY (`)
+		buf.WriteString(stringz.DoubleQuote(col.Name))
+		buf.WriteString(`) REFERENCES `)
+		buf.WriteString(stringz.DoubleQuote(col.ForeignKey.RefTable))
+		buf.WriteString(` (`)
+		buf.WriteString(stringz.DoubleQuote(col.ForeignKey.RefCol))
+		buf.WriteString(`) ON DELETE `)
 		if col.ForeignKey.OnDelete == "" {
 			buf.WriteString("CASCADE")
 		} else {
@@ -104,9 +103,9 @@ func buildCreateTableStmt(tblDef *schema.Table) string {
 	fk = buf.String()
 
 	buf = &bytes.Buffer{}
-	buf.WriteString(`CREATE TABLE "`)
-	buf.WriteString(tblDef.Name)
-	buf.WriteString("\" (\n")
+	buf.WriteString(`CREATE TABLE `)
+	buf.WriteString(stringz.DoubleQuote(tblDef.Name))
+	buf.WriteString(" (\n")
 
 	for x := 0; x < len(cols)-1; x++ {
 		buf.WriteString(cols[x])
@@ -128,11 +127,16 @@ func buildUpdateStmt(tbl string, cols []string, where string) (string, error) {
 	}
 
 	buf := strings.Builder{}
-	buf.WriteString(`UPDATE "`)
-	buf.WriteString(tbl)
-	buf.WriteString(`" SET "`)
-	buf.WriteString(strings.Join(cols, `" = ?, "`))
-	buf.WriteString(`" = ?`)
+	buf.WriteString(`UPDATE `)
+	buf.WriteString(stringz.DoubleQuote(tbl))
+	buf.WriteString(` SET `)
+	for i, col := range cols {
+		if i > 0 {
+			buf.WriteString(`, `)
+		}
+		buf.WriteString(stringz.DoubleQuote(col))
+		buf.WriteString(` = ?`)
+	}
 	if where != "" {
 		buf.WriteString(" WHERE ")
 		buf.WriteString(where)

--- a/drivers/sqlserver/metadata.go
+++ b/drivers/sqlserver/metadata.go
@@ -22,6 +22,7 @@ import (
 	"github.com/neilotoole/sq/libsq/core/progress"
 	"github.com/neilotoole/sq/libsq/core/record"
 	"github.com/neilotoole/sq/libsq/core/sqlz"
+	"github.com/neilotoole/sq/libsq/core/stringz"
 	"github.com/neilotoole/sq/libsq/core/tuning"
 	"github.com/neilotoole/sq/libsq/source"
 	"github.com/neilotoole/sq/libsq/source/drivertype"
@@ -281,7 +282,11 @@ GROUP BY database_id) AS total_size_bytes`
 func getTableMetadata(ctx context.Context, db sqlz.DB, tblCatalog,
 	tblSchema, tblName, tblType string, loadConstraints bool,
 ) (*metadata.Table, error) {
-	const tplTblUsage = `sp_spaceused '%s'`
+	// sp_spaceused parses @objname as an identifier from a string literal, so
+	// the name is bracket-quoted (so a name like we"ird resolves) and then
+	// single-quoted (SingleQuote doubles any embedded ' so it can't break the
+	// literal). Raw interpolation broke on any name containing a quote char.
+	tplTblUsage := `sp_spaceused ` + stringz.SingleQuote(bracketQuote(tblName))
 
 	tblMeta := &metadata.Table{Name: tblName, DBTableType: tblType}
 	tblMeta.FQName = tblCatalog + "." + tblSchema + "." + tblName
@@ -295,7 +300,7 @@ func getTableMetadata(ctx context.Context, db sqlz.DB, tblCatalog,
 	}
 
 	var rowCount, reserved, data, indexSize, unused sql.NullString
-	row := db.QueryRowContext(ctx, fmt.Sprintf(tplTblUsage, tblName))
+	row := db.QueryRowContext(ctx, tplTblUsage)
 
 	// REVISIT: This error can occur:
 	//
@@ -319,8 +324,9 @@ func getTableMetadata(ctx context.Context, db sqlz.DB, tblCatalog,
 		}
 	} else {
 		// We can't get the "row count" for a VIEW from sp_spaceused,
-		// so we need to select it the old-fashioned way.
-		err = db.QueryRowContext(ctx, fmt.Sprintf("SELECT COUNT(*) FROM %q", tblName)).Scan(&tblMeta.RowCount)
+		// so we need to select it the old-fashioned way. DoubleQuote escapes the
+		// identifier (%q applies Go backslash-quoting, not SQL doubling).
+		err = db.QueryRowContext(ctx, `SELECT COUNT(*) FROM `+stringz.DoubleQuote(tblName)).Scan(&tblMeta.RowCount)
 		if err != nil {
 			return nil, errw(err)
 		}

--- a/drivers/sqlserver/render.go
+++ b/drivers/sqlserver/render.go
@@ -10,6 +10,7 @@ import (
 	"github.com/neilotoole/sq/libsq/core/errz"
 	"github.com/neilotoole/sq/libsq/core/kind"
 	"github.com/neilotoole/sq/libsq/core/schema"
+	"github.com/neilotoole/sq/libsq/core/stringz"
 )
 
 func renderRange(_ *render.Context, rr *ast.RowRangeNode) (string, error) {
@@ -105,14 +106,14 @@ var createTblKindDefaults = map[kind.Kind]string{ //nolint:exhaustive
 // The implementation is minimal: it does not honor PK, FK, etc.
 func buildCreateTableStmt(tblDef *schema.Table) string {
 	sb := strings.Builder{}
-	sb.WriteString(`CREATE TABLE "`)
-	sb.WriteString(tblDef.Name)
-	sb.WriteString("\" (")
+	sb.WriteString(`CREATE TABLE `)
+	sb.WriteString(stringz.DoubleQuote(tblDef.Name))
+	sb.WriteString(" (")
 
 	for i, colDef := range tblDef.Cols {
-		sb.WriteString("\n\"")
-		sb.WriteString(colDef.Name)
-		sb.WriteString("\" ")
+		sb.WriteRune('\n')
+		sb.WriteString(stringz.DoubleQuote(colDef.Name))
+		sb.WriteRune(' ')
 		sb.WriteString(dbTypeNameFromKind(colDef.Kind))
 
 		if colDef.NotNull {
@@ -137,11 +138,16 @@ func buildUpdateStmt(tbl string, cols []string, where string) (string, error) {
 	}
 
 	sb := strings.Builder{}
-	sb.WriteString(`UPDATE "`)
-	sb.WriteString(tbl)
-	sb.WriteString(`" SET "`)
-	sb.WriteString(strings.Join(cols, `" = ?, "`))
-	sb.WriteString(`" = ?`)
+	sb.WriteString(`UPDATE `)
+	sb.WriteString(stringz.DoubleQuote(tbl))
+	sb.WriteString(` SET `)
+	for i, col := range cols {
+		if i > 0 {
+			sb.WriteString(`, `)
+		}
+		sb.WriteString(stringz.DoubleQuote(col))
+		sb.WriteString(` = ?`)
+	}
 	if where != "" {
 		sb.WriteString(" WHERE ")
 		sb.WriteString(where)

--- a/drivers/sqlserver/sqlserver.go
+++ b/drivers/sqlserver/sqlserver.go
@@ -309,9 +309,12 @@ func (d *driveri) Truncate(ctx context.Context, src *source.Source, tbl string, 
 	}
 
 	if reset {
-		// DBCC CHECKIDENT takes the table name as a string literal, so it is
-		// single-quoted (SingleQuote doubles any embedded ').
-		_, err = db.ExecContext(ctx, `DBCC CHECKIDENT (`+stringz.SingleQuote(tbl)+`, RESEED, 1)`)
+		// DBCC CHECKIDENT parses the table name out of a string literal (as a
+		// possibly-multipart name), so it gets the same bracket-then-single
+		// quoting as sp_spaceused: bracket-quote so a name with a '.' resolves
+		// as one identifier (matching the DELETE above), then single-quote the
+		// literal. Raw single-quoting diverged from the DELETE for such names.
+		_, err = db.ExecContext(ctx, `DBCC CHECKIDENT (`+stringz.SingleQuote(bracketQuote(tbl))+`, RESEED, 1)`)
 		if err != nil {
 			if hasErrCode(err, errNoIdentityColumn) {
 				// The table has no identity column, so we can't reseed.

--- a/drivers/sqlserver/sqlserver.go
+++ b/drivers/sqlserver/sqlserver.go
@@ -303,13 +303,15 @@ func (d *driveri) Truncate(ctx context.Context, src *source.Source, tbl string, 
 	}
 	defer lg.WarnIfFuncError(d.log, lgm.CloseDB, db.Close)
 
-	affected, err = sqlz.ExecAffected(ctx, db, fmt.Sprintf("DELETE FROM %q", tbl))
+	affected, err = sqlz.ExecAffected(ctx, db, `DELETE FROM `+stringz.DoubleQuote(tbl))
 	if err != nil {
 		return affected, errz.Wrapf(errw(err), "truncate: failed to delete from %q", tbl)
 	}
 
 	if reset {
-		_, err = db.ExecContext(ctx, fmt.Sprintf("DBCC CHECKIDENT ('%s', RESEED, 1)", tbl))
+		// DBCC CHECKIDENT takes the table name as a string literal, so it is
+		// single-quoted (SingleQuote doubles any embedded ').
+		_, err = db.ExecContext(ctx, `DBCC CHECKIDENT (`+stringz.SingleQuote(tbl)+`, RESEED, 1)`)
 		if err != nil {
 			if hasErrCode(err, errNoIdentityColumn) {
 				// The table has no identity column, so we can't reseed.
@@ -585,7 +587,7 @@ func (d *driveri) DropSchema(ctx context.Context, db sqlz.DB, schemaName string)
 		return errz.Wrapf(err, "failed to drop objects in schema {%s}", schemaName)
 	}
 
-	dropSchemaStmt := `DROP SCHEMA [` + schemaName + `]`
+	dropSchemaStmt := `DROP SCHEMA ` + stringz.DoubleQuote(schemaName)
 	if _, err := db.ExecContext(ctx, dropSchemaStmt); err != nil {
 		return errz.Wrapf(err, "failed to drop schema {%s}", schemaName)
 	}
@@ -642,7 +644,8 @@ func (d *driveri) CreateTable(ctx context.Context, db sqlz.DB, tblDef *schema.Ta
 
 // AlterTableAddColumn implements driver.SQLDriver.
 func (d *driveri) AlterTableAddColumn(ctx context.Context, db sqlz.DB, tbl, col string, knd kind.Kind) error {
-	q := fmt.Sprintf("ALTER TABLE %q ADD %q ", tbl, col) + dbTypeNameFromKind(knd)
+	q := `ALTER TABLE ` + stringz.DoubleQuote(tbl) + ` ADD ` +
+		stringz.DoubleQuote(col) + ` ` + dbTypeNameFromKind(knd)
 
 	_, err := db.ExecContext(ctx, q)
 	return errz.Wrapf(errw(err), "alter table: failed to add column %q to table %q", col, tbl)
@@ -655,7 +658,12 @@ func (d *driveri) AlterTableRename(ctx context.Context, db sqlz.DB, tbl, newName
 		return err
 	}
 
-	q := fmt.Sprintf(`exec sp_rename '[%s].[%s]', '%s'`, schma, tbl, newName)
+	// sp_rename receives the current object name inside a string literal and
+	// parses it with bracket quoting; the new name is a bare literal it uses
+	// verbatim. Bracket-quote each identifier part, then single-quote the
+	// whole literal so embedded ] or ' can't break out.
+	oldName := bracketQuote(schma) + "." + bracketQuote(tbl)
+	q := `exec sp_rename ` + stringz.SingleQuote(oldName) + `, ` + stringz.SingleQuote(newName)
 	_, err = db.ExecContext(ctx, q)
 	return errz.Wrapf(errw(err), "alter table: failed to rename table %q to %q", tbl, newName)
 }
@@ -667,7 +675,8 @@ func (d *driveri) AlterTableRenameColumn(ctx context.Context, db sqlz.DB, tbl, c
 		return err
 	}
 
-	q := fmt.Sprintf(`exec sp_rename '[%s].[%s].[%s]', '%s'`, schma, tbl, col, newName)
+	oldName := bracketQuote(schma) + "." + bracketQuote(tbl) + "." + bracketQuote(col)
+	q := `exec sp_rename ` + stringz.SingleQuote(oldName) + `, ` + stringz.SingleQuote(newName)
 	_, err = db.ExecContext(ctx, q)
 	return errz.Wrapf(errw(err), "alter table: failed to rename column {%s.%s.%s} to {%s}", schma, tbl, col, newName)
 }
@@ -706,7 +715,9 @@ func (d *driveri) DropTable(ctx context.Context, db sqlz.DB, tbl tablefq.T, ifEx
 	tblID := tblfmt(tbl)
 
 	if ifExists {
-		stmt = fmt.Sprintf("IF OBJECT_ID('%s', 'U') IS NOT NULL DROP TABLE %s", tblID, tblID)
+		// OBJECT_ID takes the object name as a string literal; single-quote the
+		// (already identifier-quoted) tblID so an embedded ' can't break it.
+		stmt = `IF OBJECT_ID(` + stringz.SingleQuote(tblID) + `, 'U') IS NOT NULL DROP TABLE ` + tblID
 	} else {
 		stmt = "DROP TABLE " + tblID
 	}
@@ -867,6 +878,14 @@ func tblfmt[T string | tablefq.T](tbl T) string {
 	return tablefq.Format(tbl, stringz.DoubleQuote)
 }
 
+// bracketQuote quotes a SQL Server identifier using [ ] delimiters, doubling
+// any embedded ] (the SQL Server escape char). It is for contexts such as
+// sp_rename that receive a name inside a string literal and parse it with
+// bracket quoting; the literal itself is single-quoted separately.
+func bracketQuote(s string) string {
+	return "[" + strings.ReplaceAll(s, "]", "]]") + "]"
+}
+
 // genDropSchemaObjectsStmt generates a SQL statement that drops all
 // objects in the named schema. It is used by driveri.DropSchema.
 // This statement is necessary because SQLServer
@@ -880,7 +899,7 @@ func tblfmt[T string | tablefq.T](tbl T) string {
 //nolint:lll
 func genDropSchemaObjectsStmt(schemaName string) string {
 	const tpl = `
-declare @SchemaName nvarchar(100) = '%s'
+declare @SchemaName nvarchar(100) = %s
 declare @SchemaID int = schema_id(@SchemaName)
 
 declare @n char(1)
@@ -928,5 +947,8 @@ where schema_id = @SchemaID and is_user_defined = 1
 exec sp_executesql @stmt
 `
 
-	return fmt.Sprintf(tpl, schemaName)
+	// @SchemaName is assigned from a string literal; single-quote it so an
+	// embedded ' can't break out. (The inner dynamic SQL still bracket-quotes
+	// object names server-side.)
+	return fmt.Sprintf(tpl, stringz.SingleQuote(schemaName))
 }

--- a/drivers/sqlserver/sqlserver_integration_test.go
+++ b/drivers/sqlserver/sqlserver_integration_test.go
@@ -360,6 +360,43 @@ func TestDriver_AlterTable_QuotedIdentifier_MSSQL(t *testing.T) {
 	require.Len(t, md.Columns, 3, "expected c\"1b, id, c\"2 after the alters")
 }
 
+// TestDriver_DropSchema_QuotedIdentifier_MSSQL exercises DropSchema and
+// genDropSchemaObjectsStmt against a schema whose name contains a single quote
+// (#1027). DropSchema first enumerates and drops the schema's objects (the
+// generated script assigns @SchemaName from a string literal, so the name must
+// be single-quoted with the ' doubled), then drops the schema itself
+// (identifier-quoted). A single quote is the char that breaks the generated
+// script's string literal; a name containing a ] can still fail server-side
+// because the generated script bracket-builds object names without doubling ]
+// (a deeper pre-existing limit, out of scope here).
+func TestDriver_DropSchema_QuotedIdentifier_MSSQL(t *testing.T) {
+	tu.SkipShort(t, true)
+	t.Parallel()
+
+	th, _, drvr, _, db := testh.NewWith(t, sakila.MS)
+	ctx := th.Context
+
+	schemaName := `s'ch_` + stringz.Uniq8()
+	require.NoError(t, drvr.CreateSchema(ctx, db, schemaName),
+		"CreateSchema must escape a quoted schema name")
+	dropped := false
+	t.Cleanup(func() {
+		if !dropped {
+			_ = drvr.DropSchema(ctx, db, schemaName)
+		}
+	})
+
+	// Put a table in the schema so genDropSchemaObjectsStmt has an object to
+	// drop before DROP SCHEMA (it enumerates sys.tables for the schema).
+	_, err := db.ExecContext(ctx,
+		`CREATE TABLE `+stringz.DoubleQuote(schemaName)+`.`+stringz.DoubleQuote(`t"1`)+` (id INT)`)
+	require.NoError(t, err)
+
+	require.NoError(t, drvr.DropSchema(ctx, db, schemaName),
+		"DropSchema must escape a quoted schema name and its objects")
+	dropped = true
+}
+
 func TestDriver_PrepareUpdateStmt_MSSQL(t *testing.T) {
 	tu.SkipShort(t, true)
 	t.Parallel()

--- a/drivers/sqlserver/sqlserver_integration_test.go
+++ b/drivers/sqlserver/sqlserver_integration_test.go
@@ -269,6 +269,40 @@ func TestDriver_Truncate_NoIdentity_MSSQL(t *testing.T) {
 	require.Equal(t, int64(2), affected)
 }
 
+// TestDriver_QuotedView_RowCount_MSSQL exercises the view row-count fallback in
+// getTableMetadata (issue #1027 P1): sp_spaceused returns a NULL row count for a
+// VIEW, so the code falls back to SELECT COUNT(*) FROM <view>. That site
+// previously interpolated the name with %q (Go backslash-quoting, not SQL
+// identifier doubling), so a view whose name contains a double-quote built
+// malformed SQL. Here the view name contains a double-quote, so metadata must
+// still load and report the correct row count.
+func TestDriver_QuotedView_RowCount_MSSQL(t *testing.T) {
+	tu.SkipShort(t, true)
+	t.Parallel()
+
+	th, src, drvr, grip, db := testh.NewWith(t, sakila.MS)
+
+	baseTbl := stringz.UniqTableName(`ba"se`)
+	tblDef := schema.NewTable(baseTbl, []string{"id", "val"}, []kind.Kind{kind.Int, kind.Text})
+	require.NoError(t, drvr.CreateTable(th.Context, db, tblDef))
+	t.Cleanup(func() { th.DropTable(src, tablefq.From(baseTbl)) })
+	th.Insert(src, baseTbl, []string{"id", "val"}, []any{int64(1), "a"}, []any{int64(2), "b"})
+
+	viewName := stringz.UniqTableName(`vi"ew`)
+	qView := stringz.DoubleQuote(viewName)
+	_, err := db.ExecContext(th.Context,
+		`CREATE VIEW `+qView+` AS SELECT id, val FROM `+stringz.DoubleQuote(baseTbl))
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_, _ = db.ExecContext(th.Context, `DROP VIEW IF EXISTS `+qView)
+	})
+
+	md, err := grip.TableMetadata(th.Context, viewName)
+	require.NoError(t, err, "view metadata must load for a quoted view name")
+	require.Equal(t, viewName, md.Name)
+	require.Equal(t, int64(2), md.RowCount, "row count must load via the COUNT(*) fallback")
+}
+
 func TestDriver_PrepareUpdateStmt_MSSQL(t *testing.T) {
 	tu.SkipShort(t, true)
 	t.Parallel()

--- a/drivers/sqlserver/sqlserver_integration_test.go
+++ b/drivers/sqlserver/sqlserver_integration_test.go
@@ -303,6 +303,63 @@ func TestDriver_QuotedView_RowCount_MSSQL(t *testing.T) {
 	require.Equal(t, int64(2), md.RowCount, "row count must load via the COUNT(*) fallback")
 }
 
+// TestDriver_Truncate_QuotedIdentity_MSSQL exercises Truncate's reseed path
+// (DBCC CHECKIDENT) against an identity table whose name contains a double
+// quote. DBCC parses the name out of a string literal, so it must be
+// bracket-quoted before single-quoting (#1027); a raw single-quoted name broke
+// object resolution after the destructive DELETE.
+func TestDriver_Truncate_QuotedIdentity_MSSQL(t *testing.T) {
+	tu.SkipShort(t, true)
+	t.Parallel()
+
+	th, src, drvr, _, db := testh.NewWith(t, sakila.MS)
+
+	tblName := stringz.UniqTableName(`tr"unc`)
+	// sq's CreateTable does not emit IDENTITY columns, so create the identity
+	// table with raw (properly quoted) DDL.
+	_, err := db.ExecContext(th.Context,
+		`CREATE TABLE `+stringz.DoubleQuote(tblName)+` (id INT IDENTITY(1,1) PRIMARY KEY, val NVARCHAR(20))`)
+	require.NoError(t, err)
+	t.Cleanup(func() { th.DropTable(src, tablefq.From(tblName)) })
+	th.Insert(src, tblName, []string{"val"}, []any{"a"}, []any{"b"})
+
+	affected, err := drvr.Truncate(th.Context, src, tblName, true)
+	require.NoError(t, err, "Truncate+reset must handle a quoted identity table name")
+	require.Equal(t, int64(2), affected)
+}
+
+// TestDriver_AlterTable_QuotedIdentifier_MSSQL exercises the ALTER-family DDL
+// (AlterTableAddColumn, AlterTableRenameColumn, AlterTableRename) against a
+// table and columns whose names contain a double quote (#1027). AddColumn
+// quotes as an identifier; the sp_rename paths bracket-quote the name inside a
+// string literal.
+func TestDriver_AlterTable_QuotedIdentifier_MSSQL(t *testing.T) {
+	tu.SkipShort(t, true)
+	t.Parallel()
+
+	th, src, drvr, _, db := testh.NewWith(t, sakila.MS)
+
+	tblName := stringz.UniqTableName(`al"ter`)
+	tblDef := schema.NewTable(tblName, []string{`c"1`, "id"}, []kind.Kind{kind.Text, kind.Int})
+	require.NoError(t, drvr.CreateTable(th.Context, db, tblDef))
+	t.Cleanup(func() { th.DropTable(src, tablefq.From(tblName)) })
+
+	require.NoError(t, drvr.AlterTableAddColumn(th.Context, db, tblName, `c"2`, kind.Int),
+		"AlterTableAddColumn must escape quoted table/column names")
+	require.NoError(t, drvr.AlterTableRenameColumn(th.Context, db, tblName, `c"1`, `c"1b`),
+		"AlterTableRenameColumn must escape quoted names")
+
+	newName := stringz.UniqTableName(`al"ter2`)
+	require.NoError(t, drvr.AlterTableRename(th.Context, db, tblName, newName),
+		"AlterTableRename must escape quoted names")
+	t.Cleanup(func() { th.DropTable(src, tablefq.From(newName)) })
+
+	md, err := th.Open(src).TableMetadata(th.Context, newName)
+	require.NoError(t, err, "renamed quoted table must load")
+	require.Equal(t, newName, md.Name)
+	require.Len(t, md.Columns, 3, "expected c\"1b, id, c\"2 after the alters")
+}
+
 func TestDriver_PrepareUpdateStmt_MSSQL(t *testing.T) {
 	tu.SkipShort(t, true)
 	t.Parallel()

--- a/libsq/driver/driver_test.go
+++ b/libsq/driver/driver_test.go
@@ -290,15 +290,16 @@ func TestDriver_CreateTable_Minimal(t *testing.T) {
 	}
 }
 
-// TestDriver_CreateTable_QuotedIdentifier is a cross-driver regression test for
-// issue #1027: a table or column name containing the dialect's own quote char
-// (e.g. we"ird, or a backtick for MySQL) must be escaped when the write-path
-// builders interpolate it into DDL, and it must still load through the metadata
-// scan path afterward. The builders previously interpolated names raw, so an
-// embedded quote built malformed SQL. This is user-reachable via ingestion,
-// where column names come from file headers (a header like weird"col is
-// untrusted input). Mirrors TestPostgres_QuotedTableName_Metadata (#1025).
-func TestDriver_CreateTable_QuotedIdentifier(t *testing.T) {
+// TestDriver_QuotedIdentifier is a cross-driver regression test for issue
+// #1027: a table or column name containing the dialect's own quote char (e.g.
+// we"ird, or a backtick for MySQL) must be escaped when the write-path builders
+// interpolate it into SQL. It exercises the CreateTable builder, the metadata
+// scan path, and the UPDATE builder in one pass. The builders previously
+// interpolated names raw, so an embedded quote built malformed SQL. This is
+// user-reachable via ingestion, where column names come from file headers (a
+// header like weird"col is untrusted input). Mirrors
+// TestPostgres_QuotedTableName_Metadata (#1025).
+func TestDriver_QuotedIdentifier(t *testing.T) {
 	t.Parallel()
 
 	for _, handle := range sakila.SQLAll() {
@@ -346,6 +347,15 @@ func TestDriver_CreateTable_QuotedIdentifier(t *testing.T) {
 			require.NoError(t, err, "TableMetadata must load for a quoted table name")
 			require.Equal(t, tblName, md.Name)
 			require.Len(t, md.Columns, len(colNames))
+
+			// Exercise the UPDATE write-path builder (buildUpdateStmt) with the
+			// quoted column: insert a row, then update the weird column by id.
+			th.Insert(src, tblName, colNames, []any{int64(1), "before"})
+			execer, err := drvr.PrepareUpdateStmt(th.Context, db, tblName, []string{weird}, "id = ?")
+			require.NoError(t, err, "PrepareUpdateStmt must escape the quoted column %q", weird)
+			require.NoError(t, execer.Munge([]any{"after"}))
+			_, err = execer.Exec(th.Context, "after", int64(1))
+			require.NoError(t, err, "UPDATE must escape the quoted column %q", weird)
 		})
 	}
 }

--- a/libsq/driver/driver_test.go
+++ b/libsq/driver/driver_test.go
@@ -290,6 +290,66 @@ func TestDriver_CreateTable_Minimal(t *testing.T) {
 	}
 }
 
+// TestDriver_CreateTable_QuotedIdentifier is a cross-driver regression test for
+// issue #1027: a table or column name containing the dialect's own quote char
+// (e.g. we"ird, or a backtick for MySQL) must be escaped when the write-path
+// builders interpolate it into DDL, and it must still load through the metadata
+// scan path afterward. The builders previously interpolated names raw, so an
+// embedded quote built malformed SQL. This is user-reachable via ingestion,
+// where column names come from file headers (a header like weird"col is
+// untrusted input). Mirrors TestPostgres_QuotedTableName_Metadata (#1025).
+func TestDriver_CreateTable_QuotedIdentifier(t *testing.T) {
+	t.Parallel()
+
+	for _, handle := range sakila.SQLAll() {
+		t.Run(handle, func(t *testing.T) {
+			t.Parallel()
+
+			th, src, drvr, grip, db := testh.NewWith(t, handle)
+
+			// ClickHouse already escapes identifiers (issue #1027), and its
+			// MergeTree DDL imposes ORDER BY / nullability constraints unrelated
+			// to escaping, so it is skipped here to keep the test focused.
+			tu.SkipIf(t, drvr.DriverMetadata().Type == drivertype.ClickHouse,
+				"ClickHouse: already escapes; MergeTree DDL constraints are out of scope")
+
+			// Oracle forbids a double-quote char in an identifier outright
+			// (ORA-25716), even when escaped, so its own delimiter can never
+			// appear in a name — there is nothing to escape-test. Oracle's
+			// write-path builders still route through enquoteOracle for hygiene.
+			tu.SkipIf(t, drvr.DriverMetadata().Type == drivertype.Oracle,
+				"Oracle: ORA-25716 forbids a double-quote char in identifiers")
+
+			// The "weird" char is the dialect's own identifier delimiter (the
+			// first rune Enquote emits) — the exact char that must be doubled:
+			// a double-quote for most dialects, a backtick for MySQL.
+			delim := []rune(drvr.Dialect().Enquote(""))[0]
+			weird := "we" + string(delim) + "ird"
+
+			// An int PK column comes first (some engines order/constrain the
+			// first column); the delimiter appears in both a column name and
+			// the table name. On MySQL, the PK also exercises index-name
+			// escaping (the UNIQUE KEY name embeds the table name).
+			tblName := stringz.UniqTableName(weird + "_tbl")
+			colNames := []string{"id", weird}
+			colKinds := []kind.Kind{kind.Int, kind.Text}
+			tblDef := schema.NewTable(tblName, colNames, colKinds)
+			tblDef.PKColName = "id"
+
+			require.NoError(t, drvr.CreateTable(th.Context, db, tblDef),
+				"CreateTable must escape the delimiter in %q", weird)
+			t.Cleanup(func() { th.DropTable(src, tablefq.From(tblName)) })
+
+			// The scan path must also load metadata for the quoted name
+			// (SQL Server's sp_spaceused was raw-interpolated).
+			md, err := grip.TableMetadata(th.Context, tblName)
+			require.NoError(t, err, "TableMetadata must load for a quoted table name")
+			require.Equal(t, tblName, md.Name)
+			require.Len(t, md.Columns, len(colNames))
+		})
+	}
+}
+
 func TestDriver_TableColumnTypes(t *testing.T) { //nolint:tparallel
 	testCases := sakila.SQLAll()
 	for _, handle := range testCases {

--- a/libsq/driver/driver_test.go
+++ b/libsq/driver/driver_test.go
@@ -315,13 +315,13 @@ func TestDriver_CreateTable_QuotedIdentifier(t *testing.T) {
 
 			// Oracle forbids a double-quote char in an identifier outright
 			// (ORA-25716), even when escaped, so its own delimiter can never
-			// appear in a name — there is nothing to escape-test. Oracle's
+			// appear in a name, so there is nothing to escape-test. Oracle's
 			// write-path builders still route through enquoteOracle for hygiene.
 			tu.SkipIf(t, drvr.DriverMetadata().Type == drivertype.Oracle,
 				"Oracle: ORA-25716 forbids a double-quote char in identifiers")
 
 			// The "weird" char is the dialect's own identifier delimiter (the
-			// first rune Enquote emits) — the exact char that must be doubled:
+			// first rune Enquote emits): the exact char that must be doubled,
 			// a double-quote for most dialects, a backtick for MySQL.
 			delim := []rune(drvr.Dialect().Enquote(""))[0]
 			weird := "we" + string(delim) + "ird"


### PR DESCRIPTION
Addresses #1027 (P1–P3 identifier escaping). Drop-tolerance gaps and the
postgres `getMatviewMetadata` tidy are deliberately left for a separate PR.

## What

Table/column/schema names were interpolated **raw** into SQL strings in the
write-path statement builders and several SQL Server sites, so a name
containing the dialect's quote char (e.g. `we"ird`, or a backtick for MySQL)
built malformed SQL. This is user-reachable: `CreateTable` runs during
CSV/JSON/XLSX ingestion, where column names come from **file headers** (a
header like `weird"col` is untrusted input).

The correct primitives already exist (`stringz.DoubleQuote` / `BacktickQuote` /
`SingleQuote`, each of which doubles its delimiter); the write-path builders
were the blind spot. This PR routes every identifier through the driver's own
quote func.

## How

### P2 — write-path builders (reachable via ingestion)
`buildCreateTableStmt` / `buildUpdateStmt` for **mysql, oracle, duckdb,
sqlite3, rqlite, sqlserver** now quote via the dialect's func
(`BacktickQuote` / `DoubleQuote` / `enquoteOracle`) instead of hand-written
quote chars — including constructed constraint/index names (e.g. MySQL's
`<tbl>_<col>_uindex`). The builders are package-level free funcs, so each
calls its own dialect's quoter directly; no signature change, and output is
byte-identical for valid names (the internal builder tests are unchanged and
still pass). Identifiers can't be bind-parameterized, so quoting is the fix.

### P1 — SQL Server scan path (reachable via `sq inspect`)
- `sp_spaceused`: the object name is now **bracket-quoted inside** the string
  literal and then single-quoted (`sp_spaceused '[we"ird]'`). A raw
  single-quoted name (`'we"ird'`) fails object resolution because sp_spaceused
  parses `"` as a quoting delimiter.
- View row-count fallback: `SELECT COUNT(*) FROM %q` → `DoubleQuote`. `%q` is
  Go backslash-quoting, **not** SQL identifier doubling.

### P3 — SQL Server DDL
`AlterTableAddColumn`, `AlterTableRename`, `AlterTableRenameColumn`,
`DropSchema`, `DropTable`, `Truncate`, and `genDropSchemaObjectsStmt` now
escape identifiers. A small `bracketQuote` helper (`]` → `]]`) handles the
names that `sp_rename` parses out of a string literal; `SingleQuote` handles
string-literal args (`OBJECT_ID('…')`, `DBCC CHECKIDENT ('…', …)`,
`@SchemaName = '…'`).

## Testing

- **`TestDriver_CreateTable_QuotedIdentifier`** (cross-driver, `libsq/driver`):
  creates a table whose name and one column name contain the **dialect's own
  delimiter** (derived from `Dialect().Enquote`), then asserts `CreateTable`
  and `TableMetadata` both succeed. Passes on **sqlite3, duckdb, postgres,
  mysql, sqlserver, rqlite**; **fails on the pre-fix code**. ClickHouse is
  skipped (already escapes; MergeTree DDL constraints are unrelated). Oracle is
  skipped: `ORA-25716` forbids a double-quote char in an identifier outright,
  so its own delimiter can never appear in a name — nothing to escape-test
  (the write-path builder still routes through `enquoteOracle` for hygiene).
- **`TestDriver_QuotedView_RowCount_MSSQL`**: a quoted view name exercises the
  P1 view `COUNT(*)` fallback and asserts the row count loads.
- Full cross-driver conformance suite + all six modified driver packages green
  against live DBs. `go build ./...`, `make fmt`, and pinned `golangci-lint`
  all clean.

## Notes / follow-ups (out of scope, tracked in #1027)

- **Concurrent-DDL drop tolerance:** sqlite3's batched `UNION ALL COUNT(*)` and
  SQL Server's untolerated error 208 (view scan) can still fail a full
  `SourceMetadata` scan when a table is dropped mid-scan. This is a
  **pre-existing** race (reproducible on `master`), independent of escaping —
  left for the drop-tolerance PR.
- **postgres `getMatviewMetadata`** hand-rolled escaping tidy — also deferred.
