### PR TITLE
test(postgres): pin quoted-name constraint/matview escaping and scan retry

### DIFF
--- a/drivers/postgres/internal_test.go
+++ b/drivers/postgres/internal_test.go
@@ -89,6 +89,10 @@ func TestIsErrScanRetryable(t *testing.T) {
 		{name: "relation_not_exist", err: &pgconn.PgError{Code: errCodeRelationNotExist}, want: true},
 		{name: "too_many_connections", err: &pgconn.PgError{Code: errCodeTooManyConnections}, want: true},
 		{name: "internal_error", err: &pgconn.PgError{Code: errCodeInternalError}, want: true},
+		// The predicate sees errors that have already been wrapped via errw, so
+		// each retryable code is also covered in wrapped form.
+		{name: "wrapped_relation_not_exist", err: errw(&pgconn.PgError{Code: errCodeRelationNotExist}), want: true},
+		{name: "wrapped_too_many_connections", err: errw(&pgconn.PgError{Code: errCodeTooManyConnections}), want: true},
 		{name: "wrapped_internal_error", err: errw(&pgconn.PgError{Code: errCodeInternalError}), want: true},
 		{name: "syntax_error", err: &pgconn.PgError{Code: "42601"}, want: false},
 		{name: "non_pg_error", err: errors.New("boom"), want: false},

--- a/drivers/postgres/internal_test.go
+++ b/drivers/postgres/internal_test.go
@@ -1,6 +1,8 @@
 package postgres
 
 import (
+	"context"
+	"errors"
 	"testing"
 
 	"github.com/jackc/pgx/v5/pgconn"
@@ -70,6 +72,71 @@ func TestIsErrTooManyConnections(t *testing.T) {
 	// Test with a wrapped error
 	err = errw(err)
 	require.True(t, isErrTooManyConnections(err))
+}
+
+// TestIsErrScanRetryable pins the retry predicate used by the bulk metadata
+// loaders (loadWithRetry / doRetryVanished): too-many-connections, a relation
+// that no longer exists, and the XX000 internal error raised when a relation
+// is dropped between OID resolution and access are retryable; anything else
+// is not. See issue #1025.
+func TestIsErrScanRetryable(t *testing.T) {
+	testCases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "nil", err: nil, want: false},
+		{name: "relation_not_exist", err: &pgconn.PgError{Code: errCodeRelationNotExist}, want: true},
+		{name: "too_many_connections", err: &pgconn.PgError{Code: errCodeTooManyConnections}, want: true},
+		{name: "internal_error", err: &pgconn.PgError{Code: errCodeInternalError}, want: true},
+		{name: "wrapped_internal_error", err: errw(&pgconn.PgError{Code: errCodeInternalError}), want: true},
+		{name: "syntax_error", err: &pgconn.PgError{Code: "42601"}, want: false},
+		{name: "non_pg_error", err: errors.New("boom"), want: false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, isErrScanRetryable(tc.err))
+		})
+	}
+}
+
+// TestLoadWithRetry_VanishedRelation pins the retry behavior of the bulk
+// metadata loaders: a transient vanished-relation error (a relation dropped
+// mid-scan by concurrent DDL) is retried and resolves on the next attempt,
+// while a non-retryable error surfaces immediately without a retry.
+func TestLoadWithRetry_VanishedRelation(t *testing.T) {
+	t.Parallel()
+
+	t.Run("transient_vanished_relation", func(t *testing.T) {
+		t.Parallel()
+		var calls int
+		got, err := loadWithRetry(context.Background(), func() (int, error) {
+			calls++
+			if calls == 1 {
+				return 0, errw(&pgconn.PgError{
+					Code:    errCodeInternalError,
+					Message: "could not open relation with OID 12345",
+				})
+			}
+			return 7, nil
+		})
+		require.NoError(t, err)
+		require.Equal(t, 7, got)
+		require.Equal(t, 2, calls, "should succeed on the first retry")
+	})
+
+	t.Run("non_retryable_error", func(t *testing.T) {
+		t.Parallel()
+		wantErr := errors.New("boom")
+		var calls int
+		_, err := loadWithRetry(context.Background(), func() (int, error) {
+			calls++
+			return 0, wantErr
+		})
+		require.ErrorIs(t, err, wantErr)
+		require.Equal(t, 1, calls, "a non-retryable error must not be retried")
+	})
 }
 
 func TestParseSemver(t *testing.T) {

--- a/drivers/postgres/metadata_test.go
+++ b/drivers/postgres/metadata_test.go
@@ -304,9 +304,13 @@ func TestPostgres_QuotedTableName_Metadata(t *testing.T) {
 	src := th.Source(sakila.Pg)
 	db := th.OpenDB(src)
 
+	// The PRIMARY KEY matters: getPgConstraints resolves each constraint row's
+	// table via quote_ident(kcu.table_name)::regclass, and that expression only
+	// evaluates when the table has at least one constraint. Without the PK, the
+	// constraint path would go untested for a quoted name.
 	tbl := stringz.UniqTableName(`me"ta`)
 	qtbl := stringz.DoubleQuote(tbl)
-	_, err := db.ExecContext(th.Context, `CREATE TABLE `+qtbl+` (id INT, name TEXT)`)
+	_, err := db.ExecContext(th.Context, `CREATE TABLE `+qtbl+` (id INT PRIMARY KEY, name TEXT)`)
 	require.NoError(t, err)
 	t.Cleanup(func() { th.DropTable(src, tablefq.From(tbl)) })
 
@@ -318,6 +322,48 @@ func TestPostgres_QuotedTableName_Metadata(t *testing.T) {
 	require.Equal(t, tbl, md.Name)
 	require.Equal(t, int64(2), md.RowCount, "RowCount must load for a quoted table name")
 	require.Len(t, md.Columns, 2)
+
+	idCol := md.Column("id")
+	require.NotNil(t, idCol)
+	require.True(t, idCol.PrimaryKey,
+		"PK must load for a quoted table name (getPgConstraints)")
+}
+
+// TestPostgres_QuotedMatviewName_Metadata pins that matview metadata loads for
+// a name that regclass text-parsing mishandles. getMatviewMetadata resolves
+// name via quote_ident($1)::regclass; the previous raw $1::regclass parsed the
+// value as SQL identifier syntax, so an uppercase name case-folded to a miss,
+// a dotted name was read as a schema qualifier, and a leading double-quote was
+// a syntax error. (An embedded mid-name double-quote happens to survive the
+// old form, so it alone would not catch a regression.) The name here combines
+// uppercase, a dot, and a double-quote to cover case-folding, qualification,
+// and the COUNT(*) identifier escaping at once.
+func TestPostgres_QuotedMatviewName_Metadata(t *testing.T) {
+	tu.SkipShort(t, true)
+	t.Parallel()
+
+	th := testh.New(t)
+	src := th.Source(sakila.Pg)
+	db := th.OpenDB(src)
+
+	// Not stringz.UniqTableName, which lowercases: the uppercase char is part
+	// of the regression surface.
+	mv := `Mv.we"ird__` + stringz.Uniq8()
+	qmv := stringz.DoubleQuote(mv)
+	_, err := db.ExecContext(th.Context,
+		`CREATE MATERIALIZED VIEW `+qmv+` AS SELECT 1 AS id, 'a' AS label`)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_, _ = db.ExecContext(th.Context, `DROP MATERIALIZED VIEW IF EXISTS `+qmv)
+	})
+
+	md, err := th.Open(src).TableMetadata(th.Context, mv)
+	require.NoError(t, err, "TableMetadata must load for a quoted matview name")
+	require.Equal(t, mv, md.Name)
+	require.Equal(t, sqlz.TableTypeMaterializedView, md.TableType)
+	require.Equal(t, int64(1), md.RowCount, "RowCount must load for a quoted matview name")
+	require.Len(t, md.Columns, 2)
+	require.NotEmpty(t, md.ViewDefinition, "ViewDefinition must load for a quoted matview name")
 }
 
 // TestPostgres_ViewDefinition verifies that ViewDefinition is populated for


