### PR TITLE
fix(postgres): gate row-count query and pin schema in table metadata lookups (#945)

### DIFF
--- a/drivers/postgres/errors.go
+++ b/drivers/postgres/errors.go
@@ -49,6 +49,16 @@ func isErrRelationNotExist(err error) bool {
 	return hasErrCode(err, errCodeRelationNotExist)
 }
 
+// isErrTableNotFound reports whether err indicates a relation that does not
+// exist, however it surfaced: a 42P01 (which errw wraps in
+// driver.NotExistError), or the typed not-found error returned by the
+// getTableMetadata / getMatviewMetadata existence gates (#945). The
+// source-wide scan in getSourceMetadata uses this to tolerate a table dropped
+// mid-scan by concurrent DDL.
+func isErrTableNotFound(err error) bool {
+	return errz.Has[*driver.NotExistError](err)
+}
+
 // isErrScanRetryable reports whether a bulk metadata-loader error is worth
 // retrying during a source-wide scan of a live database: too-many-connections,
 // or a relation that vanished mid-query. The latter surfaces either as 42P01,

--- a/drivers/postgres/internal_test.go
+++ b/drivers/postgres/internal_test.go
@@ -7,6 +7,9 @@ import (
 
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/stretchr/testify/require"
+
+	"github.com/neilotoole/sq/libsq/core/errz"
+	"github.com/neilotoole/sq/libsq/driver"
 )
 
 // Export for testing.
@@ -103,6 +106,25 @@ func TestIsErrScanRetryable(t *testing.T) {
 			require.Equal(t, tc.want, isErrScanRetryable(tc.err))
 		})
 	}
+}
+
+// TestIsErrTableNotFound pins the predicate that getSourceMetadata uses to
+// tolerate a table dropped mid-scan: it must match a 42P01 wrapped by errw AND
+// the typed not-found error returned by the getTableMetadata /
+// getMatviewMetadata existence gates, and nothing else. See issue #945.
+func TestIsErrTableNotFound(t *testing.T) {
+	t.Parallel()
+
+	require.True(t, isErrTableNotFound(errw(&pgconn.PgError{Code: errCodeRelationNotExist})))
+	require.True(t, isErrTableNotFound(driver.NewNotExistError(errz.Errorf("table {%s} not found", "tbl"))))
+
+	require.False(t, isErrTableNotFound(nil))
+	// A raw 42P01 that has NOT passed through errw is not matched: every db
+	// interaction in this package wraps via errw, so an unwrapped pg error
+	// reaching the scan would be a bug worth surfacing.
+	require.False(t, isErrTableNotFound(&pgconn.PgError{Code: errCodeRelationNotExist}))
+	require.False(t, isErrTableNotFound(errw(&pgconn.PgError{Code: errCodeTooManyConnections})))
+	require.False(t, isErrTableNotFound(errors.New("boom")))
 }
 
 // TestLoadWithRetry_VanishedRelation pins the retry behavior of the bulk

--- a/drivers/postgres/metadata.go
+++ b/drivers/postgres/metadata.go
@@ -25,6 +25,7 @@ import (
 	"github.com/neilotoole/sq/libsq/core/sqlz"
 	"github.com/neilotoole/sq/libsq/core/stringz"
 	"github.com/neilotoole/sq/libsq/core/tuning"
+	"github.com/neilotoole/sq/libsq/driver"
 	"github.com/neilotoole/sq/libsq/source"
 	"github.com/neilotoole/sq/libsq/source/metadata"
 )
