### PR TITLE
test: rewrite hardcoded external-engine pairings onto embedded handles

### DIFF
--- a/cli/complete_test.go
+++ b/cli/complete_test.go
@@ -131,23 +131,27 @@ func TestCompleteFlagActiveSchema_query_cmds(t *testing.T) { //nolint:tparallel
 			wantDirective: wantDirective,
 		},
 		{
-			handles:           []string{sakila.My, sakila.Pg},
-			withFlagActiveSrc: sakila.Pg,
-			arg:               "publ",
-			wantContains:      []string{"public"},
-			wantDirective:     wantDirective,
+			// The flag selects Duck, whose catalog "sakila" completes. SL3
+			// offers no such catalog, so the case fails if the flag is ignored.
+			handles:           []string{sakila.SL3, sakila.Duck},
+			withFlagActiveSrc: sakila.Duck,
+			arg:               "sak",
+			wantContains:      []string{"sakila."},
+			wantDirective:     wantDirective | cobra.ShellCompDirectiveNoSpace,
 		},
 		{
-			handles:           []string{sakila.Pg, sakila.My},
-			withFlagActiveSrc: sakila.My,
+			// The flag selects SL3, which offers only the "main" schema, and so
+			// no NoSpace directive. Duck would also offer its catalog.
+			handles:           []string{sakila.Duck, sakila.SL3},
+			withFlagActiveSrc: sakila.SL3,
 			arg:               "",
-			wantContains:      []string{"mysql", "sys", "information_schema", "sakila"},
+			wantContains:      []string{"main"},
 			wantDirective:     wantDirective,
 		},
 		{
-			handles:           []string{sakila.My, sakila.Pg},
+			handles:           []string{sakila.SL3, sakila.Duck},
 			withFlagActiveSrc: sakila.MS,
-			arg:               "publ",
+			arg:               "ma",
 			// Should error because sakila.MS isn't a loaded source (via "handles").
 			wantDirective: cobra.ShellCompDirectiveError,
 		},
@@ -246,23 +250,27 @@ func TestCompleteFlagActiveSchema_inspect(t *testing.T) {
 			wantDirective: wantDirective,
 		},
 		{
-			handles:          []string{sakila.My, sakila.Pg},
-			withArgActiveSrc: sakila.Pg,
-			arg:              "publ",
-			wantContains:     []string{"public"},
-			wantDirective:    wantDirective,
+			// The arg selects Duck, whose catalog "sakila" completes. SL3
+			// offers no such catalog, so the case fails if the arg is ignored.
+			handles:          []string{sakila.SL3, sakila.Duck},
+			withArgActiveSrc: sakila.Duck,
+			arg:              "sak",
+			wantContains:     []string{"sakila."},
+			wantDirective:    wantDirective | cobra.ShellCompDirectiveNoSpace,
 		},
 		{
-			handles:          []string{sakila.Pg, sakila.My},
-			withArgActiveSrc: sakila.My,
+			// The arg selects SL3, which offers only the "main" schema, and so
+			// no NoSpace directive. Duck would also offer its catalog.
+			handles:          []string{sakila.Duck, sakila.SL3},
+			withArgActiveSrc: sakila.SL3,
 			arg:              "",
-			wantContains:     []string{"mysql", "sys", "information_schema", "sakila"},
+			wantContains:     []string{"main"},
 			wantDirective:    wantDirective,
 		},
 		{
-			handles:          []string{sakila.My, sakila.Pg},
+			handles:          []string{sakila.SL3, sakila.Duck},
 			withArgActiveSrc: sakila.MS,
-			arg:              "publ",
+			arg:              "ma",
 			// Should error because sakila.MS isn't a loaded source (via "handles").
 			wantDirective: cobra.ShellCompDirectiveError,
 		},

--- a/cli/complete_test.go
+++ b/cli/complete_test.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
@@ -78,6 +79,22 @@ type completion struct {
 	values     []string
 	result     cobra.ShellCompDirective
 	directives []cobra.ShellCompDirective
+}
+
+// schemaCompletionTimeout is the shell-completion timeout used by the
+// flag.ActiveSchema tests. The 500ms default is a UX budget, not a correctness
+// property, and these tests assert what completion returns, not how fast it
+// returns it. A cold source open on a loaded CI runner can exceed 500ms, which
+// surfaces as an empty result and ShellCompDirectiveError. See gh #595.
+const schemaCompletionTimeout = time.Second * 10
+
+// setCompletionTimeout sets cli.OptShellCompletionTimeout in tr's config store.
+// The store is what testComplete's run loads from, so the value must be
+// persisted, not just set on tr's in-memory config.
+func setCompletionTimeout(tb testing.TB, tr *testrun.TestRun, d time.Duration) {
+	tb.Helper()
+	tr.Run.Config.Options[cli.OptShellCompletionTimeout.Key()] = d
+	require.NoError(tb, tr.Run.ConfigStore.Save(tr.Context, tr.Run.Config))
 }
 
 // TestCompleteFlagActiveSchema_query_cmds tests flag.ActiveSchema
