### PR TITLE
fix(genxlsx): handle discarded sql.Rows.Close errors

### DIFF
--- a/drivers/xlsx/internal/genxlsx/main.go
+++ b/drivers/xlsx/internal/genxlsx/main.go
@@ -175,7 +175,7 @@ func buildWorkbook(ctx context.Context, db *sql.DB, file string, tables []string
 			for j, c := range cols {
 				cell, _ := excelize.CoordinatesToCellName(j+1, rowIdx)
 				if err = f.SetCellStr(table, cell, c.name); err != nil {
-					dataRows.Close()
+					_ = dataRows.Close()
 					return err
 				}
 			}
@@ -190,7 +190,7 @@ func buildWorkbook(ctx context.Context, db *sql.DB, file string, tables []string
 
 		for dataRows.Next() {
 			if err = dataRows.Scan(ptrs...); err != nil {
-				dataRows.Close()
+				_ = dataRows.Close()
 				return err
 			}
 			for j, c := range cols {
@@ -199,17 +199,17 @@ func buildWorkbook(ctx context.Context, db *sql.DB, file string, tables []string
 				}
 				cell, _ := excelize.CoordinatesToCellName(j+1, rowIdx)
 				if err = writeCell(f, table, cell, c, vals[j].String); err != nil {
-					dataRows.Close()
+					_ = dataRows.Close()
 					return err
 				}
 			}
 			rowIdx++
 		}
 		if err = dataRows.Err(); err != nil {
-			dataRows.Close()
+			_ = dataRows.Close()
 			return err
 		}
-		dataRows.Close()
+		_ = dataRows.Close()
 	}
 
 	// Drop the default empty sheet that NewFile creates.


### PR DESCRIPTION
`make lint` fails on a clean checkout of master when run on macOS:

```
drivers/xlsx/internal/genxlsx/main.go:178:6  revive  unhandled-error: Unhandled error in call to function database/sql.Rows.Close
drivers/xlsx/internal/genxlsx/main.go:193:5  revive  unhandled-error: ...
drivers/xlsx/internal/genxlsx/main.go:202:6  revive  unhandled-error: ...
```

CI does not see these, so the local gate and CI disagree and macOS
contributors hit a red `make lint` before writing a line.

## The fix

`buildWorkbook` calls `dataRows.Close()` bare, discarding the returned error.
This marks the discards explicit with `_ =`, which is the idiom already used
in about 25 places in this repo, including bare discards in error paths
(`cli/output/xlsxw/xlsxw.go:389`, `cli/config/yamlstore/yamlstore.go:333`).

The Close error is genuinely not actionable at these call sites. Three are
error paths that already return a more useful error, and the other two close
the rows at the end of a successful iteration.

## There were five, not three

golangci-lint reported three, but the file has five bare `dataRows.Close()`
calls. `.golangci.yml` sets `issues.max-same-issues: 3`, which capped the
report. Rerunning with `--max-same-issues 0` shows all five:

```
main.go:178:6, 193:5, 202:6, 209:4, 212:3
```

All five are fixed here. Fixing only the three reported would have left two
behind for the next person to trip over.

## Why CI never caught this

The divergence is platform-dependent, not a config or version problem. Using
the identical official golangci-lint release binary (same build hash
`c0d3ddc9`), the same `.golangci.yml`, the same commit, and `GOTOOLCHAIN=local`:

| Platform | Result |
|----------|--------|
| linux/amd64 (CI) | 0 issues |
| darwin/arm64 | 3 issues (5 uncapped) |

Ruled out individually: config resolution, golangci-lint build, Go toolchain
version (1.26.3 and 1.26.5 both give 0 on Linux and 3 on darwin), cgo and
package loading (`CGO_ENABLED=1`, gcc present, `go list` resolves the package
fine on Linux), whole-repo versus subpath invocation, and local working-tree
state (reproduced against a pristine `git archive` of master). Upgrading to
golangci-lint v2.13.2 does not change it either.

I did not identify the root cause inside golangci-lint or revive, only that
platform is the discriminator with every other variable held constant. Fixing
the code sidesteps it: both platforms now agree, under both versions.

## Verification

- Full-repo `golangci-lint run --max-same-issues 0` on darwin: 0 issues
  (was 5). This is the first time `make lint`'s Go step passes on macOS.
- `go build ./...`, `go vet ./drivers/xlsx/...`, `go test ./drivers/xlsx/...`,
  and `make fmt` all pass.

## Note

An alternative fix is to extract the per-table loop body into a helper so a
single `defer` replaces all five calls. That is arguably cleaner, but it
restructures a tool that regenerates committed fixtures, so I kept this change
to the error handling alone. Happy to do the refactor separately if preferred.
