### PR TITLE
fix(test): filter transient views from exact view count (#1160)

### DIFF
--- a/libsq/core/stringz/stringz.go
+++ b/libsq/core/stringz/stringz.go
@@ -289,6 +289,26 @@ func UniqTableName(tbl string) string {
 	return tbl
 }
 
+// uniqTableNameSuffixRegex matches the suffix that [UniqTableName] appends:
+// a double underscore followed by a [Uniq8] value, i.e. a lower-case letter
+// and seven lower-case alphanumerics. Keep in sync with [UniqTableName].
+var uniqTableNameSuffixRegex = regexp.MustCompile(`__[a-z][a-z0-9]{7}$`)
+
+// HasUniqTableNameSuffix reports whether s ends with the unique suffix
+// appended by [UniqTableName].
+//
+// It exists for tests that count objects in a shared database: test binaries
+// for different packages run concurrently, so a test that asserts an exact
+// count can observe another package's transient table or view before its
+// cleanup runs. Filtering with this func keeps the exact-count assertion,
+// rather than weakening it to a lower bound.
+//
+// Note that it matches on shape alone: a real table whose name happens to end
+// in that pattern would also match.
+func HasUniqTableNameSuffix(s string) bool {
+	return uniqTableNameSuffixRegex.MatchString(s)
+}
+
 // SanitizeAlphaNumeric replaces any non-alphanumeric
 // runes of s with r (which is typically underscore).
 //

--- a/libsq/core/stringz/stringz_test.go
+++ b/libsq/core/stringz/stringz_test.go
@@ -3,6 +3,7 @@ package stringz_test
 import (
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
 	"testing"
 	"unicode"
@@ -586,4 +587,91 @@ func TestUniqTableName_Sanitize(t *testing.T) {
 	require.NotContains(t, got, "@")
 	require.NotContains(t, got, "/")
 	require.Equal(t, got, strings.ToLower(got))
+}
+
+func TestHasUniqTableNameSuffix(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		in   string
+		want bool
+	}{
+		// The name from the gh1160 flake report.
+		{"vdef_view__bhx8wuhv", true},
+		{"tbl__a1234567", true},
+		// UniqTableName falls back to "tbl" for an empty input.
+		{"tbl__abcdefgh", true},
+		// Sakila's permanent views and tables must never match.
+		{"actor_info", false},
+		{"customer_list", false},
+		{"film_list", false},
+		{"nicer_but_slower_film_list", false},
+		{"sales_by_film_category", false},
+		{"sales_by_store", false},
+		{"staff_list", false},
+		{"actor", false},
+		{"", false},
+		// Single underscore, not the double that UniqTableName appends.
+		{"vdef_view_bhx8wuhv", false},
+		// Uniq8's first rune is a letter, so a leading digit is not a match.
+		{"vdef_view__1bx8wuhv", false},
+		// Suffix must be exactly 8 runes.
+		{"vdef_view__bhx8wuh", false},
+		{"vdef_view__bhx8wuhvv", false},
+		// Uniq8 is lower-case only.
+		{"vdef_view__BHX8WUHV", false},
+		// Must be a suffix, not a substring.
+		{"vdef_view__bhx8wuhv_x", false},
+	}
+
+	for _, tc := range testCases {
+		require.Equal(t, tc.want, stringz.HasUniqTableNameSuffix(tc.in), tc.in)
+	}
+}
+
+// TestHasUniqTableNameSuffix_gh1160 replays the exact ListTableNames result
+// from the gh1160 flake, where a concurrently-created view from another test
+// package pushed the count from 7 to 8. This is the filter that
+// TestSQLDriver_ListTableNames_ArgSchemaNotEmpty applies; that test needs live
+// Sakila databases, so the filtering logic is covered here instead.
+func TestHasUniqTableNameSuffix_gh1160(t *testing.T) {
+	t.Parallel()
+
+	// Verbatim from the failure: "should have 7 item(s), but has 8".
+	got := []string{
+		"actor_info",
+		"customer_list",
+		"film_list",
+		"nicer_but_slower_film_list",
+		"sales_by_film_category",
+		"sales_by_store",
+		"staff_list",
+		"vdef_view__bhx8wuhv",
+	}
+
+	gotViews := slices.DeleteFunc(slices.Clone(got), stringz.HasUniqTableNameSuffix)
+
+	require.Len(t, gotViews, 7)
+	require.Equal(t, []string{
+		"actor_info",
+		"customer_list",
+		"film_list",
+		"nicer_but_slower_film_list",
+		"sales_by_film_category",
+		"sales_by_store",
+		"staff_list",
+	}, gotViews, "the seven permanent Sakila views must survive filtering")
+}
+
+// TestHasUniqTableNameSuffix_MatchesGenerator guards the coupling between
+// UniqTableName and HasUniqTableNameSuffix: if the suffix format changes,
+// the predicate must change with it.
+func TestHasUniqTableNameSuffix_MatchesGenerator(t *testing.T) {
+	t.Parallel()
+
+	for _, tbl := range []string{"", "a", "vdef_view", "My@Tbl/Name", strings.Repeat("a", 88)} {
+		got := stringz.UniqTableName(tbl)
+		require.True(t, stringz.HasUniqTableNameSuffix(got),
+			"UniqTableName(%q) = %q, which HasUniqTableNameSuffix does not match", tbl, got)
+	}
 }

--- a/libsq/driver/driver_test.go
+++ b/libsq/driver/driver_test.go
@@ -868,17 +868,27 @@ func TestSQLDriver_ListTableNames_ArgSchemaNotEmpty(t *testing.T) { //nolint:tpa
 			// other packages (e.g. cli's TestCmdSQL_ExecMode) transiently
 			// create scratch tables in these shared sakila schemas, which would
 			// make an exact table count flaky. A missing expected table still
-			// fails (len < wantTables). The views-only count stays exact: those
-			// tests create tables, not views.
+			// fails (len < wantTables).
 			got, err = drvr.ListTableNames(th.Context, db, tc.schema, true, false)
 			require.NoError(t, err)
 			require.NotNil(t, got)
 			require.GreaterOrEqual(t, len(got), wantTables)
 
+			// Views are counted exactly, but transient views must be excluded
+			// first. TestMySQL_ViewDefinition, and its Postgres and ClickHouse
+			// counterparts, create a view named by stringz.UniqTableName in
+			// these same shared schemas. Those tests live in other packages, so
+			// their binaries run concurrently with this one and the view can be
+			// live when this count runs: an unfiltered count intermittently saw
+			// 8 views instead of 7 (gh1160). Filtering keeps the assertion
+			// exact, so a missing or extra permanent view is still caught.
 			got, err = drvr.ListTableNames(th.Context, db, tc.schema, false, true)
 			require.NoError(t, err)
 			require.NotNil(t, got)
-			require.Len(t, got, tc.wantViews)
+			gotViews := slices.DeleteFunc(slices.Clone(got), stringz.HasUniqTableNameSuffix)
+			require.Len(t, gotViews, tc.wantViews,
+				"expected exactly %d permanent views; got %v (unfiltered: %v)",
+				tc.wantViews, gotViews, got)
 
 			got, err = drvr.ListTableNames(th.Context, db, tc.schema, true, true)
 			require.NoError(t, err)


### PR DESCRIPTION
Fixes #1160

`TestSQLDriver_ListTableNames_ArgSchemaNotEmpty` asserts an exact view count against the shared sakila schemas:

```
"[actor_info customer_list film_list nicer_but_slower_film_list
sales_by_film_category sales_by_store staff_list vdef_view__bhx8wuhv]"
should have 7 item(s), but has 8
```

`TestMySQL_ViewDefinition`, and its Postgres and ClickHouse counterparts, create a view named by `stringz.UniqTableName` in those same schemas. Those tests live in other packages, so `go test` runs their binaries concurrently with this one, and the view can still be live when the count runs.

The comment above the assertion already explained why the *table* counts use a lower bound, and asserted that "the views-only count stays exact: those tests create tables, not views". That has not held since those view tests were added.

### Approach

Rather than weakening the assertion to a lower bound — which would stop catching a missing or extra permanent view — transient objects are filtered out and the count stays exact.

The predicate `stringz.HasUniqTableNameSuffix` lives beside the generator in `stringz` so the two stay in sync, and `TestHasUniqTableNameSuffix_MatchesGenerator` asserts that coupling directly by feeding `UniqTableName` output back through the predicate.

Only this one assertion needed changing: it is the only exact count over a shared schema. The neighbouring tables+views assertion is already a lower bound, and rqlite's `TestSourceMetadata` already handles the same hazard the same way.

The predicate matches on shape alone, so a real table whose name happens to end in `__` plus eight lower-case alphanumerics would also be filtered. That is noted in its doc comment; narrowing it to the exact `Uniq8` charset would couple the two more tightly than seems worth it, but happy to do that if you would prefer.

### Tests

`stringz` gains `HasUniqTableNameSuffix` coverage, including a case that replays the exact eight-name list from the failure and asserts the seven permanent Sakila views survive filtering. That covers the filtering logic without live databases, which `TestSQLDriver_ListTableNames_ArgSchemaNotEmpty` itself requires.
