### PR TITLE
refactor(jsonw): single source for the jsoncolor palette

### DIFF
--- a/cli/output/jsonw/internal/colors_test.go
+++ b/cli/output/jsonw/internal/colors_test.go
@@ -1,0 +1,51 @@
+package internal_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/neilotoole/sq/cli/output"
+	"github.com/neilotoole/sq/cli/output/jsonw/internal"
+)
+
+// TestNewColors_Clipped asserts each Color's Prefix and Suffix have no spare
+// capacity. Both are cut from one buffer holding "prefix + space + suffix", so
+// without clipping each retains the other's bytes and, worse, an append to one
+// would write into the shared backing array rather than allocating. These
+// slices outlive the buffer: they are handed to a long-lived *jsoncolor.Colors
+// via JSONPalette, and jsoncolor.Color is an exported []byte that a consumer
+// could append to.
+func TestNewColors_Clipped(t *testing.T) {
+	pr := output.NewPrinting()
+	pr.EnableColor(true)
+	require.False(t, pr.IsMonochrome())
+
+	c := internal.NewColors(pr)
+
+	cases := []struct {
+		name string
+		clr  internal.Color
+	}{
+		{"Null", c.Null},
+		{"Bool", c.Bool},
+		{"Number", c.Number},
+		{"String", c.String},
+		{"Key", c.Key},
+		{"Bytes", c.Bytes},
+		{"Time", c.Time},
+		{"Punc", c.Punc},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.NotEmpty(t, tc.clr.Prefix, "fixture should carry a prefix")
+			require.Equal(t, len(tc.clr.Prefix), cap(tc.clr.Prefix),
+				"Prefix must be clipped: len %d, cap %d",
+				len(tc.clr.Prefix), cap(tc.clr.Prefix))
+			require.Equal(t, len(tc.clr.Suffix), cap(tc.clr.Suffix),
+				"Suffix must be clipped: len %d, cap %d",
+				len(tc.clr.Suffix), cap(tc.clr.Suffix))
+		})
+	}
+}

--- a/cli/output/jsonw/internal/internal.go
+++ b/cli/output/jsonw/internal/internal.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"slices"
 	"strconv"
 
 	fcolor "github.com/fatih/color"
@@ -100,7 +101,11 @@ func newColor(c *fcolor.Color) Color {
 		return Color{}
 	}
 
-	return Color{Prefix: b[:i], Suffix: b[i+1:]}
+	// Clip both halves. They are cut from the same buffer, so without this
+	// each retains the other's bytes, and an append to one would write into
+	// the shared backing array instead of allocating. These slices outlive b:
+	// JSONPalette hands them to a long-lived *jsoncolor.Colors.
+	return Color{Prefix: slices.Clip(b[:i]), Suffix: slices.Clip(b[i+1:])}
 }
 
 // NewColors builds a Colors instance from a Printing instance.

