### PR TITLE
docs(install): document SQLite build tags for source installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,8 @@ scoop install sq
 ### Source
 
 Prefer a package manager above, or a [release binary](https://github.com/neilotoole/sq/releases).
-A source build needs the SQLite build tags, and reports its version as `v0.0.0-dev`.
+`go install` needs the SQLite build tags, and its binary reports version `v0.0.0-dev`; use
+`make install` from a clone for a version-stamped build.
 
 ```shell
 go install -tags "sqlite_vtable sqlite_stat4 sqlite_fts5 sqlite_introspect sqlite_json sqlite_math_functions" \

--- a/README.md
+++ b/README.md
@@ -86,10 +86,14 @@ scoop bucket add sq https://github.com/neilotoole/sq
 scoop install sq
 ```
 
-### Go
+### Source
+
+Prefer a package manager above, or a [release binary](https://github.com/neilotoole/sq/releases).
+A source build needs the SQLite build tags, and reports its version as `v0.0.0-dev`.
 
 ```shell
-go install github.com/neilotoole/sq@latest
+go install -tags "sqlite_vtable sqlite_stat4 sqlite_fts5 sqlite_introspect sqlite_json sqlite_math_functions" \
+  github.com/neilotoole/sq@latest
 ```
 
 ### Docker

--- a/site/content/en/docs/install.md
+++ b/site/content/en/docs/install.md
@@ -9,7 +9,7 @@ toc: true
 url: /docs/install
 ---
 
-`sq` can be installed from source, via an install script, or via package managers for various platforms.
+`sq` can be installed via an install script, via package managers for various platforms, or from source.
 
 ## Quick install
 
@@ -48,11 +48,17 @@ sq completion --help
 
 ## Source
 
-Requires [Go](https://go.dev/dl/).
+Requires [Go](https://go.dev/dl/). The build tags enable the SQLite features that `sq` needs.
+Without them, FTS5 tables cannot be read, and the SQLite math functions are missing.
 
 ```shell
-go install github.com/neilotoole/sq@latest
+go install -tags "sqlite_vtable sqlite_stat4 sqlite_fts5 sqlite_introspect sqlite_json sqlite_math_functions" \
+  github.com/neilotoole/sq@latest
 ```
+
+A binary installed this way reports its version as `v0.0.0-dev`, so `sq version` always shows that
+an update is available. To get a stamped version, build from a clone with `make install`, which sets
+the build tags and the version ldflags.
 
 ## Binaries
 


### PR DESCRIPTION
Fixes #1130.

The documented `go install` command in `README.md` and `site/content/en/docs/install.md` omitted the
SQLite build tags that `Makefile:26`, all four `.goreleaser-*.yml` configs and all three CI workflows
pass. Users following the install docs got a binary missing SQLite features the release artifacts have.

## Verified

Built both ways from the current latest tag and exercised the result:

| | without tags (old docs) | with tags (new docs) |
| --- | --- | --- |
| `sq inspect` on an FTS5 db | `no such module: fts5` | 20 tables listed |
| `select sqrt(4)` | `no such function: sqrt` | `2` |

`sq version` on a `go install`ed binary prints `sq v0.0.0-dev    Update available: v0.54.1`, which is
the second half of the issue. `-tags` is accepted alongside `pkg@version`, so the fix fits in the
existing one-command shape.

## Changes

- Add the build tags to the `go install` command in both files.
- Note the `v0.0.0-dev` version stamping, and point at `make install` for a source build that sets
  both the tags and the version ldflags.
- Demote the source path: rename the README `### Go` heading to `### Source`, point at a package
  manager or a release binary first, and reorder the install.md intro sentence to mention source last.

## Not done

The issue floated a `debug.ReadBuildInfo()` fallback in `cli/buildinfo` as an alternative to
documenting the `v0.0.0-dev` behavior. Taking the documentation route here instead, since `go install`
is not the path we want to steer people toward. Worth reconsidering separately if the false "update
available" report generates support noise.

`make fmt-check` passes.
