### PR TITLE
site: run Hugo dev server directly on 1313, drop proxy

### DIFF
--- a/site/scripts/dev-server.js
+++ b/site/scripts/dev-server.js
@@ -1,42 +1,20 @@
 /**
  * Local dev server: generates the build-time version data file (honoring
- * SQ_SITE_OFFLINE), then runs Hugo and proxies to it. No Netlify required
- * locally.
+ * SQ_SITE_OFFLINE), then runs Hugo directly on PORT (default 1313). No Netlify
+ * required locally.
  *
  * site/Makefile passes SQ_SITE_OFFLINE=1 by default for site-local, so the
  * header badge shows the committed last-known version without a network call;
  * use SQ_SITE_OFFLINE=0 make site-local to fetch the latest from GitHub.
  */
 
-const http = require("http");
 const path = require("path");
 const { spawn, spawnSync } = require("child_process");
 const { requireHugoBin } = require("./resolve-hugo.js");
 
-const HUGO_PORT = Number(process.env.HUGO_PORT) || 1314;
-const SERVER_PORT = Number(process.env.SERVER_PORT) || process.env.PORT || 1313;
+const PORT = Number(process.env.PORT) || 1313;
 
 const hugoBin = requireHugoBin();
-
-function waitForHugo() {
-  return new Promise((resolve, reject) => {
-    const deadline = Date.now() + 60000;
-    function tryFetch() {
-      if (Date.now() > deadline) {
-        reject(new Error("Hugo did not become ready in time"));
-        return;
-      }
-      const req = http.get(`http://127.0.0.1:${HUGO_PORT}/`, (res) => {
-        res.resume();
-        resolve();
-      });
-      req.on("error", () => {
-        setTimeout(tryFetch, 300);
-      });
-    }
-    tryFetch();
-  });
-}
 
 // Bake the GitHub data file before Hugo starts (honors SQ_SITE_OFFLINE).
 spawnSync("bun", [path.join(__dirname, "gen-site-data.js")], {
@@ -48,7 +26,7 @@ spawnSync("bun", [path.join(__dirname, "gen-site-data.js")], {
 const hugoArgs = [
   "server",
   "--port",
-  String(HUGO_PORT),
+  String(PORT),
   "--bind",
   "0.0.0.0",
   "--disableFastRender",
@@ -70,38 +48,10 @@ hugo.on("error", (err) => {
 });
 
 hugo.on("exit", (code) => {
-  if (code != null && code !== 0) process.exit(code);
+  process.exit(code ?? 0);
 });
 
-const server = http.createServer((req, res) => {
-  // Proxy to Hugo.
-  const proxyReq = http.request(
-    {
-      hostname: "127.0.0.1",
-      port: HUGO_PORT,
-      path: req.url,
-      method: req.method,
-      headers: req.headers,
-    },
-    (proxyRes) => {
-      res.writeHead(proxyRes.statusCode ?? 200, proxyRes.headers);
-      proxyRes.pipe(res);
-    },
-  );
-  proxyReq.on("error", () => {
-    res.writeHead(502, { "Content-Type": "text/plain" });
-    res.end("Bad Gateway");
-  });
-  req.pipe(proxyReq);
-});
-
-waitForHugo()
-  .then(() => {
-    server.listen(SERVER_PORT, "0.0.0.0", () => {
-      console.log(`Dev server at http://localhost:${SERVER_PORT} (Hugo)`);
-    });
-  })
-  .catch((err) => {
-    console.error(err);
-    process.exit(1);
-  });
+// Forward termination signals so Hugo isn't orphaned when the wrapper is killed.
+for (const sig of ["SIGINT", "SIGTERM"]) {
+  process.on(sig, () => hugo.kill(sig));
+}


### PR DESCRIPTION
## Summary

`make site-local` printed two servers starting: Hugo on `:1314` and a "Dev server" on `:1313`. The second was a Node HTTP proxy in `site/scripts/dev-server.js` that forwarded every request to Hugo.

The proxy originally existed to serve `GET /version` locally, emulating the Netlify function behind the header version badge. That handler was removed in #690 when the badge moved to build-time data (`gen-site-data.js`), leaving a pass-through proxy that only added a hop, a `502 Bad Gateway` failure mode, and a confusing second server line in the startup output.

## Changes

- Drop the proxy and the `waitForHugo` poller. The script now runs `gen-site-data.js` and spawns Hugo directly on `PORT` (default 1313).
- Collapse `HUGO_PORT` / `SERVER_PORT` into a single `PORT`. `HUGO_BASEURL` and `SQ_SITE_OFFLINE` behavior are unchanged.
- Forward `SIGINT` / `SIGTERM` to the Hugo child so killing the wrapper by PID no longer orphans Hugo (the old script had the same problem).

No docs or Makefile changes needed: `site/Makefile` already describes Hugo on `:1313`, and nothing else referenced `:1314` or the proxy env vars.

## Verification

- `make site-local`: Hugo answers `200` on `:1313`, nothing listens on `:1314`, startup log shows a single `Web Server is available at http://localhost:1313/` line.
- `SIGTERM` to the Bun wrapper stops Hugo as well.
- `bunx dprint check site/scripts/dev-server.js` passes.

https://claude.ai/code/session_01CuXc9DQWFxqthoZK8dXE8T
