### PR TITLE
fix(drivers): honor PKColName in postgres, sqlserver, oracle, clickhouse CreateTable

### DIFF
--- a/drivers/clickhouse/clickhouse_test.go
+++ b/drivers/clickhouse/clickhouse_test.go
@@ -468,6 +468,41 @@ func TestDriver_CopyTable_TargetSchema(t *testing.T) {
 	require.Equal(t, sakila.TblActorCount, len(sink.Recs))
 }
 
+// TestCreateTable_PKColName_SortingKey verifies that CreateTable honors
+// schema.Table.PKColName as the MergeTree sorting key (#1029). ClickHouse has
+// no ANSI primary key: the ORDER BY / PRIMARY KEY key defines the sort order
+// without enforcing uniqueness, so PKColName maps to the sorting key and the
+// PK column is created non-nullable (a nullable column cannot be a sorting
+// key). This is the engine-specific counterpart to the cross-driver
+// TestDriver_CreateTable_PKColName in libsq/driver.
+func TestCreateTable_PKColName_SortingKey(t *testing.T) {
+	tu.SkipShort(t, true)
+	t.Parallel()
+
+	th, _, drvr, _, db := testh.NewWith(t, sakila.CH)
+	ctx := th.Context
+
+	tblName := stringz.UniqTableName("pk_col")
+	tblDef := schema.NewTable(tblName, []string{"id", "name"}, []kind.Kind{kind.Int, kind.Text})
+	tblDef.PKColName = "id"
+
+	require.NoError(t, drvr.CreateTable(ctx, db, tblDef))
+	t.Cleanup(func() { assert.NoError(t, drvr.DropTable(ctx, db, tablefq.From(tblName), true)) })
+
+	var sortingKey string
+	require.NoError(t, db.QueryRowContext(ctx,
+		"SELECT sorting_key FROM system.tables WHERE database = currentDatabase() AND name = ?",
+		tblName).Scan(&sortingKey))
+	require.Equal(t, "id", sortingKey, "PKColName must become the MergeTree sorting key")
+
+	// The PK column must be non-nullable even though the col def is nullable.
+	var idType string
+	require.NoError(t, db.QueryRowContext(ctx,
+		"SELECT type FROM system.columns WHERE database = currentDatabase() AND table = ? AND name = 'id'",
+		tblName).Scan(&idType))
+	require.Equal(t, "Int64", idType, "the PK column must not be Nullable")
+}
+
 func TestDBSemver(t *testing.T) {
 	tu.SkipShort(t, true)
 	t.Parallel()

--- a/drivers/clickhouse/render.go
+++ b/drivers/clickhouse/render.go
@@ -91,13 +91,19 @@ func dbTypeNameFromKind(knd kind.Kind) string {
 //     data storage, compression, and query performance.
 //
 //  2. ORDER BY clause is required for MergeTree. This defines the primary
-//     sort order for data storage and affects query performance. This function
-//     uses the first NOT NULL column as the ordering key. If no NOT NULL column
-//     exists, it uses tuple() which means no specific ordering.
+//     sort order for data storage and affects query performance. When
+//     tblDef.PKColName names one of the table's columns, that column is the
+//     ordering key: MergeTree's ORDER BY / PRIMARY KEY is the closest analogue
+//     to an ANSI primary key, though it does not enforce uniqueness (#1029).
+//     Otherwise this function falls back to the first NOT NULL column. If no
+//     NOT NULL column exists either, it uses tuple() which means no specific
+//     ordering.
 //
 //  3. Nullable types must be explicit. Unlike many SQL databases where columns
 //     are nullable by default, ClickHouse columns are non-nullable by default.
 //     This function wraps types with Nullable(T) when colDef.NotNull is false.
+//     The PK column is never wrapped: an ANSI primary key implies NOT NULL,
+//     and ClickHouse forbids nullable columns in the sorting key by default.
 //
 // Generated SQL format:
 //
@@ -123,14 +129,27 @@ func buildCreateTableStmtName(qtblName string, tblDef *schema.Table) string {
 	sb.WriteString(qtblName)
 	sb.WriteString(" (\n")
 
+	// pkColName is honored only if it names an actual column; a dangling
+	// PKColName must not produce an ORDER BY that references a column
+	// missing from the DDL.
+	pkColName := ""
+	for _, colDef := range tblDef.Cols {
+		if colDef.Name == tblDef.PKColName {
+			pkColName = colDef.Name
+			break
+		}
+	}
+
 	for i, colDef := range tblDef.Cols {
 		sb.WriteString("  ")
 		sb.WriteString(stringz.BacktickQuote(colDef.Name))
 		sb.WriteString(" ")
 
 		typeName := dbTypeNameFromKind(colDef.Kind)
-		if !colDef.NotNull {
-			// Wrap with Nullable for columns that allow NULL values
+		if !colDef.NotNull && colDef.Name != pkColName {
+			// Wrap with Nullable for columns that allow NULL values.
+			// The PK column is exempt: it becomes the sorting key below,
+			// and ClickHouse forbids nullable columns in the sorting key.
 			typeName = "Nullable(" + typeName + ")"
 		}
 		sb.WriteString(typeName)
@@ -144,14 +163,17 @@ func buildCreateTableStmtName(qtblName string, tblDef *schema.Table) string {
 
 	// ORDER BY clause is required for MergeTree.
 	// ClickHouse does not allow nullable columns in the sorting key by default.
-	// Find the first NOT NULL column to use as the ordering key, or use tuple()
-	// if all columns are nullable (tuple() means no specific ordering).
+	// Prefer the PK column as the ordering key (#1029); otherwise find the
+	// first NOT NULL column, or use tuple() if all columns are nullable
+	// (tuple() means no specific ordering).
 	sb.WriteString("ORDER BY ")
-	orderByCol := ""
-	for _, colDef := range tblDef.Cols {
-		if colDef.NotNull {
-			orderByCol = colDef.Name
-			break
+	orderByCol := pkColName
+	if orderByCol == "" {
+		for _, colDef := range tblDef.Cols {
+			if colDef.NotNull {
+				orderByCol = colDef.Name
+				break
+			}
 		}
 	}
 	if orderByCol != "" {

--- a/drivers/clickhouse/render_test.go
+++ b/drivers/clickhouse/render_test.go
@@ -126,6 +126,33 @@ func TestBuildCreateTableStmt(t *testing.T) {
 
 	// ORDER BY should use the first NOT NULL column, even if not first in table
 	require.Contains(t, stmt3, "ORDER BY `not_null_col`")
+
+	// Scenario 4: PKColName is set (#1029). The PK column becomes the sorting
+	// key even though other NOT NULL columns exist, and it is created
+	// non-nullable (ClickHouse forbids nullable sorting-key columns) even
+	// though its col def is nullable.
+	tblDef4 := schema.NewTable("test_table4",
+		[]string{"id", "name"},
+		[]kind.Kind{kind.Int, kind.Text})
+	tblDef4.PKColName = "id"
+	tblDef4.Cols[1].NotNull = true // without PKColName, name would be the key
+
+	stmt4 := clickhouse.BuildCreateTableStmt(tblDef4)
+	require.Contains(t, stmt4, "ORDER BY `id`")
+	require.Contains(t, stmt4, "`id` Int64")
+	require.NotContains(t, stmt4, "`id` Nullable")
+
+	// Scenario 5: PKColName that doesn't name an actual column is ignored;
+	// the first-NOT-NULL fallback applies.
+	tblDef5 := schema.NewTable("test_table5",
+		[]string{"id", "name"},
+		[]kind.Kind{kind.Int, kind.Text})
+	tblDef5.PKColName = "no_such_col"
+	tblDef5.Cols[1].NotNull = true
+
+	stmt5 := clickhouse.BuildCreateTableStmt(tblDef5)
+	require.Contains(t, stmt5, "ORDER BY `name`")
+	require.Contains(t, stmt5, "`id` Nullable(Int64)")
 }
 
 // TestBuildCreateTableStmtName_SchemaQualified is a short-mode (no live

--- a/drivers/oracle/render.go
+++ b/drivers/oracle/render.go
@@ -266,7 +266,10 @@ func preRenderOracle(_ *render.Context, f *render.Fragments) error {
 	return nil
 }
 
-// buildCreateTableStmt builds a CREATE TABLE statement for Oracle.
+// buildCreateTableStmt builds a CREATE TABLE statement for Oracle. It honors
+// PKColName as an inline PRIMARY KEY constraint (which implies NOT NULL).
+// Oracle requires the DEFAULT clause to precede inline constraints, so the
+// PRIMARY KEY clause is emitted after the DEFAULT / NOT NULL block (#1029).
 func buildCreateTableStmt(tblDef *schema.Table) string {
 	sb := strings.Builder{}
 	sb.WriteString(`CREATE TABLE `)
@@ -287,6 +290,10 @@ func buildCreateTableStmt(tblDef *schema.Table) string {
 				sb.WriteString(defaultVal)
 			}
 			sb.WriteString(" NOT NULL")
+		}
+
+		if colDef.Name == tblDef.PKColName {
+			sb.WriteString(" PRIMARY KEY")
 		}
 
 		if i < len(tblDef.Cols)-1 {

--- a/drivers/postgres/render.go
+++ b/drivers/postgres/render.go
@@ -61,7 +61,11 @@ var createTblKindDefaults = map[kind.Kind]string{ //nolint:exhaustive
 }
 
 // buildCreateTableStmt builds a CREATE TABLE statement from tblDef.
-// The implementation is minimal: it does not honor PK, FK, etc.
+// The implementation is minimal: it honors PKColName (as an inline
+// PRIMARY KEY, which implies NOT NULL) but not FK, etc. The PRIMARY KEY
+// clause is emitted after the DEFAULT / NOT NULL block for cross-driver
+// consistency: Oracle requires DEFAULT before inline constraints, and the
+// sqlserver and oracle builders mirror this function (#1029).
 func buildCreateTableStmt(tblDef *schema.Table) string {
 	sb := strings.Builder{}
 	sb.WriteString("CREATE TABLE ")
@@ -78,6 +82,10 @@ func buildCreateTableStmt(tblDef *schema.Table) string {
 			sb.WriteRune(' ')
 			sb.WriteString(createTblKindDefaults[colDef.Kind])
 			sb.WriteString(" NOT NULL")
+		}
+
+		if colDef.Name == tblDef.PKColName {
+			sb.WriteString(" PRIMARY KEY")
 		}
 
 		if i < len(tblDef.Cols)-1 {

--- a/drivers/postgres/unit_test.go
+++ b/drivers/postgres/unit_test.go
@@ -136,6 +136,13 @@ func TestBuildCreateTableStmt(t *testing.T) {
 	got = buildCreateTableStmt(tblDef)
 	require.Contains(t, got, `"id" BIGINT DEFAULT 0 NOT NULL`)
 	require.Contains(t, got, `"name" TEXT DEFAULT '' NOT NULL`)
+
+	// With PKColName set, an inline PRIMARY KEY is emitted after the
+	// DEFAULT / NOT NULL block (#1029).
+	tblDef.PKColName = "id"
+	got = buildCreateTableStmt(tblDef)
+	require.Contains(t, got, `"id" BIGINT DEFAULT 0 NOT NULL PRIMARY KEY`)
+	require.NotContains(t, got, `"name" TEXT DEFAULT '' NOT NULL PRIMARY KEY`)
 }
 
 func TestBuildUpdateStmt(t *testing.T) {

--- a/drivers/sqlserver/render.go
+++ b/drivers/sqlserver/render.go
@@ -103,7 +103,10 @@ var createTblKindDefaults = map[kind.Kind]string{ //nolint:exhaustive
 }
 
 // buildCreateTableStmt builds a CREATE TABLE statement from tblDef.
-// The implementation is minimal: it does not honor PK, FK, etc.
+// The implementation is minimal: it honors PKColName (as an inline
+// PRIMARY KEY, which implies NOT NULL) but not FK, etc. The PRIMARY KEY
+// clause is emitted after the DEFAULT / NOT NULL block, mirroring the
+// postgres and oracle builders (#1029).
 func buildCreateTableStmt(tblDef *schema.Table) string {
 	sb := strings.Builder{}
 	sb.WriteString(`CREATE TABLE `)
@@ -120,6 +123,10 @@ func buildCreateTableStmt(tblDef *schema.Table) string {
 			sb.WriteRune(' ')
 			sb.WriteString(createTblKindDefaults[colDef.Kind])
 			sb.WriteString(" NOT NULL")
+		}
+
+		if colDef.Name == tblDef.PKColName {
+			sb.WriteString(" PRIMARY KEY")
 		}
 
 		if i < len(tblDef.Cols)-1 {

--- a/libsq/driver/driver_test.go
+++ b/libsq/driver/driver_test.go
@@ -348,6 +348,15 @@ func TestDriver_QuotedIdentifier(t *testing.T) {
 			require.Equal(t, tblName, md.Name)
 			require.Len(t, md.Columns, len(colNames))
 
+			// The PK must materialize (#1029) so that constraint metadata is
+			// exercised for the quoted table name: postgres getPgConstraints
+			// initially shipped without coverage (#1026) because no PK ever
+			// existed here.
+			idCol := md.Column("id")
+			require.NotNil(t, idCol)
+			require.True(t, idCol.PrimaryKey,
+				"CreateTable must honor PKColName so constraint metadata is exercised")
+
 			// Exercise the UPDATE write-path builder (buildUpdateStmt) with the
 			// quoted column: insert a row, then update the weird column by id.
 			th.Insert(src, tblName, colNames, []any{int64(1), "before"})
@@ -356,6 +365,61 @@ func TestDriver_QuotedIdentifier(t *testing.T) {
 			require.NoError(t, execer.Munge([]any{"after"}))
 			_, err = execer.Exec(th.Context, "after", int64(1))
 			require.NoError(t, err, "UPDATE must escape the quoted column %q", weird)
+		})
+	}
+}
+
+// TestDriver_CreateTable_PKColName verifies that SQLDriver.CreateTable honors
+// schema.Table.PKColName on every SQL engine (#1029). Before that fix the
+// postgres, sqlserver, oracle and clickhouse builders silently ignored the
+// field, so the same schema.Table input yielded a primary key on half the
+// engines and none on the others.
+//
+// ClickHouse has no ANSI primary key: PKColName maps to the MergeTree sorting
+// key (ORDER BY), which does not enforce uniqueness, and the driver
+// deliberately reports Column.PrimaryKey as false. The metadata assertion is
+// therefore skipped for ClickHouse here; TestCreateTable_PKColName_SortingKey
+// in drivers/clickhouse asserts the sorting key directly.
+func TestDriver_CreateTable_PKColName(t *testing.T) {
+	t.Parallel()
+
+	for _, handle := range sakila.SQLAll() {
+		t.Run(handle, func(t *testing.T) {
+			t.Parallel()
+
+			th, src, drvr, grip, db := testh.NewWith(t, handle)
+
+			tblName := stringz.UniqTableName("pk_col")
+			tblDef := schema.NewTable(tblName,
+				[]string{"id", "name"}, []kind.Kind{kind.Int, kind.Text})
+			tblDef.PKColName = "id"
+
+			require.NoError(t, drvr.CreateTable(th.Context, db, tblDef))
+			t.Cleanup(func() { th.DropTable(src, tablefq.From(tblName)) })
+
+			// A PK column is implicitly NOT NULL, so a row with a non-null id
+			// must insert cleanly on every engine.
+			th.Insert(src, tblName, []string{"id", "name"}, []any{int64(1), "a"})
+
+			if drvr.DriverMetadata().Type == drivertype.ClickHouse {
+				return // see comment above
+			}
+
+			// enquoteOracle uppercases identifiers, and Oracle reports names
+			// in their stored case.
+			pkColName := "id"
+			if drvr.DriverMetadata().Type == drivertype.Oracle {
+				pkColName = "ID"
+			}
+
+			md, err := grip.TableMetadata(th.Context, tblName)
+			require.NoError(t, err)
+			idCol := md.Column(pkColName)
+			require.NotNil(t, idCol)
+			require.True(t, idCol.PrimaryKey, "CreateTable must honor PKColName")
+			pkCols := md.PKCols()
+			require.Len(t, pkCols, 1)
+			require.Equal(t, pkColName, pkCols[0].Name)
 		})
 	}
 }


### PR DESCRIPTION
Closes #1029.

`schema.Table.PKColName` was honored by the sqlite3, mysql, duckdb, and rqlite CREATE TABLE builders but silently ignored by postgres, sqlserver, oracle, and clickhouse, so the same `schema.Table` input yielded a primary key on half the engines and none on the others. This is how the `getPgConstraints` escaping fix (#1026) initially shipped without coverage: the test set `PKColName`, but on postgres no constraint ever materialized.

## Changes

- **postgres, sqlserver, oracle** (`render.go`): `buildCreateTableStmt` now emits an inline `PRIMARY KEY` on the matching column. The clause is placed after the `DEFAULT` / `NOT NULL` block because Oracle requires `DEFAULT` to precede inline constraints; the other two accept either order, so all three builders stay symmetrical. An inline PK implies NOT NULL on all three engines.
- **clickhouse** (`render.go`): MergeTree has no ANSI primary key, so `PKColName` maps to its closest analogue, the sorting key: when it names an actual column, that column becomes the `ORDER BY` key (previously the key was always derived from the first NOT NULL column, which remains the fallback). The PK column is created non-nullable even if its col def is nullable, since ClickHouse forbids nullable sorting-key columns and an ANSI PK implies NOT NULL anyway. A dangling `PKColName` that names no column is ignored, matching the other builders. `Column.PrimaryKey` metadata deliberately remains `false` (unchanged): the sorting key does not enforce uniqueness.

## Ingest call sites reviewed

Per the issue's caveat about `CreateTable` running during ingestion: the only production code that sets `PKColName` is userdriver ingestion (`drivers/userdriver/def.go`), and its destination is always the sqlite3 scratch source (`cli/run.go` wires `sqlite3.NewScratchSource`), an engine that already honored the field. The CSV/JSON/XLSX ingest paths and the query-result writers (`libsq/dbwriter.go`, `libsq/copyfanin.go`) build tables via `schema.NewTable`, which leaves `PKColName` empty. No ingest behavior changes on the newly honoring engines.

## Testing

- New cross-driver `TestDriver_CreateTable_PKColName` (`libsq/driver/driver_test.go`) runs on all 8 SQL engines: creates a table with `PKColName = "id"`, inserts a row, and asserts `Column.PrimaryKey` / `PKCols()` via table metadata (Oracle asserts against `ID`, its stored case). ClickHouse is asserted separately by `TestCreateTable_PKColName_SortingKey` (`drivers/clickhouse/clickhouse_test.go`), which checks `system.tables.sorting_key` and that the PK column type is non-Nullable.
- `TestDriver_QuotedIdentifier` now asserts the PK materializes, so constraint-metadata paths are exercised for quoted table names (the #1026 gap class).
- Unit coverage: postgres `TestBuildCreateTableStmt` asserts the `PRIMARY KEY` clause and its position after `DEFAULT ... NOT NULL`; clickhouse `TestBuildCreateTableStmt` gains scenarios for PK-as-sorting-key, the Nullable exemption, and the dangling-`PKColName` fallback.
- Mutation checks: each of the five new hunks (three ANSI `PRIMARY KEY` emissions, clickhouse `ORDER BY` preference, clickhouse Nullable exemption) was reverted in isolation and a test failed each time.
- Full suites green locally against live containers for `libsq/driver`, `drivers/{postgres,sqlserver,oracle,clickhouse}`, and `drivers/userdriver/...` (postgres:18, mysql:9, sqlserver:2022, oracle:23, clickhouse:25, rqlite:10).