@@ -273,7 +274,7 @@ current_setting('server_version'), version(), "current_user"()`
 
 			if mdErr != nil {
 				switch {
-				case isErrRelationNotExist(mdErr):
+				case isErrTableNotFound(mdErr):
 					// For example, if the table is dropped while we're collecting
 					// metadata, we log a warning and suppress the error.
 					log.Warn(
@@ -475,16 +476,16 @@ ORDER BY table_name`
 func getTableMetadata(ctx context.Context, db sqlz.DB, tblName string) (*metadata.Table, error) {
 	log := lg.FromContext(ctx)
 
+	// Step A: resolve the relation from the catalogs on the bound name ($1).
 	// A table name can legally contain a double-quote (e.g. `we"ird`). The
-	// relation's OID is resolved via a pg_class JOIN on the raw name ($1, a
-	// bind parameter) rather than a regclass text cast, which mis-parses such
-	// names; the size/oid/comment functions then take the OID directly. The
-	// only interpolation is the COUNT subquery's FROM, which uses a
-	// double-quoted (escaped) identifier. Raw interpolation built malformed
-	// SQL. See issue #1025.
-	safeIdent := stringz.DoubleQuote(tblName)
-	tablesQuery := `SELECT t.table_catalog, t.table_schema, t.table_name, t.table_type, t.is_insertable_into,
-  (SELECT COUNT(*) FROM ` + safeIdent + `) AS table_row_count,
+	// relation's OID is resolved via a pg_class JOIN on the raw name rather
+	// than a regclass text cast, which mis-parses such names; the size and
+	// comment functions then take the OID directly (#1025). The row count is
+	// NOT computed here: a relation name cannot be a bind parameter in a FROM
+	// clause, so the COUNT query must interpolate the identifier, and it runs
+	// as Step B only after this step confirms that tblName is a real relation
+	// in the current schema (#945).
+	const tablesQuery = `SELECT t.table_catalog, t.table_schema, t.table_name, t.table_type, t.is_insertable_into,
   pg_total_relation_size(c.oid) AS table_size,
   c.oid AS table_oid,
   obj_description(c.oid, 'pg_class') AS table_comment
@@ -498,7 +499,7 @@ AND t.table_name = $1`
 	pgTbl := &pgTable{}
 	err := db.QueryRowContext(ctx, tablesQuery, tblName).
 		Scan(&pgTbl.tableCatalog, &pgTbl.tableSchema, &pgTbl.tableName, &pgTbl.tableType, &pgTbl.isInsertable,
-			&pgTbl.rowCount, &pgTbl.size, &pgTbl.oid, &pgTbl.comment)
+			&pgTbl.size, &pgTbl.oid, &pgTbl.comment)
 	if errors.Is(err, sql.ErrNoRows) {
 		// A matview is absent from information_schema.tables, so the
 		// query above returns no rows. Fall back to the pg_catalog path,
@@ -507,6 +508,23 @@ AND t.table_name = $1`
 		return getMatviewMetadata(ctx, db, tblName)
 	}
 	if err != nil {
+		return nil, errw(err)
+	}
+	progress.Incr(ctx, 1)
+	debugz.DebugSleep(ctx)
+
+	// Step B: tblName is confirmed to exist; fetch its row count. The COUNT
+	// identifier is double-quoted (escaped) and qualified with the schema
+	// resolved in Step A: an unqualified name resolves via the search path,
+	// where a same-named pg_temp relation would shadow the table and supply a
+	// row count belonging to a different relation than the OID describes. This
+	// mirrors getMatviewMetadata (#945). If the relation is dropped between
+	// the steps, the COUNT fails with 42P01, which errw maps to
+	// driver.NotExistError, and the source-wide scan tolerates it like any
+	// other mid-scan drop.
+	countQuery := `SELECT COUNT(*) FROM ` +
+		stringz.DoubleQuote(pgTbl.tableSchema) + `.` + stringz.DoubleQuote(pgTbl.tableName)
+	if err = db.QueryRowContext(ctx, countQuery).Scan(&pgTbl.rowCount); err != nil {
 		return nil, errw(err)
 	}
 	progress.Incr(ctx, 1)
