### PR TITLE
docs: sync overview help output and fix two broken links

### DIFF
--- a/drivers/sqlite3/testdata/README.md
+++ b/drivers/sqlite3/testdata/README.md
@@ -4,7 +4,7 @@
 
 [`sakila.db`](./sakila.db) contains the standard Sakila dataset. It can be regenerated
 from the `sqlite-sakila-X.sql` SQL scripts
-using [`recreate_sakila_sqlite.sh`](./recreate_sakila_sqlite.sh%60).
+using [`recreate_sakila_sqlite.sh`](./recreate_sakila_sqlite.sh).
 
 ## sakila_diff.db
 

--- a/site/README.md
+++ b/site/README.md
@@ -259,7 +259,7 @@ Note: `linkinator` timeouts are configured in **milliseconds** in
 - You can use the Hugo [alias](https://gohugo.io/content-management/urls/#aliases) mechanism to
   maintain an old path that will redirect to the new path.
 - If you need a redirect that's not associated with Hugo content, add an entry to
-  the [`static/_redirects`](/static/_redirects) file. This is what the site uses to
+  the [`static/_redirects`](./static/_redirects) file. This is what the site uses to
   serve the [sq.io/install.sh](https://sq.io/install.sh) script.
 
 ## Misc

--- a/site/content/en/docs/overview.md
+++ b/site/content/en/docs/overview.md
@@ -106,16 +106,18 @@ Available Commands:
   ping        Ping data sources
   sql         Execute DB-native SQL query or statement
   tbl         Useful table actions (copy, truncate, drop)
+  db          Useful database actions
   diff        BETA: Compare sources, or tables
   driver      Manage drivers
   config      Manage config
   cache       Manage cache
-  completion  Generate shell completion script
   version     Show version info
   help        Show help
+  completion  Generate the autocompletion script for the specified shell
 
 Flags:
   -f, --format string                  Specify output format (default "text")
+      --format.decimal string          Render decimal as string or number (JSON, YAML) (default "string")
   -t, --text                           Output text
   -h, --header                         Print header row (default true)
   -H, --no-header                      Don't print header row
@@ -132,6 +134,7 @@ Flags:
       --xml                            Output XML
   -y, --yaml                           Output YAML
   -c, --compact                        Compact instead of pretty-printed output
+      --format.html.embed-assets       Embed assets (Mermaid.js) in HTML output for offline use
       --format.datetime string         Timestamp format: constant such as RFC3339 or a strftime format (default "RFC3339")
       --format.datetime.number         Render numeric datetime value as number instead of string (default true)
       --format.date string             Date format: constant such as DateOnly or a strftime format (default "DateOnly")
@@ -144,21 +147,28 @@ Flags:
   -o, --output string                  Write output to <file> instead of stdout
       --insert string                  Insert query results into @HANDLE.TABLE; if not existing, TABLE will be created
       --src string                     Override active source for this query
-      --src.schema string              Override active schema or catalog.schema for this query
+      --src.schema string              Override active schema (and/or catalog) for this query
       --ingest.driver string           Explicitly specify driver to use for ingesting data
-      --ingest.header                  Treat first row of ingest data as header
-      --no-cache                       Cache ingest data
-      --driver.csv.empty-as-null       Treat empty CSV fields as null (default true)
-      --driver.csv.delim string        CSV delimiter: one of comma, space, pipe, tab, colon, semi, period (default "comma")
+      --ingest.header                  Ingest data has a header row
+      --no-cache                       Don't cache ingest data
+      --driver.csv.delim string        Delimiter for ingest CSV data (default "comma")
+      --driver.csv.empty-as-null       Treat ingest empty CSV fields as NULL (default true)
+      --render-sql                     Render the SLQ to SQL without executing it
       --version                        Print version info
-  -M, --monochrome                     Don't colorize output
-      --no-progress                    Progress bar for long-running operations
-  -v, --verbose                        Verbose output
+  -M, --monochrome                     Don't print color output
+      --no-progress                    Don't show progress bar
+      --reveal                         Show secret values in output (don't redact passwords; print keyring values)
+      --no-redact                      Don't redact passwords in output (deprecated, use --reveal)
+      --expand                         Resolve ${scheme:path} placeholders to their underlying values
+  -v, --verbose                        Print verbose output
+      --debug.pprof string             pprof profiling mode (default "off")
       --config string                  Load config from here
       --log                            Enable logging
-      --log.file string                Path to log file; empty disables logging
-      --log.level string               Log level: one of DEBUG, INFO, WARN, ERROR
-      --log.format string              Log format: one of "text" or "json"
+      --log.file string                Log file path (default "$HOME/Library/Logs/sq/sq.log")
+      --log.level string               Log level, one of: DEBUG, INFO, WARN, ERROR (default "DEBUG")
+      --log.format string              Log output format (text or json) (default "text")
+      --error.format string            Error output format (default "text")
+  -E, --error.stack                    Print error stack trace to stderr
 ```
 
 ## Issues


### PR DESCRIPTION
Three small docs fixes, no code changes.

**`site/content/en/docs/overview.md`** — the command and flag listing embedded in the page had drifted from the generated help in `site/content/en/docs/cmd/sq.help.txt`. Two descriptions were the inverse of what the flag actually does:

| flag | page said | actual (`sq.help.txt`, `cli/output.go`) |
|---|---|---|
| `--no-cache` | Cache ingest data | Don't cache ingest data |
| `--no-progress` | Progress bar for long-running operations | Don't show progress bar |

The block was also missing the `db` command and several flags (`--format.decimal`, `--render-sql`, `--reveal`, `--expand`, `--error.format`, `-E/--error.stack`, others). I replaced it wholesale with the current contents of `sq.help.txt` rather than patching line by line.

**`drivers/sqlite3/testdata/README.md`** — a stray `%60` (escaped backtick) had leaked into the link target, so the `recreate_sakila_sqlite.sh` link 404s.

**`site/README.md`** — the `static/_redirects` link was root-absolute (`/static/_redirects`), which resolves to `github.com/neilotoole/sq/static/_redirects` and doesn't exist; the file is at `site/static/_redirects`.