--- a/cli/output/jsonw/internal/internal_test.go
+++ b/cli/output/jsonw/internal/internal_test.go
@@ -25,31 +25,6 @@ type Encoder interface {
 // jsoncolor.Encoder satisfies the Encoder interface.
 var _ Encoder = (*jsoncolor.Encoder)(nil)
 
-// toJSONColorPalette converts an internal.Colors (prefix+suffix per token)
-// to a *jsoncolor.Colors (prefix-only; jsoncolor emits its own fixed reset).
-// Returns nil when c is the zero value (i.e., no colorization active).
-//
-// This mirrors jsonw.newJSONColorPalette, which cannot be imported here
-// without creating an import cycle through the internal package.
-func toJSONColorPalette(c internal.Colors) *jsoncolor.Colors {
-	if len(c.Null.Prefix) == 0 && len(c.Bool.Prefix) == 0 &&
-		len(c.Number.Prefix) == 0 && len(c.String.Prefix) == 0 &&
-		len(c.Key.Prefix) == 0 && len(c.Bytes.Prefix) == 0 &&
-		len(c.Time.Prefix) == 0 && len(c.Punc.Prefix) == 0 {
-		return nil
-	}
-	return &jsoncolor.Colors{
-		Null:   jsoncolor.Color(c.Null.Prefix),
-		Bool:   jsoncolor.Color(c.Bool.Prefix),
-		Number: jsoncolor.Color(c.Number.Prefix),
-		String: jsoncolor.Color(c.String.Prefix),
-		Key:    jsoncolor.Color(c.Key.Prefix),
-		Bytes:  jsoncolor.Color(c.Bytes.Prefix),
-		Time:   jsoncolor.Color(c.Time.Prefix),
-		Punc:   jsoncolor.Color(c.Punc.Prefix),
-	}
-}
-
 func TestEncode(t *testing.T) {
 	testCases := []struct {
 		name    string
@@ -156,7 +131,7 @@ func TestEncode(t *testing.T) {
 			enc := jsoncolor.NewEncoder(buf)
 			enc.SetEscapeHTML(false)
 			enc.SetSortMapKeys(tc.sortMap)
-			enc.SetColors(toJSONColorPalette(internal.NewColors(pr)))
+			enc.SetColors(internal.NewColors(pr).JSONPalette())
 
 			if !pr.Compact {
 				enc.SetIndent("", pr.Indent)
@@ -218,7 +193,7 @@ func TestEncode_Slice(t *testing.T) {
 			buf := &bytes.Buffer{}
 			enc := jsoncolor.NewEncoder(buf)
 			enc.SetEscapeHTML(false)
-			enc.SetColors(toJSONColorPalette(internal.NewColors(pr)))
+			enc.SetColors(internal.NewColors(pr).JSONPalette())
 			if !pr.Compact {
 				enc.SetIndent("", "  ")
 			}
@@ -269,7 +244,7 @@ func TestEncode_SmallStruct(t *testing.T) {
 			enc := jsoncolor.NewEncoder(buf)
 			enc.SetEscapeHTML(false)
 			enc.SetSortMapKeys(true)
-			enc.SetColors(toJSONColorPalette(internal.NewColors(pr)))
+			enc.SetColors(internal.NewColors(pr).JSONPalette())
 
 			if !pr.Compact {
 				enc.SetIndent("", "  ")
@@ -322,7 +297,7 @@ func TestEncode_Map_Nested(t *testing.T) {
 			enc := jsoncolor.NewEncoder(buf)
 			enc.SetEscapeHTML(false)
 			enc.SetSortMapKeys(true)
-			enc.SetColors(toJSONColorPalette(internal.NewColors(pr)))
+			enc.SetColors(internal.NewColors(pr).JSONPalette())
 
 			if !pr.Compact {
 				enc.SetIndent("", "  ")
@@ -407,7 +382,7 @@ func TestEncode_Map_StringNotInterface(t *testing.T) {
 			enc := jsoncolor.NewEncoder(buf)
 			enc.SetEscapeHTML(false)
 			enc.SetSortMapKeys(tc.sortMap)
-			enc.SetColors(toJSONColorPalette(internal.NewColors(pr)))
+			enc.SetColors(internal.NewColors(pr).JSONPalette())
 			if !pr.Compact {
 				enc.SetIndent("", pr.Indent)
 			}
@@ -470,7 +445,7 @@ func TestEncode_RawMessage(t *testing.T) {
 			enc := jsoncolor.NewEncoder(buf)
 			enc.SetEscapeHTML(false)
 			enc.SetSortMapKeys(true)
-			enc.SetColors(toJSONColorPalette(internal.NewColors(pr)))
+			enc.SetColors(internal.NewColors(pr).JSONPalette())
 			if !pr.Compact {
 				enc.SetIndent("", pr.Indent)
 			}
@@ -551,7 +526,7 @@ func TestEncode_Map_StringRawMessage(t *testing.T) {
 			enc := jsoncolor.NewEncoder(buf)
 			enc.SetEscapeHTML(false)
 			enc.SetSortMapKeys(tc.sortMap)
-			enc.SetColors(toJSONColorPalette(internal.NewColors(pr)))
+			enc.SetColors(internal.NewColors(pr).JSONPalette())
 			if !pr.Compact {
 				enc.SetIndent("", pr.Indent)
 			}
@@ -591,7 +566,7 @@ func TestEncode_BigStruct(t *testing.T) {
 			enc := jsoncolor.NewEncoder(buf)
 			enc.SetEscapeHTML(false)
 			enc.SetSortMapKeys(true)
-			enc.SetColors(toJSONColorPalette(internal.NewColors(pr)))
+			enc.SetColors(internal.NewColors(pr).JSONPalette())
 
 			if !pr.Compact {
 				enc.SetIndent("", "  ")
@@ -620,7 +595,7 @@ func TestEncode_Map_Not_StringInterface(t *testing.T) {
 	enc := jsoncolor.NewEncoder(buf)
 	enc.SetEscapeHTML(false)
 	enc.SetSortMapKeys(true)
-	enc.SetColors(toJSONColorPalette(internal.NewColors(pr)))
+	enc.SetColors(internal.NewColors(pr).JSONPalette())
 	if !pr.Compact {
 		enc.SetIndent("", "  ")
 	}

--- a/cli/output/jsonw/internal/jsonpalette.go
+++ b/cli/output/jsonw/internal/jsonpalette.go
@@ -1,0 +1,38 @@
+package internal
+
+import (
+	"github.com/neilotoole/jsoncolor"
+)
+
+// JSONPalette returns c as a *jsoncolor.Colors, or nil if c carries no
+// prefixes at all. The encoder treats a nil palette as "no colorization",
+// which is what NewColors yields for a nil or monochrome Printing.
+//
+// A jsoncolor.Color is the ANSI prefix only: jsoncolor emits its own fixed
+// reset after every colored token, whereas fatih/color emits
+// attribute-specific resets (\x1b[22m for Bold/Faint, for instance). The two
+// are visually equivalent but not byte-identical, so each Color's Suffix is
+// deliberately discarded in favor of jsoncolor's reset.
+//
+// This is the only conversion from Colors to a jsoncolor palette. Both the
+// JSON writers and this package's encode tests go through it, so the encoder
+// is configured identically in production and under test.
+func (c Colors) JSONPalette() *jsoncolor.Colors {
+	if len(c.Null.Prefix) == 0 && len(c.Bool.Prefix) == 0 &&
+		len(c.Number.Prefix) == 0 && len(c.String.Prefix) == 0 &&
+		len(c.Key.Prefix) == 0 && len(c.Bytes.Prefix) == 0 &&
+		len(c.Time.Prefix) == 0 && len(c.Punc.Prefix) == 0 {
+		return nil
+	}
+
+	return &jsoncolor.Colors{
+		Null:   c.Null.Prefix,
+		Bool:   c.Bool.Prefix,
+		Number: c.Number.Prefix,
+		String: c.String.Prefix,
+		Key:    c.Key.Prefix,
+		Bytes:  c.Bytes.Prefix,
+		Time:   c.Time.Prefix,
+		Punc:   c.Punc.Prefix,
+	}
+}

--- a/cli/output/jsonw/internal/jsonpalette_test.go
+++ b/cli/output/jsonw/internal/jsonpalette_test.go
@@ -1,0 +1,66 @@
+package internal_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/neilotoole/sq/cli/output"
+	"github.com/neilotoole/sq/cli/output/jsonw/internal"
+)
+
+// TestColors_JSONPalette covers the single conversion from internal.Colors to
+// a *jsoncolor.Colors. Both the JSON writers and this package's own encode
+// tests go through it, so the encoder is configured identically in production
+// and under test.
+func TestColors_JSONPalette(t *testing.T) {
+	t.Run("zero_value_is_nil", func(t *testing.T) {
+		require.Nil(t, internal.Colors{}.JSONPalette(),
+			"a Colors carrying no prefixes means no colorization")
+	})
+
+	t.Run("nil_printing_is_nil", func(t *testing.T) {
+		require.Nil(t, internal.NewColors(nil).JSONPalette())
+	})
+
+	t.Run("monochrome_is_nil", func(t *testing.T) {
+		pr := output.NewPrinting()
+		pr.EnableColor(false)
+		require.True(t, pr.IsMonochrome())
+		require.Nil(t, internal.NewColors(pr).JSONPalette())
+	})
+
+	t.Run("colored_carries_prefixes", func(t *testing.T) {
+		pr := output.NewPrinting()
+		pr.EnableColor(true)
+		require.False(t, pr.IsMonochrome())
+
+		c := internal.NewColors(pr)
+		pal := c.JSONPalette()
+		require.NotNil(t, pal)
+
+		cases := []struct {
+			name string
+			want internal.Color
+			got  []byte
+		}{
+			{"Null", c.Null, pal.Null},
+			{"Bool", c.Bool, pal.Bool},
+			{"Number", c.Number, pal.Number},
+			{"String", c.String, pal.String},
+			{"Key", c.Key, pal.Key},
+			{"Bytes", c.Bytes, pal.Bytes},
+			{"Time", c.Time, pal.Time},
+			{"Punc", c.Punc, pal.Punc},
+		}
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				require.NotEmpty(t, tc.want.Prefix, "fixture should carry a prefix")
+				require.Equal(t, string(tc.want.Prefix), string(tc.got),
+					"palette field must be the Color's prefix")
+				require.NotContains(t, string(tc.got), string(tc.want.Suffix),
+					"jsoncolor emits its own reset, so the suffix must be discarded")
+			})
+		}
+	})
+}

--- a/cli/output/jsonw/palette.go
+++ b/cli/output/jsonw/palette.go
@@ -1,55 +1,19 @@
 package jsonw
 
 import (
-	"bytes"
-
-	"github.com/fatih/color"
-
 	"github.com/neilotoole/jsoncolor"
 
 	"github.com/neilotoole/sq/cli/output"
+	"github.com/neilotoole/sq/cli/output/jsonw/internal"
 )
 
-// newJSONColorPalette returns a *jsoncolor.Colors built from pr's
-// fatih/color fields. Returns nil for nil or monochrome Printing,
-// which disables colorization at the encoder level.
+// newJSONColorPalette returns the *jsoncolor.Colors for pr, or nil for a nil
+// or monochrome Printing, which disables colorization at the encoder level.
 //
-// jsoncolor.Color is just a []byte of the ANSI prefix; jsoncolor emits
-// a hardcoded \x1b[0m as the suffix after every colored token.
-// fatih/color emits attribute-specific resets (e.g. \x1b[22m for
-// Bold/Faint), so the two reset sequences are visually equivalent but
-// not byte-identical. The adapter intentionally discards fatih/color's
-// suffix in favor of jsoncolor's own reset.
+// Both the mapping and the nil behavior live in internal.Colors.JSONPalette,
+// so these writers and the internal package's own encode tests configure the
+// encoder identically. See that method for why each Color's suffix is
+// discarded.
 func newJSONColorPalette(pr *output.Printing) *jsoncolor.Colors {
-	if pr == nil || pr.IsMonochrome() {
-		return nil
-	}
-
-	return &jsoncolor.Colors{
-		Null:   jsonColorPrefix(pr.Null),
-		Bool:   jsonColorPrefix(pr.Bool),
-		Number: jsonColorPrefix(pr.Number),
-		String: jsonColorPrefix(pr.String),
-		Key:    jsonColorPrefix(pr.Key),
-		Bytes:  jsonColorPrefix(pr.Bytes),
-		Time:   jsonColorPrefix(pr.Datetime),
-		Punc:   jsonColorPrefix(pr.Punc),
-	}
-}
-
-// jsonColorPrefix returns the ANSI prefix bytes that c writes before a
-// value. It mirrors the prefix-extraction trick from internal.newColor
-// but discards the suffix (jsoncolor uses a fixed reset).
-func jsonColorPrefix(c *color.Color) jsoncolor.Color {
-	if c == nil {
-		return nil
-	}
-	c2 := *c
-	c2.EnableColor()
-	b := []byte(c2.Sprint(" "))
-	i := bytes.IndexByte(b, ' ')
-	if i <= 0 {
-		return nil
-	}
-	return jsoncolor.Color(b[:i])
+	return internal.NewColors(pr).JSONPalette()
 }

--- a/cli/output/jsonw/pingwriter.go
+++ b/cli/output/jsonw/pingwriter.go
@@ -15,12 +15,17 @@ var _ output.PingWriter = (*pingWriter)(nil)
 
 // NewPingWriter returns JSON impl of output.PingWriter.
 func NewPingWriter(out io.Writer, pr *output.Printing) output.PingWriter {
-	return &pingWriter{out: out, pr: pr}
+	return &pingWriter{out: out, pr: pr, pal: newJSONColorPalette(pr)}
 }
 
 type pingWriter struct {
 	out io.Writer
 	pr  *output.Printing
+
+	// pal is built once at construction. Result is called once per source,
+	// and pr's colors are fixed for the writer's lifetime, so rebuilding the
+	// palette per source would repeat the same work for every source pinged.
+	pal *jsoncolor.Colors
 }
 
 // Open implements output.PingWriter.
@@ -61,7 +66,7 @@ func (p pingWriter) Result(src *source.Source, d time.Duration, err error) error
 	}
 
 	enc := jsoncolor.NewEncoder(p.out)
-	enc.SetColors(newJSONColorPalette(p.pr))
+	enc.SetColors(p.pal)
 	enc.SetEscapeHTML(false)
 	enc.SetIndent("", "  ")
 


### PR DESCRIPTION
Supersedes #1099, which set out to remove the duplicated palette mapping.
This takes the same approach and finishes it. Credit to @no-hup for
identifying the duplication and for the `internal.NewColors` direction.

## The duplication

The `Printing` to `jsoncolor.Colors` mapping existed twice:

- `newJSONColorPalette` in `cli/output/jsonw/palette.go`, via the
  `jsonColorPrefix` helper.
- `toJSONColorPalette` in `cli/output/jsonw/internal/internal_test.go`, used
  by the nine encode tests in that file.

Worse than the duplication, the two had **different nil rules**.
`newJSONColorPalette` returned nil for a nil or monochrome `Printing`, while
the test helper returned nil when every prefix was empty. So the encoder could
be configured one way in production and another way under test, and the tests
would not notice.

## The fix

Move the conversion to `internal.Colors.JSONPalette` and have both call it.
`internal` already owns the `Printing` to `Colors` mapping, so this puts the
whole chain in one place.

```go
func newJSONColorPalette(pr *output.Printing) *jsoncolor.Colors {
	return internal.NewColors(pr).JSONPalette()
}
```

`jsonColorPrefix` goes away with its only caller, and the nine call sites in
`internal_test.go` use the same method, so the two can no longer drift.

### On the unified nil rule

The rule kept is the test helper's: nil when no prefixes are set. That subsumes
the old production rule, since `NewColors` already returns the zero `Colors`
for a nil or monochrome `Printing`.

The one input where the two differed is a non-monochrome `Printing` whose
colors are all empty. That now yields nil rather than a non-nil palette of
empty prefixes. Under jsoncolor v0.9.1 this distinction mattered a great deal:
a non-nil palette of empty prefixes emitted a bare reset after every token.
Since v0.10.0 (#1137) the two are output-identical, because an empty `Color`
emits neither a prefix nor a reset.

This also drops the guard in `newJSONColorPalette` that duplicated the one
inside `NewColors`, and moves the explanation of why each `Color`'s suffix is
discarded next to the code that discards it.

## Second commit: two small fixes in the same path

**`newColor` returned unclipped slices.** `Prefix` and `Suffix` are cut from a
single buffer holding `prefix + space + suffix`, so each half kept the other's
bytes alive and carried spare capacity: a 4-byte prefix had capacity 16. That
matters now that these slices escape into a long-lived `*jsoncolor.Colors`,
where `jsoncolor.Color` is an exported `[]byte` that a consumer could append
to, writing into the shared backing array instead of allocating. Both halves
are now clipped, matching the guard already used in `csvw/csvdiff.go` and
`tablew/tablewdiff.go`.

**`pingWriter.Result` rebuilt the palette on every call**, and it is called
once per source, so pinging N sources repeated the same eight fatih/color
conversions N times. It is now built once in `NewPingWriter`, where `pr` is
already held for the writer's lifetime.

The other `writeJSON` callers are deliberately left alone. Each builds the
palette once or twice per command invocation rather than in a loop, so caching
there would mean a field on eight writer structs for no measurable gain.

## Tests

- `TestColors_JSONPalette` covers the new exported conversion: zero value, nil
  `Printing`, monochrome, and the colored case field by field, including that
  each `Color`'s suffix is discarded.
- `TestNewColors_Clipped` asserts every `Prefix` and `Suffix` has `cap == len`.
  Written first, and confirmed failing with `len 4, cap 16` before the fix.
- The existing `palette_test.go` and `TestPingWriter_*` tests pass **unchanged**,
  which is the main evidence that behavior is preserved.
- `TestWritersGolden` (#1140) passes, giving byte-level confirmation that
  colored output is identical before and after.

## Verification

`go build ./...`, `go test ./cli/output/...` (19 packages), `make fmt`,
`bunx dprint check`, and `golangci-lint run --max-same-issues 0
./cli/output/...` (0 issues) all pass. Branch is based on current master.
