### PR TITLE
chore: upgrade to Go 1.27.1 with modernizers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ Breaking changes are annotated with ☢️, and alpha/beta features with 🐥.
   invocation. The server version, needed for version-aware SQL rendering, is read
   during the connectivity check when the source is opened, instead of in a
   separate query.
+- ☢️ `sq` is now built with Go 1.27, which requires macOS 13 Ventura or later. macOS 12 Monterey
+  is no longer supported.
 
 ## [v0.55.0] - 2026-09-09
 

--- a/cli/config/yamlstore/internal_test.go
+++ b/cli/config/yamlstore/internal_test.go
@@ -813,8 +813,7 @@ func Test_Store_writeConfigBackupOnce_ConcurrentAtMostOnce(t *testing.T) {
 	var wg sync.WaitGroup
 	var wroteCount atomic.Int32
 	wg.Add(n)
-	for i := 0; i < n; i++ {
-		i := i
+	for i := range n {
 		go func() {
 			defer wg.Done()
 			ctx := lg.NewContext(context.Background(), lgt.New(t))

--- a/cli/error.go
+++ b/cli/error.go
@@ -228,8 +228,7 @@ func humanizeError(err error) error {
 	// An error anywhere in the chain that implements errz.HumanReadable
 	// supplies its own concise user-facing message, replacing the full
 	// rendered chain (which remains in the log and in verbose output).
-	var hr errz.HumanReadable
-	if errors.As(err, &hr) {
+	if hr, ok := errors.AsType[errz.HumanReadable](err); ok {
 		return errz.New(hr.HumanError())
 	}
 

--- a/cli/expand_writer_test.go
+++ b/cli/expand_writer_test.go
@@ -140,7 +140,7 @@ func TestExpandSourceWriter_Source_FlagSet_Expands(t *testing.T) {
 	})
 
 	rec := &recordingSourceWriter{}
-	ew := &expandSourceWriter{w: rec, expander: expander{cmd: cmd, ru: ru}}
+	ew := &expandSourceWriter{w: rec, cmd: cmd, ru: ru}
 
 	src := &source.Source{
 		Handle:   "@a",
@@ -157,7 +157,7 @@ func TestExpandSourceWriter_Source_FlagUnset_PassThrough(t *testing.T) {
 	cmd, ru := newExpanderCmd(t, false, nil)
 
 	rec := &recordingSourceWriter{}
-	ew := &expandSourceWriter{w: rec, expander: expander{cmd: cmd, ru: ru}}
+	ew := &expandSourceWriter{w: rec, cmd: cmd, ru: ru}
 
 	src := &source.Source{
 		Handle:   "@a",
@@ -174,7 +174,7 @@ func TestExpandSourceWriter_ParseErrorPropagates(t *testing.T) {
 	cmd, ru := newExpanderCmd(t, true, nil)
 
 	rec := &recordingSourceWriter{}
-	ew := &expandSourceWriter{w: rec, expander: expander{cmd: cmd, ru: ru}}
+	ew := &expandSourceWriter{w: rec, cmd: cmd, ru: ru}
 
 	src := &source.Source{
 		Handle:   "@bad",
@@ -193,7 +193,7 @@ func TestExpandSourceWriter_Collection_Expands(t *testing.T) {
 	})
 
 	rec := &recordingSourceWriter{}
-	ew := &expandSourceWriter{w: rec, expander: expander{cmd: cmd, ru: ru}}
+	ew := &expandSourceWriter{w: rec, cmd: cmd, ru: ru}
 
 	coll := &source.Collection{}
 	require.NoError(t, coll.Add(&source.Source{
@@ -218,7 +218,7 @@ func TestExpandSourceWriter_Group_ExpandsNestedSources(t *testing.T) {
 	})
 
 	rec := &recordingSourceWriter{}
-	ew := &expandSourceWriter{w: rec, expander: expander{cmd: cmd, ru: ru}}
+	ew := &expandSourceWriter{w: rec, cmd: cmd, ru: ru}
 
 	group := &source.Group{
 		Name: "/",
@@ -264,7 +264,7 @@ func TestExpandPingWriter_OpenCachesForResult(t *testing.T) {
 	cmd.SetContext(context.Background())
 
 	rec := &recordingPingWriter{}
-	ew := &expandPingWriter{w: rec, expander: expander{cmd: cmd, ru: ru}}
+	ew := &expandPingWriter{w: rec, cmd: cmd, ru: ru}
 
 	src := &source.Source{
 		Handle:   "@a",
@@ -290,7 +290,7 @@ func TestExpandMetadataWriter_SourceMetadata_Expands(t *testing.T) {
 	})
 
 	rec := &recordingMetadataWriter{}
-	ew := &expandMetadataWriter{w: rec, expander: expander{cmd: cmd, ru: ru}}
+	ew := &expandMetadataWriter{w: rec, cmd: cmd, ru: ru}
 
 	srcMeta := &metadata.Source{
 		Handle:   "@a",
@@ -311,7 +311,7 @@ func TestExpandMetadataWriter_SecretsResolved_Skipped(t *testing.T) {
 	cmd, ru := newExpanderCmd(t, true, nil)
 
 	rec := &recordingMetadataWriter{}
-	ew := &expandMetadataWriter{w: rec, expander: expander{cmd: cmd, ru: ru}}
+	ew := &expandMetadataWriter{w: rec, cmd: cmd, ru: ru}
 
 	srcMeta := &metadata.Source{
 		Handle:          "@a",

--- a/cli/output.go
+++ b/cli/output.go
@@ -441,9 +441,9 @@ func newWriters(ru *run.Run, o options.Options) (w *output.Writers, outCfg *outp
 		// writer impl. See expand_writer.go for that rationale.) Any
 		// command that prints a location gets --expand for free; the
 		// decorators no-op when the flag is unset.
-		w.Source = &expandSourceWriter{w: w.Source, expander: expander{cmd: cmd, ru: ru}}
-		w.Ping = &expandPingWriter{w: w.Ping, expander: expander{cmd: cmd, ru: ru}}
-		w.Metadata = &expandMetadataWriter{w: w.Metadata, expander: expander{cmd: cmd, ru: ru}}
+		w.Source = &expandSourceWriter{w: w.Source, cmd: cmd, ru: ru}
+		w.Ping = &expandPingWriter{w: w.Ping, cmd: cmd, ru: ru}
+		w.Metadata = &expandMetadataWriter{w: w.Metadata, cmd: cmd, ru: ru}
 	}
 
 	return w, outCfg

--- a/cli/output/jsonw/encode_test.go
+++ b/cli/output/jsonw/encode_test.go
@@ -18,7 +18,7 @@ import (
 // character has to render identically whichever sq command produced the JSON.
 func TestEncodeString_MatchesJSONColor(t *testing.T) {
 	var samples []string
-	for c := 0; c < 0x80; c++ {
+	for c := range 0x80 {
 		samples = append(samples, fmt.Sprintf("a%sb", string(rune(c))))
 	}
 	samples = append(

--- a/drivers/clickhouse/clickhouse.go
+++ b/drivers/clickhouse/clickhouse.go
@@ -250,10 +250,10 @@ func placeholders(numCols, numRows int) string {
 	rows := make([]string, numRows)
 
 	var sb strings.Builder
-	for i := 0; i < numRows; i++ {
+	for i := range numRows {
 		sb.Reset()
 		sb.WriteRune('(')
-		for j := 0; j < numCols; j++ {
+		for j := range numCols {
 			sb.WriteRune('?')
 			if j < numCols-1 {
 				sb.WriteString(driver.Comma)

--- a/drivers/clickhouse/errors.go
+++ b/drivers/clickhouse/errors.go
@@ -85,8 +85,7 @@ func hasErrCode(err error, code int32) bool {
 		return false
 	}
 
-	var chErr *clickhouse.Exception
-	if errors.As(err, &chErr) {
+	if chErr, ok := errors.AsType[*clickhouse.Exception](err); ok {
 		return chErr.Code == code
 	}
 

--- a/drivers/duckdb/internal/portsakila/portsakila.go
+++ b/drivers/duckdb/internal/portsakila/portsakila.go
@@ -520,8 +520,8 @@ func reorderDropTables(s string, order []string) (string, error) {
 	// every output line ends with "\n".
 	var b strings.Builder
 	b.WriteString(prologueText)
-	for i := len(order) - 1; i >= 0; i-- {
-		b.WriteString(drops[order[i]])
+	for _, o := range slices.Backward(order) {
+		b.WriteString(drops[o])
 	}
 	b.WriteString(epilogueText)
 	out := b.String()

--- a/drivers/duckdb/internal/portsakila/portsakila_test.go
+++ b/drivers/duckdb/internal/portsakila/portsakila_test.go
@@ -222,10 +222,9 @@ func requireTopologicalCreateOrder(t *testing.T, out string) {
 	var curTable string
 	for _, line := range lines {
 		trimmed := strings.TrimSpace(line)
-		if strings.HasPrefix(trimmed, "CREATE TABLE ") {
+		if after, ok := strings.CutPrefix(trimmed, "CREATE TABLE "); ok {
 			// Extract table name.
-			rest := strings.TrimPrefix(trimmed, "CREATE TABLE ")
-			rest = strings.TrimSpace(rest)
+			rest := strings.TrimSpace(after)
 			parenIdx := strings.IndexByte(rest, '(')
 			if parenIdx >= 0 {
 				rest = rest[:parenIdx]
@@ -242,11 +241,10 @@ func requireTopologicalCreateOrder(t *testing.T, out string) {
 		if !strings.Contains(trimmed, "FOREIGN KEY") {
 			continue
 		}
-		refIdx := strings.Index(trimmed, "REFERENCES ")
-		if refIdx < 0 {
+		_, rest, ok := strings.Cut(trimmed, "REFERENCES ")
+		if !ok {
 			continue
 		}
-		rest := trimmed[refIdx+len("REFERENCES "):]
 		spaceIdx := strings.IndexAny(rest, " (")
 		if spaceIdx < 0 {
 			continue

--- a/drivers/mysql/altercol.go
+++ b/drivers/mysql/altercol.go
@@ -14,7 +14,7 @@ import (
 // AUTO_INCREMENT, comment) is preserved verbatim.
 func extractColumnDef(showCreate, col string) (string, error) {
 	prefix := stringz.BacktickQuote(col) // `col`
-	for _, line := range strings.Split(showCreate, "\n") {
+	for line := range strings.SplitSeq(showCreate, "\n") {
 		trimmed := strings.TrimSpace(line)
 		if !strings.HasPrefix(trimmed, prefix+" ") {
 			continue

--- a/drivers/mysql/errors.go
+++ b/drivers/mysql/errors.go
@@ -31,8 +31,7 @@ func hasErrCode(err error, code uint16) bool {
 		return false
 	}
 
-	var mysqlErr *mysql.MySQLError
-	if errors.As(err, &mysqlErr) {
+	if mysqlErr, ok := errors.AsType[*mysql.MySQLError](err); ok {
 		return mysqlErr.Number == code
 	}
 

--- a/drivers/oracle/internal_test.go
+++ b/drivers/oracle/internal_test.go
@@ -126,7 +126,6 @@ func TestKindFromOracleNumber(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.typeName, func(t *testing.T) {
 			t.Parallel()
 			got := kindFromOracleNumber(tc.typeName)

--- a/drivers/oracle/metadata.go
+++ b/drivers/oracle/metadata.go
@@ -857,7 +857,7 @@ FROM user_triggers`
 		// the leading word. Deduplicate in case normalization produces repeats.
 		var events []string
 		seen := make(map[string]bool)
-		for _, e := range strings.Split(strings.ToUpper(trigEvent), " OR ") {
+		for e := range strings.SplitSeq(strings.ToUpper(trigEvent), " OR ") {
 			e = strings.TrimSpace(e)
 			if e == "" {
 				continue

--- a/drivers/oracle/oracle.go
+++ b/drivers/oracle/oracle.go
@@ -141,7 +141,7 @@ func placeholders(numCols, numRows int) string {
 
 	n := 1
 	var sb strings.Builder
-	for i := 0; i < numRows; i++ {
+	for i := range numRows {
 		sb.Reset()
 		sb.WriteRune('(')
 		for j := 1; j <= numCols; j++ {

--- a/drivers/oracle/orshared/wrap.go
+++ b/drivers/oracle/orshared/wrap.go
@@ -23,8 +23,7 @@ const (
 // go-ora exposes the code as the exported field network.OracleError.ErrCode
 // (no Code() accessor), so a method-set type assertion does not match.
 func errCode(err error) int {
-	var oraErr *goora.OracleError
-	if errors.As(err, &oraErr) {
+	if oraErr, ok := errors.AsType[*goora.OracleError](err); ok {
 		return oraErr.ErrCode
 	}
 	return 0

--- a/drivers/postgres/errors.go
+++ b/drivers/postgres/errors.go
@@ -79,9 +79,8 @@ func hasErrCode(err error, code string) bool {
 	if err == nil {
 		return false
 	}
-	var pgErr *pgconn.PgError
 
-	if errors.As(err, &pgErr) {
+	if pgErr, ok := errors.AsType[*pgconn.PgError](err); ok {
 		return pgErr.Code == code
 	}
 

--- a/drivers/rqlite/cover_internal_test.go
+++ b/drivers/rqlite/cover_internal_test.go
@@ -25,10 +25,6 @@ import (
 	"github.com/neilotoole/sq/libsq/source/drivertype"
 )
 
-// anyPtr returns a *any pointing at v, to exercise the *any unwrap in
-// newRecordFromScanRow.
-func anyPtr(v any) *any { return &v }
-
 // TestProvider_DriverFor verifies the Provider returns a driver for the
 // rqlite type and rejects everything else.
 func TestProvider_DriverFor(t *testing.T) {
@@ -268,7 +264,7 @@ func TestNewRecordFromScanRow(t *testing.T) {
 		want any
 	}{
 		{name: "nil", knd: kind.Int, in: nil, want: nil},
-		{name: "any_wrapping_int", knd: kind.Int, in: anyPtr(int64(7)), want: int64(7)},
+		{name: "any_wrapping_int", knd: kind.Int, in: new(any(int64(7))), want: int64(7)},
 		{name: "ptr_int64", knd: kind.Int, in: &i64, want: int64(42)},
 		{name: "int64", knd: kind.Int, in: int64(42), want: int64(42)},
 		{name: "ptr_float64_to_int", knd: kind.Int, in: &f64, want: int64(3)},

--- a/drivers/rqlite/detect.go
+++ b/drivers/rqlite/detect.go
@@ -42,8 +42,7 @@ import (
 //     defense against a false tls=true.
 func probeIndicatesTLS(resp *http.Response, body []byte, err error) bool {
 	if err != nil {
-		var rec tls.RecordHeaderError
-		if errors.As(err, &rec) {
+		if _, ok := errors.AsType[tls.RecordHeaderError](err); ok {
 			return true
 		}
 		if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {

--- a/drivers/rqlite/errors.go
+++ b/drivers/rqlite/errors.go
@@ -37,8 +37,7 @@ func errw(err error) error {
 // kept. Non-*url.Error values pass through unchanged. Used wherever a
 // net/url-produced error could otherwise echo a source DSN's userinfo.
 func stripURLError(err error) error {
-	var uerr *url.Error
-	if errors.As(err, &uerr) {
+	if uerr, ok := errors.AsType[*url.Error](err); ok {
 		return uerr.Err
 	}
 	return err
@@ -496,8 +495,7 @@ func isTLSSignal(err error) bool {
 	// 1. Go's net/http detected a TLS record on a plain-HTTP socket.
 	// Dead in production today (gorqlite breaks the error chain) but
 	// retained for forward-compat.
-	var rec tls.RecordHeaderError
-	if errors.As(err, &rec) {
+	if _, ok := errors.AsType[tls.RecordHeaderError](err); ok {
 		return true
 	}
 
@@ -583,16 +581,13 @@ func isCertVerificationError(err error) bool {
 	if err == nil {
 		return false
 	}
-	var unkAuth x509.UnknownAuthorityError
-	if errors.As(err, &unkAuth) {
+	if _, ok := errors.AsType[x509.UnknownAuthorityError](err); ok {
 		return true
 	}
-	var hostErr x509.HostnameError
-	if errors.As(err, &hostErr) {
+	if _, ok := errors.AsType[x509.HostnameError](err); ok {
 		return true
 	}
-	var verifyErr *tls.CertificateVerificationError
-	if errors.As(err, &verifyErr) {
+	if _, ok := errors.AsType[*tls.CertificateVerificationError](err); ok {
 		return true
 	}
 	// Substring fallback: the canonical "x509:" prefix on Go's

--- a/drivers/rqlite/metadata.go
+++ b/drivers/rqlite/metadata.go
@@ -260,7 +260,7 @@ func DBTypeForKind(knd kind.Kind) string {
 func newRecordFromScanRow(meta record.Meta, row []any) (rec record.Record) {
 	rec = make([]any, len(row))
 
-	for i := 0; i < len(row); i++ {
+	for i := range row {
 		if row[i] == nil {
 			rec[i] = nil
 			continue
@@ -796,7 +796,7 @@ func getTblRowCounts(ctx context.Context, db sqlz.DB, tblNames []string) ([]int6
 		j     int
 	)
 
-	for i := 0; i < len(tblNames); i++ {
+	for i := range tblNames {
 		if terms > 0 {
 			sb.WriteString(" UNION ALL ")
 		}

--- a/drivers/rqlite/rqlite.go
+++ b/drivers/rqlite/rqlite.go
@@ -363,7 +363,7 @@ func (d *driveri) Dialect() dialect.Dialect {
 
 func placeholders(numCols, numRows int) string {
 	rows := make([]string, numRows)
-	for i := 0; i < numRows; i++ {
+	for i := range numRows {
 		rows[i] = "(" + stringz.RepeatJoin("?", numCols, driver.Comma) + ")"
 	}
 	return strings.Join(rows, driver.Comma)

--- a/drivers/rqlite/rqlite_test.go
+++ b/drivers/rqlite/rqlite_test.go
@@ -363,7 +363,7 @@ func TestTruncate_Reset(t *testing.T) {
 	require.NoError(t, drvr.CreateTable(th.Context, db, tblDef))
 
 	// Insert 3 rows so sqlite_sequence has data for this table.
-	for i := 0; i < 3; i++ {
+	for range 3 {
 		_, err = db.ExecContext(th.Context,
 			fmt.Sprintf(`INSERT INTO %q (name) VALUES (?)`, tblName), "x")
 		require.NoError(t, err)
@@ -833,7 +833,7 @@ func TestBatchInsert(t *testing.T) {
 	const total = 1500
 	go func() {
 		defer close(bi.RecordCh)
-		for i := 0; i < total; i++ {
+		for i := range total {
 			rec := []any{int64(i), "b", "c", "2026-01-01T00:00:00"}
 			if mErr := bi.Munge(rec); mErr != nil {
 				t.Errorf("munge failed: %v", mErr)

--- a/drivers/rqlite/sqldriver.go
+++ b/drivers/rqlite/sqldriver.go
@@ -330,7 +330,7 @@ func convertWireValue(conv wireConv, v any) driver.Value {
 
 // rtypeRawValues is the expected reflect.Type of
 // gorqlite.QueryResult's values field.
-var rtypeRawValues = reflect.TypeOf([][]any(nil))
+var rtypeRawValues = reflect.TypeFor[[][]any]()
 
 // rawValues extracts the raw row data (the JSON-decoded "values"
 // array) from qr. gorqlite provides no public access to it: Map,

--- a/drivers/sqlite3/sqlparser/create_table.go
+++ b/drivers/sqlite3/sqlparser/create_table.go
@@ -1,6 +1,7 @@
 package sqlparser
 
 import (
+	"slices"
 	"sort"
 
 	antlr "github.com/antlr4-go/antlr/v4"
@@ -326,8 +327,7 @@ func ApplyEdits(input string, edits []Edit) (string, error) {
 	}
 
 	out := input
-	for i := len(sorted) - 1; i >= 0; i-- {
-		e := sorted[i]
+	for _, e := range slices.Backward(sorted) {
 		out = out[:e.Start] + e.Replacement + out[e.End:]
 	}
 	return out, nil

--- a/drivers/sqlserver/errors.go
+++ b/drivers/sqlserver/errors.go
@@ -29,8 +29,7 @@ func hasErrCode(err error, code int32) bool {
 		return false
 	}
 
-	var msErr mssql.Error
-	if errors.As(err, &msErr) {
+	if msErr, ok := errors.AsType[mssql.Error](err); ok {
 		return msErr.Number == code
 	}
 
@@ -75,8 +74,7 @@ func errw(err error) error {
 	case hasErrCode(err, errCodeBadObject):
 		return driver.NewNotExistError(err)
 	default:
-		var mssqlErr mssql.Error
-		if errors.As(err, &mssqlErr) {
+		if mssqlErr, ok := errors.AsType[mssql.Error](err); ok {
 			return errz.Wrapf(err, "ERROR %d", mssqlErr.Number)
 		}
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/neilotoole/sq
 
-go 1.26.3
+go 1.27.1
 
 // godebug x509negativeserial=1 is set here because of an issue with older
 // SQL Server versions not doing the right thing with X509 certs (see RFC 5280).
@@ -54,6 +54,7 @@ require (
 	github.com/muesli/mango-cobra v1.3.0
 	github.com/muesli/roff v0.1.0
 	github.com/ncruces/go-strftime v1.0.0
+	github.com/neilotoole/jsoncolor v0.10.1
 	github.com/neilotoole/oncecache v0.1.0
 	github.com/neilotoole/shelleditor v0.4.1
 	github.com/neilotoole/slogt v1.1.0
@@ -62,6 +63,7 @@ require (
 	github.com/nightlyone/lockfile v1.0.0
 	github.com/otiai10/copy v1.14.1
 	github.com/pkg/profile v1.7.0
+	github.com/rqlite/gorqlite v0.0.0-20260504155303-50d445fd0ab9
 	github.com/ryboe/q v1.0.26
 	github.com/samber/lo v1.53.0
 	github.com/segmentio/encoding v0.5.4 // benchmark comparison only; see cli/output/jsonw/internal/benchmark_test.go
@@ -79,7 +81,9 @@ require (
 	// future.
 	github.com/xo/usql v0.21.4
 	github.com/xuri/excelize/v2 v2.11.0
+	github.com/zalando/go-keyring v0.2.9-0.20260616202443-860ea660ec62
 	go.uber.org/atomic v1.11.0
+	go.uber.org/goleak v1.3.0
 	golang.org/x/exp v0.0.0-20260908205506-85c1c2202aba
 	golang.org/x/mod v0.41.0
 	golang.org/x/sync v0.23.0
@@ -87,13 +91,6 @@ require (
 	golang.org/x/term v0.46.0
 	golang.org/x/text v0.42.0
 	gopkg.in/yaml.v3 v3.0.1
-)
-
-require (
-	github.com/neilotoole/jsoncolor v0.10.1
-	github.com/rqlite/gorqlite v0.0.0-20260504155303-50d445fd0ab9
-	github.com/zalando/go-keyring v0.2.9-0.20260616202443-860ea660ec62
-	go.uber.org/goleak v1.3.0
 )
 
 require (

--- a/libsq/ast/inspector.go
+++ b/libsq/ast/inspector.go
@@ -2,6 +2,7 @@ package ast
 
 import (
 	"reflect"
+	"slices"
 
 	"github.com/samber/lo"
 
@@ -97,8 +98,8 @@ func (in *Inspector) FindColExprSegment() (*SegmentNode, error) {
 	segs := in.ast.Segments()
 
 	// work backwards from the end
-	for i := len(segs) - 1; i >= 0; i-- {
-		elems := segs[i].Children()
+	for i, seg := range slices.Backward(segs) {
+		elems := seg.Children()
 		numColExprs := 0
 
 		for _, elem := range elems {
@@ -115,7 +116,7 @@ func (in *Inspector) FindColExprSegment() (*SegmentNode, error) {
 		}
 
 		if numColExprs > 0 {
-			return segs[i], nil
+			return seg, nil
 		}
 	}
 

--- a/libsq/core/cleanup/cleanup.go
+++ b/libsq/core/cleanup/cleanup.go
@@ -4,6 +4,7 @@ package cleanup
 
 import (
 	"io"
+	"slices"
 	"sync"
 
 	"github.com/neilotoole/sq/libsq/core/errz"
@@ -132,8 +133,8 @@ func (cu *Cleanup) Run() error {
 	// Run cleanups in reverse order. The fns slice can't contain nil
 	// entries: Add, AddE, AddC, and Append all reject or wrap nil before
 	// appending, so no nil guard is needed here.
-	for i := len(cu.fns) - 1; i >= 0; i-- {
-		err = errz.Append(err, cu.fns[i]())
+	for _, v := range slices.Backward(cu.fns) {
+		err = errz.Append(err, v())
 	}
 
 	// Set fns to nil so that the cleanup funcs

--- a/libsq/core/errz/errz.go
+++ b/libsq/core/errz/errz.go
@@ -329,7 +329,7 @@ func WithExitCode(err error, code int) error {
 		return &exitCoder{errz: *ez, code: code}
 	}
 
-	return &exitCoder{errz: errz{stack: callers(0), error: err}, code: code}
+	return &exitCoder{stack: callers(0), error: err, code: code}
 }
 
 var _ ExitCoder = (*exitCoder)(nil)
@@ -529,8 +529,7 @@ func HumanMessage(err error) string {
 	if err == nil {
 		return ""
 	}
-	var hr HumanReadable
-	if errors.As(err, &hr) {
+	if hr, ok := errors.AsType[HumanReadable](err); ok {
 		return hr.HumanError()
 	}
 	return err.Error()

--- a/libsq/core/ioz/contextio/contextio.go
+++ b/libsq/core/ioz/contextio/contextio.go
@@ -80,7 +80,7 @@ func NewWriter(ctx context.Context, w io.Writer) io.Writer {
 
 	wr := writer{ctx: ctx, w: w}
 	if _, ok := w.(io.Closer); ok {
-		return &copyCloser{writeCloser: writeCloser{writer: wr}}
+		return &copyCloser{writer: wr}
 	}
 
 	return &copier{writer: wr}

--- a/libsq/core/ioz/httpz/httpz.go
+++ b/libsq/core/ioz/httpz/httpz.go
@@ -19,6 +19,7 @@ import (
 	"net/textproto"
 	"path"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -47,8 +48,8 @@ func NewClient(opts ...Opt) *http.Client {
 
 	c.Transport = tr
 	// Apply the round trip functions in reverse order.
-	for i := len(opts) - 1; i >= 0; i-- {
-		if tf, ok := opts[i].(TripFunc); ok {
+	for _, opt := range slices.Backward(opts) {
+		if tf, ok := opt.(TripFunc); ok {
 			c.Transport = RoundTrip(c.Transport, tf)
 		}
 	}

--- a/libsq/core/secret/memo_test.go
+++ b/libsq/core/secret/memo_test.go
@@ -95,11 +95,9 @@ func TestRegistry_ConcurrentResolveSingleflight(t *testing.T) {
 	errs := make([]error, goroutines)
 	vals := make([]string, goroutines)
 	for i := range goroutines {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			vals[i], errs[i] = reg.Expand(ctx, "${test:pw}")
-		}()
+		})
 	}
 	wg.Wait()
 

--- a/libsq/files/internal/downloader/downloader_extra_test.go
+++ b/libsq/files/internal/downloader/downloader_extra_test.go
@@ -150,10 +150,10 @@ func TestGet_notModifiedRefresh(t *testing.T) {
 
 	const body = "conditional body"
 	lastModified := time.Now().UTC().Add(-time.Hour)
-	var hits int32
+	var hits atomic.Int32
 
 	srvr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		atomic.AddInt32(&hits, 1)
+		hits.Add(1)
 		if r.Header.Get("If-Modified-Since") != "" {
 			// Refresh request: nothing changed.
 			w.WriteHeader(http.StatusNotModified)
@@ -191,7 +191,7 @@ func TestGet_notModifiedRefresh(t *testing.T) {
 	require.Nil(t, gotStream)
 	require.NotEmpty(t, gotFile)
 	require.Equal(t, body, tu.ReadFileToString(t, gotFile))
-	require.GreaterOrEqual(t, atomic.LoadInt32(&hits), int32(2))
+	require.GreaterOrEqual(t, hits.Load(), int32(2))
 }
 
 // TestGet_staleIfErrorServesStaleOn500 exercises the

--- a/libsq/source/handle_test.go
+++ b/libsq/source/handle_test.go
@@ -367,7 +367,6 @@ func TestIsValidHandle(t *testing.T) {
 	}
 
 	for i, tc := range testCases {
-		tc := tc
 		t.Run(tu.Name(i, tc.in), func(t *testing.T) {
 			got := source.IsValidHandle(tc.in)
 			require.Equal(t, tc.valid, got)
@@ -395,7 +394,6 @@ func TestValidGroup(t *testing.T) {
 	}
 
 	for i, tc := range testCases {
-		tc := tc
 		t.Run(tu.Name(i, tc.in), func(t *testing.T) {
 			err := source.ValidGroup(tc.in)
 			if tc.wantErr {
@@ -439,7 +437,6 @@ func TestHandle2SafePath(t *testing.T) {
 	}
 
 	for i, tc := range testCases {
-		tc := tc
 		t.Run(tu.Name(i, tc.handle), func(t *testing.T) {
 			got := source.Handle2SafePath(tc.handle)
 			require.Equal(t, tc.want, got)

--- a/libsq/source/location/location.go
+++ b/libsq/source/location/location.go
@@ -462,8 +462,7 @@ func parseRqlite(loc string, fields *Fields) (*Fields, error) {
 		// url.Error embeds the raw input URL, which may carry inline
 		// credentials. Strip that wrapper so only the redacted loc
 		// appears in the message, but keep the underlying cause.
-		var uerr *url.Error
-		if errors.As(err, &uerr) {
+		if uerr, ok := errors.AsType[*url.Error](err); ok {
 			err = uerr.Err
 		}
 		return nil, errz.Wrapf(err, "parse location: %s", redactBestEffort(loc))
@@ -968,8 +967,7 @@ func MergeQuery(loc string, params url.Values) (string, error) {
 	if err != nil {
 		// url.Error embeds the raw input (which may carry inline
 		// credentials); strip the wrapper and redact the loc.
-		var uerr *url.Error
-		if errors.As(err, &uerr) {
+		if uerr, ok := errors.AsType[*url.Error](err); ok {
 			err = uerr.Err
 		}
 		return "", errz.Wrapf(err, "merge query: invalid location: %s",

--- a/libsq/source/metadata/metadata_test.go
+++ b/libsq/source/metadata/metadata_test.go
@@ -1703,8 +1703,7 @@ func TestSource_RecomputeTableCounts(t *testing.T) {
 func TestColumn_Clone_AllFieldsCovered(t *testing.T) {
 	orig := &metadata.Column{}
 	v := reflect.ValueOf(orig).Elem()
-	for i := 0; i < v.NumField(); i++ {
-		f := v.Field(i)
+	for _, f := range v.Fields() {
 		if !f.CanSet() {
 			continue
 		}

--- a/tools/betteralign/go.mod
+++ b/tools/betteralign/go.mod
@@ -1,6 +1,6 @@
 module github.com/neilotoole/sq/tools/betteralign
 
-go 1.26.0
+go 1.27.1
 
 tool github.com/dkorunic/betteralign/cmd/betteralign
 

--- a/tools/goimports-reviser/go.mod
+++ b/tools/goimports-reviser/go.mod
@@ -1,6 +1,6 @@
 module github.com/neilotoole/sq/tools/goimports-reviser
 
-go 1.26.0
+go 1.27.1
 
 tool github.com/incu6us/goimports-reviser/v3
 

--- a/tools/golangci-lint/go.mod
+++ b/tools/golangci-lint/go.mod
@@ -1,6 +1,6 @@
 module github.com/neilotoole/sq/tools/golangci-lint
 
-go 1.26.0
+go 1.27.1
 
 tool github.com/golangci/golangci-lint/v2/cmd/golangci-lint
 

--- a/tools/tparse/go.mod
+++ b/tools/tparse/go.mod
@@ -1,6 +1,6 @@
 module github.com/neilotoole/sq/tools/tparse
 
-go 1.26.0
+go 1.27.1
 
 tool github.com/mfridman/tparse
 


### PR DESCRIPTION
## Summary

Upgrades sq to Go 1.27.1 and applies the Go 1.27 `go fix` modernizers, following the pattern of #543 (Go 1.26).

## Changes

- **Go version:** `go.mod` goes from 1.26.3 to 1.27.1, and the `tools/*` modules from 1.26.0 to 1.27.1. Under Go 1.27, `go mod tidy` merges the stray second `require` block into the direct-dependency block. No dependency versions change (`go.sum` is untouched).
- **Modernizers:** `go fix ./...` run until it reports nothing further (35 Go files): `errors.As` to `errors.AsType`, `slices.Backward`, range over int, `strings.SplitSeq` / `Cut` / `CutPrefix`, `wg.Go`, `atomic.Int32`, `reflect.TypeFor`, `reflect.Value.Fields`, removal of redundant `tc := tc` copies, and flattened embedded-field struct literals (`embedlit`, new Go 1.27 syntax).
- **Cleanup:** removed the `anyPtr` test helper that `go fix` inlined away, plus a stray blank line and awkward `rest := after` temporaries left by the rewrites.
- **Not applied:** the `embedlit` rewrite of the `TblSelectorNode` literal in `libsq/ast/join.go`. It flattens two levels of embedding, which hides which struct owns each field, and a field added later to an outer struct would silently capture a flattened key. A plain `go fix ./...` will propose it again; `go fix -embedlit=false ./...` skips it.
- **CHANGELOG:** ☢️ entry noting that Go 1.27 requires macOS 13 Ventura or later (Go 1.26 still supported macOS 12).

## Compatibility checks

- All workflows read the Go version from `go.mod` (`go-version-file`), so no workflow changes are needed.
- golangci-lint v2.13.2 (the CI pin) is built with Go 1.27.0; go1.27 support landed in v2.13.0.
- `codeql-action` v4.37.9 bundles CodeQL 2.26.4, whose Go library added Go 1.27 support.
- The `x509negativeserial` godebug in `go.mod` still exists in Go 1.27, and none of the GODEBUG settings removed in 1.27 are used.
- `encoding/json` is now backed by the v2 implementation by default. v1 API behavior is preserved, but the text of JSON parse error messages may differ.

## Testing

- `go build` and `go vet` with the CI build tags: pass. The only vet output is 141 "unreachable code" reports in the ANTLR-generated parsers, identical under Go 1.26.8.
- `golangci-lint run`: 0 issues.
- `dprint check`: pass.
- `go test -short ./...` with the CI build tags: 99 packages ok, 26 without tests.
- Not run locally: Docker-backed DB integration tests, Windows.

Contributors: gopls built with Go 1.26 or earlier reports false "unknown field" errors on the flattened literals. Reinstall gopls with Go 1.27.
