### PR TITLE
fix(drivers): tolerate objects dropped mid-scan; tidy pg matview lookup

### DIFF
--- a/drivers/postgres/metadata.go
+++ b/drivers/postgres/metadata.go
@@ -557,8 +557,9 @@ AND t.table_name = $1`
 // the detail query against that OID. Passing the OID (rather than a
 // quote_ident($1)::regclass text lookup) pins the relation resolved in Step A
 // regardless of search_path, mirroring getTableMetadata's pg_class JOIN. Only
-// the COUNT(*) FROM identifier is interpolated, as a double-quoted (escaped)
-// identifier, and only after Step A confirms name is a real matview.
+// the COUNT(*) FROM identifier is interpolated, as a schema-qualified,
+// double-quoted (escaped) identifier, and only after Step A confirms name is
+// a real matview.
 func getMatviewMetadata(ctx context.Context, db sqlz.DB, name string) (*metadata.Table, error) {
 	// Step A: confirm name is a matview in the current schema, resolving its
 	// OID, and get the catalog & schema for the FQ name.
@@ -585,9 +586,12 @@ WHERE c.relname = $1 AND n.nspname = current_schema() AND c.relkind = 'm'`
 	// Step B: name is confirmed a matview; the size/comment/viewdef functions
 	// take its OID directly. Only the COUNT(*) FROM identifier must be
 	// interpolated: a relation name cannot be a bind parameter in a FROM
-	// clause. DoubleQuote escapes it.
+	// clause. DoubleQuote escapes it, and it is qualified with the schema
+	// resolved in Step A: an unqualified name resolves via the search path,
+	// where a same-named pg_temp relation would shadow the matview and supply
+	// a row count belonging to a different relation than the OID describes.
 	detailQuery := `SELECT
-  (SELECT COUNT(*) FROM ` + stringz.DoubleQuote(name) + `) AS row_count,
+  (SELECT COUNT(*) FROM ` + stringz.DoubleQuote(schema) + `.` + stringz.DoubleQuote(name) + `) AS row_count,
   pg_total_relation_size($1::oid) AS mv_size,
   obj_description($1::oid, 'pg_class') AS mv_comment,
   pg_get_viewdef($1::oid, true) AS view_def`