### PR DESCRIPTION
Follow-up to #1026 (issue #1025). Mutation testing on the #1026 fixes (revert a hunk, run the full `drivers/postgres` suite plus the cross-driver quoted-identifier test) found three hunks that no test pinned. This PR adds the missing coverage; each new test fails when its corresponding #1026 hunk is reverted.

## What

### 1. `getPgConstraints` escaping (was: zero coverage)

The `quote_ident(kcu.table_name)::regclass` fix only evaluates when a constraint row exists for the table, and no test created a constraint on a quoted-name table. `TestPostgres_QuotedTableName_Metadata`'s table now has a `PRIMARY KEY`, and the test asserts the PK loads into metadata. (The cross-driver `TestDriver_QuotedIdentifier` sets `PKColName`, but postgres's `CreateTable` silently ignores it, so no PK ever materialized there — filed as #1029.)

### 2. `getMatviewMetadata` escaping (was: only a plain-name matview test)

The old raw `$1::regclass` form actually *handles* a plain lowercase name — and even a mid-name double-quote — so the existing `TestPostgres_Matview` couldn't catch a regression. Probing showed the shapes regclass text-parsing mishandles are: **uppercase** (case-folds to a miss), **dotted** (parsed as a schema qualifier), and **leading-quote** (syntax error). The new `TestPostgres_QuotedMatviewName_Metadata` uses a name combining uppercase, a dot, and a double-quote (built without `stringz.UniqTableName`, which lowercases), covering case-folding, qualification, and the `COUNT(*)` identifier escaping in one.

### 3. Retry machinery (was: no tests at all)

`isErrScanRetryable`, `loadWithRetry`, and `doRetryVanished` had no tests; dropping `XX000` from the predicate or unwrapping the bulk loaders failed nothing. New unit tests (no DB required) pin:

- `TestIsErrScanRetryable`: table-driven over the retryable codes (`42P01`, `53300`, `XX000`, wrapped via `errw`) and non-retryable cases (other codes, non-pg errors, nil).
- `TestLoadWithRetry_VanishedRelation`: a transient vanished-relation error is retried and resolves on the next attempt; a non-retryable error surfaces immediately without a retry.

## Verification

- Each new/extended test **fails with its #1026 hunk reverted** (constraints revert, matview revert, predicate minus `XX000`) and passes on current master.
- Full `drivers/postgres` suite green against `sakiladb/postgres:18`; the two integration tests also green against `sakiladb/postgres:9` (oldest supported).
- `make fmt` clean; pinned `golangci-lint` (v2.12.2) reports 0 issues for the repo (the 3 pre-existing `genxlsx` revive issues exist on master).
