### PR TITLE
fix(config): process source options on load

### DIFF
--- a/cli/config/yamlstore/internal_test.go
+++ b/cli/config/yamlstore/internal_test.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -698,6 +699,41 @@ func Test_Store_doLoad_EmptyVersionStampsBuildVersion(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "v0.55.0", cfg.Version,
 		"an empty version stamps the build version when no registry is configured")
+}
+
+// Test_Store_doLoad_ProcessesSourceOptions verifies that per-source options are
+// run through the registry on load, the same as the base config options.
+// Without this a source option loaded from YAML keeps its raw string form, so
+// options.Duration.Get's type assertion fails and every consumer silently falls
+// back to the option's default.
+func Test_Store_doLoad_ProcessesSourceOptions(t *testing.T) {
+	opt := options.NewDuration("conn.max-idle-time", nil, 2*time.Second, "", "")
+	reg := &options.Registry{}
+	reg.Add(opt)
+
+	const cfgYAML = `config.version: v0.55.0
+collection:
+  active.source: '@src'
+  sources:
+    - handle: '@src'
+      driver: sqlite3
+      location: 'sqlite3://test.db'
+      options:
+        conn.max-idle-time: 100s
+`
+	_, cfgPath := writeTestConfig(t, cfgYAML)
+	ctx := lg.NewContext(context.Background(), lgt.New(t))
+	store := &Store{Path: cfgPath, OptionsRegistry: reg}
+
+	cfg, err := store.Load(ctx)
+	require.NoError(t, err)
+
+	src, err := cfg.Collection.Get("@src")
+	require.NoError(t, err)
+	// On unmodified main src.Options holds the string "100s", so Get returns the
+	// 2s default instead of the configured value.
+	require.Equal(t, 100*time.Second, opt.Get(src.Options),
+		"a source option must be processed into its typed form on load")
 }
 
 // Test_Store_writeConfigBackupOnce_DirError verifies that an unusable

--- a/cli/config/yamlstore/yamlstore.go
+++ b/cli/config/yamlstore/yamlstore.go
@@ -191,6 +191,21 @@ func (fs *Store) doLoad(ctx context.Context) (*config.Config, error) {
 		cfg.Collection = &source.Collection{}
 	}
 
+	// Process each source's options, the same as the base config options
+	// above. Without this a source option loaded from YAML keeps its raw
+	// (e.g. string) form, so consumers such as options.Duration.Get fail
+	// the type assertion and silently fall back to the option's default.
+	// Save does this via canonicalizeConfig; the load path must match.
+	if err = cfg.Collection.Visit(func(src *source.Source) error {
+		var pErr error
+		if src.Options, pErr = fs.OptionsRegistry.Process(src.Options); pErr != nil {
+			return errz.Wrapf(pErr, "processing source options for %s", src.Handle)
+		}
+		return nil
+	}); err != nil {
+		return nil, errz.Wrapf(err, "config: %s", fs.Path)
+	}
+
 	repaired, err := source.VerifyIntegrity(cfg.Collection)
 	if err != nil {
 		if repaired {


### PR DESCRIPTION
Source options set in the config are silently ignored after `sq` restarts. The value stays in `sq.yml`, but the source falls back to the option's default.

`doLoad` runs the base config options through `OptionsRegistry.Process` but never the per-source ones. `canonicalizeConfig` does both on save. So after load a source option is still its raw YAML string, and `Duration.Get`'s `v.(time.Duration)` assertion fails and returns the default. For `conn.max-idle-time` that means the configured value never reaches `db.SetConnMaxIdleTime`.

The fix processes each source's options in `doLoad`, matching what `canonicalizeConfig` already does on save.

The regression test loads a source with `conn.max-idle-time: 100s` and reads it back. On current `master` it returns the 2s default; with the fix it returns 100s.

`go test ./cli/config/...` is green (92 tests).

Fixes #1165