--- a/drivers/postgres/metadata.go
+++ b/drivers/postgres/metadata.go
@@ -553,21 +553,24 @@ AND t.table_name = $1`
 // pg_catalog. Matviews are absent from information_schema, so this is the
 // fallback path from getTableMetadata. It is a two-step operation: first
 // confirm that name actually is a matview (returning the canonical not-found
-// error otherwise), and only then run the detail query. The size/comment/viewdef
-// functions take name via quote_ident($1)::regclass; only the COUNT(*) FROM
-// identifier is interpolated, and only after Step A confirms name is a real
-// matview.
+// error otherwise) and resolve its OID on the bound name, and only then run
+// the detail query against that OID. Passing the OID (rather than a
+// quote_ident($1)::regclass text lookup) pins the relation resolved in Step A
+// regardless of search_path, mirroring getTableMetadata's pg_class JOIN. Only
+// the COUNT(*) FROM identifier is interpolated, as a double-quoted (escaped)
+// identifier, and only after Step A confirms name is a real matview.
 func getMatviewMetadata(ctx context.Context, db sqlz.DB, name string) (*metadata.Table, error) {
-	// Step A: confirm name is a matview in the current schema, and get
-	// the catalog & schema for the FQ name.
-	const confirmQuery = `SELECT current_database(), current_schema()
-WHERE EXISTS (
-  SELECT 1 FROM pg_catalog.pg_class c
-  JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
-  WHERE c.relname = $1 AND n.nspname = current_schema() AND c.relkind = 'm'
-)`
-	var catalog, schema string
-	err := db.QueryRowContext(ctx, confirmQuery, name).Scan(&catalog, &schema)
+	// Step A: confirm name is a matview in the current schema, resolving its
+	// OID, and get the catalog & schema for the FQ name.
+	const confirmQuery = `SELECT current_database(), current_schema(), c.oid
+FROM pg_catalog.pg_class c
+JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+WHERE c.relname = $1 AND n.nspname = current_schema() AND c.relkind = 'm'`
+	var (
+		catalog, schema string
+		oid             int64
+	)
+	err := db.QueryRowContext(ctx, confirmQuery, name).Scan(&catalog, &schema, &oid)
 	if errors.Is(err, sql.ErrNoRows) {
 		// Not a matview (nor any other relation found in info-schema):
 		// behave as before for a genuinely-missing relation.
@@ -579,19 +582,15 @@ WHERE EXISTS (
 	progress.Incr(ctx, 1)
 	debugz.DebugSleep(ctx)
 
-	// Step B: name is confirmed a matview. The size/comment/viewdef
-	// functions take name via quote_ident($1)::regclass. Only the
-	// COUNT(*) FROM identifier must be interpolated: a relation name
-	// cannot be a bind parameter in a FROM clause, and it's safe here
-	// because Step A confirmed name is a real matview in this schema.
-	const detailQueryTpl = `SELECT
-  (SELECT COUNT(*) FROM "%s") AS row_count,
-  pg_total_relation_size(quote_ident($1)::regclass) AS mv_size,
-  obj_description(quote_ident($1)::regclass, 'pg_class') AS mv_comment,
-  pg_get_viewdef(quote_ident($1)::regclass, true) AS view_def`
-	// Double any embedded double-quotes so the identifier literal can't be broken out of.
-	safeName := strings.ReplaceAll(name, `"`, `""`)
-	detailQuery := fmt.Sprintf(detailQueryTpl, safeName)
+	// Step B: name is confirmed a matview; the size/comment/viewdef functions
+	// take its OID directly. Only the COUNT(*) FROM identifier must be
+	// interpolated: a relation name cannot be a bind parameter in a FROM
+	// clause. DoubleQuote escapes it.
+	detailQuery := `SELECT
+  (SELECT COUNT(*) FROM ` + stringz.DoubleQuote(name) + `) AS row_count,
+  pg_total_relation_size($1::oid) AS mv_size,
+  obj_description($1::oid, 'pg_class') AS mv_comment,
+  pg_get_viewdef($1::oid, true) AS view_def`
 
 	var (
 		rowCount int64
@@ -599,7 +598,7 @@ WHERE EXISTS (
 		comment  sql.NullString
 		viewDef  sql.NullString
 	)
-	err = db.QueryRowContext(ctx, detailQuery, name).Scan(&rowCount, &mvSize, &comment, &viewDef)
+	err = db.QueryRowContext(ctx, detailQuery, oid).Scan(&rowCount, &mvSize, &comment, &viewDef)
 	if err != nil {
 		return nil, errw(err)
 	}

--- a/drivers/rqlite/metadata.go
+++ b/drivers/rqlite/metadata.go
@@ -850,11 +850,12 @@ func countTblsIndividually(ctx context.Context, db sqlz.DB, names []string, coun
 		err := db.QueryRowContext(ctx,
 			"SELECT COUNT(*) FROM "+stringz.DoubleQuote(name)).Scan(&count)
 		if err != nil {
-			if errz.Has[*driver.NotExistError](errw(err)) {
+			wrapped := errw(err)
+			if errz.Has[*driver.NotExistError](wrapped) {
 				counts[i] = -1
 				continue
 			}
-			return errw(err)
+			return wrapped
 		}
 		counts[i] = count
 	}

--- a/drivers/rqlite/metadata.go
+++ b/drivers/rqlite/metadata.go
@@ -726,9 +726,21 @@ ORDER BY m.name, p.cid
 	if err != nil {
 		return nil, errw(err)
 	}
+
+	// Assign counts, omitting any table that vanished mid-scan (recorded as -1
+	// by getTblRowCounts): a dropped table must not appear in the results with
+	// a nonsensical count.
+	kept := tblMetas[:0]
 	for i := range rowCounts {
+		if rowCounts[i] < 0 {
+			lg.FromContext(ctx).Warn("Table vanished during metadata scan; omitting",
+				lga.Table, tblMetas[i].Name)
+			continue
+		}
 		tblMetas[i].RowCount = rowCounts[i]
+		kept = append(kept, tblMetas[i])
 	}
+	tblMetas = kept
 
 	// Batch-fetch all triggers in a single round-trip (replaces N per-table
 	// getTableTriggers calls).
@@ -771,7 +783,8 @@ ORDER BY m.name, p.cid
 // between the enumerate step in getAllTableMetadata and the COUNT
 // batch here, the UNION ALL fails with "no such table:". We fall
 // back to per-table COUNTs for that batch and record -1 for any
-// table that has since vanished, so callers can detect (or skip).
+// table that has since vanished. The caller (getAllTableMetadata)
+// omits such tables from the results.
 func getTblRowCounts(ctx context.Context, db sqlz.DB, tblNames []string) ([]int64, error) {
 	log := lg.FromContext(ctx)
 	const maxCompoundSelect = 500

--- a/drivers/sqlite3/metadata.go
+++ b/drivers/sqlite3/metadata.go
@@ -994,11 +994,12 @@ func countTblsIndividually(ctx context.Context, db sqlz.DB, names []string, coun
 		err := db.QueryRowContext(ctx,
 			"SELECT COUNT(*) FROM "+stringz.DoubleQuote(name)).Scan(&count)
 		if err != nil {
-			if errz.Has[*driver.NotExistError](errw(err)) {
+			wrapped := errw(err)
+			if errz.Has[*driver.NotExistError](wrapped) {
 				counts[i] = -1
 				continue
 			}
-			return errw(err)
+			return wrapped
 		}
 		counts[i] = count
 		progress.Incr(ctx, 1)

--- a/drivers/sqlite3/metadata.go
+++ b/drivers/sqlite3/metadata.go
@@ -878,7 +878,11 @@ ORDER BY m.name, p.cid
 	return tblMetas, nil
 }
 
-// getTblRowCounts returns the number of rows in each table.
+// getTblRowCounts returns the number of rows in each table. If a table named
+// in tblNames is dropped by concurrent DDL between enumeration and the COUNT
+// batch here, the batch fails with "no such table"; getTblRowCounts then falls
+// back to per-table COUNTs for that batch (countTblsIndividually) and records
+// -1 for any table that has since vanished, so callers can detect (or skip).
 func getTblRowCounts(ctx context.Context, db sqlz.DB, tblNames []string) ([]int64, error) {
 	log := lg.FromContext(ctx)
 
@@ -928,7 +932,24 @@ func getTblRowCounts(ctx context.Context, db sqlz.DB, tblNames []string) ([]int6
 
 		rows, err := db.QueryContext(ctx, query)
 		if err != nil {
-			return nil, errw(err)
+			wrapped := errw(err)
+			if errz.Has[*driver.NotExistError](wrapped) {
+				// A table enumerated earlier in the scan was dropped by
+				// concurrent DDL before we could COUNT it, which fails the
+				// whole compound statement. Fall back to per-table COUNTs
+				// across the current batch, recording -1 for any name that
+				// has since vanished, so one dropped table doesn't abort the
+				// whole source scan.
+				batchEnd := j + terms
+				if err = countTblsIndividually(ctx, db, tblNames[j:batchEnd], tblCounts[j:batchEnd]); err != nil {
+					return nil, err
+				}
+				j = batchEnd
+				terms = 0
+				sb.Reset()
+				continue
+			}
+			return nil, wrapped
 		}
 
 		for rows.Next() {
@@ -957,6 +978,33 @@ func getTblRowCounts(ctx context.Context, db sqlz.DB, tblNames []string) ([]int6
 	}
 
 	return tblCounts, nil
+}
+
+// countTblsIndividually issues a per-table SELECT COUNT(*) for each name in
+// names, writing the result to the matching slot in counts. Tables that have
+// vanished (NotExistError) are recorded as -1; any other error aborts. This is
+// the fallback path used by getTblRowCounts when the UNION ALL batch fails
+// because of a concurrent DROP TABLE.
+func countTblsIndividually(ctx context.Context, db sqlz.DB, names []string, counts []int64) error {
+	for i, name := range names {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return ctxErr
+		}
+		var count int64
+		err := db.QueryRowContext(ctx,
+			"SELECT COUNT(*) FROM "+stringz.DoubleQuote(name)).Scan(&count)
+		if err != nil {
+			if errz.Has[*driver.NotExistError](errw(err)) {
+				counts[i] = -1
+				continue
+			}
+			return errw(err)
+		}
+		counts[i] = count
+		progress.Incr(ctx, 1)
+		debugz.DebugSleep(ctx)
+	}
+	return nil
 }
 
 // getTableDDL returns the CREATE statement text recorded in

--- a/drivers/sqlite3/metadata.go
+++ b/drivers/sqlite3/metadata.go
@@ -830,9 +830,21 @@ ORDER BY m.name, p.cid
 		return nil, errw(err)
 	}
 
+	// Assign counts, omitting any table that vanished mid-scan (recorded as -1
+	// by getTblRowCounts): a dropped table must not appear in the results with
+	// a nonsensical count, and the per-table FK/index queries below would be
+	// querying a relation that no longer exists.
+	kept := tblMetas[:0]
 	for i := range rowCounts {
+		if rowCounts[i] < 0 {
+			lg.FromContext(ctx).Warn("Table vanished during metadata scan; omitting",
+				lga.Table, tblMetas[i].Name)
+			continue
+		}
 		tblMetas[i].RowCount = rowCounts[i]
+		kept = append(kept, tblMetas[i])
 	}
+	tblMetas = kept
 
 	// Batch-fetch all triggers in a single round-trip (replaces N per-table
 	// getTableTriggers calls).
@@ -882,7 +894,8 @@ ORDER BY m.name, p.cid
 // in tblNames is dropped by concurrent DDL between enumeration and the COUNT
 // batch here, the batch fails with "no such table"; getTblRowCounts then falls
 // back to per-table COUNTs for that batch (countTblsIndividually) and records
-// -1 for any table that has since vanished, so callers can detect (or skip).
+// -1 for any table that has since vanished. The caller (getAllTableMetadata)
+// omits such tables from the results.
 func getTblRowCounts(ctx context.Context, db sqlz.DB, tblNames []string) ([]int64, error) {
 	log := lg.FromContext(ctx)
 

--- a/drivers/sqlite3/metadata_test.go
+++ b/drivers/sqlite3/metadata_test.go
@@ -419,6 +419,24 @@ func TestGetTblRowCounts(t *testing.T) {
 	require.Equal(t, len(tblNames), len(counts))
 }
 
+// TestGetTblRowCounts_MissingTableFallback deterministically exercises the
+// concurrent-DROP fallback in getTblRowCounts: when the batched UNION ALL
+// COUNT(*) fails with "no such table", it falls back to per-table COUNTs
+// (countTblsIndividually), recording -1 for any table that has vanished. Here
+// a name that never existed stands in for one dropped mid-flight. Previously,
+// the failed batch aborted the whole source scan (issue #1027).
+func TestGetTblRowCounts_MissingTableFallback(t *testing.T) {
+	th, _, _, _, db := testh.NewWith(t, sakila.SL3)
+
+	counts, err := sqlite3.GetTblRowCounts(th.Context, db,
+		[]string{sakila.TblActor, "no_such_table_zzz", sakila.TblFilm})
+	require.NoError(t, err)
+	require.Len(t, counts, 3)
+	require.Equal(t, int64(sakila.TblActorCount), counts[0])
+	require.Equal(t, int64(-1), counts[1], "vanished table records -1")
+	require.Equal(t, int64(sakila.TblFilmCount), counts[2])
+}
+
 func BenchmarkGetTblRowCounts(b *testing.B) {
 	const numTables = 1300
 

--- a/drivers/sqlserver/errors.go
+++ b/drivers/sqlserver/errors.go
@@ -17,6 +17,7 @@ const (
 	errCodeIdentityInsert int32 = 544
 	errCodeObjectNotExist int32 = 15009
 	errCodeBadObject      int32 = 208
+	errCodeViewBindingErr int32 = 4413
 	errNoIdentityColumn   int32 = 7997
 )
 
@@ -33,6 +34,23 @@ func hasErrCode(err error, code int32) bool {
 	}
 
 	return false
+}
+
+// isObjectVanishedErr reports whether err indicates that an object vanished
+// mid-scan because of concurrent DDL. This surfaces as error 15009 ("object
+// does not exist", from sp_spaceused) when the object itself is gone, as
+// error 208 ("invalid object name", e.g. from the view row-count fallback's
+// SELECT COUNT(*)) when it vanishes after resolution, or as error 4413
+// ("could not use view or function because of binding errors") when a view's
+// underlying object is what vanished. Matching is by error code, so it holds
+// whether or not err has been wrapped (errw maps 208 to driver.NotExistError,
+// which unwraps to the mssql.Error). A source-wide metadata scan of a live
+// database tolerates all three rather than failing the whole scan over one
+// dropped object.
+func isObjectVanishedErr(err error) bool {
+	return hasErrCode(err, errCodeObjectNotExist) ||
+		hasErrCode(err, errCodeBadObject) ||
+		hasErrCode(err, errCodeViewBindingErr)
 }
 
 // errw wraps any error from the db. It should be called at

--- a/drivers/sqlserver/errors.go
+++ b/drivers/sqlserver/errors.go
@@ -18,6 +18,7 @@ const (
 	errCodeObjectNotExist int32 = 15009
 	errCodeBadObject      int32 = 208
 	errCodeViewBindingErr int32 = 4413
+	errCodeDeadlockVictim int32 = 1205
 	errNoIdentityColumn   int32 = 7997
 )
 
@@ -42,15 +43,25 @@ func hasErrCode(err error, code int32) bool {
 // error 208 ("invalid object name", e.g. from the view row-count fallback's
 // SELECT COUNT(*)) when it vanishes after resolution, or as error 4413
 // ("could not use view or function because of binding errors") when a view's
-// underlying object is what vanished. Matching is by error code, so it holds
-// whether or not err has been wrapped (errw maps 208 to driver.NotExistError,
-// which unwraps to the mssql.Error). A source-wide metadata scan of a live
-// database tolerates all three rather than failing the whole scan over one
-// dropped object.
+// underlying object is what vanished. Code matching holds whether or not err
+// has been wrapped (errw maps 208 to driver.NotExistError, which unwraps to
+// the mssql.Error). A bare driver.NotExistError also matches: getTableMetadata
+// returns one when sp_spaceused reports NULL fields for an object dropped
+// mid-call. A source-wide metadata scan of a live database tolerates all of
+// these rather than failing the whole scan over one dropped object.
 func isObjectVanishedErr(err error) bool {
 	return hasErrCode(err, errCodeObjectNotExist) ||
 		hasErrCode(err, errCodeBadObject) ||
-		hasErrCode(err, errCodeViewBindingErr)
+		hasErrCode(err, errCodeViewBindingErr) ||
+		errz.Has[*driver.NotExistError](err)
+}
+
+// isErrDeadlockVictim reports whether err is mssql error 1205: the query was
+// chosen as a deadlock victim. Catalog metadata queries can lose a lock race
+// against concurrent DDL; error 1205 is retryable by definition ("Rerun the
+// transaction").
+func isErrDeadlockVictim(err error) bool {
+	return hasErrCode(err, errCodeDeadlockVictim)
 }
 
 // errw wraps any error from the db. It should be called at

--- a/drivers/sqlserver/grip.go
+++ b/drivers/sqlserver/grip.go
@@ -61,9 +61,11 @@ WHERE TABLE_NAME = @p1`
 	progress.Incr(ctx, 1)
 	debugz.DebugSleep(ctx)
 
-	// TODO: getTableMetadata can cause deadlock in the DB. Needs further investigation.
-	// But a quick hack would be to use retry on a deadlock error.
-	return getTableMetadata(ctx, g.db, catalog, schema, tblName, tblType, true)
+	// The per-table catalog queries can lose a lock race against concurrent
+	// DDL and be chosen as a deadlock victim (error 1205); retry.
+	return loadWithRetry(ctx, func() (*metadata.Table, error) {
+		return getTableMetadata(ctx, g.db, catalog, schema, tblName, tblType, true)
+	})
 }
 
 // SourceMetadata implements driver.Grip.

--- a/drivers/sqlserver/internal_test.go
+++ b/drivers/sqlserver/internal_test.go
@@ -6,6 +6,8 @@ import (
 
 	mssql "github.com/microsoft/go-mssqldb"
 	"github.com/stretchr/testify/require"
+
+	"github.com/neilotoole/sq/libsq/driver"
 )
 
 func Test_placeholders(t *testing.T) {
@@ -62,6 +64,11 @@ func Test_isObjectVanishedErr(t *testing.T) {
 		{name: "bad_object_208_wrapped", err: errw(mssql.Error{Number: errCodeBadObject}), want: true},
 		{name: "view_binding_4413", err: mssql.Error{Number: errCodeViewBindingErr}, want: true},
 		{name: "view_binding_4413_wrapped", err: errw(mssql.Error{Number: errCodeViewBindingErr}), want: true},
+		{
+			name: "not_exist_error",
+			err:  driver.NewNotExistError(errors.New("table {t} not found")),
+			want: true,
+		},
 		{name: "identity_insert_544", err: mssql.Error{Number: errCodeIdentityInsert}, want: false},
 		{name: "wrapped_other_code", err: errw(mssql.Error{Number: errCodeIdentityInsert}), want: false},
 		{name: "non_mssql_error", err: errors.New("huzzah"), want: false},
@@ -72,6 +79,17 @@ func Test_isObjectVanishedErr(t *testing.T) {
 			require.Equal(t, tc.want, isObjectVanishedErr(tc.err))
 		})
 	}
+}
+
+// Test_isErrDeadlockVictim pins the retry predicate for catalog metadata
+// queries chosen as a deadlock victim (error 1205) by concurrent DDL. See
+// issue #1031.
+func Test_isErrDeadlockVictim(t *testing.T) {
+	require.False(t, isErrDeadlockVictim(nil))
+	require.False(t, isErrDeadlockVictim(errors.New("huzzah")))
+	require.False(t, isErrDeadlockVictim(mssql.Error{Number: errCodeBadObject}))
+	require.True(t, isErrDeadlockVictim(mssql.Error{Number: errCodeDeadlockVictim}))
+	require.True(t, isErrDeadlockVictim(errw(mssql.Error{Number: errCodeDeadlockVictim})))
 }
 
 func TestParseSemver(t *testing.T) {

--- a/drivers/sqlserver/internal_test.go
+++ b/drivers/sqlserver/internal_test.go
@@ -42,6 +42,38 @@ func Test_hasErrCode(t *testing.T) {
 	require.True(t, hasErrCode(err, wantCode))
 }
 
+// Test_isObjectVanishedErr pins the predicate that a source-wide metadata scan
+// uses to tolerate objects dropped mid-scan by concurrent DDL: error 15009
+// (sp_spaceused, object does not exist), error 208 (invalid object name, e.g.
+// from the view row-count fallback), and error 4413 (view binding errors,
+// when a view's underlying object vanished). In production the errors arrive
+// wrapped via errw (which maps 208 to driver.NotExistError), so wrapped forms
+// are covered too. See issue #1027.
+func Test_isObjectVanishedErr(t *testing.T) {
+	testCases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "nil", err: nil, want: false},
+		{name: "object_not_exist_15009", err: mssql.Error{Number: errCodeObjectNotExist}, want: true},
+		{name: "object_not_exist_15009_wrapped", err: errw(mssql.Error{Number: errCodeObjectNotExist}), want: true},
+		{name: "bad_object_208", err: mssql.Error{Number: errCodeBadObject}, want: true},
+		{name: "bad_object_208_wrapped", err: errw(mssql.Error{Number: errCodeBadObject}), want: true},
+		{name: "view_binding_4413", err: mssql.Error{Number: errCodeViewBindingErr}, want: true},
+		{name: "view_binding_4413_wrapped", err: errw(mssql.Error{Number: errCodeViewBindingErr}), want: true},
+		{name: "identity_insert_544", err: mssql.Error{Number: errCodeIdentityInsert}, want: false},
+		{name: "wrapped_other_code", err: errw(mssql.Error{Number: errCodeIdentityInsert}), want: false},
+		{name: "non_mssql_error", err: errors.New("huzzah"), want: false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, isObjectVanishedErr(tc.err))
+		})
+	}
+}
+
 func TestParseSemver(t *testing.T) {
 	testCases := []struct {
 		raw     string

--- a/drivers/sqlserver/metadata.go
+++ b/drivers/sqlserver/metadata.go
@@ -182,11 +182,14 @@ GROUP BY database_id) AS total_size_bytes`
 
 			tblMeta, gErr := getTableMetadata(gCtx, db, catalog, schema, tblNames[i], tblTypes[i], false)
 			if gErr != nil {
-				if hasErrCode(gErr, errCodeObjectNotExist) {
-					// This can happen if the table is dropped while
-					// we're collecting metadata. We log a warning and continue.
+				if isObjectVanishedErr(gErr) {
+					// This can happen if the table or view is dropped while
+					// we're collecting metadata: sp_spaceused raises 15009,
+					// and the view row-count fallback's SELECT COUNT(*)
+					// raises 208. We log a warning and continue rather than
+					// failing the whole source scan.
 					log.Warn(
-						"Table metadata: table not found (continuing regardless)",
+						"Table metadata: object not found (continuing regardless)",
 						lga.Table, tblNames[i],
 						lga.Err, gErr,
 					)

--- a/drivers/sqlserver/metadata.go
+++ b/drivers/sqlserver/metadata.go
@@ -8,6 +8,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/c2h5oh/datasize"
 	"golang.org/x/mod/semver"
@@ -21,9 +22,11 @@ import (
 	"github.com/neilotoole/sq/libsq/core/options"
 	"github.com/neilotoole/sq/libsq/core/progress"
 	"github.com/neilotoole/sq/libsq/core/record"
+	"github.com/neilotoole/sq/libsq/core/retry"
 	"github.com/neilotoole/sq/libsq/core/sqlz"
 	"github.com/neilotoole/sq/libsq/core/stringz"
 	"github.com/neilotoole/sq/libsq/core/tuning"
+	"github.com/neilotoole/sq/libsq/driver"
 	"github.com/neilotoole/sq/libsq/source"
 	"github.com/neilotoole/sq/libsq/source/drivertype"
 	"github.com/neilotoole/sq/libsq/source/metadata"
@@ -117,6 +120,35 @@ func setScanType(ct *record.ColumnTypeData, knd kind.Kind) {
 	}
 }
 
+// deadlockRetryBudget bounds the total retry window for doRetryDeadlock. It
+// is deliberately larger than tuning.OptMaxRetryInterval (the general retry
+// budget, 3s by default): a deadlock storm lasts as long as the competing DDL
+// keeps running, and a deadlock-victim error returns instantly, so waiting
+// out a storm is cheap. Observed under parallel test load: a 3s window was
+// exhausted while a storm was still in progress.
+const deadlockRetryBudget = 15 * time.Second
+
+// doRetryDeadlock runs fn, retrying if fn's query is chosen as a deadlock
+// victim (error 1205), which happens when catalog metadata queries lose a
+// lock race against concurrent DDL. The error is still returned if the retry
+// budget is exhausted.
+func doRetryDeadlock(ctx context.Context, fn func() error) error {
+	return retry.Do(ctx, deadlockRetryBudget, fn, isErrDeadlockVictim)
+}
+
+// loadWithRetry runs a metadata loader with deadlock retry (doRetryDeadlock),
+// so a catalog query chosen as a deadlock victim by concurrent DDL doesn't
+// fail the scan.
+func loadWithRetry[T any](ctx context.Context, load func() (T, error)) (T, error) {
+	var result T
+	err := doRetryDeadlock(ctx, func() error {
+		var e error
+		result, e = load()
+		return e
+	})
+	return result, err
+}
+
 func getSourceMetadata(ctx context.Context, src *source.Source, db sqlz.DB, noSchema bool) (*metadata.Source, error) {
 	log := lg.FromContext(ctx)
 	ctx = options.NewContext(ctx, src.Options)
@@ -180,14 +212,21 @@ GROUP BY database_id) AS total_size_bytes`
 			default:
 			}
 
-			tblMeta, gErr := getTableMetadata(gCtx, db, catalog, schema, tblNames[i], tblTypes[i], false)
+			tblMeta, gErr := loadWithRetry(gCtx, func() (*metadata.Table, error) {
+				return getTableMetadata(gCtx, db, catalog, schema, tblNames[i], tblTypes[i], false)
+			})
 			if gErr != nil {
 				if isObjectVanishedErr(gErr) {
 					// This can happen if the table or view is dropped while
 					// we're collecting metadata: sp_spaceused raises 15009,
 					// and the view row-count fallback's SELECT COUNT(*)
-					// raises 208. We log a warning and continue rather than
-					// failing the whole source scan.
+					// raises 208 if the view itself is gone. (A view with
+					// binding errors, 4413, is handled inside
+					// getTableMetadata and stays visible; the predicate
+					// retains 4413 so a binding error from any other site
+					// skips that object rather than failing the scan.) We
+					// log a warning and continue rather than failing the
+					// whole source scan.
 					log.Warn(
 						"Table metadata: object not found (continuing regardless)",
 						lga.Table, tblNames[i],
@@ -224,38 +263,52 @@ GROUP BY database_id) AS total_size_bytes`
 	// Fetch FKs / unique constraints / indexes / check constraints / triggers
 	// in bulk queries rather than N per-table calls inside the errgroup above.
 	// The Assign* helpers route each result to its owning table by name,
-	// and LinkForeignKeys derives FK.Incoming across the whole source.
-	allFKs, err := getMSSQLForeignKeys(ctx, db, catalog, schema, "")
+	// and LinkForeignKeys derives FK.Incoming across the whole source. Each
+	// bulk loader is retried if it loses a lock race against concurrent DDL
+	// and is chosen as a deadlock victim (loadWithRetry).
+	allFKs, err := loadWithRetry(ctx, func() ([]*metadata.ForeignKey, error) {
+		return getMSSQLForeignKeys(ctx, db, catalog, schema, "")
+	})
 	if err != nil {
 		return nil, err
 	}
 	metadata.AssignForeignKeys(log, md.Tables, allFKs)
 
-	allUCs, err := getMSSQLUniqueConstraints(ctx, db, catalog, schema, "")
+	allUCs, err := loadWithRetry(ctx, func() ([]*metadata.UniqueConstraint, error) {
+		return getMSSQLUniqueConstraints(ctx, db, catalog, schema, "")
+	})
 	if err != nil {
 		return nil, err
 	}
 	metadata.AssignUniqueConstraints(log, md.Tables, allUCs)
 
-	allChecks, err := getMSSQLCheckConstraints(ctx, db, schema, "")
+	allChecks, err := loadWithRetry(ctx, func() ([]*metadata.CheckConstraint, error) {
+		return getMSSQLCheckConstraints(ctx, db, schema, "")
+	})
 	if err != nil {
 		return nil, err
 	}
 	metadata.AssignCheckConstraints(log, md.Tables, allChecks)
 
-	allTriggers, err := getMSSQLTriggers(ctx, db, schema, "")
+	allTriggers, err := loadWithRetry(ctx, func() ([]*metadata.Trigger, error) {
+		return getMSSQLTriggers(ctx, db, schema, "")
+	})
 	if err != nil {
 		return nil, err
 	}
 	metadata.AssignTriggers(log, md.Tables, allTriggers)
 
-	allIdxs, err := getMSSQLIndexes(ctx, db, schema, "")
+	allIdxs, err := loadWithRetry(ctx, func() ([]*metadata.Index, error) {
+		return getMSSQLIndexes(ctx, db, schema, "")
+	})
 	if err != nil {
 		return nil, err
 	}
 	metadata.AssignIndexes(log, md.Tables, allIdxs)
 
-	allViewDefs, err := getMSSQLViewDefinitions(ctx, db, schema, "")
+	allViewDefs, err := loadWithRetry(ctx, func() (map[string]string, error) {
+		return getMSSQLViewDefinitions(ctx, db, schema, "")
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -302,21 +355,22 @@ func getTableMetadata(ctx context.Context, db sqlz.DB, tblCatalog,
 	default:
 	}
 
-	var rowCount, reserved, data, indexSize, unused sql.NullString
+	var spName, rowCount, reserved, data, indexSize, unused sql.NullString
 	row := db.QueryRowContext(ctx, tplTblUsage)
 
-	// REVISIT: This error can occur:
-	//
-	//  sql: Scan error on column index 0, name "name": converting NULL to string is unsupported
-	//
-	// We should probably use sql.NullString? This situation can arise if the table
-	// is deleted while this process is taking place. Maybe wrap the entire thing
-	// in a transaction? Or figure out how to fail more gracefully?
-
-	err := row.Scan(&tblMeta.Name, &rowCount, &reserved, &data, &indexSize, &unused)
+	err := row.Scan(&spName, &rowCount, &reserved, &data, &indexSize, &unused)
 	if err != nil {
 		return nil, errw(err)
 	}
+	if !spName.Valid {
+		// sp_spaceused reports NULL fields when the object is dropped
+		// mid-call by concurrent DDL (previously this surfaced as an opaque
+		// "converting NULL to string" scan error). Return the canonical
+		// vanished error: the source scan skips the object
+		// (isObjectVanishedErr), and the per-table path reports not-found.
+		return nil, driver.NewNotExistError(errz.Errorf("table {%s} not found", tblName))
+	}
+	tblMeta.Name = spName.String
 	progress.Incr(ctx, 1)
 	debugz.DebugSleep(ctx)
 
@@ -330,11 +384,20 @@ func getTableMetadata(ctx context.Context, db sqlz.DB, tblCatalog,
 		// so we need to select it the old-fashioned way. DoubleQuote escapes the
 		// identifier (%q applies Go backslash-quoting, not SQL doubling).
 		err = db.QueryRowContext(ctx, `SELECT COUNT(*) FROM `+stringz.DoubleQuote(tblName)).Scan(&tblMeta.RowCount)
-		if err != nil {
+		switch {
+		case err == nil:
+			progress.Incr(ctx, 1)
+			debugz.DebugSleep(ctx)
+		case hasErrCode(err, errCodeViewBindingErr):
+			// Error 4413: the view exists but is unusable because an
+			// underlying object is gone (e.g. its base table was dropped).
+			// Keep the view visible with no row count rather than failing
+			// the scan or omitting the view from the results.
+			lg.FromContext(ctx).Warn("View has binding errors; row count unavailable",
+				lga.Table, tblName, lga.Err, err)
+		default:
 			return nil, errw(err)
 		}
-		progress.Incr(ctx, 1)
-		debugz.DebugSleep(ctx)
 	}
 
 	if reserved.Valid {

--- a/drivers/sqlserver/sqlserver_integration_test.go
+++ b/drivers/sqlserver/sqlserver_integration_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/neilotoole/sq/libsq/core/stringz"
 	"github.com/neilotoole/sq/libsq/core/tablefq"
 	"github.com/neilotoole/sq/libsq/driver"
+	"github.com/neilotoole/sq/libsq/source/metadata"
 	"github.com/neilotoole/sq/testh"
 	"github.com/neilotoole/sq/testh/sakila"
 	"github.com/neilotoole/sq/testh/tu"
@@ -303,17 +304,19 @@ func TestDriver_QuotedView_RowCount_MSSQL(t *testing.T) {
 	require.Equal(t, int64(2), md.RowCount, "row count must load via the COUNT(*) fallback")
 }
 
-// TestSourceMetadata_VanishedView_MSSQL pins that a source-wide metadata scan
-// tolerates a view whose underlying object has vanished. A base table dropped
-// mid-scan by concurrent DDL leaves its dependent views broken: sp_spaceused
-// still succeeds (a view has no storage, so it reports a NULL row count), and
-// then the SELECT COUNT(*) row-count fallback raises error 4413 ("binding
+// TestSourceMetadata_BrokenView_MSSQL pins that a metadata scan tolerates a
+// view whose underlying object has vanished. A base table dropped mid-scan by
+// concurrent DDL leaves its dependent views broken: sp_spaceused still
+// succeeds (a view has no storage, so it reports a NULL row count), and then
+// the SELECT COUNT(*) row-count fallback raises error 4413 ("binding
 // errors"); a view that itself vanishes raises 208 from the same site.
 // Previously only error 15009 was tolerated, so either failed the whole scan;
 // this was the cause of TestDBSemver flakes under parallel test load (issue
-// #1027). The dangling view used here reproduces the 4413 shape
-// deterministically, with no race; 208 is pinned by Test_isObjectVanishedErr.
-func TestSourceMetadata_VanishedView_MSSQL(t *testing.T) {
+// #1027). A broken view exists in the catalog, so it stays visible in the
+// results, with no row count; an object that is gone (15009/208) is omitted.
+// The dangling view used here reproduces the 4413 shape deterministically,
+// with no race; 208 is pinned by Test_isObjectVanishedErr.
+func TestSourceMetadata_BrokenView_MSSQL(t *testing.T) {
 	tu.SkipShort(t, true)
 	t.Parallel()
 
@@ -337,18 +340,28 @@ func TestSourceMetadata_VanishedView_MSSQL(t *testing.T) {
 	// enumerable, but its COUNT(*) now raises error 4413 (binding errors).
 	require.NoError(t, drvr.DropTable(th.Context, db, tablefq.From(baseTbl), false))
 
+	// Source-wide path: the scan succeeds, and the broken view stays visible
+	// with no row count.
 	md, err := grip.SourceMetadata(th.Context, false)
 	require.NoError(t, err,
-		"source scan must tolerate a view whose object cannot be resolved (error 208)")
+		"source scan must tolerate a view with binding errors (error 4413)")
 
-	var foundView bool
+	var foundView *metadata.Table
 	for _, tbl := range md.Tables {
 		if tbl.Name == viewName {
-			foundView = true
+			foundView = tbl
 			break
 		}
 	}
-	require.False(t, foundView, "the unresolvable view is skipped, not failed")
+	require.NotNil(t, foundView, "the broken view stays visible in the results")
+	require.Equal(t, int64(0), foundView.RowCount, "no row count for a broken view")
+
+	// Per-table path: same behavior.
+	tblMd, err := grip.TableMetadata(th.Context, viewName)
+	require.NoError(t, err,
+		"per-table metadata must tolerate a view with binding errors (error 4413)")
+	require.Equal(t, viewName, tblMd.Name)
+	require.Equal(t, int64(0), tblMd.RowCount, "no row count for a broken view")
 }
 
 // TestDriver_Truncate_QuotedIdentity_MSSQL exercises Truncate's reseed path

--- a/drivers/sqlserver/sqlserver_integration_test.go
+++ b/drivers/sqlserver/sqlserver_integration_test.go
@@ -334,7 +334,7 @@ func TestSourceMetadata_VanishedView_MSSQL(t *testing.T) {
 	})
 
 	// Drop the base table out from under the view: the view remains
-	// enumerable, but its COUNT(*) now raises error 208.
+	// enumerable, but its COUNT(*) now raises error 4413 (binding errors).
 	require.NoError(t, drvr.DropTable(th.Context, db, tablefq.From(baseTbl), false))
 
 	md, err := grip.SourceMetadata(th.Context, false)

--- a/drivers/sqlserver/sqlserver_integration_test.go
+++ b/drivers/sqlserver/sqlserver_integration_test.go
@@ -303,6 +303,54 @@ func TestDriver_QuotedView_RowCount_MSSQL(t *testing.T) {
 	require.Equal(t, int64(2), md.RowCount, "row count must load via the COUNT(*) fallback")
 }
 
+// TestSourceMetadata_VanishedView_MSSQL pins that a source-wide metadata scan
+// tolerates a view whose underlying object has vanished. A base table dropped
+// mid-scan by concurrent DDL leaves its dependent views broken: sp_spaceused
+// still succeeds (a view has no storage, so it reports a NULL row count), and
+// then the SELECT COUNT(*) row-count fallback raises error 4413 ("binding
+// errors"); a view that itself vanishes raises 208 from the same site.
+// Previously only error 15009 was tolerated, so either failed the whole scan;
+// this was the cause of TestDBSemver flakes under parallel test load (issue
+// #1027). The dangling view used here reproduces the 4413 shape
+// deterministically, with no race; 208 is pinned by Test_isObjectVanishedErr.
+func TestSourceMetadata_VanishedView_MSSQL(t *testing.T) {
+	tu.SkipShort(t, true)
+	t.Parallel()
+
+	th, src, drvr, grip, db := testh.NewWith(t, sakila.MS)
+
+	baseTbl := stringz.UniqTableName("vanish_base")
+	tblDef := schema.NewTable(baseTbl, []string{"id", "val"}, []kind.Kind{kind.Int, kind.Text})
+	require.NoError(t, drvr.CreateTable(th.Context, db, tblDef))
+	t.Cleanup(func() { th.DropTable(src, tablefq.From(baseTbl)) })
+
+	viewName := stringz.UniqTableName("vanish_view")
+	qView := stringz.DoubleQuote(viewName)
+	_, err := db.ExecContext(th.Context,
+		`CREATE VIEW `+qView+` AS SELECT id, val FROM `+stringz.DoubleQuote(baseTbl))
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_, _ = db.ExecContext(th.Context, `DROP VIEW IF EXISTS `+qView)
+	})
+
+	// Drop the base table out from under the view: the view remains
+	// enumerable, but its COUNT(*) now raises error 208.
+	require.NoError(t, drvr.DropTable(th.Context, db, tablefq.From(baseTbl), false))
+
+	md, err := grip.SourceMetadata(th.Context, false)
+	require.NoError(t, err,
+		"source scan must tolerate a view whose object cannot be resolved (error 208)")
+
+	var foundView bool
+	for _, tbl := range md.Tables {
+		if tbl.Name == viewName {
+			foundView = true
+			break
+		}
+	}
+	require.False(t, foundView, "the unresolvable view is skipped, not failed")
+}
+
 // TestDriver_Truncate_QuotedIdentity_MSSQL exercises Truncate's reseed path
 // (DBCC CHECKIDENT) against an identity table whose name contains a double
 // quote. DBCC parses the name out of a string literal, so it must be


### PR DESCRIPTION
Closes #1027. Closes #1031.

Completes the remaining items deferred from #1028 (which shipped the identifier escaping): concurrent-DDL drop tolerance for sqlite3 and SQL Server, the postgres `getMatviewMetadata` tidy -- plus two further pre-existing race classes that stress-validation surfaced (SQL Server deadlock victims and the `sp_spaceused` NULL race).

## What

### 1. sqlite3 (and rqlite): batched row-count scan tolerates dropped tables

`getTblRowCounts` batches up to 500 `SELECT COUNT(*) ... UNION ALL` terms into one compound statement (a benchmarked ~5x win). A table dropped mid-scan by concurrent DDL failed the whole statement and aborted the entire `SourceMetadata` scan. On a no-such-table error the batch now falls back to per-table COUNTs (`countTblsIndividually`), a direct port of the rqlite driver's existing fallback. Per deep review, vanished tables are **omitted from the results** (in both drivers) rather than leaking the `-1` sentinel into user-visible `row_count`.

### 2. sqlserver: scan tolerates vanished and broken objects

The scan tolerated only error 15009 (`sp_spaceused`, object gone). Sibling shapes still failed the whole scan; all are now handled, each according to what it means:

- **208** "invalid object name" (the view itself vanished after enumeration): tolerated, object omitted.
- **4413** "binding errors" (the view's *base table* vanished, leaving the view broken -- discovered while writing the test: a dangling view raises 4413, not 208): handled at the COUNT site; the view **stays visible with no row count**, on both the source-scan and per-table paths. Per deep review: a permanently-broken view is real schema the user should see, not silently hide.
- **`sp_spaceused` NULL race** (object dropped mid-call yields NULL fields; the old `REVISIT` at the site): now returns the canonical `NotExistError` instead of an opaque scan error; tolerated by the scan.
- **1205 deadlock victim** (closes #1031; the old TODO in `grip.go`): catalog queries losing lock races against concurrent DDL are retried via new `doRetryDeadlock`/`loadWithRetry` (mirroring the postgres #1026 pattern) around `getTableMetadata` (both paths) and all seven bulk loaders, with a dedicated 15s budget -- a deadlock storm outlasts the general 3s retry budget, and victim errors return instantly, so waiting out a storm is cheap.

The `isObjectVanishedErr` predicate (15009 | 208 | 4413 | `NotExistError`, matched wrapped or raw) guards the scan's per-table errgroup. This class was the cause of the `TestDBSemver` flakes under parallel test load.

### 3. postgres: `getMatviewMetadata` OID resolution + escaping tidy

Step A resolves the matview's OID on the bound name (same `pg_class` JOIN pattern as `getTableMetadata` from #1026); Step B passes that OID directly to `pg_total_relation_size` / `obj_description` / `pg_get_viewdef`, removing the search-path-dependent `quote_ident($1)::regclass` lookup and the hand-rolled `ReplaceAll` escaping. Per deep review, the interpolated `COUNT(*)` identifier is additionally **schema-qualified** with Step A's schema: an unqualified name resolves via the search path, where a same-named `pg_temp` relation would shadow the matview and supply a row count belonging to a different relation than the OID describes.

## Review

Copilot (2 findings: double-wrapped error, stale comment) and the deep-review workflow (5 findings: pg_temp shadow, `-1` sentinel leak, silent broken-view omission, comment gap -- all fixed; sqlite3/rqlite helper duplication declined, as the rqlite driver deliberately mirrors sqlite3 wholesale) are addressed in follow-up commits.

## Testing

- **`TestGetTblRowCounts_MissingTableFallback`** (sqlite3): a never-existed name stands in for a mid-flight drop; asserts the batch falls back. **Fails with the fallback disabled.**
- **`TestSourceMetadata_BrokenView_MSSQL`**: deterministic, race-free repro of the broken-view shape (view over a dropped base table -> 4413); asserts the scan succeeds and the view stays visible with no row count, on both the source-wide and per-table paths.
- **`Test_isObjectVanishedErr`** / **`Test_isErrDeadlockVictim`**: table-driven over all tolerated/retried codes, raw and errw-wrapped, plus negative cases.
- Postgres matview behavior pinned by `TestPostgres_Matview` + `TestPostgres_QuotedMatviewName_Metadata` (#1030); green on **pg18 and pg9** (oid-overload compatibility verified live).
- Full suites green locally for all four touched packages against live DBs.
- **Flake stress validation**: 6 rounds of the `drivers/sqlserver` package plus 3 rounds of `drivers/sqlserver` + `libsq/driver` in parallel against live SQL Server: **0 failures**. Baseline on the pre-fix code: 4 failing tests in a single package round (deadlocks + NULL-scan), and the original `TestDBSemver` flake reproduced 2/4 on master.
- `make fmt` clean; pinned `golangci-lint` 0 issues.
