### PR TITLE
Add sq-actions-dependabot skill for GitHub Actions PRs

### DIFF
--- a/.agents/skills/sq-actions-dependabot/SKILL.md
+++ b/.agents/skills/sq-actions-dependabot/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: sq-actions-dependabot
+description: >-
+  Reviews and merges Dependabot pull requests for GitHub Actions (the
+  github-actions ecosystem) that bump `uses:` pins in `.github/workflows/`. Use
+  for dependabot github_actions PRs, not go.mod or site/ Bun PRs.
+license: MIT
+compatibility: >-
+  Requires gh CLI (authenticated) and network access to GitHub. actionlint is
+  optional for local linting; CI already runs it in the `lint` job.
+metadata:
+  author: Todd Papaioannou
+  homepage: https://sq.io
+  version: "0.1.0"
+---
+
+# sq-actions-dependabot
+
+Maintainer workflow for Dependabot PRs in the **github-actions** ecosystem:
+version bumps to `uses:` action pins under
+[`.github/workflows/`](../../../.github/workflows/). For [`go.mod`](../../../go.mod) /
+[`go.sum`](../../../go.sum) PRs use
+[`sq-gomod-dependabot`](../sq-gomod-dependabot/SKILL.md); for
+[`site/`](../../../site/) Bun/Hugo PRs use
+[`sq-site-dependabot`](../sq-site-dependabot/SKILL.md).
+
+Actions are pinned by **full commit SHA** with a trailing `# vX` tag comment (for
+example `docker/login-action@650006c... # v4`). Dependabot bumps the SHA and the
+comment together; confirm they stay in sync.
+
+No lockfile is involved, so action PRs are loosely coupled. Two PRs can still
+conflict when they edit adjacent `uses:` lines in the same workflow file
+([`.github/workflows/main.yml`](../../../.github/workflows/main.yml) holds most
+pins), so merge sequentially and `@dependabot rebase` the next PR after each
+squash merge.
+
+## Operating modes
+
+| Mode         | Actions                              | Merge  |
+| ------------ | ------------------------------------ | ------ |
+| **Audit**    | List/classify; publisher + bump type | No     |
+| **Validate** | Diff review; CI green; actionlint    | No     |
+| **Full**     | Validate + merge with consent        | Per PR |
+
+Default to **Audit** unless the user asks to merge.
+
+## Phase 0 — Tool bootstrap
+
+```bash
+command -v gh >/dev/null && gh auth status
+# Optional local workflow lint (CI already runs actionlint in the `lint` job):
+#   bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
+```
+
+## Phase 1 — Discovery
+
+From repository root:
+
+```bash
+gh pr list --author 'app/dependabot' --state open \
+  --json number,title,headRefName,mergeable,statusCheckRollup \
+  --jq '.[] | select(.headRefName | test("^dependabot/github_actions/"))'
+```
+
+Match on `headRefName`, not the title. Titles such as "bump **go**releaser-action"
+or "bump **golang**ci-lint-action" trip the gomod skill's word filter but belong
+here. Confirm the diff only touches `.github/` (`gh pr diff <n> --name-only`).
+
+## Phase 2 — Risk
+
+| Level  | Examples                                                                                    | Action                       |
+| ------ | ------------------------------------------------------------------------------------------- | ---------------------------- |
+| Low    | Patch/minor bump, first-party publisher (`actions/`, `docker/`, `golangci/`, `goreleaser/`) | Merge after CI               |
+| Medium | Major bump (`v4` to `v5`); action used only in release/publish jobs                         | Read changelog; check inputs |
+| High   | New/untrusted publisher; SHA and `# vX` comment disagree; non-SHA (tag or branch) pin       | Hold; manual review          |
+
+Trusted publishers already in `.github/workflows/` carry low supply-chain risk. A
+**major** bump can change or remove `with:` inputs, so read the release notes and
+confirm the workflow still passes the right inputs.
+
+**Release-only caveat:** PR CI runs the workflows triggered by `pull_request`
+(`lint`, `test-nix`, `test-windows-smoke`). Jobs gated to releases or tags
+(`goreleaser`, `docker/login`, publish, `binaries-*`) show as `skipping` on the
+PR, so green CI does **not** exercise them. For those, lean on the changelog and
+trusted-publisher status.
+
+## Phase 3 — Validate
+
+- Required checks green on the current head (`gh pr checks <n>`). The `lint` job
+  runs `actionlint` over the workflow files.
+- SHA/tag consistency: the new `# vX` comment matches the tag for the bumped SHA.
+- Optional local lint after installing actionlint: `./actionlint -color`.
+- Stale-head guard: after any `@dependabot rebase`, re-check that the required
+  checks passed on the new `headRefOid` before merging.
+
+## Phase 4 — Merge (consent-gated)
+
+After required checks pass on the current head:
+
+```bash
+gh pr merge <n> --squash --delete-branch
+```
+
+Multiple action PRs: merge one, then `@dependabot rebase` the next and wait for
+`mergeable` plus fresh CI before merging it. Use `--admin` only when the user
+explicitly requests it and checks are green but merge is blocked.
+
+## Verdict template
+
+```markdown
+## Dependabot github-actions PR #NNN — <action>
+
+- **Publisher / bump:** first-party? patch | minor | major
+- **Runs on PR CI:** yes | release-only (not exercised)
+- **CI (lint/actionlint, test-nix):** pass / fail
+- **SHA vs tag comment:** consistent?
+- **Verdict:** merge | hold
+```
+
+See [AGENTS.md](../../../AGENTS.md#agent-skills-contributors) and
+[`docs/WORKFLOW.md`](../../../docs/WORKFLOW.md) for the CI job map.

--- a/.agents/skills/sq-actions-dependabot/SKILL.md
+++ b/.agents/skills/sq-actions-dependabot/SKILL.md
@@ -3,7 +3,8 @@ name: sq-actions-dependabot
 description: >-
   Reviews and merges Dependabot pull requests for GitHub Actions (the
   github-actions ecosystem) that bump `uses:` pins in `.github/workflows/`. Use
-  for dependabot github_actions PRs, not go.mod or site/ Bun PRs.
+  for Dependabot github_actions PRs (branches like `dependabot/github_actions/...`),
+  not go.mod or site/ Bun PRs.
 license: MIT
 compatibility: >-
   Requires gh CLI (authenticated) and network access to GitHub. actionlint is
@@ -58,13 +59,13 @@ From repository root:
 
 ```bash
 gh pr list --author 'app/dependabot' --state open \
-  --json number,title,headRefName,mergeable,statusCheckRollup \
+  --json number,title,headRefName,headRefOid,mergeable,statusCheckRollup \
   --jq '.[] | select(.headRefName | test("^dependabot/github_actions/"))'
 ```
 
 Match on `headRefName`, not the title. Titles such as "bump **go**releaser-action"
 or "bump **golang**ci-lint-action" trip the gomod skill's word filter but belong
-here. Confirm the diff only touches `.github/` (`gh pr diff <n> --name-only`).
+here. Confirm the diff only touches `.github/workflows/` (`gh pr diff <n> --name-only`).
 
 ## Phase 2 — Risk
 
@@ -78,9 +79,9 @@ Trusted publishers already in `.github/workflows/` carry low supply-chain risk. 
 **major** bump can change or remove `with:` inputs, so read the release notes and
 confirm the workflow still passes the right inputs.
 
-**Release-only caveat:** PR CI runs the workflows triggered by `pull_request`
-(`lint`, `test-nix`, `test-windows-smoke`). Jobs gated to releases or tags
-(`goreleaser`, `docker/login`, publish, `binaries-*`) show as `skipping` on the
+**Release-only caveat:** PR CI runs the jobs triggered by the `pull_request` event
+(`lint`, `test-nix`, `test-windows-smoke`). Steps and jobs gated to releases or tags
+(`goreleaser`, `docker/login`, publish, `binaries-*`) are skipped on the
 PR, so green CI does **not** exercise them. For those, lean on the changelog and
 trusted-publisher status.
 

--- a/.agents/skills/sq-gomod-dependabot/SKILL.md
+++ b/.agents/skills/sq-gomod-dependabot/SKILL.md
@@ -52,7 +52,7 @@ gh pr list --author 'app/dependabot' --state open \
   --jq '.[] | select(.headRefName | test("^dependabot/")) | select(.title | test("go|gomod|golang"; "i"))'
 ```
 
-The title filter matches `go`/`golang`, so it also catches github-actions PRs
+The title filter matches `go`/`golang`, so it also catches GitHub Actions PRs
 like `goreleaser-action` or `golangci-lint-action`. Those touch only
 `.github/workflows/`, not `go.mod`; hand them to
 [`sq-actions-dependabot`](../sq-actions-dependabot/SKILL.md). Confirm the PR does

--- a/.agents/skills/sq-gomod-dependabot/SKILL.md
+++ b/.agents/skills/sq-gomod-dependabot/SKILL.md
@@ -11,14 +11,16 @@ compatibility: >-
 metadata:
   author: Todd Papaioannou
   homepage: https://sq.io
-  version: "0.2.0"
+  version: "0.2.1"
 ---
 
 # sq-gomod-dependabot
 
 Maintainer workflow for Dependabot PRs updating [`go.mod`](../../../go.mod) /
 [`go.sum`](../../../go.sum) at the repository root. For [`site/`](../../../site/)
-Bun/Hugo PRs, use [`sq-site-dependabot`](../sq-site-dependabot/SKILL.md).
+Bun/Hugo PRs, use [`sq-site-dependabot`](../sq-site-dependabot/SKILL.md); for
+GitHub Actions pins under `.github/workflows/`, use
+[`sq-actions-dependabot`](../sq-actions-dependabot/SKILL.md).
 
 No `bun.lock` sequencing — multiple gomod PRs are less coupled than site PRs,
 but still prefer merging after CI is green.
@@ -50,8 +52,12 @@ gh pr list --author 'app/dependabot' --state open \
   --jq '.[] | select(.headRefName | test("^dependabot/")) | select(.title | test("go|gomod|golang"; "i"))'
 ```
 
-Confirm the PR does **not** only touch `site/` (`gh pr diff <n> --name-only`). If it
-touches both, split judgment: site hunks → `sq-site-dependabot`.
+The title filter matches `go`/`golang`, so it also catches github-actions PRs
+like `goreleaser-action` or `golangci-lint-action`. Those touch only
+`.github/workflows/`, not `go.mod`; hand them to
+[`sq-actions-dependabot`](../sq-actions-dependabot/SKILL.md). Confirm the PR does
+**not** only touch `site/` (`gh pr diff <n> --name-only`); if it touches both,
+split judgment: site hunks → `sq-site-dependabot`.
 
 ## Phase 2 — Risk
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -311,10 +311,14 @@ tree as documented in [`CONTRIBUTING.md`](./CONTRIBUTING.md).
 
 ### Skills in this repo
 
-| Skill                                                        | Use when                                                              |
-| ------------------------------------------------------------ | --------------------------------------------------------------------- |
-| [`sq-site-dependabot`](.agents/skills/sq-site-dependabot/)   | Triaging or merging Dependabot PRs for [`site/`](site/) (Bun / Hugo). |
-| [`sq-gomod-dependabot`](.agents/skills/sq-gomod-dependabot/) | Dependabot PRs for Go modules (`go.mod`/`go.sum`) at repo root.       |
+| Skill                                                            | Use when                                                              |
+| ---------------------------------------------------------------- | --------------------------------------------------------------------- |
+| [`sq-site-dependabot`](.agents/skills/sq-site-dependabot/)       | Triaging or merging Dependabot PRs for [`site/`](site/) (Bun / Hugo). |
+| [`sq-gomod-dependabot`](.agents/skills/sq-gomod-dependabot/)     | Dependabot PRs for Go modules (`go.mod`/`go.sum`) at repo root.       |
+| [`sq-actions-dependabot`](.agents/skills/sq-actions-dependabot/) | Dependabot PRs for GitHub Actions pins under `.github/workflows/`.    |
+
+These cover all four Dependabot ecosystems in [`.github/dependabot.yml`](.github/dependabot.yml):
+`gomod`, both `bun` manifests (`/` dev tooling and `/site`), and `github-actions`.
 
 Invoke explicitly when your agent supports it (e.g. `/sq-site-dependabot` in
 Cursor, `$sq-site-dependabot` in Codex) or ask to “clear site dependabot PRs”.
@@ -332,6 +336,7 @@ npx skills add <owner/repo> --skill <skill-name>
 ```bash
 npx skills add neilotoole/sq --skill sq-site-dependabot
 npx skills add neilotoole/sq --skill sq-gomod-dependabot
+npx skills add neilotoole/sq --skill sq-actions-dependabot
 ```
 
 **From a local checkout** (verify before opening a PR that touches skills):

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,9 +40,13 @@ Changes under `site/` are validated by
 live [sq.io](https://sq.io) updates on a manual **Site Publish (dispatch)** or a stable
 `sq` release.
 
-To triage or merge a batch of **Dependabot PRs** for `site/`, use the
-[`sq-site-dependabot`](./.agents/skills/sq-site-dependabot/) agent skill (invoke
-explicitly in your agent, e.g. `/sq-site-dependabot` in Cursor). See
+To triage or merge a batch of **Dependabot PRs**, use the matching agent skill
+(invoke explicitly in your agent, e.g. `/sq-site-dependabot` in Cursor):
+[`sq-site-dependabot`](./.agents/skills/sq-site-dependabot/) for `site/` (Bun /
+Hugo), [`sq-gomod-dependabot`](./.agents/skills/sq-gomod-dependabot/) for
+`go.mod`/`go.sum`, and
+[`sq-actions-dependabot`](./.agents/skills/sq-actions-dependabot/) for GitHub
+Actions pins under `.github/workflows/`. See
 [AGENTS.md](./AGENTS.md#agent-skills-contributors).
 
 ## Tooling


### PR DESCRIPTION
This pull request introduces a new agent skill for handling Dependabot PRs that update GitHub Actions pins and updates documentation to clarify when to use each skill for Dependabot PRs. The main changes are the addition of the `sq-actions-dependabot` skill, updates to the skill selection guidance in multiple docs, and improvements to the workflow for triaging PRs by ecosystem.

**New skill and documentation updates:**

* **New skill for GitHub Actions Dependabot PRs**
  - Added `.agents/skills/sq-actions-dependabot/SKILL.md`, documenting the workflow for reviewing and merging Dependabot PRs that bump `uses:` pins in `.github/workflows/`. This includes risk assessment, validation, and merge guidance specific to GitHub Actions updates.

* **Documentation and workflow improvements**
  - Updated `AGENTS.md` to add `sq-actions-dependabot` to the skills table, clarify which skill to use for each Dependabot ecosystem, and show how to add the new skill. [[1]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9L315-R321) [[2]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9R339)
  - Updated `CONTRIBUTING.md` to direct maintainers to use the appropriate skill for each type of Dependabot PR: `sq-site-dependabot` for site/Bun/Hugo, `sq-gomod-dependabot` for Go modules, and `sq-actions-dependabot` for GitHub Actions pins.

**Skill selection logic and filtering:**

* **Clarified filtering and assignment for PRs**
  - Improved the guidance in `sq-gomod-dependabot` (`.agents/skills/sq-gomod-dependabot/SKILL.md`) to clarify that PRs which only touch `.github/workflows/` (even if their titles match `go`/`golang`) should be handled by `sq-actions-dependabot`, not the Go modules skill.
  - Updated references in the Go modules skill to point to the new Actions skill and incremented its version.

These changes ensure each Dependabot PR is routed to the correct workflow and reviewed with the appropriate risk assessment and validation steps.