### PR TITLE
test(xlsx): drop stale GH371 Windows skips

### DIFF
--- a/cli/cmd_inspect_test.go
+++ b/cli/cmd_inspect_test.go
@@ -256,7 +256,6 @@ func TestCmdInspect_json_yaml(t *testing.T) { //nolint:tparallel
 			for _, tc := range testCases {
 				t.Run(tc.handle, func(t *testing.T) {
 					t.Parallel()
-					tu.SkipWindowsIf(t, tc.handle == sakila.XLSX, "XLSX too slow on windows workflow")
 
 					th := testh.New(t)
 					src := th.Source(tc.handle)
@@ -366,8 +365,6 @@ func TestCmdInspect_text(t *testing.T) { //nolint:tparallel
 	for _, tc := range testCases {
 		t.Run(tc.handle, func(t *testing.T) {
 			t.Parallel()
-
-			tu.SkipWindowsIf(t, tc.handle == sakila.XLSX, "XLSX too slow on windows workflow")
 
 			th := testh.New(t)
 			src := th.Source(tc.handle)

--- a/drivers/xlsx/xlsx_test.go
+++ b/drivers/xlsx/xlsx_test.go
@@ -51,7 +51,6 @@ var sakilaSheets = []string{
 
 func TestSakilaInspectSource(t *testing.T) {
 	t.Parallel()
-	tu.SkipIssueWindows(t, tu.GH371ExcelSlowWin)
 	tu.SkipShort(t, true)
 
 	th := testh.New(t)
@@ -65,7 +64,6 @@ func TestSakilaInspectSource(t *testing.T) {
 
 func TestSakilaInspectSheets(t *testing.T) {
 	t.Parallel()
-	tu.SkipIssueWindows(t, tu.GH371ExcelSlowWin)
 	tu.SkipShort(t, true)
 
 	for _, sheet := range sakilaSheets {
@@ -83,7 +81,6 @@ func TestSakilaInspectSheets(t *testing.T) {
 }
 
 func BenchmarkInspectSheets(b *testing.B) {
-	tu.SkipIssueWindows(b, tu.GH371ExcelSlowWin)
 	tu.SkipShort(b, true)
 
 	for _, sheet := range sakilaSheets {
@@ -105,7 +102,6 @@ func BenchmarkInspectSheets(b *testing.B) {
 
 func TestSakila_query_cmd(t *testing.T) {
 	t.Parallel()
-	tu.SkipIssueWindows(t, tu.GH371ExcelSlowWin)
 	tu.SkipShort(t, true)
 
 	for _, sheet := range sakilaSheets {
@@ -125,7 +121,6 @@ func TestSakila_query_cmd(t *testing.T) {
 
 func TestOpenFileFormats(t *testing.T) {
 	t.Parallel()
-	tu.SkipIssueWindows(t, tu.GH371ExcelSlowWin)
 	tu.SkipShort(t, true)
 
 	testCases := []struct {
@@ -184,7 +179,6 @@ func TestOpenFileFormats(t *testing.T) {
 
 func TestSakila_query(t *testing.T) {
 	t.Parallel()
-	tu.SkipIssueWindows(t, tu.GH371ExcelSlowWin)
 	tu.SkipShort(t, true)
 
 	testCases := []struct {

--- a/testh/sakila/sakila_test.go
+++ b/testh/sakila/sakila_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/neilotoole/sq/testh"
 	"github.com/neilotoole/sq/testh/sakila"
-	"github.com/neilotoole/sq/testh/tu"
 )
 
 // TestSQLEmbedded verifies that the embedded SQL handles are exactly SQLite and
@@ -124,11 +123,7 @@ func TestSakila_SQL(t *testing.T) { //nolint:tparallel
 
 // TestSakila_XLSX is a sanity check for Sakila XLSX test sources.
 func TestSakila_XLSX(t *testing.T) {
-	tu.SkipIssueWindows(t, tu.GH371ExcelSlowWin)
-
-	handles := []string{sakila.XLSXSubset}
-	// TODO: Append sakila.XLSX to handles when performance is reasonable
-	//  enough not to break CI.
+	handles := []string{sakila.XLSXSubset, sakila.XLSX}
 
 	for _, handle := range handles {
 		t.Run(handle, func(t *testing.T) {

--- a/testh/tu/skip.go
+++ b/testh/tu/skip.go
@@ -26,7 +26,6 @@ func (g GHIssue) String() string {
 
 const (
 	GH355SQLiteDecimalWin   GHIssue = 355 // https://github.com/neilotoole/sq/issues/355
-	GH371ExcelSlowWin       GHIssue = 371 // https://github.com/neilotoole/sq/issues/371
 	GH372ShellCompletionWin GHIssue = 372 // https://github.com/neilotoole/sq/issues/372
 )
 


### PR DESCRIPTION
Closes #371.

Removes the Windows-only skips gated on #371 (six in the xlsx driver tests, one in the sakila sanity test, two in the CLI inspect tests) and the `GH371ExcelSlowWin` constant. `TestSakila_XLSX` now also covers the full `@sakila_xlsx` handle.

## Why

The Windows XLSX slowness is gone. The per-row fsync problem that dominated Windows CI was in JSON ingest and was fixed in #866 / #870, with the cache DB pragma relaxation in #868 also landed. What remains is ordinary excelize parse cost, which Windows pays at the same order of magnitude as the other runners.

Verified with a full Windows suite run on this branch: https://github.com/neilotoole/sq/actions/runs/34415832253. All platforms green; the Windows job finished in 11m31s, the same as the nightly with the skips in place.

| | Windows | macOS | Ubuntu |
|---|---|---|---|
| `drivers/xlsx` package elapsed | 53s | 72s | 81s |
| `TestSakila_query_cmd/rental` | 18.9s | 4.8s | 7.9s |
| `TestSakila_query_cmd/payment` | 18.3s | 3.6s | 8.0s |

The slowest Windows tests today are all DuckDB (`TestCmdInspect_*/@sakila_duck`, up to 84s), which is unrelated to this issue.