@@ -167,6 +184,7 @@ func TestCompleteFlagActiveSchema_query_cmds(t *testing.T) { //nolint:tparallel
 
 					th := testh.New(t)
 					tr := testrun.New(th.Context, t, nil)
+					setCompletionTimeout(t, tr, schemaCompletionTimeout)
 					for _, handle := range tc.handles {
 						tr.Add(*th.Source(handle))
 					}
@@ -282,6 +300,7 @@ func TestCompleteFlagActiveSchema_inspect(t *testing.T) {
 
 			th := testh.New(t)
 			tr := testrun.New(th.Context, t, nil)
+			setCompletionTimeout(t, tr, schemaCompletionTimeout)
 			for _, handle := range tc.handles {
 				tr.Add(*th.Source(handle))
 			}

--- a/drivers/oracle/oracle_test.go
+++ b/drivers/oracle/oracle_test.go
@@ -176,12 +176,15 @@ func TestListTables(t *testing.T) {
 	assert.NotNil(t, tables)
 }
 
-// TestSakilaCrossDatabase tests reading data from Postgres and writing to Oracle.
-// This is a real-world integration test demonstrating cross-database data migration.
+// TestSakilaCrossDatabase tests reading data from DuckDB and writing to Oracle.
+// This is a real-world integration test demonstrating cross-database data
+// migration. The read side is deliberately an embedded source: it needs no
+// container, so the test exercises the Oracle write path in an Oracle-only
+// environment, which is what the per-engine CI model provides. See gh #1143.
 func TestSakilaCrossDatabase(t *testing.T) {
 	tu.SkipShort(t, true)
 	th := testh.New(t)
-	pgDB := th.OpenDB(th.Source(sakila.Pg))
+	srcDB := th.OpenDB(th.Source(sakila.Duck))
 	oraGrip := th.Open(th.Source(sakila.Ora))
 	oraDrvr := oraGrip.SQLDriver()
 	ctx := th.Context
@@ -192,9 +195,9 @@ func TestSakilaCrossDatabase(t *testing.T) {
 	t.Run("CopyActorTable", func(t *testing.T) {
 		testTableName := stringz.UniqSuffix("ACTOR")
 
-		// Read actor data from Postgres
-		rows, err := pgDB.QueryContext(ctx, "SELECT actor_id, first_name, last_name FROM actor ORDER BY actor_id")
-		require.NoError(t, err, "Failed to query Postgres actor table")
+		// Read actor data from DuckDB
+		rows, err := srcDB.QueryContext(ctx, "SELECT actor_id, first_name, last_name FROM actor ORDER BY actor_id")
+		require.NoError(t, err, "Failed to query DuckDB actor table")
 		defer rows.Close()
 
 		// Collect rows
@@ -212,9 +215,9 @@ func TestSakilaCrossDatabase(t *testing.T) {
 			actors = append(actors, a)
 		}
 		require.NoError(t, rows.Err())
-		require.NotEmpty(t, actors, "Expected actor data in Postgres")
+		require.NotEmpty(t, actors, "Expected actor data in DuckDB")
 
-		pgRowCount := len(actors)
+		srcRowCount := len(actors)
 
 		// Create table in Oracle
 		tblDef := &schema.Table{
@@ -249,7 +252,7 @@ func TestSakilaCrossDatabase(t *testing.T) {
 		err = oraDB.QueryRowContext(ctx, countQuery).Scan(&oracleRowCount)
 		require.NoError(t, err, "Failed to count Oracle rows")
 
-		assert.Equal(t, pgRowCount, oracleRowCount, "Row count mismatch between Postgres and Oracle")
+		assert.Equal(t, srcRowCount, oracleRowCount, "Row count mismatch between DuckDB and Oracle")
 
 		// Verify data integrity - spot check first and last rows
 		if len(actors) > 0 {

--- a/libsq/query_join_test.go
+++ b/libsq/query_join_test.go
@@ -145,6 +145,12 @@ func TestQuery_join_inner(t *testing.T) {
 	}
 }
 
+// TestQuery_join_multi_source tests joins that span sources. The additional
+// sources are always embedded handles (sakila.SL3, sakila.Duck): they need no
+// container, so these cases run in every CI leg. Hardcoding external engines
+// here would pin the cases to a leg that has two engines live at once, which
+// no leg does. See gh #1143.
+//
 //nolint:lll
 func TestQuery_join_multi_source(t *testing.T) {
 	testCases := []queryTestCase{
@@ -178,7 +184,7 @@ func TestQuery_join_multi_source(t *testing.T) {
 			name: "n1/equals-with-alias",
 			in: fmt.Sprintf(
 				`@sakila | .store:s | join(%s.address:a, .s.address_id == .a.address_id)`,
-				sakila.Pg,
+				sakila.Duck,
 			),
 			wantRecCount:  2,
 			repeatReplace: innerJoins,
@@ -190,7 +196,7 @@ func TestQuery_join_multi_source(t *testing.T) {
 			name: "n2/two-sources",
 			in: fmt.Sprintf(
 				`@sakila | .actor | join(%s.film_actor, .actor_id) | join(.film, .film_id) | .first_name, .last_name, .title`,
-				sakila.Pg,
+				sakila.Duck,
 			),
 			wantRecCount:  sakila.TblFilmActorCount,
 			repeatReplace: innerJoins,
@@ -202,8 +208,8 @@ func TestQuery_join_multi_source(t *testing.T) {
 			name: "n2/three-sources-no-alias-no-col-alias",
 			in: fmt.Sprintf(
 				`@sakila | .actor | join(%s.film_actor, .actor_id) | join(%s.film, .film_id) | .first_name, .last_name, .title`,
-				sakila.Pg,
-				sakila.My,
+				sakila.Duck,
+				sakila.SL3,
 			),
 			wantSQL:       `SELECT "first_name", "last_name", "title" FROM "actor" INNER JOIN "film_actor" ON "actor"."actor_id" = "film_actor"."actor_id" INNER JOIN "film" ON "film_actor"."film_id" = "film"."film_id"`,
 			wantRecCount:  sakila.TblFilmActorCount,
@@ -216,8 +222,8 @@ func TestQuery_join_multi_source(t *testing.T) {
 			name: "n2/three-sources-no-alias-all-cols",
 			in: fmt.Sprintf(
 				`@sakila | .actor | join(%s.film_actor, .actor_id) | join(%s.film, .film_id)`,
-				sakila.Pg,
-				sakila.My,
+				sakila.Duck,
+				sakila.SL3,
 			),
 			wantSQL:       `SELECT * FROM "actor" INNER JOIN "film_actor" ON "actor"."actor_id" = "film_actor"."actor_id" INNER JOIN "film" ON "film_actor"."film_id" = "film"."film_id"`,
 			wantRecCount:  sakila.TblFilmActorCount,
@@ -230,8 +236,8 @@ func TestQuery_join_multi_source(t *testing.T) {
 			name: "n2/equals-with-alias/unqualified-cols",
 			in: fmt.Sprintf(
 				`@sakila | .actor:a | join(%s.film_actor:fa, .a.actor_id == .fa.actor_id) | join(%s.film:f, .fa.film_id == .f.film_id) | .first_name, .last_name, .title`,
-				sakila.Pg,
-				sakila.My,
+				sakila.Duck,
+				sakila.SL3,
 			),
 			wantRecCount: sakila.TblFilmActorCount,
 			sinkFns: []SinkTestFunc{


### PR DESCRIPTION
Closes #1143.

A handful of test cases hardcoded two external engines at once (Postgres plus
MySQL, or Postgres plus Oracle). Under the per-engine CI model from #958, no job
ever has two external engines live, so those cases skipped silently: they read
as coverage in the source and provided none in CI. They ran only against a full
local stack.

This rewrites them onto the embedded handles, which need no container and so are
always available. Where a single embedded source suffices, DuckDB is used. Same
reasoning as #964, which restricted the cross-source loops to embedded x target;
these are the cases it did not reach.

## Changes

**`libsq/query_join_test.go`**, `TestQuery_join_multi_source`: the two
Postgres-only cases become `Duck`, the three Postgres plus MySQL cases become
`Duck` plus `SL3`. The test now carries a doc comment explaining why the
additional sources must stay embedded, so the pairings do not get reintroduced.

**`cli/complete_test.go`**, three cases each in
`TestCompleteFlagActiveSchema_query_cmds` and
`TestCompleteFlagActiveSchema_inspect`. The old expectations were engine
specific (`"public"`, `"mysql"`/`"sys"`/`"information_schema"`), so this is not
a handle swap. The rewritten cases key off the Duck/SL3 difference: Duck offers
its `sakila` catalog (and thus `NoSpace`), SL3 offers only the `main` schema.
Both cases still fail if source resolution ignores the flag or the arg.

**`drivers/oracle/oracle_test.go`**, `TestSakilaCrossDatabase`: reads from DuckDB
rather than Postgres. Despite the name, Postgres was only a row source; the test
asserts nothing about it. What it exercises is the Oracle write path (create
table, prepared-statement insert, count, spot check first and last rows, drop),
which is unchanged.

## Coverage goes up, not down

The three-source join cases previously ran only on a full local stack. They now
run in every leg, so `Pg` joined to `Duck` joined to `SL3` is exercised nightly
for the first time. `TestSakilaCrossDatabase` starts running in the Oracle leg
instead of nowhere.

Measured against an embedded-only environment (every `SQ_TEST_SRC__*` unset),
`TestQuery_join_multi_source` goes from 27 pass / 18 skip to 45 pass / 0 skip.

## Verification

| Environment | Result |
| --- | --- |
| Full local stack (all six containers) | 140 pass, 0 skip, 0 fail |
| Embedded only | 0 fail; the five join cases run where they previously skipped |
| Oracle only | `TestSakilaCrossDatabase` passes, previously skipped |

The subtlety called out in the issue holds. Substituting embedded handles means
some origins pair a case with the same handle it hardcodes, which collapses the
query to fewer distinct sources and renders it in the source dialect rather than
the scratch database's. `wantSQL` and `wantRecCount` hold for all seven origins
in `SQLLatest()`, verified against the full stack.

The remaining skips in a reduced environment are all single-external cases,
which run correctly in their own engine's leg.