@@ -573,9 +591,11 @@ WHERE c.relname = $1 AND n.nspname = current_schema() AND c.relkind = 'm'`
 	)
 	err := db.QueryRowContext(ctx, confirmQuery, name).Scan(&catalog, &schema, &oid)
 	if errors.Is(err, sql.ErrNoRows) {
-		// Not a matview (nor any other relation found in info-schema):
-		// behave as before for a genuinely-missing relation.
-		return nil, errz.Errorf("table {%s} not found", name)
+		// Not a matview (nor any other relation found in info-schema). The
+		// canonical not-found error is typed driver.NotExistError so that the
+		// source-wide scan in getSourceMetadata can tolerate a relation
+		// dropped mid-scan, the same as a 42P01 wrapped by errw (#945).
+		return nil, driver.NewNotExistError(errz.Errorf("table {%s} not found", name))
 	}
 	if err != nil {
 		return nil, errw(err)
@@ -862,7 +882,7 @@ func getPgColumns(ctx context.Context, db sqlz.DB, tblName string) ([]*pgColumn,
 	FROM
 		pg_catalog.pg_class c
 	WHERE
-		c.oid = (SELECT quote_ident(cols.table_name)::regclass::oid)
+		c.oid = (SELECT (quote_ident(cols.table_schema) || '.' || quote_ident(cols.table_name))::regclass::oid)
 		AND c.relname = cols.table_name
 	) AS column_comment
 FROM information_schema.columns cols
@@ -941,14 +961,16 @@ func getPgConstraints(ctx context.Context, db sqlz.DB, tblName string) ([]*pgCon
     (
        SELECT pg_catalog.pg_get_constraintdef(pgc.oid, TRUE)
        FROM pg_catalog.pg_constraint pgc
-       WHERE pgc.conrelid = (SELECT quote_ident(kcu.table_name)::regclass::oid)
+       WHERE pgc.conrelid =
+         (SELECT (quote_ident(kcu.table_schema) || '.' || quote_ident(kcu.table_name))::regclass::oid)
        AND pgc.conname = tc.constraint_name
        limit 1
     )  AS constraint_def,
     (
        SELECT pgc.confrelid::regclass
        FROM pg_catalog.pg_constraint pgc
-       WHERE pgc.conrelid = (SELECT quote_ident(kcu.table_name)::regclass::oid)
+       WHERE pgc.conrelid =
+         (SELECT (quote_ident(kcu.table_schema) || '.' || quote_ident(kcu.table_name))::regclass::oid)
        AND pgc.conname = tc.constraint_name
        AND pgc.confrelid > 0
        LIMIT 1

--- a/drivers/postgres/metadata_test.go
+++ b/drivers/postgres/metadata_test.go
@@ -5,9 +5,12 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/neilotoole/sq/libsq/core/errz"
+	"github.com/neilotoole/sq/libsq/core/options"
 	"github.com/neilotoole/sq/libsq/core/sqlz"
 	"github.com/neilotoole/sq/libsq/core/stringz"
 	"github.com/neilotoole/sq/libsq/core/tablefq"
+	"github.com/neilotoole/sq/libsq/driver"
 	"github.com/neilotoole/sq/libsq/source/metadata"
 	"github.com/neilotoole/sq/testh"
 	"github.com/neilotoole/sq/testh/sakila"
@@ -364,6 +367,77 @@ func TestPostgres_QuotedMatviewName_Metadata(t *testing.T) {
 	require.Equal(t, int64(1), md.RowCount, "RowCount must load for a quoted matview name")
 	require.Len(t, md.Columns, 2)
 	require.NotEmpty(t, md.ViewDefinition, "ViewDefinition must load for a quoted matview name")
+}
+
+// TestPostgres_TempTableShadow_TableMetadata pins that per-table metadata
+// describes the schema table even when a same-named temp table exists in the
+// session. A relation name cannot be a bind parameter in a FROM clause, so the
+// row-count query interpolates the identifier; if that identifier (or a
+// quote_ident()::regclass lookup) is unqualified, it resolves via the search
+// path, where pg_temp precedes the current schema, and the value describes a
+// different relation than the OID-resolved size and comment. getTableMetadata
+// must schema-qualify the COUNT identifier, and the getPgColumns comment
+// subquery must schema-qualify its regclass lookup (issue #945).
+//
+// The pool is pinned to a single connection so that the session-scoped temp
+// table is deterministically visible to the metadata queries.
+func TestPostgres_TempTableShadow_TableMetadata(t *testing.T) {
+	tu.SkipShort(t, true)
+	t.Parallel()
+
+	th := testh.New(t)
+	src := th.Source(sakila.Pg)
+	src.Options = options.Options{driver.OptConnMaxOpen.Key(): 1}
+	db := th.OpenDB(src)
+
+	tbl := stringz.UniqTableName("shadow")
+	_, err := db.ExecContext(th.Context, `CREATE TABLE `+tbl+` (id INT PRIMARY KEY)`)
+	require.NoError(t, err)
+	t.Cleanup(func() { th.DropTable(src, tablefq.From(tbl)) })
+	_, err = db.ExecContext(th.Context, `INSERT INTO `+tbl+` (id) VALUES (1), (2)`)
+	require.NoError(t, err)
+	_, err = db.ExecContext(th.Context, `COMMENT ON COLUMN `+tbl+`.id IS 'the real id'`)
+	require.NoError(t, err)
+
+	// The temp table shadows tbl on the search path for this session: it has a
+	// different row count and no column comment. Its auto-named PK constraint
+	// (tbl_pkey) collides with the schema table's, exercising the constraint
+	// subqueries too.
+	_, err = db.ExecContext(th.Context, `CREATE TEMP TABLE `+tbl+` (id INT PRIMARY KEY)`)
+	require.NoError(t, err)
+	t.Cleanup(func() { _, _ = db.ExecContext(th.Context, `DROP TABLE IF EXISTS pg_temp.`+tbl) })
+	_, err = db.ExecContext(th.Context,
+		`INSERT INTO pg_temp.`+tbl+` (id) VALUES (1), (2), (3), (4), (5)`)
+	require.NoError(t, err)
+
+	md, err := th.Open(src).TableMetadata(th.Context, tbl)
+	require.NoError(t, err)
+	require.Equal(t, int64(2), md.RowCount,
+		"RowCount must come from the schema table, not the pg_temp shadow")
+	idCol := md.Column("id")
+	require.NotNil(t, idCol)
+	require.Equal(t, "the real id", idCol.Comment,
+		"column comment must come from the schema table, not the pg_temp shadow")
+	require.True(t, idCol.PrimaryKey)
+}
+
+// TestPostgres_TableMetadata_NotFound pins the error classification for a
+// nonexistent relation. Since #945, getTableMetadata confirms existence before
+// running the row-count query, so a missing relation surfaces via the
+// getMatviewMetadata fallback's canonical not-found error. That error must be
+// typed driver.NotExistError, the same as a 42P01 wrapped by errw, so that the
+// source-wide scan's dropped-mid-scan tolerance still recognizes it.
+func TestPostgres_TableMetadata_NotFound(t *testing.T) {
+	tu.SkipShort(t, true)
+	t.Parallel()
+
+	th := testh.New(t)
+	src := th.Source(sakila.Pg)
+
+	_, err := th.Open(src).TableMetadata(th.Context, stringz.UniqTableName("no_such"))
+	require.Error(t, err)
+	require.True(t, errz.Has[*driver.NotExistError](err),
+		"a missing table must surface as driver.NotExistError")
 }
 
 // TestPostgres_ViewDefinition verifies that ViewDefinition is populated for

--- a/drivers/postgres/metadata_test.go
+++ b/drivers/postgres/metadata_test.go
@@ -387,7 +387,10 @@ func TestPostgres_TempTableShadow_TableMetadata(t *testing.T) {
 
 	th := testh.New(t)
 	src := th.Source(sakila.Pg)
-	src.Options = options.Options{driver.OptConnMaxOpen.Key(): 1}
+	if src.Options == nil {
+		src.Options = options.Options{}
+	}
+	src.Options[driver.OptConnMaxOpen.Key()] = 1
 	db := th.OpenDB(src)
 
 	tbl := stringz.UniqTableName("shadow")


### PR DESCRIPTION
Closes #945.

Most of what #945 originally described was already fixed by #1025: the `fmt.Sprintf`/`%q` interpolation is gone, the relation's OID is resolved via a `pg_class` JOIN on the bound name, and the size/comment functions take the OID directly. This PR applies the remaining hardening the issue asks for: gating the one unavoidable interpolation behind an existence check, and pinning every name lookup to the resolved schema so it cannot be diverted by the search path.

## Changes

- **`getTableMetadata` is now two-step**, mirroring `getMatviewMetadata` (#941): Step A resolves the relation from the catalogs on the bound name (`$1`); only after that confirms the relation does Step B interpolate the `COUNT(*)` identifier, double-quoted and qualified with the schema resolved in Step A. Previously the COUNT ran un-gated in the same statement with an unqualified identifier, which resolves via the search path, where a same-named `pg_temp` relation shadows the schema table and supplies a row count belonging to a different relation than the OID-resolved size and comment describe.
- **The same search-path pinning is applied to the `quote_ident()::regclass` lookups** in `getPgColumns` (the column-comment subquery, observable as a wrong/missing column comment under a temp-table shadow) and `getPgConstraints` (both constraint subqueries; those columns are currently scanned but unused downstream, so this one has no observable behavior change and no dedicated test, but it closes out the pattern in the file).
- **Not-found classification**: a missing relation previously surfaced as a plan-time 42P01 from the interpolated COUNT (wrapped as `driver.NotExistError` by `errw`). With the gate, it now surfaces via the matview fallback's canonical `table {x} not found` error, which is typed `driver.NotExistError` so callers see the same classification. The source-wide scan's dropped-mid-scan check now goes through a new, broader predicate, `isErrTableNotFound`, which matches both an `errw`-wrapped 42P01 and the typed not-found error, preserving the #1032 behavior for tables dropped between listing and Step A. This replaces `isErrRelationNotExist` at that one call site; the narrower predicate remains in use by `isErrScanRetryable`.

## Testing

- New `TestPostgres_TempTableShadow_TableMetadata`: pins the pool to a single connection (`OptConnMaxOpen=1`) so a session-scoped temp table deterministically shadows the schema table, then asserts the row count, column comment, and PK all describe the schema table. Fails on the previous code (row count 5 vs 2; comment lost).
- New `TestPostgres_TableMetadata_NotFound`: asserts a missing relation surfaces as `driver.NotExistError`.
- New `TestIsErrTableNotFound` (unit): the scan-tolerance predicate matches an `errw`-wrapped 42P01 and the typed not-found error, and rejects raw/unrelated errors.
- Mutation checks: each hunk was reverted in isolation and a test failed each time (4/4 killed): unqualified COUNT ident, unqualified column-comment regclass, unwrapped not-found error, predicate reverted to 42P01-only. The `getPgConstraints` qualification is unobservable (see above) and is the one deliberate exception.
- Review follow-up: the temp-table shadow test now overlays `OptConnMaxOpen` onto the source's existing options rather than replacing the map wholesale, so it cannot discard options configured for `@sakila_pg` in `test.sq.yml`.
- Rebased onto current master. Full suites green locally against live containers: `drivers/postgres` (67 passed, 0 failed, 0 skipped) and a full-tree `make test` (`go test ./...`), which covers `libsq/driver` across all 8 engines and `cli`'s `TestCmdInspect` with every `SQ_TEST_SRC__*` set.

