### PR TITLE
test: unskip SQLite decimal tests on Windows

### DIFF
--- a/drivers/csv/csv_test.go
+++ b/drivers/csv/csv_test.go
@@ -51,7 +51,6 @@ func TestSmoke(t *testing.T) {
 
 func TestSakila_query(t *testing.T) {
 	t.Parallel()
-	tu.SkipIssueWindows(t, tu.GH355SQLiteDecimalWin)
 
 	testCases := []struct {
 		file      string

--- a/drivers/sqlite3/db_type_test.go
+++ b/drivers/sqlite3/db_type_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/neilotoole/sq/testh"
 	"github.com/neilotoole/sq/testh/fixt"
 	"github.com/neilotoole/sq/testh/sakila"
-	"github.com/neilotoole/sq/testh/tu"
 )
 
 // typeTestTableDDLPath is the location of the SQL CREATE statement
@@ -166,8 +165,6 @@ func createTypeTestTbls(th *testh.Helper, src *source.Source, nTimes int, withDa
 // the returned data matches the inserted data, including verifying
 // that NULL is handled correctly.
 func TestDatabaseTypes(t *testing.T) {
-	tu.SkipIssueWindows(t, tu.GH355SQLiteDecimalWin)
-
 	th := testh.New(t)
 	src := th.Source(sakila.SL3)
 	actualTblName := createTypeTestTbls(th, src, 1, true)[0]

--- a/testh/tu/skip.go
+++ b/testh/tu/skip.go
@@ -25,7 +25,6 @@ func (g GHIssue) String() string {
 }
 
 const (
-	GH355SQLiteDecimalWin   GHIssue = 355 // https://github.com/neilotoole/sq/issues/355
 	GH372ShellCompletionWin GHIssue = 372 // https://github.com/neilotoole/sq/issues/372
 )
 


### PR DESCRIPTION
Closes #355.

Removes the Windows skip from `TestDatabaseTypes` (drivers/sqlite3) and `TestSakila_query` (drivers/csv), and drops the `GH355SQLiteDecimalWin` constant.

## Root cause

The intermittent `77.77` -> `77.77000000000001` drift came from SQLite's text-to-float conversion, not from sq. When #355 was filed, go-sqlite3 v1.14.19 bundled SQLite 3.44.0, whose `sqlite3AtoF` scaled the mantissa by repeated `*= 1.0e-01L` in `long double`. On the Windows CGO build (MinGW x87 long double, 53-bit precision control by default) that chain rounds twice and lands one ULP high. `7777 * 0.1 * 0.1` in double precision is exactly `77.77000000000001`. On Linux/macOS the 80-bit intermediate rounds correctly.

SQLite 3.45.0 replaced the long double path with Dekker double-double arithmetic. go-sqlite3 v1.14.52 bundles SQLite 3.53.4, which has no long double code left, so the skip no longer guards anything.

## Verification

Two `workflow_dispatch` runs of the Main Pipeline on this branch, both fully green, with both tests passing on `test-windows-full`:

- https://github.com/neilotoole/sq/actions/runs/34416551683
- https://github.com/neilotoole/sq/actions/runs/34417387996
